### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -18,9 +18,9 @@ jobs:
     name: Lint & validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: helm lint
         run: helm lint --strict charts/marimohub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # Installs Vite+/Node, caches deps, and runs a frozen `vp install` wrapped in
       # Socket Firewall (sfw). SHA-pinned so a moved tag can't change what runs.
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # See ci.yml for why setup-vp is SHA-pinned + sfw + frozen install.
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1
         with:
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm e2e
       - name: Upload report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: apps/e2e/playwright-report/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,17 +24,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Derive version
         id: v
         # Strip the leading "v" from the tag -> semver used for image + chart.
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Image metadata (tags + labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE }}
           # v1.4.2 -> tags 1.4.2, 1.4, 1, latest, plus the commit SHA.
@@ -54,7 +54,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build & push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: apps/server/Dockerfile
@@ -75,9 +75,9 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Derive version
         id: v

--- a/.github/workflows/sandbox-image.yml
+++ b/.github/workflows/sandbox-image.yml
@@ -27,7 +27,7 @@ jobs:
     name: Build & acceptance test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # docker (with buildx) and curl are preinstalled on ubuntu-latest runners,
       # so the script needs no extra setup. It builds the context and runs every
       # check against the image.


### PR DESCRIPTION
Pins all external GitHub Actions to full-length commit SHAs (with the version as a trailing comment). Tag references like `@v4` can be force-moved to point at arbitrary code; SHA pins are tamper-resistant and reproducible.

13 references across `chart.yml`, `ci.yml`, `e2e.yml`, `release.yml`, `sandbox-image.yml` (actions/checkout, actions/upload-artifact, azure/setup-helm, docker/setup-buildx-action, docker/login-action, docker/metadata-action, docker/build-push-action). Each SHA is the current tip of the tag it replaces — no version/behavior change.

_Flagged by github-maintenance Action Pin Audit (marimo-team/github-maintenance#332)._