### PR TITLE
feat: W&B sandboxes compute backend (wandb)

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -1420,6 +1420,172 @@ const app = createApi({
 });"
 `;
 
+exports[`config -> code generators > s3 + wandb + oidc > .env 1`] = `
+"# --- Storage ---
+MARIMOHUB_STORAGE_BACKEND=s3
+MARIMOHUB_STORAGE_S3_BUCKET=orgname-marimohub
+MARIMOHUB_STORAGE_S3_ENDPOINT=https://s3.us-east-1.amazonaws.com
+MARIMOHUB_STORAGE_S3_REGION=us-east-1
+MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID=  # secret
+MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY=  # secret
+MARIMOHUB_STORAGE_S3_FORCE_PATH_STYLE=true
+
+# --- Compute ---
+MARIMOHUB_COMPUTE_BACKEND=wandb
+MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
+MARIMOHUB_COMPUTE_IDLE_TIMEOUT=20m
+MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
+MARIMOHUB_COMPUTE_WORKDIR=/workspace
+MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_COMPUTE_WANDB_API_KEY=  # required, secret
+MARIMOHUB_COMPUTE_WANDB_ENTITY=my-team
+MARIMOHUB_COMPUTE_WANDB_PROJECT=sandbox
+MARIMOHUB_COMPUTE_WANDB_BASE_URL=https://api.cwsandbox.com
+MARIMOHUB_COMPUTE_WANDB_OWNER_TAG=marimohub
+MARIMOHUB_COMPUTE_WANDB_MAX_LIFETIME_SECONDS=28800
+
+# --- Auth ---
+MARIMOHUB_AUTH_BACKEND=oidc
+MARIMOHUB_AUTH_OIDC_ISSUER=https://accounts.example.com
+MARIMOHUB_AUTH_OIDC_CLIENT_ID=  # required
+MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=  # required, secret
+MARIMOHUB_AUTH_OIDC_REDIRECT_URI=https://hub.example.com/api/auth/callback
+MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_SESSION_SECRET=  # required, secret
+MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com,example.org
+
+# --- Managed AI ---
+MARIMOHUB_AI_BACKEND=none
+
+# --- Options ---
+MARIMOHUB_PERSIST_WORKSPACE=source"
+`;
+
+exports[`config -> code generators > s3 + wandb + oidc > compose 1`] = `
+"services:
+  marimohub:
+    image: ghcr.io/marimo-team/marimohub:latest
+    ports:
+      - '3000:3000'
+    environment:
+      MARIMOHUB_STORAGE_BACKEND: s3
+      MARIMOHUB_STORAGE_S3_BUCKET: orgname-marimohub
+      MARIMOHUB_STORAGE_S3_ENDPOINT: https://s3.us-east-1.amazonaws.com
+      MARIMOHUB_STORAGE_S3_REGION: us-east-1
+      MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID: ""
+      MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY: ""
+      MARIMOHUB_STORAGE_S3_FORCE_PATH_STYLE: true
+      MARIMOHUB_COMPUTE_BACKEND: wandb
+      MARIMOHUB_COMPUTE_IMAGE: ghcr.io/orgname/marimo-sandbox:latest
+      MARIMOHUB_COMPUTE_IDLE_TIMEOUT: 20m
+      MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
+      MARIMOHUB_COMPUTE_WORKDIR: /workspace
+      MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_COMPUTE_WANDB_API_KEY: ""
+      MARIMOHUB_COMPUTE_WANDB_ENTITY: my-team
+      MARIMOHUB_COMPUTE_WANDB_PROJECT: sandbox
+      MARIMOHUB_COMPUTE_WANDB_BASE_URL: https://api.cwsandbox.com
+      MARIMOHUB_COMPUTE_WANDB_OWNER_TAG: marimohub
+      MARIMOHUB_COMPUTE_WANDB_MAX_LIFETIME_SECONDS: 28800
+      MARIMOHUB_AUTH_BACKEND: oidc
+      MARIMOHUB_AUTH_OIDC_ISSUER: https://accounts.example.com
+      MARIMOHUB_AUTH_OIDC_CLIENT_ID: ""
+      MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: ""
+      MARIMOHUB_AUTH_OIDC_REDIRECT_URI: https://hub.example.com/api/auth/callback
+      MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_SESSION_SECRET: ""
+      MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: "example.com,example.org"
+      MARIMOHUB_AI_BACKEND: none
+      MARIMOHUB_PERSIST_WORKSPACE: source"
+`;
+
+exports[`config -> code generators > s3 + wandb + oidc > helm 1`] = `
+"# Non-secret MARIMOHUB_* config -> ConfigMap.
+config:
+  MARIMOHUB_STORAGE_BACKEND: s3
+  MARIMOHUB_STORAGE_S3_BUCKET: orgname-marimohub
+  MARIMOHUB_STORAGE_S3_ENDPOINT: https://s3.us-east-1.amazonaws.com
+  MARIMOHUB_STORAGE_S3_REGION: us-east-1
+  MARIMOHUB_STORAGE_S3_FORCE_PATH_STYLE: true
+  MARIMOHUB_COMPUTE_BACKEND: wandb
+  MARIMOHUB_COMPUTE_IMAGE: ghcr.io/orgname/marimo-sandbox:latest
+  MARIMOHUB_COMPUTE_IDLE_TIMEOUT: 20m
+  MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
+  MARIMOHUB_COMPUTE_WORKDIR: /workspace
+  MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_COMPUTE_WANDB_ENTITY: my-team
+  MARIMOHUB_COMPUTE_WANDB_PROJECT: sandbox
+  MARIMOHUB_COMPUTE_WANDB_BASE_URL: https://api.cwsandbox.com
+  MARIMOHUB_COMPUTE_WANDB_OWNER_TAG: marimohub
+  MARIMOHUB_COMPUTE_WANDB_MAX_LIFETIME_SECONDS: 28800
+  MARIMOHUB_AUTH_BACKEND: oidc
+  MARIMOHUB_AUTH_OIDC_ISSUER: https://accounts.example.com
+  MARIMOHUB_AUTH_OIDC_CLIENT_ID: ""
+  MARIMOHUB_AUTH_OIDC_REDIRECT_URI: https://hub.example.com/api/auth/callback
+  MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: "example.com,example.org"
+  MARIMOHUB_AI_BACKEND: none
+  MARIMOHUB_PERSIST_WORKSPACE: source
+
+# Secret values -> Secret (prefer secrets.existingSecret in production).
+secrets:
+  data:
+    MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID: ""
+    MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY: ""
+    MARIMOHUB_COMPUTE_WANDB_API_KEY: ""
+    MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: ""
+    MARIMOHUB_AUTH_SESSION_SECRET: """
+`;
+
+exports[`config -> code generators > s3 + wandb + oidc > library 1`] = `
+"import { createApi } from '@marimo-hub/api';
+import { createServices } from '@marimo-hub/core';
+import { S3Storage } from '@marimo-hub/storage-s3';
+import { createWandbCompute } from '@marimo-hub/compute-coreweave/wandb';
+import { createOidcAuth } from '@marimo-hub/auth-oidc';
+
+const bucket = new S3Storage({
+	bucket: process.env.MARIMOHUB_STORAGE_S3_BUCKET!,
+	endpoint: "https://s3.us-east-1.amazonaws.com",
+	region: "us-east-1",
+	forcePathStyle: true,
+});
+
+const compute = createWandbCompute({
+	apiKey: process.env.MARIMOHUB_COMPUTE_WANDB_API_KEY!,
+	entity: "my-team",
+	project: "sandbox",
+	image: process.env.MARIMOHUB_COMPUTE_IMAGE,
+});
+
+const { authenticator, routes: authRoutes } = createOidcAuth({
+	issuer: process.env.MARIMOHUB_AUTH_OIDC_ISSUER!,
+	clientId: process.env.MARIMOHUB_AUTH_OIDC_CLIENT_ID!,
+	clientSecret: process.env.MARIMOHUB_AUTH_OIDC_CLIENT_SECRET!,
+	redirectUri: process.env.MARIMOHUB_AUTH_OIDC_REDIRECT_URI!,
+	sessionSecret: process.env.MARIMOHUB_AUTH_SESSION_SECRET!,
+	allowedEmailDomains: (process.env.MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS ?? '').split(','),
+});
+
+const app = createApi({
+	services: createServices(bucket),
+	bucket,
+	compute,
+	authenticator,
+	authRoutes,
+	sandbox: {
+		bucket: {
+			name: process.env.MARIMOHUB_STORAGE_S3_BUCKET ?? '',
+			endpoint: process.env.MARIMOHUB_STORAGE_S3_ENDPOINT ?? '',
+		},
+		hostname: process.env.MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME ?? '',
+		workdir: process.env.MARIMOHUB_COMPUTE_WORKDIR ?? '/workspace',
+		persistWorkspace: "source",
+	},
+	policy: {},
+});"
+`;
+
 exports[`validateSelection > flags dev auth, volatile storage, and unisolated/absent compute 1`] = `
 [
   {

--- a/apps/docs/.vitepress/wizard/generate.test.ts
+++ b/apps/docs/.vitepress/wizard/generate.test.ts
@@ -36,6 +36,13 @@ const CASES: Record<string, WizardSelection> = {
 		ai: 'none',
 		options: { MARIMOHUB_COMPUTE_IMAGE: 'ghcr.io/acme/marimo-sandbox:v1' },
 	},
+	's3 + wandb + oidc': {
+		storage: 's3',
+		compute: 'wandb',
+		auth: 'oidc',
+		ai: 'none',
+		values: { MARIMOHUB_COMPUTE_WANDB_ENTITY: 'my-team' },
+	},
 	's3 + docker + dev': { storage: 's3', compute: 'docker', auth: 'dev', ai: 'none' },
 	's3 + e2b + oidc': { storage: 's3', compute: 'e2b', auth: 'oidc', ai: 'none' },
 	's3 + none + dev': { storage: 's3', compute: 'none', auth: 'dev', ai: 'none' },

--- a/apps/docs/.vitepress/wizard/setup.ts
+++ b/apps/docs/.vitepress/wizard/setup.ts
@@ -31,6 +31,7 @@ const DOC_HREFS: Record<string, string> = {
 	'storage/gcs': '/storage#google-cloud-storage',
 	'storage/memory': '/storage#memory-dev-tests',
 	'compute/coreweave': '/compute#coreweave',
+	'compute/wandb': '/compute#w-b',
 	'compute/modal': '/compute#modal',
 	'compute/e2b': '/compute#e2b',
 	'compute/kubernetes': '/compute#kubernetes',

--- a/apps/docs/.vitepress/wizard/spec.ts
+++ b/apps/docs/.vitepress/wizard/spec.ts
@@ -57,6 +57,7 @@ const ICONS: Record<string, string> = {
 	// compute
 	modal: '🚀',
 	coreweave: '🧶',
+	wandb: '🪄',
 	docker: '🐳',
 	e2b: '📦',
 	kubernetes: '☸️',
@@ -231,6 +232,18 @@ export const COMPUTE_WIRING: Record<string, BackendWiring> = {
 			[
 				`new CoreWeaveCompute({`,
 				`\tapiKey: ${env('MARIMOHUB_COMPUTE_COREWEAVE_API_KEY', true)},`,
+				`\timage: ${env('MARIMOHUB_COMPUTE_IMAGE')},`,
+				`})`,
+			].join('\n'),
+	},
+	wandb: {
+		imports: [`import { createWandbCompute } from '@marimo-hub/compute-coreweave/wandb';`],
+		rhs: (r) =>
+			[
+				`createWandbCompute({`,
+				`\tapiKey: ${env('MARIMOHUB_COMPUTE_WANDB_API_KEY', true)},`,
+				`\tentity: ${lit('MARIMOHUB_COMPUTE_WANDB_ENTITY', r)},`,
+				`\tproject: ${lit('MARIMOHUB_COMPUTE_WANDB_PROJECT', r)},`,
 				`\timage: ${env('MARIMOHUB_COMPUTE_IMAGE')},`,
 				`})`,
 			].join('\n'),

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -11,7 +11,7 @@ MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY=      # secret
 MARIMOHUB_STORAGE_S3_FORCE_PATH_STYLE=false  # true for MinIO/Ceph
 
 # --- Compute (kernel sandboxes) ---
-MARIMOHUB_COMPUTE_BACKEND=modal              # required: modal | coreweave | kubernetes | docker | e2b | local | none
+MARIMOHUB_COMPUTE_BACKEND=modal              # required: modal | coreweave | wandb | kubernetes | docker | e2b | local | none
 MARIMOHUB_COMPUTE_IMAGE=                     # sandbox image (marimo + uv + python)
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=          # public hostname for exposed kernel ports
 MARIMOHUB_COMPUTE_IDLE_TIMEOUT=20m
@@ -25,6 +25,15 @@ MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=        # secret
 # MARIMOHUB_COMPUTE_COREWEAVE_HOSTNAME_TEMPLATE=https://{sandboxId}-{port}.{host}  # public kernel URL scheme
 # MARIMOHUB_COMPUTE_COREWEAVE_MAX_LIFETIME_SECONDS=  # hard lifetime cap (orphan protection; no listActive)
 # MARIMOHUB_COMPUTE_COREWEAVE_OBJECT_STORAGE_BUCKETS=  # sandbox-native CAIOS creds (disables MARIMOHUB_WIF_*; see docs/workload-identity-federation.md)
+# wandb backend (CoreWeave Sandboxes via the W&B gateway; same adapter as coreweave, W&B API key auth.
+# Kernel URLs auto-resolve to per-sandbox public IPs (plain HTTP) — no SANDBOX_HOSTNAME needed.
+# No profile/GPU/egress overrides or CAIOS vending through the gateway — use MARIMOHUB_WIF_* for bucket access):
+# MARIMOHUB_COMPUTE_WANDB_API_KEY=             # secret (WANDB_API_KEY, from wandb.ai user settings)
+# MARIMOHUB_COMPUTE_WANDB_ENTITY=              # optional W&B entity (team/user) sandboxes are attributed to
+# MARIMOHUB_COMPUTE_WANDB_PROJECT=             # optional W&B project sandboxes are attributed to
+# MARIMOHUB_COMPUTE_WANDB_BASE_URL=            # optional gateway override (default https://api.cwsandbox.com)
+# MARIMOHUB_COMPUTE_WANDB_OWNER_TAG=marimohub  # tag applied to owned sandboxes (discovery/cleanup)
+# MARIMOHUB_COMPUTE_WANDB_MAX_LIFETIME_SECONDS=  # hard lifetime cap (orphan protection; no listActive)
 # kubernetes backend (native Pod + Service + Ingress per session via @kubernetes/client-node,
 # a bring-your-own dep — `pnpm add @kubernetes/client-node` and bake it into the image).
 # Set MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME (kernels served at https://<id>.<host>) and an ingress class + TLS.

--- a/docs/compute.md
+++ b/docs/compute.md
@@ -11,6 +11,7 @@ Selector: `MARIMOHUB_COMPUTE_BACKEND`. Full variables:
 | Backend    | Selector     | Use for                                     |
 | ---------- | ------------ | ------------------------------------------- |
 | CoreWeave  | `coreweave`  | Production on CoreWeave Sandboxes           |
+| W&B        | `wandb`      | CoreWeave Sandboxes via your W&B account    |
 | Modal      | `modal`      | Production serverless sandboxes             |
 | E2B        | `e2b`        | Managed code sandboxes                      |
 | Kubernetes | `kubernetes` | Pods in your own cluster                    |
@@ -49,6 +50,10 @@ model.
 ### CoreWeave
 
 <!--@include: ./setup/compute/coreweave.md-->
+
+### W&B
+
+<!--@include: ./setup/compute/wandb.md-->
 
 ### Modal
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -64,7 +64,7 @@ _No environment variables to set here._
 
 ## Compute
 
-Selected by `MARIMOHUB_COMPUTE_BACKEND`; one of `coreweave`, `modal`, `docker`, `e2b`, `kubernetes`, `local`, `none`.
+Selected by `MARIMOHUB_COMPUTE_BACKEND`; one of `coreweave`, `wandb`, `modal`, `docker`, `e2b`, `kubernetes`, `local`, `none`.
 
 Where notebook kernels run. The shared variables apply across compute backends.
 
@@ -101,6 +101,21 @@ CoreWeave Sandboxes via the vendored `@coreweave/cwsandbox` SDK.
 | `MARIMOHUB_COMPUTE_COREWEAVE_OBJECT_STORAGE_ENDPOINT` | S3 endpoint injected into sandboxes as `AWS_ENDPOINT_URL_S3` (only when buckets are set) so plain SDK clients target CAIOS without per-call configuration. | — | — | `https://cwobject.com` |
 | `MARIMOHUB_COMPUTE_COREWEAVE_OBJECT_STORAGE_REGION` | Region injected into sandboxes as `AWS_REGION` (only when buckets are set). | — | — | `us-east-04a` |
 | `MARIMOHUB_COMPUTE_COREWEAVE_FILESYSTEM_SNAPSHOT` | Capture the whole sandbox filesystem (venv, packages, caches) as a native snapshot on teardown and restore it on the next session — full-state fidelity and fast cold-start. Off by default. NOT recommended alongside `MARIMOHUB_PERSIST_WORKSPACE=workspace`: the two double-persist state and waste storage. | — | `false` | `true` |
+
+### W&B Sandboxes
+
+`MARIMOHUB_COMPUTE_BACKEND=wandb`
+
+CoreWeave Sandboxes via the W&B (Weights & Biases) gateway — the `coreweave` backend authenticated with a W&B API key. Kernel URLs are resolved automatically: the managed runner assigns each sandbox a public IP served over plain HTTP, so no sandbox hostname is needed. Profile/placement overrides, GPU requests, egress overrides, and CAIOS vending are not available through the gateway; use hub-minted WIF (docs/workload-identity-federation.md) for bucket access.
+
+| Variable | Description | Required | Default | Example |
+| --- | --- | --- | --- | --- |
+| `MARIMOHUB_COMPUTE_WANDB_API_KEY` 🔒 | W&B API key (from wandb.ai user settings). | Yes | — | — |
+| `MARIMOHUB_COMPUTE_WANDB_ENTITY` | W&B entity (team or user) sandboxes are attributed to. | — | — | `my-team` |
+| `MARIMOHUB_COMPUTE_WANDB_PROJECT` | W&B project sandboxes are attributed to. | — | — | `sandbox` |
+| `MARIMOHUB_COMPUTE_WANDB_BASE_URL` | Override the sandbox gateway URL. | — | `https://api.cwsandbox.com` | — |
+| `MARIMOHUB_COMPUTE_WANDB_OWNER_TAG` | Tag applied to owned sandboxes for discovery and cleanup. | — | `marimohub` | — |
+| `MARIMOHUB_COMPUTE_WANDB_MAX_LIFETIME_SECONDS` | Hard provider-side sandbox lifetime cap (SIGKILL, no save) — an orphan backstop behind the graceful session lifetime (`MARIMOHUB_SESSION_MAX_LIFETIME_SECONDS`). Must be >= the session lifetime; leave unset to default to 2x it. | — | `2x MARIMOHUB_SESSION_MAX_LIFETIME_SECONDS` | `28800` |
 
 ### Modal
 

--- a/docs/setup/compute/wandb.md
+++ b/docs/setup/compute/wandb.md
@@ -1,0 +1,31 @@
+<!-- Setup snippet — included by docs/compute.md and rendered in the deployment wizard. -->
+
+1. Get a **W&B API key** from your [wandb.ai user settings](https://wandb.ai/settings)
+   (optionally note the entity/team and project to attribute sandboxes to).
+2. Build or pick a sandbox image (marimo + uv + python), as for
+   [CoreWeave](/compute#coreweave).
+3. Set the env and start marimohub:
+
+```bash
+MARIMOHUB_COMPUTE_BACKEND=wandb
+MARIMOHUB_COMPUTE_WANDB_API_KEY=…               # secret
+MARIMOHUB_COMPUTE_WANDB_ENTITY=my-team          # optional
+MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
+```
+
+::: tip Same backend as CoreWeave — no hostname config
+W&B sandboxes are [CoreWeave Sandboxes](/compute#coreweave) behind the W&B
+gateway — same adapter and API; only the credential differs. Kernel URLs are
+resolved automatically (the managed runner assigns each sandbox its own public
+IP), so `MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME` is not needed. See the
+[Configuration reference](/configuration#w-b-sandboxes) for all variables.
+:::
+
+::: warning Gateway limitations
+Kernels are served over **plain HTTP** at a per-sandbox public IP — an
+HTTPS-served hub will hit mixed-content blocking in the browser, so this
+backend currently suits local/HTTP deployments. The gateway also doesn't
+support profile/placement overrides, GPU requests, egress overrides, or
+automatic CAIOS bucket credentials — for cloud-storage access use hub-minted
+[Workload Identity Federation](/workload-identity-federation) instead.
+:::

--- a/docs/setup/compute/wandb.md
+++ b/docs/setup/compute/wandb.md
@@ -10,6 +10,7 @@
 MARIMOHUB_COMPUTE_BACKEND=wandb
 MARIMOHUB_COMPUTE_WANDB_API_KEY=…               # secret
 MARIMOHUB_COMPUTE_WANDB_ENTITY=my-team          # optional
+MARIMOHUB_COMPUTE_WANDB_PROJECT=my-project      # optional
 MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 ```
 

--- a/packages/compute-coreweave/package.json
+++ b/packages/compute-coreweave/package.json
@@ -9,6 +9,7 @@
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",
+		"./wandb": "./src/wandb.ts",
 		"./package.json": "./package.json"
 	},
 	"scripts": {

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -1,187 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import { CWSandboxNotFoundError } from '@coreweave/cwsandbox';
-import type { CommandProcess, FileWrites, ProcessResult, SandboxInfo } from '@coreweave/cwsandbox';
+import type { SandboxInfo } from '@coreweave/cwsandbox';
 import type { SandboxId, SandboxProvider } from '@marimo-hub/core';
 import { computeContract } from '@marimo-hub/core/testing/compute-contract';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
 import { CoreWeaveCompute } from './index';
 import type { CoreWeaveClient, CoreWeaveConfig } from './index';
+import { fakeProcess, makeWorld, procResult } from './testWorld';
 
 /**
  * Tests for the CoreWeave compute adapter.
  *
- * Hermetic: an in-memory fake `CoreWeaveClient` is injected via the constructor
- * (no gRPC, no live creds), the cleanest analogue of `compute-cloudflare`'s
- * SDK-mock test. The fake keeps a registry of created sandboxes keyed by the
- * CoreWeave id it assigns, so reconnect/list/delete-by-tag behave realistically.
+ * Hermetic: the in-memory fake `CoreWeaveClient` from `testWorld.ts` is
+ * injected via the constructor (no gRPC, no live creds), the cleanest analogue
+ * of `compute-cloudflare`'s SDK-mock test.
  */
 
 const SANDBOX_ID = 'sb-abc' as SandboxId;
 const ID_TAG = 'mh-sbx-sb-abc';
 
 const baseConfig: CoreWeaveConfig = { apiKey: 'key', image: 'my-image' };
-
-function procResult(over: Partial<ProcessResult> = {}): ProcessResult {
-	return {
-		command: ['sh'] as unknown as ProcessResult['command'],
-		exitCode: 0,
-		failed: false,
-		ok: true,
-		stderr: '',
-		stderrBytes: new Uint8Array(),
-		stderrBytesProduced: 0,
-		stderrTruncated: false,
-		stdout: '',
-		stdoutBytes: new Uint8Array(),
-		stdoutBytesProduced: 0,
-		stdoutTruncated: false,
-		...over,
-	};
-}
-
-function fakeProcess(): CommandProcess {
-	async function* empty(): AsyncGenerator<string> {
-		// no output
-	}
-	return {
-		command: ['sh'] as unknown as CommandProcess['command'],
-		exitCode: undefined,
-		status: 'running',
-		stdout: empty(),
-		stderr: empty(),
-		cancel: async () => {},
-		poll: () => {},
-		wait: async () => procResult(),
-	};
-}
-
-interface FakeSandbox {
-	sandboxId: string;
-	runCalls: string[][];
-	startCalls: string[][];
-	/** One entry per `files.write(files)` call — the set sent in that call. */
-	batchWrites: { path: string; content: unknown }[][];
-	reads: Record<string, string>;
-	deleted: number;
-}
-
-// `FileWrites` also admits a path→content record, but the adapter only ever
-// sends the array form; normalize so the fake satisfies the SDK type.
-function recordWrite(fake: FakeSandbox) {
-	return async (files: FileWrites): Promise<void> => {
-		const list = Array.isArray(files)
-			? (files as readonly { path: string; content: unknown }[]).map((f) => ({ ...f }))
-			: Object.entries(files).map(([path, content]) => ({ path, content }));
-		fake.batchWrites.push(list);
-	};
-}
-
-function makeWorld(opts?: { runImpl?: (cmd: readonly string[]) => Promise<ProcessResult> }) {
-	const created: NonNullable<Parameters<CoreWeaveClient['create']>[0]>[] = [];
-	const deleted: string[] = [];
-	const listCalls: (readonly string[])[] = [];
-	const registry = new Map<string, { fake: FakeSandbox; tags: string[] }>();
-	let seq = 0;
-	const runImpl = opts?.runImpl ?? (async () => procResult());
-
-	function build(sandboxId: string) {
-		const fake: FakeSandbox = {
-			sandboxId,
-			runCalls: [],
-			startCalls: [],
-			batchWrites: [],
-			reads: {},
-			deleted: 0,
-		};
-		const sandbox = {
-			sandboxId,
-			commands: {
-				run: async (command: readonly string[]) => {
-					fake.runCalls.push([...command]);
-					return runImpl(command);
-				},
-				start: async (command: readonly string[]) => {
-					fake.startCalls.push([...command]);
-					return fakeProcess();
-				},
-			},
-			files: {
-				readText: async (path: string) => {
-					if (path in fake.reads) return fake.reads[path];
-					throw new Error('not found');
-				},
-				write: recordWrite(fake),
-			},
-			delete: async () => {
-				fake.deleted++;
-				deleted.push(sandboxId);
-				registry.delete(sandboxId);
-			},
-		};
-		return { fake, sandbox };
-	}
-
-	const client: CoreWeaveClient = {
-		create: async (options) => {
-			created.push(options!);
-			const cwId = `cw-${++seq}`;
-			const { fake, sandbox } = build(cwId);
-			registry.set(cwId, { fake, tags: [...(options?.tags ?? [])] });
-			return sandbox;
-		},
-		fromId: async (cwId) => {
-			const entry = registry.get(cwId);
-			if (!entry) throw new Error(`no sandbox ${cwId}`);
-			return reconnect(entry, cwId);
-		},
-		list: async (options) => {
-			const tags = options?.tags ?? [];
-			listCalls.push(tags);
-			const sandboxes: SandboxInfo[] = [];
-			for (const [cwId, entry] of registry) {
-				if (tags.every((t) => entry.tags.includes(t))) {
-					sandboxes.push({ sandboxId: cwId, status: 'running' });
-				}
-			}
-			return { sandboxes };
-		},
-		delete: async (cwId) => {
-			deleted.push(cwId);
-			registry.delete(cwId);
-		},
-	};
-
-	// Reconnect returns a handle backed by the SAME recorded FakeSandbox state.
-	function reconnect(entry: { fake: FakeSandbox }, cwId: string) {
-		return {
-			sandboxId: cwId,
-			commands: {
-				run: async (command: readonly string[]) => {
-					entry.fake.runCalls.push([...command]);
-					return runImpl(command);
-				},
-				start: async (command: readonly string[]) => {
-					entry.fake.startCalls.push([...command]);
-					return fakeProcess();
-				},
-			},
-			files: {
-				readText: async (path: string) => {
-					if (path in entry.fake.reads) return entry.fake.reads[path];
-					throw new Error('not found');
-				},
-				write: recordWrite(entry.fake),
-			},
-			delete: async () => {
-				entry.fake.deleted++;
-				deleted.push(cwId);
-				registry.delete(cwId);
-			},
-		};
-	}
-
-	return { client, created, deleted, listCalls, registry };
-}
 
 function makeCompute(world: ReturnType<typeof makeWorld>, config: CoreWeaveConfig = baseConfig) {
 	return new CoreWeaveCompute(config, world.client);
@@ -441,6 +279,17 @@ describe('CoreWeaveCompute', () => {
 			expect(url).toBe('https://hub.example.com/s/cw-1/2718');
 		});
 
+		it('uses resolveExposedUrl over the template when configured', async () => {
+			const world = makeWorld();
+			const inst = makeCompute(world, {
+				...baseConfig,
+				resolveExposedUrl: async (sandboxId, port) => `http://10.0.0.9:${port}/${sandboxId}`,
+			}).create(SANDBOX_ID);
+			await inst.exec('true');
+			const { url } = await inst.exposePort(2718, { hostname: 'ignored.example.com' });
+			expect(url).toBe('http://10.0.0.9:2718/cw-1');
+		});
+
 		it('builds a wildcard per-sandbox subdomain (no {port}) for ingress host routing', async () => {
 			const world = makeWorld();
 			const inst = makeCompute(world, {
@@ -513,6 +362,12 @@ describe('CoreWeaveCompute', () => {
 		it('proxy() is a no-op (kernel reached via public ingress)', async () => {
 			const world = makeWorld();
 			expect(await makeCompute(world).proxy(new Request('http://x/'))).toBeNull();
+		});
+
+		it('throws on first use when neither an apiKey nor a client is provided', () => {
+			expect(() => new CoreWeaveCompute({}).create(SANDBOX_ID)).toThrow(
+				/apiKey.*or an injected client/,
+			);
 		});
 
 		it('does not implement listActive (the list API cannot map back to our ids)', () => {

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -85,8 +85,12 @@ const DEFAULT_OWNER_TAG = 'marimohub';
 const ID_TAG_PREFIX = 'mh-sbx-';
 
 export interface CoreWeaveConfig {
-	/** CoreWeave Sandbox API key (`CWSANDBOX_API_KEY`). */
-	apiKey: string;
+	/**
+	 * CoreWeave Sandbox API key (`CWSANDBOX_API_KEY`). Optional only when a
+	 * pre-authenticated client is injected (the W&B gateway path in `wandb.ts`
+	 * authenticates via gRPC metadata instead).
+	 */
+	apiKey?: string;
 	/** API base URL (`CWSANDBOX_BASE_URL`); defaults to the SDK's production endpoint. */
 	baseUrl?: string;
 	/** Container image with marimo + uv + python. Defaults to the SDK's `python:3.11`. */
@@ -111,6 +115,13 @@ export interface CoreWeaveConfig {
 	 * `hostname` the provisioner passes (`MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME`).
 	 */
 	hostnameTemplate?: string;
+	/**
+	 * Resolve the public kernel URL for a sandbox at expose time, for runners
+	 * that assign per-sandbox addresses instead of a static hostname scheme
+	 * (the W&B gateway vends a per-sandbox public IP). Wins over
+	 * `hostnameTemplate` when set.
+	 */
+	resolveExposedUrl?: (sandboxId: string, port: number) => Promise<string>;
 	/** Optional CPU/memory request (and limit) for each sandbox. */
 	resources?: ResourceOptions;
 	/**
@@ -459,10 +470,13 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	}
 
 	async exposePort(port: number, options: ExposePortOptions): Promise<ExposePortResult> {
-		// The SDK has no ingress-URL accessor; construct the public URL from a template
-		// (the kernel port was declared `public` at create). Integration surface — the
-		// exact ingress hostname scheme is CoreWeave backend/profile specific.
 		const sandbox = await this.ensure();
+		if (this.config.resolveExposedUrl) {
+			return { url: await this.config.resolveExposedUrl(sandbox.sandboxId, port) };
+		}
+		// Without a resolver, construct the public URL from a template (the kernel
+		// port was declared `public` at create). Integration surface — the exact
+		// ingress hostname scheme is CoreWeave backend/profile specific.
 		const template = this.config.hostnameTemplate ?? 'https://{sandboxId}-{port}.{host}';
 		const url = template
 			.replaceAll('{sandboxId}', sandbox.sandboxId)
@@ -508,6 +522,11 @@ export class CoreWeaveCompute implements SandboxProvider {
 
 	private getClient(): CoreWeaveClient {
 		if (!this.client) {
+			if (!this.config.apiKey) {
+				throw new Error(
+					'CoreWeaveCompute requires either an apiKey in its config or an injected client',
+				);
+			}
 			// The real SDK client exposes the CoreWeaveClient surface at runtime; one
 			// controlled cast at the construction boundary avoids overload-variance
 			// friction between the SDK's broad signatures and our narrow seam.

--- a/packages/compute-coreweave/src/testWorld.ts
+++ b/packages/compute-coreweave/src/testWorld.ts
@@ -1,0 +1,171 @@
+/**
+ * Test-only hermetic fake for the CoreWeave adapter, shared by `index.test.ts`
+ * and `wandb.test.ts` (no gRPC, no live creds). Not exported from the package.
+ *
+ * The fake keeps a registry of created sandboxes keyed by the CoreWeave id it
+ * assigns, so reconnect/list/delete-by-tag behave realistically.
+ */
+import type { CommandProcess, FileWrites, ProcessResult, SandboxInfo } from '@coreweave/cwsandbox';
+import type { CoreWeaveClient } from './index';
+
+export function procResult(over: Partial<ProcessResult> = {}): ProcessResult {
+	return {
+		command: ['sh'] as unknown as ProcessResult['command'],
+		exitCode: 0,
+		failed: false,
+		ok: true,
+		stderr: '',
+		stderrBytes: new Uint8Array(),
+		stderrBytesProduced: 0,
+		stderrTruncated: false,
+		stdout: '',
+		stdoutBytes: new Uint8Array(),
+		stdoutBytesProduced: 0,
+		stdoutTruncated: false,
+		...over,
+	};
+}
+
+export function fakeProcess(): CommandProcess {
+	async function* empty(): AsyncGenerator<string> {
+		// no output
+	}
+	return {
+		command: ['sh'] as unknown as CommandProcess['command'],
+		exitCode: undefined,
+		status: 'running',
+		stdout: empty(),
+		stderr: empty(),
+		cancel: async () => {},
+		poll: () => {},
+		wait: async () => procResult(),
+	};
+}
+
+export interface FakeSandbox {
+	sandboxId: string;
+	runCalls: string[][];
+	startCalls: string[][];
+	/** One entry per `files.write(files)` call — the set sent in that call. */
+	batchWrites: { path: string; content: unknown }[][];
+	reads: Record<string, string>;
+	deleted: number;
+}
+
+// `FileWrites` also admits a path→content record, but the adapter only ever
+// sends the array form; normalize so the fake satisfies the SDK type.
+function recordWrite(fake: FakeSandbox) {
+	return async (files: FileWrites): Promise<void> => {
+		const list = Array.isArray(files)
+			? (files as readonly { path: string; content: unknown }[]).map((f) => ({ ...f }))
+			: Object.entries(files).map(([path, content]) => ({ path, content }));
+		fake.batchWrites.push(list);
+	};
+}
+
+export function makeWorld(opts?: { runImpl?: (cmd: readonly string[]) => Promise<ProcessResult> }) {
+	const created: NonNullable<Parameters<CoreWeaveClient['create']>[0]>[] = [];
+	const deleted: string[] = [];
+	const listCalls: (readonly string[])[] = [];
+	const registry = new Map<string, { fake: FakeSandbox; tags: string[] }>();
+	let seq = 0;
+	const runImpl = opts?.runImpl ?? (async () => procResult());
+
+	function build(sandboxId: string) {
+		const fake: FakeSandbox = {
+			sandboxId,
+			runCalls: [],
+			startCalls: [],
+			batchWrites: [],
+			reads: {},
+			deleted: 0,
+		};
+		const sandbox = {
+			sandboxId,
+			commands: {
+				run: async (command: readonly string[]) => {
+					fake.runCalls.push([...command]);
+					return runImpl(command);
+				},
+				start: async (command: readonly string[]) => {
+					fake.startCalls.push([...command]);
+					return fakeProcess();
+				},
+			},
+			files: {
+				readText: async (path: string) => {
+					if (path in fake.reads) return fake.reads[path];
+					throw new Error('not found');
+				},
+				write: recordWrite(fake),
+			},
+			delete: async () => {
+				fake.deleted++;
+				deleted.push(sandboxId);
+				registry.delete(sandboxId);
+			},
+		};
+		return { fake, sandbox };
+	}
+
+	const client: CoreWeaveClient = {
+		create: async (options) => {
+			created.push(options!);
+			const cwId = `cw-${++seq}`;
+			const { fake, sandbox } = build(cwId);
+			registry.set(cwId, { fake, tags: [...(options?.tags ?? [])] });
+			return sandbox;
+		},
+		fromId: async (cwId) => {
+			const entry = registry.get(cwId);
+			if (!entry) throw new Error(`no sandbox ${cwId}`);
+			return reconnect(entry, cwId);
+		},
+		list: async (options) => {
+			const tags = options?.tags ?? [];
+			listCalls.push(tags);
+			const sandboxes: SandboxInfo[] = [];
+			for (const [cwId, entry] of registry) {
+				if (tags.every((t) => entry.tags.includes(t))) {
+					sandboxes.push({ sandboxId: cwId, status: 'running' });
+				}
+			}
+			return { sandboxes };
+		},
+		delete: async (cwId) => {
+			deleted.push(cwId);
+			registry.delete(cwId);
+		},
+	};
+
+	// Reconnect returns a handle backed by the SAME recorded FakeSandbox state.
+	function reconnect(entry: { fake: FakeSandbox }, cwId: string) {
+		return {
+			sandboxId: cwId,
+			commands: {
+				run: async (command: readonly string[]) => {
+					entry.fake.runCalls.push([...command]);
+					return runImpl(command);
+				},
+				start: async (command: readonly string[]) => {
+					entry.fake.startCalls.push([...command]);
+					return fakeProcess();
+				},
+			},
+			files: {
+				readText: async (path: string) => {
+					if (path in entry.fake.reads) return entry.fake.reads[path];
+					throw new Error('not found');
+				},
+				write: recordWrite(entry.fake),
+			},
+			delete: async () => {
+				entry.fake.deleted++;
+				deleted.push(cwId);
+				registry.delete(cwId);
+			},
+		};
+	}
+
+	return { client, created, deleted, listCalls, registry };
+}

--- a/packages/compute-coreweave/src/wandb.test.ts
+++ b/packages/compute-coreweave/src/wandb.test.ts
@@ -33,6 +33,10 @@ describe('buildWandbMetadata', () => {
 		expect(Object.keys(metadata).some((k) => k.toLowerCase() === 'authorization')).toBe(false);
 	});
 
+	it('rejects a missing or whitespace-only API key up front', () => {
+		expect(() => buildWandbMetadata({ apiKey: '  ' })).toThrow(/missing or blank/);
+	});
+
 	it('trims values and drops whitespace-only entity/project', () => {
 		const metadata = buildWandbMetadata({
 			apiKey: 'wb-key\n',
@@ -49,6 +53,11 @@ describe('serviceAddressResolver', () => {
 	it('builds a plain-HTTP URL from the sandbox serviceAddress', async () => {
 		const resolve = serviceAddressResolver(async () => ({ serviceAddress: '166.19.118.62' }));
 		expect(await resolve('cw-1', 2718)).toBe('http://166.19.118.62:2718');
+	});
+
+	it('brackets IPv6 addresses', async () => {
+		const resolve = serviceAddressResolver(async () => ({ serviceAddress: '2001:db8::1' }));
+		expect(await resolve('cw-1', 2718)).toBe('http://[2001:db8::1]:2718');
 	});
 
 	it('throws when no serviceAddress is assigned', async () => {

--- a/packages/compute-coreweave/src/wandb.test.ts
+++ b/packages/compute-coreweave/src/wandb.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { Seconds } from '@marimo-hub/core';
+import type { SandboxId } from '@marimo-hub/core';
+import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import { expectExecResult } from '@marimo-hub/core/testing';
+import { CoreWeaveCompute } from './index';
+import { buildWandbMetadata, createWandbCompute, serviceAddressResolver } from './wandb';
+import type { WandbConfig } from './wandb';
+import { makeWorld } from './testWorld';
+
+const SANDBOX_ID = 'sb-abc' as SandboxId;
+
+const baseConfig: WandbConfig = { apiKey: 'wb-key', image: 'my-image' };
+
+describe('buildWandbMetadata', () => {
+	it('sends the W&B API key and the constant telemetry headers', () => {
+		expect(buildWandbMetadata({ apiKey: 'wb-key' })).toEqual({
+			'x-wandb-api-key': 'wb-key',
+			'x-cwsandbox-client-version': '0.0.0',
+			'x-wandb-sdk-version': '0.0.0',
+			'x-sandbox-integration': 'js-sdk',
+		});
+	});
+
+	it('includes entity and project headers only when set', () => {
+		const metadata = buildWandbMetadata({ apiKey: 'k', entity: 'my-team', project: 'sandbox' });
+		expect(metadata['x-entity-id']).toBe('my-team');
+		expect(metadata['x-project-name']).toBe('sandbox');
+	});
+
+	it('never emits an authorization header (the W&B key is the sole credential)', () => {
+		const metadata = buildWandbMetadata({ apiKey: 'k', entity: 'e', project: 'p' });
+		expect(Object.keys(metadata).some((k) => k.toLowerCase() === 'authorization')).toBe(false);
+	});
+
+	it('trims values and drops whitespace-only entity/project', () => {
+		const metadata = buildWandbMetadata({
+			apiKey: 'wb-key\n',
+			entity: ' my-team ',
+			project: '  ',
+		});
+		expect(metadata['x-wandb-api-key']).toBe('wb-key');
+		expect(metadata['x-entity-id']).toBe('my-team');
+		expect(metadata).not.toHaveProperty('x-project-name');
+	});
+});
+
+describe('serviceAddressResolver', () => {
+	it('builds a plain-HTTP URL from the sandbox serviceAddress', async () => {
+		const resolve = serviceAddressResolver(async () => ({ serviceAddress: '166.19.118.62' }));
+		expect(await resolve('cw-1', 2718)).toBe('http://166.19.118.62:2718');
+	});
+
+	it('throws when no serviceAddress is assigned', async () => {
+		const resolve = serviceAddressResolver(async () => ({}));
+		await expect(resolve('cw-1', 2718)).rejects.toThrow(/no serviceAddress/);
+	});
+});
+
+describe('createWandbCompute', () => {
+	it('returns a CoreWeaveCompute (same adapter, W&B-authenticated client)', () => {
+		expect(createWandbCompute(baseConfig)).toBeInstanceOf(CoreWeaveCompute);
+	});
+
+	it('falls back to the default gateway on a set-but-empty baseUrl', () => {
+		expect(createWandbCompute({ ...baseConfig, baseUrl: '' })).toBeInstanceOf(CoreWeaveCompute);
+	});
+
+	it('an injected client takes over (test seam), and the adapter works through it', async () => {
+		const world = makeWorld();
+		const compute = createWandbCompute(baseConfig, world.client);
+		const result = await compute.create(SANDBOX_ID).exec('echo hi');
+		expectExecResult(result, { success: true, stdout: '', stderr: '' });
+		expect(world.created).toHaveLength(1);
+		expect(world.created[0].containerImage).toBe('my-image');
+	});
+
+	it('passes the restricted config subset through to the CoreWeave adapter', async () => {
+		const world = makeWorld();
+		const compute = createWandbCompute(
+			{
+				...baseConfig,
+				ownerTag: 'my-hub',
+				maxLifetimeSeconds: Seconds.of(3600),
+			},
+			world.client,
+		);
+		await compute.create(SANDBOX_ID).exec('true');
+		const opts = world.created[0];
+		expect(opts.tags).toContain('my-hub');
+		expect(opts.maxLifetimeSeconds).toBe(3600);
+		// Gateway-unsupported knobs are not configurable: adapter defaults apply.
+		expect(opts.profileNames).toBeUndefined();
+		expect(opts.objectStorageAccess).toBeUndefined();
+		expect(opts.network).toMatchObject({ ingressMode: 'public', egressMode: 'internet' });
+	});
+});
+
+computeContract('WandbCompute', () => createWandbCompute(baseConfig, makeWorld().client), {
+	mountFallsBack: true,
+});

--- a/packages/compute-coreweave/src/wandb.ts
+++ b/packages/compute-coreweave/src/wandb.ts
@@ -115,9 +115,7 @@ export function createWandbCompute(
 	return new CoreWeaveCompute(
 		{
 			...coreweave,
-			resolveExposedUrl: serviceAddressResolver((sandboxId) =>
-				transport.get({ sandboxId }),
-			),
+			resolveExposedUrl: serviceAddressResolver((sandboxId) => transport.get({ sandboxId })),
 		},
 		// Same controlled cast as `CoreWeaveCompute.getClient()`: the SDK client
 		// exposes the CoreWeaveClient surface at runtime. Eager construction is

--- a/packages/compute-coreweave/src/wandb.ts
+++ b/packages/compute-coreweave/src/wandb.ts
@@ -116,7 +116,7 @@ export function createWandbCompute(
 		{
 			...coreweave,
 			resolveExposedUrl: serviceAddressResolver((sandboxId) =>
-				transport.get({ sandboxId: sandboxId }),
+				transport.get({ sandboxId }),
 			),
 		},
 		// Same controlled cast as `CoreWeaveCompute.getClient()`: the SDK client

--- a/packages/compute-coreweave/src/wandb.ts
+++ b/packages/compute-coreweave/src/wandb.ts
@@ -1,0 +1,127 @@
+/**
+ * W&B Sandboxes — the CoreWeave Sandbox backend behind the W&B gateway.
+ *
+ * Same gRPC API and endpoint as the direct CoreWeave path; only auth differs.
+ * Instead of a CoreWeave API key, the gateway authenticates via gRPC metadata
+ * (`x-wandb-api-key` + optional entity/project headers). Presence of `metadata`
+ * on the SDK transport suppresses its `authorization` header entirely, so the
+ * W&B key is the sole credential sent.
+ *
+ * The upstream SDK ships this as the pruned `/wandb` entrypoint (see
+ * `vendor/cwsandbox/UPSTREAM.md`); we assemble the same headers locally against
+ * the vendored `/node` transport rather than re-vendoring. The netrc fallback is
+ * deliberately omitted — server config is env-driven.
+ *
+ * The config surface is a restricted subset of `CoreWeaveConfig`: the W&B
+ * gateway does not support profile/placement overrides, GPU resource requests,
+ * or non-default egress modes, and CAIOS object-storage vending is unconfirmed
+ * through it. Use hub-minted WIF for bucket access on this backend.
+ *
+ * Kernel URLs: the W&B managed runner assigns each public-ingress sandbox a
+ * per-sandbox public IP (`serviceAddress`, plain HTTP) instead of a hostname
+ * scheme, so this backend resolves URLs via `resolveExposedUrl` and ignores
+ * the hostname-template machinery (verified live 2026-07-21).
+ */
+import { SandboxClient } from '@coreweave/cwsandbox';
+import type { SandboxId as CwSandboxId } from '@coreweave/cwsandbox';
+import { DEFAULT_BASE_URL, GrpcSandboxTransport } from '@coreweave/cwsandbox/node';
+import { CoreWeaveCompute } from './index';
+import type { CoreWeaveClient, CoreWeaveConfig } from './index';
+
+/**
+ * Version reported in the gateway telemetry headers. The vendored SDK build's
+ * package version is literally `0.0.0` (see `vendor/cwsandbox/UPSTREAM.md` for
+ * the pinned upstream commit), so this is the truthful client version.
+ */
+const VENDORED_SDK_VERSION = '0.0.0';
+
+/**
+ * The gateway-supported subset of `CoreWeaveConfig` plus W&B credentials. The
+ * `Pick` fields pass through to the CoreWeave adapter unchanged (docs on
+ * `CoreWeaveConfig`); everything else there is intentionally unavailable here.
+ */
+export interface WandbConfig extends Pick<
+	CoreWeaveConfig,
+	'image' | 'kernelPort' | 'ownerTag' | 'maxLifetimeSeconds'
+> {
+	/** W&B API key (`WANDB_API_KEY`; from wandb.ai user settings). */
+	apiKey: string;
+	/** W&B entity (team/user) to attribute sandboxes to (`x-entity-id`). */
+	entity?: string;
+	/** W&B project to attribute sandboxes to (`x-project-name`). */
+	project?: string;
+	/** Sandbox gateway URL; defaults to the shared CoreWeave endpoint. */
+	baseUrl?: string;
+}
+
+/** gRPC metadata the W&B sandbox gateway authenticates with. */
+export function buildWandbMetadata(
+	config: Pick<WandbConfig, 'apiKey' | 'entity' | 'project'>,
+): Readonly<Record<string, string>> {
+	// Trim like the upstream wrapper: a stray trailing newline (a common
+	// secret-file artifact) is an illegal gRPC metadata value that fails
+	// cryptically at the first call.
+	const entity = config.entity?.trim();
+	const project = config.project?.trim();
+	return {
+		'x-wandb-api-key': config.apiKey.trim(),
+		...(entity ? { 'x-entity-id': entity } : {}),
+		...(project ? { 'x-project-name': project } : {}),
+		'x-cwsandbox-client-version': VENDORED_SDK_VERSION,
+		'x-wandb-sdk-version': VENDORED_SDK_VERSION,
+		// Keep the upstream SDK's integration marker: we ARE a (vendored) build of
+		// the JS SDK, and a custom value risks a gateway-side allowlist rejection.
+		'x-sandbox-integration': 'js-sdk',
+	};
+}
+
+/**
+ * Build a `resolveExposedUrl` from a sandbox-metadata lookup. The W&B managed
+ * runner does not serve sandboxes under a hostname scheme — each public-ingress
+ * sandbox gets a per-sandbox public IP (`serviceAddress`), plain HTTP.
+ */
+export function serviceAddressResolver(
+	get: (sandboxId: string) => Promise<{ serviceAddress?: string }>,
+): (sandboxId: string, port: number) => Promise<string> {
+	return async (sandboxId, port) => {
+		const { serviceAddress } = await get(sandboxId);
+		if (!serviceAddress) {
+			throw new Error(
+				`W&B sandbox ${sandboxId} has no serviceAddress (public ingress not assigned yet?)`,
+			);
+		}
+		return `http://${serviceAddress}:${port}`;
+	};
+}
+
+/**
+ * A `SandboxProvider` for W&B sandboxes: `CoreWeaveCompute` composed with a
+ * W&B-gateway-authenticated client and per-sandbox URL resolution. The optional
+ * `client` preserves the same test-injection seam as the CoreWeave constructor
+ * (URL resolution then falls back to the hostname template).
+ */
+export function createWandbCompute(
+	config: WandbConfig,
+	client?: CoreWeaveClient,
+): CoreWeaveCompute {
+	const { apiKey, entity, project, baseUrl, ...coreweave } = config;
+	if (client) return new CoreWeaveCompute(coreweave, client);
+
+	const transport = new GrpcSandboxTransport({
+		// `||` (not `??`): a set-but-empty env var must also fall back.
+		baseUrl: baseUrl?.trim() || DEFAULT_BASE_URL,
+		metadata: buildWandbMetadata({ apiKey, entity, project }),
+	});
+	return new CoreWeaveCompute(
+		{
+			...coreweave,
+			resolveExposedUrl: serviceAddressResolver((sandboxId) =>
+				transport.get({ sandboxId: sandboxId }),
+			),
+		},
+		// Same controlled cast as `CoreWeaveCompute.getClient()`: the SDK client
+		// exposes the CoreWeaveClient surface at runtime. Eager construction is
+		// safe — grpc-js channels dial lazily.
+		new SandboxClient({ transport }) as unknown as CoreWeaveClient,
+	);
+}

--- a/packages/compute-coreweave/src/wandb.ts
+++ b/packages/compute-coreweave/src/wandb.ts
@@ -60,10 +60,14 @@ export function buildWandbMetadata(
 	// Trim like the upstream wrapper: a stray trailing newline (a common
 	// secret-file artifact) is an illegal gRPC metadata value that fails
 	// cryptically at the first call.
+	const apiKey = config.apiKey.trim();
+	if (!apiKey) {
+		throw new Error('W&B API key is missing or blank');
+	}
 	const entity = config.entity?.trim();
 	const project = config.project?.trim();
 	return {
-		'x-wandb-api-key': config.apiKey.trim(),
+		'x-wandb-api-key': apiKey,
 		...(entity ? { 'x-entity-id': entity } : {}),
 		...(project ? { 'x-project-name': project } : {}),
 		'x-cwsandbox-client-version': VENDORED_SDK_VERSION,
@@ -89,7 +93,9 @@ export function serviceAddressResolver(
 				`W&B sandbox ${sandboxId} has no serviceAddress (public ingress not assigned yet?)`,
 			);
 		}
-		return `http://${serviceAddress}:${port}`;
+		// Bracket IPv6 literals; the gateway returns bare addresses.
+		const host = serviceAddress.includes(':') ? `[${serviceAddress}]` : serviceAddress;
+		return `http://${host}:${port}`;
 	};
 }
 

--- a/packages/compute-coreweave/src/wandb.ts
+++ b/packages/compute-coreweave/src/wandb.ts
@@ -23,7 +23,6 @@
  * the hostname-template machinery (verified live 2026-07-21).
  */
 import { SandboxClient } from '@coreweave/cwsandbox';
-import type { SandboxId as CwSandboxId } from '@coreweave/cwsandbox';
 import { DEFAULT_BASE_URL, GrpcSandboxTransport } from '@coreweave/cwsandbox/node';
 import { CoreWeaveCompute } from './index';
 import type { CoreWeaveClient, CoreWeaveConfig } from './index';

--- a/packages/config/src/compute.test.ts
+++ b/packages/config/src/compute.test.ts
@@ -3,6 +3,7 @@ import { Seconds } from '@marimo-hub/core';
 import { ModalCompute } from '@marimo-hub/compute-modal';
 import { LocalCompute } from '@marimo-hub/compute-local';
 import { DockerCompute } from '@marimo-hub/compute-docker';
+import { CoreWeaveCompute } from '@marimo-hub/compute-coreweave';
 import {
 	makeCompute,
 	resolveLifetimeBackstop,
@@ -46,6 +47,16 @@ describe('makeCompute backend selection', () => {
 		expect(makeCompute({ MARIMOHUB_COMPUTE_BACKEND: 'local' })).toBeInstanceOf(LocalCompute);
 	});
 
+	it('selects wandb (the CoreWeave adapter behind the W&B gateway)', () => {
+		expect(
+			makeCompute({
+				MARIMOHUB_COMPUTE_BACKEND: 'wandb',
+				MARIMOHUB_COMPUTE_WANDB_API_KEY: 'wb-key',
+				MARIMOHUB_COMPUTE_IMAGE: 'img',
+			}),
+		).toBeInstanceOf(CoreWeaveCompute);
+	});
+
 	it.each(['none', 'noop'])('returns a no-op provider for %s', (backend) => {
 		const provider = makeCompute({ MARIMOHUB_COMPUTE_BACKEND: backend });
 		expect(() => provider.create('sb-x' as never)).toThrow(/No compute backend configured/);
@@ -86,6 +97,12 @@ describe('makeCompute fail-fast', () => {
 		);
 	});
 
+	it('requires the wandb api key before constructing the adapter', () => {
+		expect(() => makeCompute({ MARIMOHUB_COMPUTE_BACKEND: 'wandb' })).toThrow(
+			/MARIMOHUB_COMPUTE_WANDB_API_KEY/,
+		);
+	});
+
 	it('rejects an unknown coreweave object-storage permission', () => {
 		expect(() =>
 			makeCompute({
@@ -109,6 +126,15 @@ describe('usesSandboxNativeObjectStorage', () => {
 			false,
 		);
 		expect(usesSandboxNativeObjectStorage(buckets)).toBe(false);
+	});
+
+	it('stays false for wandb (CAIOS vending is unconfirmed through the W&B gateway)', () => {
+		expect(
+			usesSandboxNativeObjectStorage({
+				MARIMOHUB_COMPUTE_BACKEND: 'wandb',
+				MARIMOHUB_COMPUTE_COREWEAVE_OBJECT_STORAGE_BUCKETS: 'org-data',
+			}),
+		).toBe(false);
 	});
 });
 
@@ -207,6 +233,19 @@ describe('provider lifetime backstop', () => {
 					MARIMOHUB_COMPUTE_BACKEND: 'coreweave',
 					MARIMOHUB_COMPUTE_COREWEAVE_API_KEY: 'key',
 					MARIMOHUB_COMPUTE_COREWEAVE_MAX_LIFETIME_SECONDS: '3600',
+				},
+				{ sessionMaxLifetimeSeconds: Seconds.of(14400) },
+			),
+		).toThrow(/must be >= the session TTL/);
+	});
+
+	it('fails fast through makeCompute for a wandb cap below the session TTL', () => {
+		expect(() =>
+			makeCompute(
+				{
+					MARIMOHUB_COMPUTE_BACKEND: 'wandb',
+					MARIMOHUB_COMPUTE_WANDB_API_KEY: 'wb-key',
+					MARIMOHUB_COMPUTE_WANDB_MAX_LIFETIME_SECONDS: '3600',
 				},
 				{ sessionMaxLifetimeSeconds: Seconds.of(14400) },
 			),

--- a/packages/config/src/compute.ts
+++ b/packages/config/src/compute.ts
@@ -3,12 +3,22 @@ import type { SandboxProvider } from '@marimo-hub/core';
 import { LocalCompute } from '@marimo-hub/compute-local';
 import { ModalCompute } from '@marimo-hub/compute-modal';
 import { CoreWeaveCompute } from '@marimo-hub/compute-coreweave';
+import { createWandbCompute } from '@marimo-hub/compute-coreweave/wandb';
 import { DockerCompute } from '@marimo-hub/compute-docker';
 import { E2bCompute } from '@marimo-hub/compute-e2b';
 import { KubernetesCompute } from '@marimo-hub/compute-kubernetes';
 import { parseBool, parseIntEnv, parseList, requiredVar } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
+import { CONFIG_SPEC } from './spec';
+
+/** The selectable compute backends, from the spec (the docs/wizard source of truth). */
+const COMPUTE_BACKENDS = (
+	CONFIG_SPEC.find((g) => g.selector === 'MARIMOHUB_COMPUTE_BACKEND')?.backends ?? []
+)
+	.map((b) => b.selectorValue)
+	.filter(Boolean)
+	.join(', ');
 
 /** Parse a `"start-end"` port range (e.g. `2718-2723`); undefined if unset. */
 function parsePortRange(value: string | undefined): { start: number; end: number } | undefined {
@@ -121,7 +131,7 @@ function parseObjectStoragePermission(env: Env): 'read' | 'read-write' | undefin
 
 export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 	const backend = requiredVar(env, 'MARIMOHUB_COMPUTE_BACKEND', {
-		remediation: 'Set it to one of: modal, coreweave, kubernetes, docker, e2b, local, none.',
+		remediation: `Set it to one of: ${COMPUTE_BACKENDS}.`,
 		docs: 'docs/configuration.md',
 	});
 	// Each provider is constructed with the DEFAULT image (first of the list); a
@@ -178,6 +188,27 @@ export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 				objectStoragePermission: parseObjectStoragePermission(env),
 				objectStorageEndpoint: env.MARIMOHUB_COMPUTE_COREWEAVE_OBJECT_STORAGE_ENDPOINT,
 				objectStorageRegion: env.MARIMOHUB_COMPUTE_COREWEAVE_OBJECT_STORAGE_REGION,
+			});
+		case 'wandb':
+			// CoreWeave Sandboxes via the W&B gateway — the same adapter and endpoint as
+			// `coreweave`, authenticated with a W&B API key (gRPC metadata) instead of a
+			// CoreWeave key. The option surface is deliberately restricted: the gateway
+			// does not support profile/placement overrides, GPU requests, or non-default
+			// egress modes, and CAIOS vending is unconfirmed through it (use hub-minted
+			// WIF for bucket access). Kernel URLs need no hostname config: the managed
+			// runner assigns each sandbox a public IP the adapter resolves at expose time.
+			return createWandbCompute({
+				apiKey: computeVar(env, 'MARIMOHUB_COMPUTE_WANDB_API_KEY', 'wandb'),
+				entity: env.MARIMOHUB_COMPUTE_WANDB_ENTITY,
+				project: env.MARIMOHUB_COMPUTE_WANDB_PROJECT,
+				baseUrl: env.MARIMOHUB_COMPUTE_WANDB_BASE_URL,
+				image: defaultImage,
+				ownerTag: env.MARIMOHUB_COMPUTE_WANDB_OWNER_TAG,
+				maxLifetimeSeconds: resolveLifetimeBackstop(
+					env,
+					'MARIMOHUB_COMPUTE_WANDB_MAX_LIFETIME_SECONDS',
+					opts?.sessionMaxLifetimeSeconds,
+				),
 			});
 		case 'docker':
 			// Each kernel runs in a container on a Docker daemon (local socket or a
@@ -268,7 +299,7 @@ export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 		default:
 			throw new ConfigError(`Unknown MARIMOHUB_COMPUTE_BACKEND: ${backend}`, {
 				variable: 'MARIMOHUB_COMPUTE_BACKEND',
-				remediation: 'Supported backends: modal, coreweave, docker, e2b, local, kubernetes, none.',
+				remediation: `Supported backends: ${COMPUTE_BACKENDS}.`,
 				docs: 'docs/configuration.md#compute',
 			});
 	}

--- a/packages/config/src/preflightChecks.ts
+++ b/packages/config/src/preflightChecks.ts
@@ -124,7 +124,7 @@ function checkSandboxConfig(env: Env, deps: ApiDeps): CheckOutcome {
 	const issues: string[] = [];
 	if (
 		mode === 'subdomain' &&
-		(backend === 'coreweave' || backend === 'kubernetes') &&
+		['coreweave', 'kubernetes'].includes(backend) &&
 		!deps.sandbox.hostname
 	) {
 		issues.push(

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -310,6 +310,53 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 				],
 			},
 			{
+				name: 'W&B Sandboxes',
+				selectorValue: 'wandb',
+				description:
+					'CoreWeave Sandboxes via the W&B (Weights & Biases) gateway — the `coreweave` backend authenticated with a W&B API key. Kernel URLs are resolved automatically: the managed runner assigns each sandbox a public IP served over plain HTTP, so no sandbox hostname is needed. Profile/placement overrides, GPU requests, egress overrides, and CAIOS vending are not available through the gateway; use hub-minted WIF (docs/workload-identity-federation.md) for bucket access.',
+				vars: [
+					{
+						id: 'MARIMOHUB_COMPUTE_WANDB_API_KEY',
+						name: 'W&B API key',
+						description: 'W&B API key (from wandb.ai user settings).',
+						required: true,
+						secret: true,
+					},
+					{
+						id: 'MARIMOHUB_COMPUTE_WANDB_ENTITY',
+						name: 'W&B entity',
+						description: 'W&B entity (team or user) sandboxes are attributed to.',
+						example: 'my-team',
+					},
+					{
+						id: 'MARIMOHUB_COMPUTE_WANDB_PROJECT',
+						name: 'W&B project',
+						description: 'W&B project sandboxes are attributed to.',
+						example: 'sandbox',
+					},
+					{
+						id: 'MARIMOHUB_COMPUTE_WANDB_BASE_URL',
+						name: 'W&B sandbox gateway URL',
+						description: 'Override the sandbox gateway URL.',
+						default: 'https://api.cwsandbox.com',
+					},
+					{
+						id: 'MARIMOHUB_COMPUTE_WANDB_OWNER_TAG',
+						name: 'W&B owner tag',
+						description: 'Tag applied to owned sandboxes for discovery and cleanup.',
+						default: 'marimohub',
+					},
+					{
+						id: 'MARIMOHUB_COMPUTE_WANDB_MAX_LIFETIME_SECONDS',
+						name: 'W&B max lifetime (seconds)',
+						description:
+							'Hard provider-side sandbox lifetime cap (SIGKILL, no save) — an orphan backstop behind the graceful session lifetime (`MARIMOHUB_SESSION_MAX_LIFETIME_SECONDS`). Must be >= the session lifetime; leave unset to default to 2x it.',
+						default: '2x MARIMOHUB_SESSION_MAX_LIFETIME_SECONDS',
+						example: '28800',
+					},
+				],
+			},
+			{
 				name: 'Modal',
 				selectorValue: 'modal',
 				description: 'Modal sandboxes.',

--- a/vendor/cwsandbox/UPSTREAM.md
+++ b/vendor/cwsandbox/UPSTREAM.md
@@ -18,6 +18,15 @@ Only the prebuilt output is committed:
 
 Re-apply after any vendor refresh (and retire once upstream exposes the option):
 
+- **`serviceAddress` on `GetSandboxResult`** — upstream's `SandboxMetadata` type
+  already declares `serviceAddress` (the runner-assigned external address of the
+  sandbox's exposed service; the W&B gateway sets it to a per-sandbox public IP),
+  and the generated proto carries it, but this pinned build's `get` mapper drops
+  it. Patched (needed by `@marimo-hub/compute-coreweave`'s wandb URL resolver):
+  - `dist/public/sandbox.d.ts` — `serviceAddress?` on `GetSandboxResult`.
+  - `dist/chunk-*.js` (`GrpcSandboxTransport.get`) — pass
+    `response.serviceAddress` through when non-empty.
+
 - **`objectStorageAccess` on `SandboxRunOptions`** — upstream's generated proto
   already carries `StartSandboxRequest.object_storage_access` (Gateway mints a
   per-sandbox OIDC token; Runner injects a credential-vending sidecar with

--- a/vendor/cwsandbox/dist/chunk-W5QKV4YH.js
+++ b/vendor/cwsandbox/dist/chunk-W5QKV4YH.js
@@ -7314,7 +7314,8 @@ var GrpcSandboxTransport = class {
     );
     return {
       sandboxId: response.sandboxId,
-      status: toSdkSandboxStatus(response.sandboxStatus)
+      status: toSdkSandboxStatus(response.sandboxStatus),
+      ...response.serviceAddress ? { serviceAddress: response.serviceAddress } : {}
     };
   }
   async list(options) {

--- a/vendor/cwsandbox/dist/public/sandbox.d.ts
+++ b/vendor/cwsandbox/dist/public/sandbox.d.ts
@@ -71,5 +71,7 @@ export interface StartSandboxResult {
 export interface GetSandboxResult {
     readonly sandboxId: SandboxId;
     readonly status: SandboxStatus;
+    /** External address of the sandbox's exposed service, when the runner assigns one (e.g. the W&B gateway's per-sandbox public IP). */
+    readonly serviceAddress?: string;
 }
 //# sourceMappingURL=sandbox.d.ts.map


### PR DESCRIPTION
## Summary

Adds `MARIMOHUB_COMPUTE_BACKEND=wandb`: CoreWeave Sandboxes via the W&B gateway, authenticated with a W&B API key. W&B sandboxes speak the same gRPC API at the same endpoint as the `coreweave` backend, so this is composition, not a new adapter:

- **`@marimo-hub/compute-coreweave/wandb`** (new subpath, mirroring the upstream SDK's own `/wandb` entrypoint): `buildWandbMetadata` assembles the gateway auth headers (`x-wandb-api-key` + optional `x-entity-id`/`x-project-name`; metadata presence suppresses the CoreWeave `authorization` header), and `createWandbCompute` hands a W&B-authenticated client to `CoreWeaveCompute` through its existing injected-client seam.
- **Kernel URLs need no hostname config.** The W&B managed runner assigns each public-ingress sandbox a per-sandbox public IP (`serviceAddress`, plain HTTP) instead of a hostname scheme — verified against the live gateway. New generic `CoreWeaveConfig.resolveExposedUrl` seam; the wandb factory resolves `http://{serviceAddress}:{port}` at expose time. The vendored SDK is patched to surface `serviceAddress` on `transport.get` (documented in `vendor/cwsandbox/UPSTREAM.md`, same convention as the `objectStorageAccess` patch).
- **Restricted option surface** per the gateway's limits: no profile/placement overrides, GPU requests, egress overrides, or CAIOS vending — hub-minted WIF remains the bucket-access path. Env vars: `MARIMOHUB_COMPUTE_WANDB_API_KEY` (secret, required), `_ENTITY`, `_PROJECT`, `_BASE_URL`, `_OWNER_TAG`, `_MAX_LIFETIME_SECONDS`.
- **DRY**: `makeCompute`'s backend-list error messages now derive from `CONFIG_SPEC`; the hermetic CoreWeave test fake moved to `testWorld.ts` and is shared by the wandb suite.
- **Docs**: setup partial (links to CoreWeave/WIF docs instead of duplicating), compute table row, regenerated configuration reference, wizard entries + snapshots, `.env.example`. Documents the plain-HTTP/mixed-content caveat.

## Verified live (entity `marimo-io`)

- Direct smoke: create → exec → destroy through the gateway.
- Full server run with zero hostname config: session provisioned in ~35s, API returned `"sandbox_url": "http://<ip>:2718"`, which served the marimo editor; teardown confirmed the sandbox gone.

## Test plan

- `pnpm check`, `pnpm typecheck`, `pnpm test` (new: metadata/resolver unit tests, `computeContract('WandbCompute', …)`, config wiring/backstop/WIF-guard tests, wizard snapshot + integrity coverage)
- `pnpm --filter @marimo-hub/docs build` (dead-link check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a W&B Sandboxes compute backend that runs CoreWeave Sandboxes through the W&B gateway using a W&B API key. Kernel URLs auto-resolve to a per-sandbox public IP over plain HTTP (IPv6-safe), so no hostname config is needed.

- **New Features**
  - `MARIMOHUB_COMPUTE_BACKEND=wandb`; `createWandbCompute` in `@marimo-hub/compute-coreweave/wandb` authenticates via gRPC metadata (`x-wandb-api-key`, optional entity/project). Missing or blank API keys now fail fast at boot.
  - New `CoreWeaveConfig.resolveExposedUrl`; W&B resolves `http://{serviceAddress}:{port}` at expose time and brackets IPv6 addresses.
  - Docs/wizard updated with W&B setup and codegen (compose/helm/env/library). Vars: `MARIMOHUB_COMPUTE_WANDB_API_KEY` (required), `*_WANDB_ENTITY`, `*_WANDB_PROJECT`, `*_WANDB_BASE_URL`, `*_WANDB_OWNER_TAG`, `*_WANDB_MAX_LIFETIME_SECONDS`. Gateway limits enforced (no profile/GPU/egress/CAIOS; use WIF for buckets).

- **Refactors**
  - Vendored `@coreweave/cwsandbox` patched to surface `serviceAddress`; noted in `vendor/cwsandbox/UPSTREAM.md`.
  - `CoreWeaveConfig.apiKey` is optional when injecting a client; added fail-fast if neither is provided. Error messages now derive supported backends from `CONFIG_SPEC`.
  - Extracted hermetic test world to `testWorld.ts`; added `wandb` unit tests and compute-contract coverage; exported `@marimo-hub/compute-coreweave/wandb`. Removed an unused SDK `SandboxId` import.

<sup>Written for commit 39cabfc0f4bb438c50c65fdfe27230cd720b984a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

