### PR TITLE
release: 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "marimohub",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",


### PR DESCRIPTION
Merging this PR tags `v0.1.2` and publishes the container image and Helm chart to GHCR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare release v0.1.2. Updates the package version to 0.1.2 and triggers publishing of the container image and Helm chart to GHCR.

<sup>Written for commit 11f6ba16b3de0a6b2016972096fb3f354c9aa9f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

