### PR TITLE
feat: filesystem storage backend (fs)

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -1758,3 +1758,13 @@ exports[`validateSelection > flags dev auth, volatile storage, and unisolated/ab
   },
 ]
 `;
+
+exports[`validateSelection > flags single-replica fs storage 1`] = `
+[
+  {
+    "level": "warning",
+    "message": "Conditional writes are enforced within one server process — run exactly one replica, and in containers mount a persistent volume at the storage root. Use s3 or gcs for multi-replica deployments.",
+    "title": "Filesystem storage is single-replica",
+  },
+]
+`;

--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -157,6 +157,144 @@ const app = createApi({
 });"
 `;
 
+exports[`config -> code generators > fs + docker + oidc (single-box) > .env 1`] = `
+"# --- Storage ---
+MARIMOHUB_STORAGE_BACKEND=fs
+MARIMOHUB_STORAGE_FS_ROOT=/var/lib/marimohub/storage
+
+# --- Compute ---
+MARIMOHUB_COMPUTE_BACKEND=docker
+MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
+MARIMOHUB_COMPUTE_IDLE_TIMEOUT=20m
+MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
+MARIMOHUB_COMPUTE_WORKDIR=/workspace
+MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_COMPUTE_DOCKER_HOST=localhost
+MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=127.0.0.1
+MARIMOHUB_COMPUTE_DOCKER_NETWORK=marimohub
+
+# --- Auth ---
+MARIMOHUB_AUTH_BACKEND=oidc
+MARIMOHUB_AUTH_OIDC_ISSUER=https://accounts.example.com
+MARIMOHUB_AUTH_OIDC_CLIENT_ID=  # required
+MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=  # required, secret
+MARIMOHUB_AUTH_OIDC_REDIRECT_URI=https://hub.example.com/api/auth/callback
+MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_SESSION_SECRET=  # required, secret
+MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com,example.org
+
+# --- Managed AI ---
+MARIMOHUB_AI_BACKEND=none
+
+# --- Options ---
+MARIMOHUB_PERSIST_WORKSPACE=source"
+`;
+
+exports[`config -> code generators > fs + docker + oidc (single-box) > compose 1`] = `
+"services:
+  marimohub:
+    image: ghcr.io/marimo-team/marimohub:latest
+    ports:
+      - '3000:3000'
+    environment:
+      MARIMOHUB_STORAGE_BACKEND: fs
+      MARIMOHUB_STORAGE_FS_ROOT: /var/lib/marimohub/storage
+      MARIMOHUB_COMPUTE_BACKEND: docker
+      MARIMOHUB_COMPUTE_IMAGE: ghcr.io/orgname/marimo-sandbox:latest
+      MARIMOHUB_COMPUTE_IDLE_TIMEOUT: 20m
+      MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
+      MARIMOHUB_COMPUTE_WORKDIR: /workspace
+      MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_COMPUTE_DOCKER_HOST: localhost
+      MARIMOHUB_COMPUTE_DOCKER_BIND_HOST: 127.0.0.1
+      MARIMOHUB_COMPUTE_DOCKER_NETWORK: marimohub
+      MARIMOHUB_AUTH_BACKEND: oidc
+      MARIMOHUB_AUTH_OIDC_ISSUER: https://accounts.example.com
+      MARIMOHUB_AUTH_OIDC_CLIENT_ID: ""
+      MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: ""
+      MARIMOHUB_AUTH_OIDC_REDIRECT_URI: https://hub.example.com/api/auth/callback
+      MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_SESSION_SECRET: ""
+      MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: "example.com,example.org"
+      MARIMOHUB_AI_BACKEND: none
+      MARIMOHUB_PERSIST_WORKSPACE: source"
+`;
+
+exports[`config -> code generators > fs + docker + oidc (single-box) > helm 1`] = `
+"# Non-secret MARIMOHUB_* config -> ConfigMap.
+config:
+  MARIMOHUB_STORAGE_BACKEND: fs
+  MARIMOHUB_STORAGE_FS_ROOT: /var/lib/marimohub/storage
+  MARIMOHUB_COMPUTE_BACKEND: docker
+  MARIMOHUB_COMPUTE_IMAGE: ghcr.io/orgname/marimo-sandbox:latest
+  MARIMOHUB_COMPUTE_IDLE_TIMEOUT: 20m
+  MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
+  MARIMOHUB_COMPUTE_WORKDIR: /workspace
+  MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_COMPUTE_DOCKER_HOST: localhost
+  MARIMOHUB_COMPUTE_DOCKER_BIND_HOST: 127.0.0.1
+  MARIMOHUB_COMPUTE_DOCKER_NETWORK: marimohub
+  MARIMOHUB_AUTH_BACKEND: oidc
+  MARIMOHUB_AUTH_OIDC_ISSUER: https://accounts.example.com
+  MARIMOHUB_AUTH_OIDC_CLIENT_ID: ""
+  MARIMOHUB_AUTH_OIDC_REDIRECT_URI: https://hub.example.com/api/auth/callback
+  MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: "example.com,example.org"
+  MARIMOHUB_AI_BACKEND: none
+  MARIMOHUB_PERSIST_WORKSPACE: source
+
+# Secret values -> Secret (prefer secrets.existingSecret in production).
+secrets:
+  data:
+    MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: ""
+    MARIMOHUB_AUTH_SESSION_SECRET: """
+`;
+
+exports[`config -> code generators > fs + docker + oidc (single-box) > library 1`] = `
+"import { createApi } from '@marimo-hub/api';
+import { createServices } from '@marimo-hub/core';
+import { FsStorage } from '@marimo-hub/storage-fs';
+import { DockerCompute } from '@marimo-hub/compute-docker';
+import { createOidcAuth } from '@marimo-hub/auth-oidc';
+
+const bucket = new FsStorage({
+	root: process.env.MARIMOHUB_STORAGE_FS_ROOT!,
+});
+
+const compute = new DockerCompute({
+	image: process.env.MARIMOHUB_COMPUTE_IMAGE,
+	host: "localhost",
+	bindHost: "127.0.0.1",
+});
+
+const { authenticator, routes: authRoutes } = createOidcAuth({
+	issuer: process.env.MARIMOHUB_AUTH_OIDC_ISSUER!,
+	clientId: process.env.MARIMOHUB_AUTH_OIDC_CLIENT_ID!,
+	clientSecret: process.env.MARIMOHUB_AUTH_OIDC_CLIENT_SECRET!,
+	redirectUri: process.env.MARIMOHUB_AUTH_OIDC_REDIRECT_URI!,
+	sessionSecret: process.env.MARIMOHUB_AUTH_SESSION_SECRET!,
+	allowedEmailDomains: (process.env.MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS ?? '').split(','),
+});
+
+const app = createApi({
+	services: createServices(bucket),
+	bucket,
+	compute,
+	authenticator,
+	authRoutes,
+	sandbox: {
+		bucket: {
+			name: process.env.MARIMOHUB_STORAGE_S3_BUCKET ?? '',
+			endpoint: process.env.MARIMOHUB_STORAGE_S3_ENDPOINT ?? '',
+		},
+		hostname: process.env.MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME ?? '',
+		workdir: process.env.MARIMOHUB_COMPUTE_WORKDIR ?? '/workspace',
+		persistWorkspace: "source",
+	},
+	policy: {},
+});"
+`;
+
 exports[`config -> code generators > gcs + kubernetes + oidc, persist workspace > .env 1`] = `
 "# --- Storage ---
 MARIMOHUB_STORAGE_BACKEND=gcs

--- a/apps/docs/.vitepress/wizard/generate.test.ts
+++ b/apps/docs/.vitepress/wizard/generate.test.ts
@@ -90,6 +90,10 @@ describe('validateSelection', () => {
 		expect(validateSelection(CASES['s3 + none + dev'])).toMatchSnapshot();
 	});
 
+	it('flags single-replica fs storage', () => {
+		expect(validateSelection(CASES['fs + docker + oidc (single-box)'])).toMatchSnapshot();
+	});
+
 	it('is silent for a safe production combo', () => {
 		expect(validateSelection(CASES['default-prod (s3 + modal + oidc)'])).toEqual([]);
 	});

--- a/apps/docs/.vitepress/wizard/generate.test.ts
+++ b/apps/docs/.vitepress/wizard/generate.test.ts
@@ -29,6 +29,13 @@ const CASES: Record<string, WizardSelection> = {
 		auth: 'dev',
 		ai: 'none',
 	},
+	'fs + docker + oidc (single-box)': {
+		storage: 'fs',
+		compute: 'docker',
+		auth: 'oidc',
+		ai: 'none',
+		values: { MARIMOHUB_STORAGE_FS_ROOT: '/var/lib/marimohub/storage' },
+	},
 	's3 + coreweave + oidc, custom image': {
 		storage: 's3',
 		compute: 'coreweave',

--- a/apps/docs/.vitepress/wizard/generate.ts
+++ b/apps/docs/.vitepress/wizard/generate.ts
@@ -200,6 +200,14 @@ export function validateSelection(sel: WizardSelection): SelectionWarning[] {
 				'The in-memory store loses all data on restart. Use s3 or gcs for anything you keep.',
 		});
 	}
+	if (sel.storage === 'fs') {
+		warnings.push({
+			level: 'warning',
+			title: 'Filesystem storage is single-replica',
+			message:
+				'Conditional writes are enforced within one server process — run exactly one replica, and in containers mount a persistent volume at the storage root. Use s3 or gcs for multi-replica deployments.',
+		});
+	}
 	if (sel.compute === 'local') {
 		warnings.push({
 			level: 'warning',

--- a/apps/docs/.vitepress/wizard/setup.ts
+++ b/apps/docs/.vitepress/wizard/setup.ts
@@ -29,6 +29,7 @@ const DOC_HREFS: Record<string, string> = {
 	'auth/dev': '/auth#dev-bypass',
 	'storage/s3': '/storage#s3-compatible-setup',
 	'storage/gcs': '/storage#google-cloud-storage',
+	'storage/fs': '/storage#filesystem-setup',
 	'storage/memory': '/storage#memory-dev-tests',
 	'compute/coreweave': '/compute#coreweave',
 	'compute/wandb': '/compute#w-b',

--- a/apps/docs/.vitepress/wizard/spec.ts
+++ b/apps/docs/.vitepress/wizard/spec.ts
@@ -53,6 +53,7 @@ const ICONS: Record<string, string> = {
 	// storage
 	s3: '🪣',
 	gcs: '☁️',
+	fs: '📁',
 	memory: '🧪',
 	// compute
 	modal: '🚀',
@@ -206,6 +207,11 @@ export const STORAGE_WIRING: Record<string, BackendWiring> = {
 				`\taccessToken: ${env('MARIMOHUB_STORAGE_GCS_ACCESS_TOKEN')},`,
 				`})`,
 			].join('\n'),
+	},
+	fs: {
+		imports: [`import { FsStorage } from '@marimo-hub/storage-fs';`],
+		rhs: () =>
+			[`new FsStorage({`, `\troot: ${env('MARIMOHUB_STORAGE_FS_ROOT', true)},`, `})`].join('\n'),
 	},
 	memory: {
 		imports: [`import { MemoryBucket } from '@marimo-hub/core/testing/memory-bucket';`],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,9 +12,9 @@ Every marimohub configuration variable, grouped by category and backend. Each ca
 
 ## Storage
 
-Selected by `MARIMOHUB_STORAGE_BACKEND` (default `s3`); one of `s3`, `gcs`, `memory`, `r2`.
+Selected by `MARIMOHUB_STORAGE_BACKEND` (default `s3`); one of `s3`, `gcs`, `fs`, `memory`, `r2`.
 
-Where all notebooks and state are stored. `s3` is the only durable backend for self-hosted servers; `r2` is Workers-only and `memory` is for dev/tests.
+Where all notebooks and state are stored. `s3` and `gcs` are the durable backends for self-hosted servers; `fs` is durable on a single node; `r2` is Workers-only and `memory` is for dev/tests.
 
 ### S3 / S3-compatible
 
@@ -43,6 +43,16 @@ Native GCS via its JSON API; uses object generations for the atomic conditional 
 | `MARIMOHUB_STORAGE_GCS_SA_KEY` 🔒 | Service-account key JSON (the file contents). Minted into short-lived access tokens. Provide this OR a static access token. | — | — | — |
 | `MARIMOHUB_STORAGE_GCS_ACCESS_TOKEN` 🔒 | Static OAuth2 access token, as an alternative to a service-account key (e.g. when an external process supplies tokens). | — | — | — |
 | `MARIMOHUB_STORAGE_GCS_API_ENDPOINT` | Override the JSON API base URL — e.g. to target a fake-gcs-server emulator. | — | `https://storage.googleapis.com` | `https://storage.googleapis.com` |
+
+### Filesystem
+
+`MARIMOHUB_STORAGE_BACKEND=fs`
+
+Local-disk object store rooted at a host directory. Durable (as durable as the disk), zero external dependencies — for single-replica self-hosting. Conditional writes are enforced per-process, so never point two hub replicas at one directory.
+
+| Variable | Description | Required | Default | Example |
+| --- | --- | --- | --- | --- |
+| `MARIMOHUB_STORAGE_FS_ROOT` | Host directory that holds all hub state. Created if missing; must stay on a single filesystem (writes rely on atomic renames). | Yes | — | `/var/lib/marimohub/storage` |
 
 ### Memory (dev/tests only)
 

--- a/docs/setup/storage/fs.md
+++ b/docs/setup/storage/fs.md
@@ -1,0 +1,25 @@
+<!-- Setup snippet — included by docs/storage.md and rendered in the deployment wizard. -->
+
+Store everything in a directory on the host — no external store to run:
+
+```bash
+MARIMOHUB_STORAGE_BACKEND=fs
+MARIMOHUB_STORAGE_FS_ROOT=/var/lib/marimohub/storage
+```
+
+The directory is created if missing, and objects appear in it as plain files
+(`_system/…`, `projects/…`) you can browse and back up directly. Keep the root
+on a single filesystem/volume — writes rely on atomic renames, which don't work
+across mount points.
+
+::: warning Single replica only
+Conditional writes (the compare-and-swap that protects concurrent notebook
+edits) are enforced within one server process. Never run two hub replicas
+against the same directory — concurrent edits could lose catalog updates. The
+server logs a preflight warning at startup to remind you. Use `s3` or `gcs` for
+multi-replica deployments.
+:::
+
+Pairs naturally with the `local` or `docker` compute backends on the same
+machine. Sandboxes can't reach the directory as an S3 bucket, so notebook file
+sync uses the hub-mediated fallback copy — which those backends already do.

--- a/docs/setup/storage/fs.md
+++ b/docs/setup/storage/fs.md
@@ -12,6 +12,11 @@ The directory is created if missing, and objects appear in it as plain files
 on a single filesystem/volume — writes rely on atomic renames, which don't work
 across mount points.
 
+When the server runs in a container, the root path is inside the container:
+mount a persistent volume at it (a Docker bind mount / named volume, or a PVC
+on Kubernetes) that the server's user can write, or the data disappears with
+the container.
+
 ::: warning Single replica only
 Conditional writes (the compare-and-swap that protects concurrent notebook
 edits) are enforced within one server process. Never run two hub replicas

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -9,15 +9,17 @@ Selector: `MARIMOHUB_STORAGE_BACKEND`. Full variables:
 
 ## Choose a backend
 
-| Backend | Selector | Durable | Use for                                       |
-| ------- | -------- | ------- | --------------------------------------------- |
-| S3      | `s3`     | Yes     | CoreWeave CAIOS, AWS S3, MinIO, Tigris, Ceph  |
-| GCS     | `gcs`    | Yes     | Google Cloud Storage                          |
-| R2      | `r2`     | Yes     | Cloudflare Workers through a platform binding |
-| Memory  | `memory` | No      | Local development and tests only              |
+| Backend    | Selector | Durable | Use for                                       |
+| ---------- | -------- | ------- | --------------------------------------------- |
+| S3         | `s3`     | Yes     | CoreWeave CAIOS, AWS S3, MinIO, Tigris, Ceph  |
+| GCS        | `gcs`    | Yes     | Google Cloud Storage                          |
+| Filesystem | `fs`     | Yes     | Single-node self-hosting on a local disk      |
+| R2         | `r2`     | Yes     | Cloudflare Workers through a platform binding |
+| Memory     | `memory` | No      | Local development and tests only              |
 
-`s3` is the default for the Node server. `r2` is Workers-only because it uses a
-runtime binding instead of credentials. `memory` requires
+`s3` is the default for the Node server. `fs` needs no external store but is
+single-replica only (see below). `r2` is Workers-only because it uses a runtime
+binding instead of credentials. `memory` requires
 `MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true` so it cannot back a real deployment by
 accident.
 
@@ -31,6 +33,9 @@ Known-good options:
 
 - CoreWeave CAIOS, AWS S3, R2, recent MinIO, and Tigris through S3 `If-Match`.
 - Google Cloud Storage through object generations (`ifGenerationMatch`).
+- The `fs` backend enforces conditional writes within a single server process
+  (and the server logs a startup warning saying so). That is safe for one
+  replica; run multiple replicas only on `s3` or `gcs`.
 
 ## Configure it
 
@@ -41,6 +46,10 @@ Known-good options:
 ### Google Cloud Storage
 
 <!--@include: ./setup/storage/gcs.md-->
+
+### Filesystem setup
+
+<!--@include: ./setup/storage/fs.md-->
 
 ### Memory (dev/tests)
 
@@ -61,6 +70,8 @@ After deploy:
 
 - Back up the object store. It is the database.
 - Do not use `memory` outside local development or tests.
+- With `fs`, run exactly one hub replica and back up the storage root directory;
+  keep it on a single filesystem/volume.
 - Keep bucket permissions narrow. The hub needs access only to its own prefix or
   bucket.
 - Treat conditional-write failures as a storage compatibility issue, not as a

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -33,6 +33,7 @@
 		"@marimo-hub/credentials-aws": "workspace:*",
 		"@marimo-hub/credentials-coreweave": "workspace:*",
 		"@marimo-hub/secrets-aws": "workspace:*",
+		"@marimo-hub/storage-fs": "workspace:*",
 		"@marimo-hub/storage-gcs": "workspace:*",
 		"@marimo-hub/storage-s3": "workspace:*",
 		"hono": "catalog:"

--- a/packages/config/src/preflightChecks.test.ts
+++ b/packages/config/src/preflightChecks.test.ts
@@ -63,6 +63,23 @@ describe('storage check', () => {
 	it('skipped when the bucket exposes no probe', async () => {
 		expect((await run({}, makeDeps())).by('storage')?.status).toBe('skipped');
 	});
+
+	it('warn (non-fatal) when the store only enforces CAS per-process', async () => {
+		const deps = makeDeps({
+			bucket: { verifyConditionalWrites: async () => {}, casScope: 'process' } as never,
+		});
+		const { report, by } = await run({ MARIMOHUB_STORAGE_BACKEND: 'fs' }, deps);
+		expect(by('storage')?.status).toBe('warn');
+		expect(by('storage')?.fatal).toBeUndefined();
+		expect(report.fatal).toBe(false);
+	});
+
+	it('ok when the store enforces CAS globally', async () => {
+		const deps = makeDeps({
+			bucket: { verifyConditionalWrites: async () => {}, casScope: 'global' } as never,
+		});
+		expect((await run({}, deps)).by('storage')?.status).toBe('ok');
+	});
 });
 
 describe('auth.oidc-discovery check', () => {

--- a/packages/config/src/preflightChecks.ts
+++ b/packages/config/src/preflightChecks.ts
@@ -42,12 +42,25 @@ async function fetchWithTimeout(
 
 async function checkStorage(env: Env, deps: ApiDeps): Promise<CheckOutcome> {
 	const backend = env.MARIMOHUB_STORAGE_BACKEND ?? 's3';
-	const bucket = deps.bucket as { verifyConditionalWrites?: () => Promise<void> };
+	const bucket = deps.bucket as {
+		verifyConditionalWrites?: () => Promise<void>;
+		casScope?: 'process' | 'global';
+	};
 	if (typeof bucket.verifyConditionalWrites !== 'function') {
 		return { status: 'skipped', message: `${backend} backend: no conditional-write probe` };
 	}
 	try {
 		await bucket.verifyConditionalWrites();
+		if (bucket.casScope === 'process') {
+			return {
+				status: 'warn',
+				message:
+					`${backend} storage enforces conditional writes within this process only — ` +
+					'concurrent hub replicas sharing the same storage can lose catalog updates',
+				remediation:
+					'Run a single hub replica against this storage, or use s3/gcs for multi-replica deployments.',
+			};
+		}
 		return { status: 'ok', message: `${backend} reachable and honors conditional writes` };
 	} catch (err) {
 		const message = errMsg(err);

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -53,7 +53,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 		selector: 'MARIMOHUB_STORAGE_BACKEND',
 		selectorDefault: 's3',
 		description:
-			'Where all notebooks and state are stored. `s3` is the only durable backend for self-hosted servers; `r2` is Workers-only and `memory` is for dev/tests.',
+			'Where all notebooks and state are stored. `s3` and `gcs` are the durable backends for self-hosted servers; `fs` is durable on a single node; `r2` is Workers-only and `memory` is for dev/tests.',
 		backends: [
 			{
 				name: 'S3 / S3-compatible',
@@ -138,6 +138,22 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 							'Override the JSON API base URL — e.g. to target a fake-gcs-server emulator.',
 						example: 'https://storage.googleapis.com',
 						default: 'https://storage.googleapis.com',
+					},
+				],
+			},
+			{
+				name: 'Filesystem',
+				selectorValue: 'fs',
+				description:
+					'Local-disk object store rooted at a host directory. Durable (as durable as the disk), zero external dependencies — for single-replica self-hosting. Conditional writes are enforced per-process, so never point two hub replicas at one directory.',
+				vars: [
+					{
+						id: 'MARIMOHUB_STORAGE_FS_ROOT',
+						name: 'Filesystem storage root',
+						description:
+							'Host directory that holds all hub state. Created if missing; must stay on a single filesystem (writes rely on atomic renames).',
+						example: '/var/lib/marimohub/storage',
+						required: true,
 					},
 				],
 			},

--- a/packages/config/src/storage.test.ts
+++ b/packages/config/src/storage.test.ts
@@ -1,7 +1,7 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { MemoryBucket } from '@marimo-hub/core/testing/memory-bucket';
 import { S3Storage } from '@marimo-hub/storage-s3';
 import { GcsStorage } from '@marimo-hub/storage-gcs';
@@ -30,10 +30,19 @@ describe('makeStorage backend selection', () => {
 		);
 	});
 
-	it('builds an FsStorage for the fs backend without an ephemeral gate', () => {
+	const tmpRoots: string[] = [];
+	afterAll(() => {
+		for (const root of tmpRoots) rmSync(root, { recursive: true, force: true });
+	});
+	const tmpRoot = () => {
 		const root = mkdtempSync(path.join(os.tmpdir(), 'marimohub-fs-config-'));
+		tmpRoots.push(root);
+		return root;
+	};
+
+	it('builds an FsStorage for the fs backend without an ephemeral gate', () => {
 		expect(
-			makeStorage({ MARIMOHUB_STORAGE_BACKEND: 'fs', MARIMOHUB_STORAGE_FS_ROOT: root }),
+			makeStorage({ MARIMOHUB_STORAGE_BACKEND: 'fs', MARIMOHUB_STORAGE_FS_ROOT: tmpRoot() }),
 		).toBeInstanceOf(FsStorage);
 	});
 
@@ -44,7 +53,7 @@ describe('makeStorage backend selection', () => {
 	});
 
 	it('wraps an unusable fs root in a ConfigError', () => {
-		const file = path.join(mkdtempSync(path.join(os.tmpdir(), 'marimohub-fs-config-')), 'a-file');
+		const file = path.join(tmpRoot(), 'a-file');
 		writeFileSync(file, '');
 		expect(() =>
 			makeStorage({

--- a/packages/config/src/storage.test.ts
+++ b/packages/config/src/storage.test.ts
@@ -1,7 +1,11 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { MemoryBucket } from '@marimo-hub/core/testing/memory-bucket';
 import { S3Storage } from '@marimo-hub/storage-s3';
 import { GcsStorage } from '@marimo-hub/storage-gcs';
+import { FsStorage } from '@marimo-hub/storage-fs';
 import { makeStorage, makeSandboxBucketConfig } from './storage';
 import { ConfigError } from './errors';
 
@@ -24,6 +28,30 @@ describe('makeStorage backend selection', () => {
 		expect(() => makeStorage({ MARIMOHUB_STORAGE_BACKEND: 'gcs' })).toThrow(
 			/MARIMOHUB_STORAGE_GCS_BUCKET/,
 		);
+	});
+
+	it('builds an FsStorage for the fs backend without an ephemeral gate', () => {
+		const root = mkdtempSync(path.join(os.tmpdir(), 'marimohub-fs-config-'));
+		expect(
+			makeStorage({ MARIMOHUB_STORAGE_BACKEND: 'fs', MARIMOHUB_STORAGE_FS_ROOT: root }),
+		).toBeInstanceOf(FsStorage);
+	});
+
+	it('requires the fs root', () => {
+		expect(() => makeStorage({ MARIMOHUB_STORAGE_BACKEND: 'fs' })).toThrow(
+			/MARIMOHUB_STORAGE_FS_ROOT/,
+		);
+	});
+
+	it('wraps an unusable fs root in a ConfigError', () => {
+		const file = path.join(mkdtempSync(path.join(os.tmpdir(), 'marimohub-fs-config-')), 'a-file');
+		writeFileSync(file, '');
+		expect(() =>
+			makeStorage({
+				MARIMOHUB_STORAGE_BACKEND: 'fs',
+				MARIMOHUB_STORAGE_FS_ROOT: path.join(file, 'nested'),
+			}),
+		).toThrow(/filesystem storage root/);
 	});
 
 	it('refuses the non-durable memory backend unless explicitly allowed', () => {

--- a/packages/config/src/storage.ts
+++ b/packages/config/src/storage.ts
@@ -4,6 +4,7 @@ import type { Bucket, BucketConfig } from '@marimo-hub/core';
 import { MemoryBucket } from '@marimo-hub/core/testing/memory-bucket';
 import { S3Storage } from '@marimo-hub/storage-s3';
 import { GcsStorage } from '@marimo-hub/storage-gcs';
+import { FsStorage } from '@marimo-hub/storage-fs';
 import { parseBool, requiredVar } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
@@ -45,6 +46,21 @@ export function makeStorage(env: Env): Bucket {
 				serviceAccountKey: env.MARIMOHUB_STORAGE_GCS_SA_KEY,
 				accessToken: env.MARIMOHUB_STORAGE_GCS_ACCESS_TOKEN,
 			});
+		case 'fs': {
+			const root = requiredVar(env, 'MARIMOHUB_STORAGE_FS_ROOT', {
+				remediation:
+					'Set it to a writable host directory that will hold all hub state (e.g. /var/lib/marimohub/storage).',
+				docs: 'docs/configuration.md#storage',
+			});
+			try {
+				return new FsStorage({ root });
+			} catch (err) {
+				throw new ConfigError(
+					`Could not initialize the filesystem storage root "${root}": ${err instanceof Error ? err.message : String(err)}`,
+					{ variable: 'MARIMOHUB_STORAGE_FS_ROOT', docs: 'docs/configuration.md#storage' },
+				);
+			}
+		}
 		case 'memory':
 			// The in-memory bucket is NON-DURABLE — all state is lost on restart. It
 			// exists for local dev and tests only. Refuse it unless the operator
@@ -54,7 +70,7 @@ export function makeStorage(env: Env): Bucket {
 				throw new ConfigError(
 					'MARIMOHUB_STORAGE_BACKEND=memory is non-durable (all state is lost on restart) and is for ' +
 						'local dev/tests only. Set MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true to use it, or choose a ' +
-						'durable backend (s3).',
+						'durable backend (s3, gcs, fs).',
 					{
 						variable: 'MARIMOHUB_ALLOW_EPHEMERAL_STORAGE',
 						docs: 'docs/configuration.md#storage',
@@ -70,7 +86,7 @@ export function makeStorage(env: Env): Bucket {
 		default:
 			throw new ConfigError(`Unknown MARIMOHUB_STORAGE_BACKEND: ${backend}`, {
 				variable: 'MARIMOHUB_STORAGE_BACKEND',
-				remediation: 'Supported backends: s3, gcs, memory (dev), r2 (Workers).',
+				remediation: 'Supported backends: s3, gcs, fs, memory (dev), r2 (Workers).',
 				docs: 'docs/configuration.md#storage',
 			});
 	}

--- a/packages/storage-fs/README.md
+++ b/packages/storage-fs/README.md
@@ -1,0 +1,5 @@
+# @marimo-hub/storage-fs
+
+`Bucket` storage adapter backed by a directory on the local filesystem.
+
+Part of [marimohub](../../README.md). See [docs/storage.md](../../docs/storage.md) for configuration.

--- a/packages/storage-fs/package.json
+++ b/packages/storage-fs/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@marimo-hub/storage-fs",
+	"version": "0.0.0",
+	"private": true,
+	"license": "Apache-2.0",
+	"files": [
+		"dist"
+	],
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts",
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"build": "vp pack",
+		"test": "vp test",
+		"check": "vp check",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@marimo-hub/core": "workspace:*"
+	},
+	"devDependencies": {
+		"@marimo-hub/tsconfig": "workspace:*",
+		"@types/node": "catalog:",
+		"typescript": "catalog:",
+		"vite-plus": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/packages/storage-fs/src/index.test.ts
+++ b/packages/storage-fs/src/index.test.ts
@@ -1,14 +1,21 @@
-import { mkdtempSync, symlinkSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterAll } from 'vitest';
 import { PreconditionFailedError } from '@marimo-hub/core';
 import { bucketContract } from '@marimo-hub/core/testing/contract';
 import { FsStorage } from './index';
 
+const tmpRoots: string[] = [];
+afterAll(() => {
+	for (const root of tmpRoots) rmSync(root, { recursive: true, force: true });
+});
+
 function makeRoot(): string {
-	return mkdtempSync(path.join(os.tmpdir(), 'marimohub-fs-'));
+	const root = mkdtempSync(path.join(os.tmpdir(), 'marimohub-fs-'));
+	tmpRoots.push(root);
+	return root;
 }
 
 bucketContract('FsStorage', () => new FsStorage({ root: makeRoot() }));
@@ -98,6 +105,34 @@ describe('FsStorage', () => {
 			await expect(
 				b.put('proj/n.json', '{"v":3}', { onlyIfEtagMatches: put.etag }),
 			).rejects.toBeInstanceOf(PreconditionFailedError);
+		});
+
+		it('CAS race across two instances in one process has exactly one winner', async () => {
+			const root = makeRoot();
+			const a = new FsStorage({ root });
+			const b = new FsStorage({ root });
+			const seed = await a.put('shared.json', '0');
+
+			const results = await Promise.allSettled(
+				Array.from({ length: 10 }, (_, i) =>
+					(i % 2 === 0 ? a : b).put('shared.json', String(i + 1), {
+						onlyIfEtagMatches: seed.etag,
+					}),
+				),
+			);
+			expect(results.filter((r) => r.status === 'fulfilled')).toHaveLength(1);
+			for (const r of results) {
+				if (r.status === 'rejected') expect(r.reason).toBeInstanceOf(PreconditionFailedError);
+			}
+		});
+
+		it('onlyIfEtagMatches with an empty etag never writes unconditionally', async () => {
+			const bucket = new FsStorage({ root: makeRoot() });
+			await bucket.put('guarded.json', 'original');
+			await expect(
+				bucket.put('guarded.json', 'clobbered', { onlyIfEtagMatches: '' }),
+			).rejects.toBeInstanceOf(PreconditionFailedError);
+			expect(await (await bucket.get('guarded.json'))!.text()).toBe('original');
 		});
 
 		it('onlyIfNotExists loses across two instances sharing a root', async () => {

--- a/packages/storage-fs/src/index.test.ts
+++ b/packages/storage-fs/src/index.test.ts
@@ -1,0 +1,230 @@
+import { mkdtempSync, symlinkSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { PreconditionFailedError } from '@marimo-hub/core';
+import { bucketContract } from '@marimo-hub/core/testing/contract';
+import { FsStorage } from './index';
+
+function makeRoot(): string {
+	return mkdtempSync(path.join(os.tmpdir(), 'marimohub-fs-'));
+}
+
+bucketContract('FsStorage', () => new FsStorage({ root: makeRoot() }));
+
+describe('FsStorage', () => {
+	describe('key validation / path traversal', () => {
+		const badKeys = [
+			'',
+			'.',
+			'..',
+			'../escape',
+			'a/../../escape',
+			'a/..',
+			'a/./b',
+			'/etc/passwd',
+			'a\0b',
+			'a\\b',
+			'a//b',
+			'.tmp/x',
+		];
+
+		it.each(badKeys)('rejects %j on every operation', async (key) => {
+			const bucket = new FsStorage({ root: makeRoot() });
+			await expect(bucket.get(key)).rejects.toThrow(/Invalid bucket key|non-empty/);
+			await expect(bucket.head(key)).rejects.toThrow(/Invalid bucket key|non-empty/);
+			await expect(bucket.put(key, 'x')).rejects.toThrow(/Invalid bucket key|non-empty/);
+			await expect(bucket.delete(key)).rejects.toThrow(/Invalid bucket key|non-empty/);
+		});
+
+		it('never touches files outside the root', async () => {
+			const parent = makeRoot();
+			const root = path.join(parent, 'store');
+			const sentinel = path.join(parent, 'sentinel.txt');
+			writeFileSync(sentinel, 'untouched');
+
+			const bucket = new FsStorage({ root });
+			await expect(bucket.put('../sentinel.txt', 'clobbered')).rejects.toThrow();
+			await expect(bucket.get('../sentinel.txt')).rejects.toThrow();
+			await expect(bucket.delete('../sentinel.txt')).rejects.toThrow();
+			expect(readFileSync(sentinel, 'utf8')).toBe('untouched');
+		});
+	});
+
+	describe('symlinks', () => {
+		it('does not read or list through a symlink pointing outside the root', async () => {
+			const parent = makeRoot();
+			const root = path.join(parent, 'store');
+			const secret = path.join(parent, 'secret.txt');
+			writeFileSync(secret, 'secret');
+
+			const bucket = new FsStorage({ root });
+			symlinkSync(secret, path.join(root, 'link'));
+
+			expect(await bucket.get('link')).toBeNull();
+			expect(await bucket.head('link')).toBeNull();
+			const listed = await bucket.list();
+			expect(listed.objects.map((o) => o.key)).toEqual([]);
+		});
+
+		it('put replaces a symlink instead of writing through it', async () => {
+			const parent = makeRoot();
+			const root = path.join(parent, 'store');
+			const target = path.join(parent, 'target.txt');
+			writeFileSync(target, 'original');
+
+			const bucket = new FsStorage({ root });
+			symlinkSync(target, path.join(root, 'link'));
+
+			await bucket.put('link', 'replaced');
+			expect(readFileSync(target, 'utf8')).toBe('original');
+			expect(await (await bucket.get('link'))!.text()).toBe('replaced');
+		});
+	});
+
+	describe('etag stability across instances', () => {
+		it('etags survive a new instance on the same root and support CAS', async () => {
+			const root = makeRoot();
+			const a = new FsStorage({ root });
+			const put = await a.put('proj/n.json', '{"v":1}');
+
+			const b = new FsStorage({ root });
+			const head = await b.head('proj/n.json');
+			expect(head!.etag).toBe(put.etag);
+
+			const updated = await b.put('proj/n.json', '{"v":2}', { onlyIfEtagMatches: put.etag });
+			expect(updated.etag).not.toBe(put.etag);
+			await expect(
+				b.put('proj/n.json', '{"v":3}', { onlyIfEtagMatches: put.etag }),
+			).rejects.toBeInstanceOf(PreconditionFailedError);
+		});
+
+		it('onlyIfNotExists loses across two instances sharing a root', async () => {
+			const root = makeRoot();
+			const a = new FsStorage({ root });
+			const b = new FsStorage({ root });
+
+			await a.put('once.txt', 'first', { onlyIfNotExists: true });
+			await expect(b.put('once.txt', 'second', { onlyIfNotExists: true })).rejects.toBeInstanceOf(
+				PreconditionFailedError,
+			);
+			expect(await (await a.get('once.txt'))!.text()).toBe('first');
+		});
+	});
+
+	describe('list semantics', () => {
+		async function seeded(): Promise<FsStorage> {
+			const bucket = new FsStorage({ root: makeRoot() });
+			await bucket.put('a/1.json', '{}');
+			await bucket.put('a/2.json', '{}');
+			await bucket.put('a/sub/3.json', '{}');
+			await bucket.put('b/4.json', '{}');
+			return bucket;
+		}
+
+		it('lists all objects sorted without options', async () => {
+			const result = await (await seeded()).list();
+			expect(result.objects.map((o) => o.key)).toEqual([
+				'a/1.json',
+				'a/2.json',
+				'a/sub/3.json',
+				'b/4.json',
+			]);
+		});
+
+		it('uses delimiter to group prefixes', async () => {
+			const result = await (await seeded()).list({ prefix: 'a/', delimiter: '/' });
+			expect(result.objects.map((o) => o.key)).toEqual(['a/1.json', 'a/2.json']);
+			expect(result.delimitedPrefixes).toEqual(['a/sub/']);
+		});
+
+		it('prefix matches on string, not directory, boundaries', async () => {
+			const bucket = new FsStorage({ root: makeRoot() });
+			await bucket.put('p/1', 'a');
+			await bucket.put('projects/x', 'b');
+			const result = await bucket.list({ prefix: 'p' });
+			expect(result.objects.map((o) => o.key)).toEqual(['p/1', 'projects/x']);
+		});
+
+		it('respects limit with truncated + cursor resume', async () => {
+			const bucket = await seeded();
+			const page1 = await bucket.list({ limit: 3 });
+			expect(page1.objects.map((o) => o.key)).toEqual(['a/1.json', 'a/2.json', 'a/sub/3.json']);
+			expect(page1.truncated).toBe(true);
+			expect(page1.cursor).toBe('a/sub/3.json');
+
+			const page2 = await bucket.list({ limit: 3, cursor: page1.cursor });
+			expect(page2.objects.map((o) => o.key)).toEqual(['b/4.json']);
+			expect(page2.truncated).toBe(false);
+			expect(page2.cursor).toBeUndefined();
+		});
+
+		it('startAfter is an exclusive lower bound; the larger of cursor/startAfter wins', async () => {
+			const bucket = await seeded();
+			const result = await bucket.list({ startAfter: 'a/2.json' });
+			expect(result.objects.map((o) => o.key)).toEqual(['a/sub/3.json', 'b/4.json']);
+
+			const both = await bucket.list({ startAfter: 'a/1.json', cursor: 'a/sub/3.json' });
+			expect(both.objects.map((o) => o.key)).toEqual(['b/4.json']);
+		});
+
+		it('delimited listings are returned whole regardless of limit', async () => {
+			const bucket = new FsStorage({ root: makeRoot() });
+			for (let i = 0; i < 5; i++) await bucket.put(`p/${i}/data`, '{}');
+			const result = await bucket.list({ prefix: 'p/', delimiter: '/', limit: 2 });
+			expect(result.truncated).toBe(false);
+			expect(result.delimitedPrefixes).toHaveLength(5);
+		});
+	});
+
+	describe('delete', () => {
+		it('accepts an array and ignores missing keys', async () => {
+			const bucket = new FsStorage({ root: makeRoot() });
+			await bucket.put('x/1', 'a');
+			await bucket.put('x/2', 'b');
+			await bucket.delete(['x/1', 'x/2', 'x/missing']);
+			expect((await bucket.list()).objects).toEqual([]);
+		});
+
+		it('prunes now-empty parent directories but keeps the root and non-empty dirs', async () => {
+			const root = makeRoot();
+			const bucket = new FsStorage({ root });
+			await bucket.put('deep/nested/dir/file.txt', 'x');
+			await bucket.put('deep/other.txt', 'y');
+
+			await bucket.delete('deep/nested/dir/file.txt');
+			expect(existsSync(path.join(root, 'deep/nested'))).toBe(false);
+			expect(existsSync(path.join(root, 'deep/other.txt'))).toBe(true);
+
+			await bucket.delete('deep/other.txt');
+			expect(existsSync(path.join(root, 'deep'))).toBe(false);
+			expect(existsSync(root)).toBe(true);
+		});
+	});
+
+	describe('hygiene', () => {
+		it('never lists entries under the .tmp staging dir', async () => {
+			const root = makeRoot();
+			const bucket = new FsStorage({ root });
+			writeFileSync(path.join(root, '.tmp', 'stray'), 'leftover');
+			await bucket.put('real.txt', 'x');
+			expect((await bucket.list()).objects.map((o) => o.key)).toEqual(['real.txt']);
+		});
+
+		it('leaves no staged files behind after puts', async () => {
+			const root = makeRoot();
+			const bucket = new FsStorage({ root });
+			await bucket.put('a.txt', '1');
+			await bucket.put('a.txt', '2', { onlyIfEtagMatches: (await bucket.head('a.txt'))!.etag });
+			await expect(bucket.put('a.txt', '3', { onlyIfNotExists: true })).rejects.toThrow();
+			expect(await fsp.readdir(path.join(root, '.tmp'))).toEqual([]);
+		});
+
+		it('verifyConditionalWrites resolves and leaves no probe object', async () => {
+			const bucket = new FsStorage({ root: makeRoot() });
+			await bucket.verifyConditionalWrites();
+			expect((await bucket.list()).objects).toEqual([]);
+		});
+	});
+});

--- a/packages/storage-fs/src/index.ts
+++ b/packages/storage-fs/src/index.ts
@@ -1,0 +1,334 @@
+/**
+ * `Bucket` adapter backed by a directory on the local filesystem (darwin/linux).
+ *
+ * Keys map 1:1 to relative paths under the root, so operators can browse the
+ * tree directly. Traversal is blocked by key validation plus a resolved-path
+ * containment check, and reads open with O_NOFOLLOW so a symlink inside the
+ * root cannot leak content from outside it. Writes stage into a reserved
+ * `.tmp/` dir and rename into place — atomic on a single filesystem.
+ *
+ * ETags are the sha-256 of the content, so they survive restarts (the catalog
+ * compare-and-swap depends on that). `onlyIfNotExists` (hard link) is atomic
+ * even across processes; `onlyIfEtagMatches` is only atomic within one process,
+ * advertised via `casScope: 'process'` and surfaced by preflight as a startup
+ * warning — never point two hub replicas at the same root.
+ *
+ * `httpMetadata`/`customMetadata` are accepted and ignored (parity with
+ * MemoryBucket), and a key cannot be both an object and a prefix of another
+ * (`a` vs `a/b`); marimohub's key layout never does this.
+ */
+import { createHash, randomUUID } from 'node:crypto';
+import { constants, mkdirSync, realpathSync } from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import { PreconditionFailedError } from '@marimo-hub/core';
+import type {
+	Bucket,
+	BucketListOptions,
+	BucketListResult,
+	BucketObject,
+	BucketObjectBody,
+	BucketPutOptions,
+} from '@marimo-hub/core/ports';
+
+export interface FsStorageConfig {
+	/** Host directory that confines all objects. Created if missing. */
+	root: string;
+}
+
+/** Staging area for atomic writes; reserved — rejected as a key prefix and skipped by list(). */
+const TMP_DIR = '.tmp';
+
+/**
+ * open() failures that mean "no object at this key": missing file, a file
+ * where a directory was expected (ENOTDIR), a directory itself (EISDIR), or a
+ * symlink refused by O_NOFOLLOW (ELOOP on linux, EMLINK on darwin).
+ */
+const NOT_FOUND_CODES = new Set(['ENOENT', 'ENOTDIR', 'EISDIR', 'ELOOP', 'EMLINK']);
+
+function errCode(err: unknown): string | undefined {
+	return err instanceof Error && 'code' in err
+		? String((err as { code?: unknown }).code)
+		: undefined;
+}
+
+function sha256hex(body: Uint8Array): string {
+	return createHash('sha256').update(body).digest('hex');
+}
+
+function assertValidKey(key: string): void {
+	if (key === '') throw new Error('Bucket key must be non-empty');
+	if (key.includes('\0')) throw new Error('Invalid bucket key: contains a null byte');
+	if (key.includes('\\')) throw new Error(`Invalid bucket key (keys are '/'-separated): "${key}"`);
+	if (key.startsWith('/')) throw new Error(`Invalid bucket key (absolute path): "${key}"`);
+	const segments = key.split('/');
+	if (segments.some((s) => s === '' || s === '.' || s === '..')) {
+		throw new Error(`Invalid bucket key (empty, "." or ".." segment): "${key}"`);
+	}
+	if (segments[0] === TMP_DIR) {
+		throw new Error(`Invalid bucket key ("${TMP_DIR}/" is reserved): "${key}"`);
+	}
+}
+
+export class FsStorage implements Bucket {
+	/** CAS is per-process only; preflight reads this and downgrades its storage check to a warn. */
+	readonly casScope = 'process' as const;
+
+	private readonly root: string;
+	private readonly tmpDir: string;
+	/** Per-key promise chains serializing put()s — the in-process CAS mutex. */
+	private readonly locks = new Map<string, Promise<void>>();
+
+	constructor(config: FsStorageConfig) {
+		mkdirSync(config.root, { recursive: true });
+		this.root = realpathSync(config.root);
+		this.tmpDir = path.join(this.root, TMP_DIR);
+		mkdirSync(this.tmpDir, { recursive: true });
+	}
+
+	private resolvePath(key: string): string {
+		assertValidKey(key);
+		const abs = path.resolve(this.root, key);
+		// assertValidKey already guarantees containment; defense in depth.
+		if (!abs.startsWith(this.root + path.sep)) {
+			throw new Error(`Bucket key escapes the storage root: "${key}"`);
+		}
+		return abs;
+	}
+
+	private async readObject(key: string): Promise<{ body: Buffer; uploaded: Date } | null> {
+		const filePath = this.resolvePath(key);
+		let handle: fsp.FileHandle;
+		try {
+			handle = await fsp.open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW);
+		} catch (err) {
+			if (NOT_FOUND_CODES.has(errCode(err) ?? '')) return null;
+			throw err;
+		}
+		try {
+			const stat = await handle.stat();
+			if (!stat.isFile()) return null;
+			return { body: await handle.readFile(), uploaded: stat.mtime };
+		} finally {
+			await handle.close();
+		}
+	}
+
+	async get(key: string): Promise<BucketObjectBody | null> {
+		const read = await this.readObject(key);
+		if (!read) return null;
+		const { body, uploaded } = read;
+		return {
+			key,
+			etag: sha256hex(body),
+			size: body.length,
+			uploaded,
+			text: async () => new TextDecoder().decode(body),
+			json: async <T>() => JSON.parse(new TextDecoder().decode(body)) as T,
+			bytes: async () => body,
+		};
+	}
+
+	async head(key: string): Promise<BucketObject | null> {
+		const read = await this.readObject(key);
+		if (!read) return null;
+		return { key, etag: sha256hex(read.body), size: read.body.length, uploaded: read.uploaded };
+	}
+
+	private withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+		const prev = this.locks.get(key) ?? Promise.resolve();
+		const run = prev.then(fn, fn);
+		const chain = run.then(
+			() => {},
+			() => {},
+		);
+		this.locks.set(key, chain);
+		void chain.then(() => {
+			if (this.locks.get(key) === chain) this.locks.delete(key);
+		});
+		return run;
+	}
+
+	async put(
+		key: string,
+		value: string | Uint8Array,
+		options?: BucketPutOptions,
+	): Promise<BucketObject> {
+		const filePath = this.resolvePath(key);
+		if (options?.onlyIfEtagMatches && options?.onlyIfNotExists) {
+			throw new Error('onlyIfEtagMatches and onlyIfNotExists are mutually exclusive');
+		}
+		return this.withKeyLock(key, async () => {
+			const body = typeof value === 'string' ? new TextEncoder().encode(value) : value;
+			const etag = sha256hex(body);
+			const tmp = path.join(this.tmpDir, randomUUID());
+			await fsp.writeFile(tmp, body);
+			try {
+				// rename/link preserve mtime, so stat the staged file for `uploaded`.
+				const uploaded = (await fsp.stat(tmp)).mtime;
+				await fsp.mkdir(path.dirname(filePath), { recursive: true });
+				if (options?.onlyIfNotExists) {
+					try {
+						await fsp.link(tmp, filePath);
+					} catch (err) {
+						if (errCode(err) === 'EEXIST') {
+							throw new PreconditionFailedError(`Key "${key}" already exists`);
+						}
+						throw err;
+					}
+				} else if (options?.onlyIfEtagMatches) {
+					const current = await this.readObject(key);
+					if (!current || sha256hex(current.body) !== options.onlyIfEtagMatches) {
+						throw new PreconditionFailedError(`ETag mismatch for key "${key}"`);
+					}
+					await fsp.rename(tmp, filePath);
+				} else {
+					await fsp.rename(tmp, filePath);
+				}
+				return { key, etag, size: body.length, uploaded };
+			} finally {
+				// ENOENT after a successful rename (the staged file was consumed).
+				await fsp.unlink(tmp).catch(() => {});
+			}
+		});
+	}
+
+	async delete(key: string | string[]): Promise<void> {
+		for (const k of Array.isArray(key) ? key : [key]) {
+			const filePath = this.resolvePath(k);
+			try {
+				await fsp.unlink(filePath);
+			} catch (err) {
+				if (errCode(err) === 'ENOENT' || errCode(err) === 'ENOTDIR') continue;
+				throw err;
+			}
+			// Best-effort prune of now-empty parent dirs, stopping at the root.
+			for (
+				let dir = path.dirname(filePath);
+				dir.startsWith(this.root + path.sep);
+				dir = path.dirname(dir)
+			) {
+				try {
+					await fsp.rmdir(dir);
+				} catch {
+					break;
+				}
+			}
+		}
+	}
+
+	private async walkKeys(): Promise<string[]> {
+		const entries = await fsp.readdir(this.root, { recursive: true, withFileTypes: true });
+		const keys: string[] = [];
+		for (const entry of entries) {
+			// Symlinks are excluded here (isFile() is lstat-based for readdir entries),
+			// so a link inside the root never surfaces in listings.
+			if (!entry.isFile()) continue;
+			const rel = path.relative(this.root, path.join(entry.parentPath, entry.name));
+			const segKey = rel.split(path.sep).join('/');
+			if (segKey.split('/')[0] === TMP_DIR) continue;
+			keys.push(segKey);
+		}
+		return keys;
+	}
+
+	async list(options?: BucketListOptions): Promise<BucketListResult> {
+		const prefix = options?.prefix ?? '';
+		const delimiter = options?.delimiter;
+		const limit = options?.limit ?? 1000;
+		// Both `cursor` (resume token) and `startAfter` are exclusive lower bounds on
+		// the key; honor whichever is larger.
+		const after = [options?.cursor, options?.startAfter]
+			.filter((v): v is string => Boolean(v))
+			.sort()
+			.pop();
+
+		const sorted = (await this.walkKeys()).filter((k) => k.startsWith(prefix)).sort();
+
+		const prefixes = new Set<string>();
+		const objectKeys: string[] = [];
+		for (const key of sorted) {
+			if (after && key <= after) continue;
+			if (delimiter) {
+				const rest = key.slice(prefix.length);
+				const idx = rest.indexOf(delimiter);
+				if (idx !== -1) {
+					prefixes.add(prefix + rest.slice(0, idx + delimiter.length));
+					continue;
+				}
+			}
+			objectKeys.push(key);
+		}
+
+		// Emulate S3/R2 paging for object listings: at most `limit` per page, with a
+		// cursor to resume. Delimited (prefix-rollup) listings are returned whole.
+		const pageKeys = delimiter ? objectKeys : objectKeys.slice(0, limit);
+		const truncated = !delimiter && objectKeys.length > limit;
+
+		const objects: BucketObject[] = [];
+		for (const key of pageKeys) {
+			const read = await this.readObject(key);
+			// A file deleted between the walk and this read is silently skipped.
+			if (!read) continue;
+			objects.push({
+				key,
+				etag: sha256hex(read.body),
+				size: read.body.length,
+				uploaded: read.uploaded,
+			});
+		}
+
+		return {
+			objects,
+			truncated,
+			cursor: truncated ? pageKeys[pageKeys.length - 1] : undefined,
+			delimitedPrefixes: [...prefixes].sort(),
+		};
+	}
+
+	/**
+	 * Boot self-check (called duck-typed by preflight): a wrong-etag put must be
+	 * rejected, and concurrent CAS puts from one base etag yield at most one winner.
+	 */
+	async verifyConditionalWrites(): Promise<void> {
+		const probeKey = '_system/.cas-probe';
+
+		await this.put(probeKey, 'v1');
+		let rejected = false;
+		try {
+			await this.put(probeKey, 'v2', { onlyIfEtagMatches: 'this-etag-is-wrong' });
+		} catch (err) {
+			if (!(err instanceof PreconditionFailedError)) {
+				await this.delete(probeKey).catch(() => {});
+				throw err;
+			}
+			rejected = true;
+		}
+		if (!rejected) {
+			await this.delete(probeKey).catch(() => {});
+			throw new Error(
+				'Filesystem storage CAS probe failed: a put with a wrong etag was accepted. The catalog ' +
+					'compare-and-swap protocol is unsafe on this root.',
+			);
+		}
+
+		const seed = await this.put(probeKey, 'v3');
+		const N = 8;
+		const results = await Promise.allSettled(
+			Array.from({ length: N }, (_, i) =>
+				this.put(probeKey, `r${i}`, { onlyIfEtagMatches: seed.etag }),
+			),
+		);
+		await this.delete(probeKey).catch(() => {});
+		for (const r of results) {
+			if (r.status === 'rejected' && !(r.reason instanceof PreconditionFailedError)) throw r.reason;
+		}
+		const winners = results.filter((r) => r.status === 'fulfilled').length;
+		if (winners > 1) {
+			throw new Error(
+				`Filesystem storage CAS probe failed: ${winners} concurrent conditional puts from the ` +
+					'same etag were accepted (expected at most 1).',
+			);
+		}
+	}
+}

--- a/packages/storage-fs/src/index.ts
+++ b/packages/storage-fs/src/index.ts
@@ -3,9 +3,12 @@
  *
  * Keys map 1:1 to relative paths under the root, so operators can browse the
  * tree directly. Traversal is blocked by key validation plus a resolved-path
- * containment check, and reads open with O_NOFOLLOW so a symlink inside the
- * root cannot leak content from outside it. Writes stage into a reserved
- * `.tmp/` dir and rename into place — atomic on a single filesystem.
+ * containment check, and reads refuse a symlink as the final path component
+ * (O_NOFOLLOW). Intermediate directories are the operator's own layout: the
+ * API only ever creates real directories, so a symlinked subdirectory can only
+ * come from the operator (e.g. a mounted volume) and is followed. Writes stage
+ * into a reserved `.tmp/` dir (fsync, then rename into place — atomic on a
+ * single filesystem).
  *
  * ETags are the sha-256 of the content, so they survive restarts (the catalog
  * compare-and-swap depends on that). `onlyIfNotExists` (hard link) is atomic
@@ -46,6 +49,13 @@ const TMP_DIR = '.tmp';
  */
 const NOT_FOUND_CODES = new Set(['ENOENT', 'ENOTDIR', 'EISDIR', 'ELOOP', 'EMLINK']);
 
+/**
+ * put() serialization shared by every instance in this process, keyed by
+ * root + key — two FsStorage instances on one root must contend for the same
+ * lock or `casScope: 'process'` would silently be instance-scoped.
+ */
+const putLocks = new Map<string, Promise<void>>();
+
 function errCode(err: unknown): string | undefined {
 	return err instanceof Error && 'code' in err
 		? String((err as { code?: unknown }).code)
@@ -75,13 +85,14 @@ export class FsStorage implements Bucket {
 	readonly casScope = 'process' as const;
 
 	private readonly root: string;
+	/** `root` with a trailing separator (already present when root is `/`). */
+	private readonly rootPrefix: string;
 	private readonly tmpDir: string;
-	/** Per-key promise chains serializing put()s — the in-process CAS mutex. */
-	private readonly locks = new Map<string, Promise<void>>();
 
 	constructor(config: FsStorageConfig) {
 		mkdirSync(config.root, { recursive: true });
 		this.root = realpathSync(config.root);
+		this.rootPrefix = this.root.endsWith(path.sep) ? this.root : this.root + path.sep;
 		this.tmpDir = path.join(this.root, TMP_DIR);
 		mkdirSync(this.tmpDir, { recursive: true });
 	}
@@ -90,7 +101,7 @@ export class FsStorage implements Bucket {
 		assertValidKey(key);
 		const abs = path.resolve(this.root, key);
 		// assertValidKey already guarantees containment; defense in depth.
-		if (!abs.startsWith(this.root + path.sep)) {
+		if (!abs.startsWith(this.rootPrefix)) {
 			throw new Error(`Bucket key escapes the storage root: "${key}"`);
 		}
 		return abs;
@@ -136,15 +147,16 @@ export class FsStorage implements Bucket {
 	}
 
 	private withKeyLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
-		const prev = this.locks.get(key) ?? Promise.resolve();
+		const lockKey = `${this.root}\0${key}`;
+		const prev = putLocks.get(lockKey) ?? Promise.resolve();
 		const run = prev.then(fn, fn);
 		const chain = run.then(
 			() => {},
 			() => {},
 		);
-		this.locks.set(key, chain);
+		putLocks.set(lockKey, chain);
 		void chain.then(() => {
-			if (this.locks.get(key) === chain) this.locks.delete(key);
+			if (putLocks.get(lockKey) === chain) putLocks.delete(lockKey);
 		});
 		return run;
 	}
@@ -155,15 +167,23 @@ export class FsStorage implements Bucket {
 		options?: BucketPutOptions,
 	): Promise<BucketObject> {
 		const filePath = this.resolvePath(key);
-		if (options?.onlyIfEtagMatches && options?.onlyIfNotExists) {
+		if (options?.onlyIfEtagMatches !== undefined && options?.onlyIfNotExists) {
 			throw new Error('onlyIfEtagMatches and onlyIfNotExists are mutually exclusive');
 		}
 		return this.withKeyLock(key, async () => {
 			const body = typeof value === 'string' ? new TextEncoder().encode(value) : value;
 			const etag = sha256hex(body);
 			const tmp = path.join(this.tmpDir, randomUUID());
-			await fsp.writeFile(tmp, body);
 			try {
+				const handle = await fsp.open(tmp, 'wx');
+				try {
+					await handle.writeFile(body);
+					// Flush to disk before the rename publishes the file, so a crash
+					// can't leave a renamed-but-empty object behind.
+					await handle.sync();
+				} finally {
+					await handle.close();
+				}
 				// rename/link preserve mtime, so stat the staged file for `uploaded`.
 				const uploaded = (await fsp.stat(tmp)).mtime;
 				await fsp.mkdir(path.dirname(filePath), { recursive: true });
@@ -176,7 +196,7 @@ export class FsStorage implements Bucket {
 						}
 						throw err;
 					}
-				} else if (options?.onlyIfEtagMatches) {
+				} else if (options?.onlyIfEtagMatches !== undefined) {
 					const current = await this.readObject(key);
 					if (!current || sha256hex(current.body) !== options.onlyIfEtagMatches) {
 						throw new PreconditionFailedError(`ETag mismatch for key "${key}"`);
@@ -205,7 +225,7 @@ export class FsStorage implements Bucket {
 			// Best-effort prune of now-empty parent dirs, stopping at the root.
 			for (
 				let dir = path.dirname(filePath);
-				dir.startsWith(this.root + path.sep);
+				dir.startsWith(this.rootPrefix);
 				dir = path.dirname(dir)
 			) {
 				try {
@@ -291,7 +311,8 @@ export class FsStorage implements Bucket {
 	 * rejected, and concurrent CAS puts from one base etag yield at most one winner.
 	 */
 	async verifyConditionalWrites(): Promise<void> {
-		const probeKey = '_system/.cas-probe';
+		// Unique per run so the probe can never clobber a real object.
+		const probeKey = `_system/.cas-probe-${randomUUID()}`;
 
 		await this.put(probeKey, 'v1');
 		let rejected = false;

--- a/packages/storage-fs/tsconfig.json
+++ b/packages/storage-fs/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "@marimo-hub/tsconfig/library.json",
+	"include": ["src"]
+}

--- a/packages/storage-fs/vite.config.ts
+++ b/packages/storage-fs/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+	pack: { dts: true },
+	test: { include: ['src/**/*.test.ts'] },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,9 @@ importers:
       '@marimo-hub/secrets-aws':
         specifier: workspace:*
         version: link:../secrets-aws
+      '@marimo-hub/storage-fs':
+        specifier: workspace:*
+        version: link:../storage-fs
       '@marimo-hub/storage-gcs':
         specifier: workspace:*
         version: link:../storage-gcs
@@ -803,6 +806,28 @@ importers:
       '@aws-sdk/client-secrets-manager':
         specifier: 'catalog:'
         version: 3.1076.0
+      '@marimo-hub/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@marimo-hub/tsconfig':
+        specifier: workspace:*
+        version: link:../ts-config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.3
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.24(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(jiti@2.7.0)(jsdom@29.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(jiti@2.7.0)(jsdom@29.1.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)'
+
+  packages/storage-fs:
+    dependencies:
       '@marimo-hub/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Add @marimo-hub/storage-fs, a zero-dependency Bucket adapter that stores
objects as plain files under a host directory (MARIMOHUB_STORAGE_FS_ROOT),
enabling single-box self-hosting with no external object store.

- Keys map 1:1 to paths; traversal is blocked by strict key validation plus
  a resolved-path containment check, and reads use O_NOFOLLOW so symlinks
  inside the root cannot leak outside content.
- Content-hash (sha-256) etags survive restarts; writes stage into a
  reserved .tmp/ dir and rename atomically. onlyIfNotExists uses a hard
  link (atomic across processes); onlyIfEtagMatches is serialized by a
  per-key in-process mutex, so cross-process CAS is best-effort — the
  adapter advertises casScope: 'process' and preflight surfaces a non-fatal
  startup warning (single replica only).
- Durable, so no MARIMOHUB_ALLOW_EPHEMERAL_STORAGE gate.
- Runs the shared bucketContract plus traversal/symlink/etag-stability and
  list-semantics tests; docs (storage.md, setup partial, generated
  configuration.md) and the deployment wizard cover the new backend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@marimo-hub/storage-fs`, a filesystem storage backend that stores objects under `MARIMOHUB_STORAGE_FS_ROOT` for single-node self-hosting without external object storage. Updates config, docs, and the deployment wizard to support `fs`.

- New Features
  - New `fs` backend (`@marimo-hub/storage-fs`): durable on one node; objects map to files under `MARIMOHUB_STORAGE_FS_ROOT`.
  - Safety: strict key validation, path containment (incl. root “/”), and O_NOFOLLOW on the final component to block traversal/symlink escape.
  - Writes: stage to `.tmp`, fsync, then atomic rename; SHA-256 etags survive restarts. `onlyIfNotExists` uses a hard link; `onlyIfEtagMatches` is per-process CAS (`casScope: 'process'`) with a process-wide per-key lock and a preflight warn for single-replica use.
  - Config/Docs/Wizard: added `MARIMOHUB_STORAGE_BACKEND=fs` and required `MARIMOHUB_STORAGE_FS_ROOT`; docs cover single-replica and container volume mount; wizard wiring for `.env`, Docker Compose, Helm, library, plus a “single-replica” warning.
  - Tests: passes shared bucket contract and adds traversal, symlink, list semantics, CAS stability (cross-instance), empty-etag, and hygiene tests.

- Bug Fixes
  - Enforce empty `onlyIfEtagMatches` as a real precondition; prevent multiple CAS winners by sharing a per-key lock across instances in one process.
  - Crash-safety and cleanup: fsync staged files before rename and ensure no `.tmp` leaks.
  - Preflight uses a per-run probe key to avoid clobbering real objects.

<sup>Written for commit 382c0bcde00db26f065baeab1a7c8723754772f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

