### PR TITLE
feat: personal access tokens (mhub_pat_) for API auth

### DIFF
--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -113,6 +113,7 @@ export default defineConfig({
 				items: [
 					{ text: 'Configuration', link: '/configuration' },
 					{ text: 'API & client', link: '/api' },
+					{ text: 'API tokens', link: '/api-tokens' },
 					{ text: 'How it works', link: '/architecture' },
 				],
 			},
@@ -169,6 +170,7 @@ export default defineConfig({
 				items: [
 					{ text: 'Configuration', link: '/configuration' },
 					{ text: 'API & client', link: '/api' },
+					{ text: 'API tokens', link: '/api-tokens' },
 					{ text: 'How it works', link: '/architecture' },
 				],
 			},

--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -382,7 +382,7 @@ A personal access token record — the machine-credential counterpart of a sessi
 
 **Why keyed by token id.** The presented bearer is `mhub_pat_<tokenId>_<secret>`, so verification is a **single GET** by the embedded ULID — no scan and, critically, no mutable index object that would need its own CAS discipline. `hash` is the SHA-256 of the secret; the plaintext is returned once at creation and never stored. Per-user listing is a prefix scan of `_system/tokens/` (fine at the 20-per-user cap).
 
-**Mutability & write semantics.** Like an identity record: mutable, last-writer-wins, no conditional PUT. The only rewrite is the `last_used_at` refresh, coalesced to once per UTC day so the request hot path stays read-only. Positive verifications are cached per process with a short TTL (`TokenService.CACHE_TTL_MS`), which also bounds the cross-replica revocation lag; revocation deletes the object.
+**Mutability & write semantics.** Creation is a plain PUT to a fresh, unique token-id key. The only rewrite is the `last_used_at` refresh, and it is **conditional** — an `If-Match` on the ETag read at load time — so a token revoked (deleted) between load and the touch is not resurrected by a stale write; the touch is also coalesced to once per UTC day, keeping the request hot path read-only. Revocation is a plain DELETE. Positive verifications are cached per process with a short TTL (`TokenService.CACHE_TTL_MS`), which also bounds the cross-replica revocation lag.
 
 ---
 

--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -70,6 +70,8 @@ s3-bucket/
 │   │   └── {session-id}.json               ← active kernel sessions
 │   ├── identities/
 │   │   └── {user-id}.json                  ← user display identity (mutable, last-writer-wins)
+│   ├── tokens/
+│   │   └── {token-id}.json                 ← personal access token record (mutable, last-writer-wins)
 │   ├── logs/
 │   │   └── {YYYY-MM-DD}.log                ← append-only, rolled daily
 │   └── events/
@@ -113,6 +115,7 @@ s3-bucket/
 | `_system/snapshots/{id}.json`                                  | JSON     | Immutable index snapshot. Lists all projects and notebooks with metadata. Written once, never modified.                                                                                                                                                                                                                                                                                                                                |
 | `_system/sessions/{pid}/{sid}.json`                            | JSON     | Live session record, partitioned by project so a project-scoped read lists only `_system/sessions/{pid}/`. Created on notebook open, updated by heartbeat, cleaned up on close or TTL expiry.                                                                                                                                                                                                                                          |
 | `_system/identities/{user-id}.json`                            | JSON     | User display identity (`{ id, email, name }`). Upserted on each authenticated request; mutable, last-writer-wins. Resolves opaque `author`/`user_id` ids to a person.                                                                                                                                                                                                                                                                  |
+| `_system/tokens/{token-id}.json`                               | JSON     | Personal access token record (`{ id, user_id, name, hash, … }`) keyed by the ULID embedded in the presented `mhub_pat_` bearer, so verification is a single GET. Stores only the SHA-256 of the secret. Mutable, last-writer-wins (coarse `last_used_at` refresh); revocation deletes the object. See §4.11.                                                                                                                           |
 | `_system/logs/{YYYY-MM-DD}.log`                                | Text     | Human-readable application log. One file per day. For ops debugging only.                                                                                                                                                                                                                                                                                                                                                              |
 | `_system/events/{YYYY-MM-DD}/{event-id}.json`                  | JSON     | Structured event log. One immutable object per event, keyed by a monotonic ULID under a per-day prefix. Primary audit trail.                                                                                                                                                                                                                                                                                                           |
 | `_system/idempotency/{digest}.json`                            | JSON     | Recorded `POST`-create response for an `Idempotency-Key`, keyed by `sha256(user:route\nkey)`. Replayed on retry; pruned after 24h. See [`idempotency.md`](./idempotency.md).                                                                                                                                                                                                                                                           |
@@ -360,6 +363,27 @@ The identity directory maps a stable user id — the auth `sub`, which is what e
 
 **Write volume.** The upsert runs in the auth middleware on every `/api/v1/*` request, but is **write-coalesced**: the service keeps a per-process `id → {email,name}` signature cache and skips the PUT when the incoming identity is unchanged since this process last wrote it (`IdentityService.upsert`, `packages/core/src/services/identity/IdentityService.ts`). So steady-state cost is ~one PUT per user per process lifetime (plus one whenever their email/name actually changes), not one per request. The upsert is best-effort — a failure is logged and never blocks the request.
 
+### 4.11 `_system/tokens/{token-id}.json`
+
+A personal access token record — the machine-credential counterpart of a session cookie. A token acts as its issuing user (`user_id` resolves through the identity directory and inherits the user's memberships), so no authz changes hang off this object.
+
+```json
+// _system/tokens/01HXY0S6GWMBASVAG3PZ7Y2K5T.json
+{
+	"id": "01HXY0S6GWMBASVAG3PZ7Y2K5T",
+	"user_id": "user_abc123",
+	"name": "ci-deploy",
+	"hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+	"created_at": "2026-07-24T14:30:00Z",
+	"expires_at": "2026-10-22T14:30:00Z",
+	"last_used_at": "2026-07-24T15:00:00Z"
+}
+```
+
+**Why keyed by token id.** The presented bearer is `mhub_pat_<tokenId>_<secret>`, so verification is a **single GET** by the embedded ULID — no scan and, critically, no mutable index object that would need its own CAS discipline. `hash` is the SHA-256 of the secret; the plaintext is returned once at creation and never stored. Per-user listing is a prefix scan of `_system/tokens/` (fine at the 20-per-user cap).
+
+**Mutability & write semantics.** Like an identity record: mutable, last-writer-wins, no conditional PUT. The only rewrite is the `last_used_at` refresh, coalesced to once per UTC day so the request hot path stays read-only. Positive verifications are cached per process with a short TTL (`TokenService.CACHE_TTL_MS`), which also bounds the cross-replica revocation lag; revocation deletes the object.
+
 ---
 
 ## 5. ID Scheme
@@ -591,7 +615,7 @@ Schema migrations are a first-class concern because there is no database to run 
 | `_system/events/**`                          | Never migrated — event records are immutable history. New event shapes get a bumped `schema_version` field. Consumers must handle multiple versions.                                                                                                                              |
 | `catalog.json`                               | Migrated in-place as part of the first write after a Worker deploy that bumps catalog schema version. Uses a strict `version` literal, so — unlike the objects above — it is **not** forward-tolerant.                                                                            |
 
-> **No `schema_version` by design:** the mutable, last-writer-wins records — sessions (`_system/sessions/**`), identities (`_system/identities/**`), and `fs_snapshot.json` — carry no `schema_version`. They are rewritten on every write or reaped shortly after creation, so they never need a migration; a shape change is absorbed with optional fields + defaults on read. API response bodies are likewise unversioned per-object — the contract is versioned at the route level (`/api/v1`).
+> **No `schema_version` by design:** the mutable, last-writer-wins records — sessions (`_system/sessions/**`), identities (`_system/identities/**`), tokens (`_system/tokens/**`), and `fs_snapshot.json` — carry no `schema_version`. They are rewritten on every write or reaped shortly after creation, so they never need a migration; a shape change is absorbed with optional fields + defaults on read. API response bodies are likewise unversioned per-object — the contract is versioned at the route level (`/api/v1`).
 
 ### Migration Worker pseudocode
 

--- a/docs/api-tokens.md
+++ b/docs/api-tokens.md
@@ -1,0 +1,74 @@
+# API tokens
+
+Personal access tokens (PATs) let CI jobs, scripts, and the CLI call the
+`/api/v1/*` HTTP API without a browser session. A token acts as the user who
+created it: it inherits their project memberships and roles unchanged, and it
+works on every deployment — there is nothing to configure.
+
+## Create a token
+
+In the app, open the user menu (top right) → **API tokens** → **Create a
+token**. Name it after what will hold it (for example `ci-deploy`) and
+optionally set an expiry in days.
+
+The dialog shows the plaintext token **exactly once** — the server stores only
+its SHA-256 hash, so it can never be shown again. Copy it immediately. Each
+user can hold up to 20 tokens.
+
+There is no way to mint a token without a signed-in session — see the
+restrictions below.
+
+## Use it
+
+Send the token as a bearer credential:
+
+```bash
+curl https://hub.example.com/api/v1/me \
+  -H "Authorization: Bearer mhub_pat_…"
+```
+
+The request authenticates as the issuing user; the response to `/api/v1/me`
+returns their identity. Token-authenticated requests are exempt from the
+cookie-oriented cross-origin (CSRF) guard — a bearer header is never attached
+ambiently by a browser, so there is nothing to forge.
+
+Know the blast radius before you create one:
+
+- **A token is full account power.** There are no scopes in v1 — a token can do
+  everything its user can on every route except token management: create and
+  delete notebooks, read and write project secrets, start sessions, and so on.
+  A leaked token is therefore equivalent to a compromised account. Treat it like
+  a password. Scoped (read-only, per-project) tokens are a planned follow-up.
+- **Expiry is optional.** Omitting `expires_in_days` mints a token that never
+  expires. For anything long-lived, prefer a bounded lifetime and rotate it, so
+  a leak has a time limit even if it goes unnoticed.
+- **Tokens cannot manage tokens.** `POST`/`GET`/`DELETE /api/v1/me/tokens`
+  require session (SSO) auth, so a leaked token cannot mint replacements or
+  revoke its neighbors — but note this only limits _token_ escalation, not the
+  account-level access above.
+
+## Token format
+
+```
+mhub_pat_<id>_<secret>
+```
+
+The fixed `mhub_pat_` prefix identifies leaked tokens to secret scanners —
+register it in the scanning tools you use. The `id` is the token's public
+identifier (shown in the token list); the 160-bit `secret` exists only in the
+create response and as a hash on the server.
+
+## Revoke a token
+
+Delete it from the **API tokens** dialog.
+
+Revocation (and expiry) takes effect immediately on the replica that served the
+request and within about 30 seconds everywhere else — verified tokens are
+positively cached per process for that long to keep per-request verification
+off the storage hot path.
+
+## Audit
+
+Token lifecycle is recorded in the audit event stream as `token.created` and
+`token.revoked`, stamped with the acting user. These are account-level events;
+they do not appear in any single project's audit log.

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,9 @@ Every `/api/v1/*` response uses one envelope:
 { "success": false, "error": { "code": "FORBIDDEN", "message": "…" } }
 ```
 
-Authentication is via the session cookie issued by your [auth](/auth) backend.
+Authentication is via the session cookie issued by your [auth](/auth) backend,
+or a [personal access token](/api-tokens) sent as `Authorization: Bearer …`
+(for CI, scripts, and the CLI).
 Reads are open to any authenticated user; writes are role-gated (see
 [Security → Authorization](/security#authorization-roles)). The one read
 exception is the audit log, which requires project `admin`.

--- a/examples/cloudflare-worker/src/index.ts
+++ b/examples/cloudflare-worker/src/index.ts
@@ -7,7 +7,12 @@
  */
 import { createApi } from '@marimo-hub/api';
 import type { ApiDeps } from '@marimo-hub/api';
-import { createServices, MaintenanceLock, ReconciliationService } from '@marimo-hub/core';
+import {
+	composeAuthenticators,
+	createServices,
+	MaintenanceLock,
+	ReconciliationService,
+} from '@marimo-hub/core';
 import { CloudflareAccessAuthenticator } from '@marimo-hub/auth-cloudflare-access';
 import { DevAuthenticator } from '@marimo-hub/auth-dev';
 import { CloudflareSandboxProvider, ContainerProxy, Sandbox } from '@marimo-hub/compute-cloudflare';
@@ -76,11 +81,14 @@ function buildDeps(request: Request, env: Env): ApiDeps {
 				}
 			: undefined;
 
+	const services = createServices(bucket);
 	return {
-		services: createServices(bucket),
+		services,
 		bucket,
 		compute: new CloudflareSandboxProvider(env.SANDBOX, { useTunnel }),
-		authenticator,
+		// Personal access tokens (`Authorization: Bearer mhub_pat_…`) work on every
+		// deployment; other requests resolve through the adapter selected above.
+		authenticator: composeAuthenticators(services.tokens, authenticator),
 		ai,
 		sandbox: {
 			// Default: credential-less R2 binding mount (no endpoint/secrets) — the

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -18,6 +18,7 @@ tags:
     description: Deployment metadata
 security:
   - cookieAuth: []
+  - bearerAuth: []
 components:
   securitySchemes:
     cookieAuth:
@@ -26,6 +27,12 @@ components:
       name: mh_session
       description: Session cookie minted by the OIDC login flow; browsers attach it
         automatically.
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: Personal access token (`mhub_pat_…`) minted at POST
+        /api/v1/me/tokens, for CI/CLI/service callers. Acts as the issuing user;
+        cannot manage tokens.
   schemas:
     Me:
       type: object
@@ -794,6 +801,35 @@ components:
         - id
         - email
         - name
+    ApiTokenCreated:
+      allOf:
+        - $ref: '#/components/schemas/ApiToken'
+        - type: object
+          properties:
+            token:
+              type: string
+          required:
+            - token
+    ApiToken:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+        last_used_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - created_at
   parameters: {}
 paths:
   /api/v1/me:
@@ -3676,6 +3712,215 @@ paths:
                   - data
         '401':
           description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/me/tokens:
+    post:
+      tags:
+        - Auth
+      summary: Create a personal access token
+      description: 'Mint a machine credential that acts as the calling user (CI,
+        scripts, the CLI): send it as `Authorization: Bearer mhub_pat_…`. The
+        plaintext token is returned once, in this response, and never again.
+        Requires session (SSO) auth — a token cannot mint tokens.'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                  maxLength: 100
+                  example: ci-deploy
+                expires_in_days:
+                  type: integer
+                  minimum: 1
+                  maximum: 3650
+                  description: Days until expiry; omit for a non-expiring token.
+                  example: 90
+              required:
+                - name
+      responses:
+        '201':
+          description: The new token — copy it now; it is never shown again
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/ApiTokenCreated'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Insufficient role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    get:
+      tags:
+        - Auth
+      summary: List the caller's personal access tokens
+      description: Metadata only — the secret is never retrievable after creation.
+      responses:
+        '200':
+          description: Tokens, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ApiToken'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Insufficient role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/me/tokens/{tokenId}:
+    delete:
+      tags:
+        - Auth
+      summary: Revoke a personal access token
+      description: Deletes the token; API requests using it fail within the
+        verification-cache TTL (~30 seconds) on other replicas, immediately on
+        this one.
+      parameters:
+        - schema:
+            type: string
+            pattern: ^[0-9A-Z]{26}$
+            example: 01HXY0S6GWMBASVAG3PZ7Y2K5T
+          required: true
+          name: tokenId
+          in: path
+      responses:
+        '200':
+          description: Token revoked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Insufficient role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
           content:
             application/json:
               schema:

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -3725,6 +3725,8 @@ paths:
         scripts, the CLI): send it as `Authorization: Bearer mhub_pat_…`. The
         plaintext token is returned once, in this response, and never again.
         Requires session (SSO) auth — a token cannot mint tokens.'
+      security: &a1
+        - cookieAuth: []
       requestBody:
         required: true
         content:
@@ -3813,6 +3815,7 @@ paths:
         - Auth
       summary: List the caller's personal access tokens
       description: Metadata only — the secret is never retrievable after creation.
+      security: *a1
       responses:
         '200':
           description: Tokens, newest first
@@ -3872,6 +3875,7 @@ paths:
       description: Deletes the token; API requests using it fail within the
         verification-cache TTL (~30 seconds) on other replicas, immediately on
         this one.
+      security: *a1
       parameters:
         - schema:
             type: string

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -255,6 +255,13 @@ export type HonoEnv = {
 	Variables: {
 		deps: ApiDeps;
 		user: AuthUser;
+		/**
+		 * How the request authenticated, decided once in the authN middleware:
+		 * `pat` (a personal access token) or `session` (cookie/SSO). Routes that
+		 * must be session-only (token management) gate on this instead of re-parsing
+		 * the Authorization header — two independent parses eventually disagree.
+		 */
+		authMethod: 'pat' | 'session';
 		/** Per-request correlation id set by the `hono/request-id` middleware. */
 		requestId: string;
 	};

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -5,6 +5,7 @@ import { requestId } from 'hono/request-id';
 import {
 	DomainError,
 	ensureInitialized,
+	isPatRequest,
 	MAX_REQUEST_BYTES,
 	probeKernelLiveness,
 	SubdomainExposure,
@@ -19,6 +20,7 @@ import projectsApp from './routes/projects';
 import secretsApp from './routes/secrets';
 import sessionsApp from './routes/sessions';
 import systemApp from './routes/system';
+import tokensApp from './routes/tokens';
 import usersApp from './routes/users';
 import { createOidcDiscovery } from './oidcDiscovery';
 import { sandboxProxyMiddleware } from './sandboxProxy';
@@ -39,9 +41,10 @@ const OPENAPI_DOC = {
 		{ name: 'Users', description: 'User identity resolution' },
 		{ name: 'System', description: 'Deployment metadata' },
 	],
-	// Every documented `/api/v1/*` route sits behind the cookie-auth guard, so the
-	// requirement is global (the scheme itself is registered on the app below).
-	security: [{ cookieAuth: [] }],
+	// Every documented `/api/v1/*` route sits behind the authN guard, satisfiable
+	// by either the session cookie or a personal access token (the schemes are
+	// registered on the app below), so the requirement is global and disjunctive.
+	security: [{ cookieAuth: [] }, { bearerAuth: [] }] as Record<string, string[]>[],
 };
 
 /** The versioned API mount. Health and auth routes live outside it, unversioned. */
@@ -251,6 +254,11 @@ export function createApi(rawDeps: ApiDeps) {
 			return fail(c, 'UNAUTHORIZED', 'Authentication required', 401);
 		}
 		c.set('user', user);
+		// A PAT-shaped bearer is resolved ONLY by the token path (see
+		// composeAuthenticators), so its presence is an exact signal for "this
+		// request authenticated with a PAT". Decided here, once, and read by the
+		// token-management guard — never re-parsed downstream.
+		c.set('authMethod', isPatRequest(c.req.raw) ? 'pat' : 'session');
 
 		// Refresh this user's identity-directory record so opaque ids (author /
 		// session user_id) resolve to a name+email at read time. Best-effort and
@@ -303,6 +311,7 @@ export function createApi(rawDeps: ApiDeps) {
 	app.route(API_PREFIX, sessionsApp);
 	app.route(API_PREFIX, secretsApp);
 	app.route(API_PREFIX, usersApp);
+	app.route(API_PREFIX, tokensApp);
 
 	// Declare the cookie-session auth scheme the global `security` requirement
 	// (OPENAPI_DOC) points at, so generated clients know the API is authenticated.
@@ -311,6 +320,13 @@ export function createApi(rawDeps: ApiDeps) {
 		in: 'cookie',
 		name: 'mh_session',
 		description: 'Session cookie minted by the OIDC login flow; browsers attach it automatically.',
+	});
+	app.openAPIRegistry.registerComponent('securitySchemes', 'bearerAuth', {
+		type: 'http',
+		scheme: 'bearer',
+		description:
+			'Personal access token (`mhub_pat_…`) minted at POST /api/v1/me/tokens, for CI/CLI/' +
+			'service callers. Acts as the issuing user; cannot manage tokens.',
 	});
 
 	// OpenAPI spec.

--- a/packages/api/src/routes/tokens.test.ts
+++ b/packages/api/src/routes/tokens.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { composeAuthenticators } from '@marimo-hub/core';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
 import { ACTOR, uid } from '@marimo-hub/core/testing';
-import { createApi } from '../createApi';
+import { createApi, generateOpenApiDocument } from '../createApi';
 import {
 	createInitializedBucket,
 	createTestApi,
@@ -61,6 +61,18 @@ describe('Token routes', () => {
 
 	it('rejects an over-long name (422)', async () => {
 		await expectError(await request('POST', '/me/tokens', { name: 'x'.repeat(101) }), 422);
+	});
+
+	it('rejects a whitespace-only name (422)', async () => {
+		await expectError(await request('POST', '/me/tokens', { name: '   ' }), 422);
+	});
+
+	it('trims surrounding whitespace from the name', async () => {
+		const data = await expectOk<TokenMeta>(
+			await request('POST', '/me/tokens', { name: '  ci-deploy  ' }),
+			201,
+		);
+		expect(data.name).toBe('ci-deploy');
 	});
 
 	it.each([
@@ -136,6 +148,18 @@ describe('Token routes', () => {
 			429,
 			'RESOURCE_EXHAUSTED',
 		);
+	});
+
+	it('advertises only cookieAuth (not bearerAuth) for the token-management routes', () => {
+		// A PAT is rejected on these routes (403), so a generated client must never
+		// offer bearerAuth here — the operation-level override enforces that.
+		const doc = generateOpenApiDocument() as {
+			paths: Record<string, Record<string, { security?: unknown }>>;
+		};
+		const collection = doc.paths['/api/v1/me/tokens'];
+		expect(collection.post.security).toEqual([{ cookieAuth: [] }]);
+		expect(collection.get.security).toEqual([{ cookieAuth: [] }]);
+		expect(doc.paths['/api/v1/me/tokens/{tokenId}'].delete.security).toEqual([{ cookieAuth: [] }]);
 	});
 
 	it('emits token.created / token.revoked audit events', async () => {

--- a/packages/api/src/routes/tokens.test.ts
+++ b/packages/api/src/routes/tokens.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { composeAuthenticators } from '@marimo-hub/core';
+import type { MemoryBucket } from '@marimo-hub/core/testing';
+import { ACTOR, uid } from '@marimo-hub/core/testing';
+import { createApi } from '../createApi';
+import {
+	createInitializedBucket,
+	createTestApi,
+	expectError,
+	expectOk,
+	makeTestDeps,
+} from '../testing';
+
+interface TokenMeta {
+	id: string;
+	name: string;
+	created_at: string;
+	expires_at?: string;
+	last_used_at?: string;
+}
+
+describe('Token routes', () => {
+	let bucket: MemoryBucket;
+	let request: ReturnType<typeof createTestApi>['request'];
+
+	beforeEach(async () => {
+		bucket = await createInitializedBucket();
+		request = createTestApi({ bucket, userId: ACTOR }).request;
+		// Record ACTOR in the identity directory (the auth middleware upserts it),
+		// so a minted PAT can resolve back to a user.
+		await request('GET', '/me');
+	});
+
+	it('POST /me/tokens returns the plaintext exactly once, with metadata', async () => {
+		const data = await expectOk<TokenMeta & { token: string }>(
+			await request('POST', '/me/tokens', { name: 'ci' }),
+			201,
+		);
+
+		// The one-time plaintext contract: exactly these fields, never a hash.
+		expect(Object.keys(data).sort()).toEqual(['created_at', 'id', 'name', 'token']);
+		expect(data.token).toMatch(/^mhub_pat_[0-9A-Z]{26}_[0-9a-z]{32}$/);
+
+		// The list never carries the token or hash again.
+		const listed = await expectOk<TokenMeta[]>(await request('GET', '/me/tokens'));
+		expect(listed).toHaveLength(1);
+		expect(Object.keys(listed[0]).sort()).toEqual(['created_at', 'id', 'name']);
+	});
+
+	it('POST /me/tokens stamps expires_at from expires_in_days', async () => {
+		const data = await expectOk<TokenMeta>(
+			await request('POST', '/me/tokens', { name: 'short', expires_in_days: 30 }),
+			201,
+		);
+		expect(data.expires_at).toBeTruthy();
+	});
+
+	it('rejects a blank name (422)', async () => {
+		await expectError(await request('POST', '/me/tokens', { name: '' }), 422);
+	});
+
+	it('rejects an over-long name (422)', async () => {
+		await expectError(await request('POST', '/me/tokens', { name: 'x'.repeat(101) }), 422);
+	});
+
+	it.each([
+		['zero days', { name: 'ci', expires_in_days: 0 }],
+		['negative days', { name: 'ci', expires_in_days: -5 }],
+		['too many days', { name: 'ci', expires_in_days: 4000 }],
+		['fractional days', { name: 'ci', expires_in_days: 1.5 }],
+	])('rejects %s (422)', async (_label, body) => {
+		await expectError(await request('POST', '/me/tokens', body), 422);
+	});
+
+	it('accepts the max expiry (3650 days)', async () => {
+		const data = await expectOk<TokenMeta>(
+			await request('POST', '/me/tokens', { name: 'long', expires_in_days: 3650 }),
+			201,
+		);
+		expect(data.expires_at).toBeTruthy();
+	});
+
+	it('rejects a malformed token id on DELETE (422)', async () => {
+		await expectError(await request('DELETE', '/me/tokens/not-a-valid-ulid'), 422);
+	});
+
+	it('rejects unauthenticated callers on every token route (401)', async () => {
+		// A fresh app with the default deny-all authenticator.
+		const app = createApi(makeTestDeps(bucket));
+		await expectError(
+			await app.request('/api/v1/me/tokens', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ name: 'x' }),
+			}),
+			401,
+			'UNAUTHORIZED',
+		);
+		await expectError(await app.request('/api/v1/me/tokens'), 401, 'UNAUTHORIZED');
+		await expectError(
+			await app.request(`/api/v1/me/tokens/${'0'.repeat(26)}`, { method: 'DELETE' }),
+			401,
+			'UNAUTHORIZED',
+		);
+	});
+
+	it('GET /me/tokens lists only the caller’s tokens', async () => {
+		await request('POST', '/me/tokens', { name: 'mine' });
+		const other = createTestApi({ bucket, userId: uid('sub-other') }).request;
+		await other('GET', '/me');
+		await other('POST', '/me/tokens', { name: 'theirs' });
+
+		const mine = await expectOk<TokenMeta[]>(await request('GET', '/me/tokens'));
+		expect(mine.map((t) => t.name)).toEqual(['mine']);
+	});
+
+	it('DELETE /me/tokens/{tokenId} revokes own tokens; 404 for others', async () => {
+		const created = await expectOk<TokenMeta>(
+			await request('POST', '/me/tokens', { name: 'doomed' }),
+			201,
+		);
+
+		const other = createTestApi({ bucket, userId: uid('sub-other') }).request;
+		await expectError(await other('DELETE', `/me/tokens/${created.id}`), 404, 'NOT_FOUND');
+
+		expect((await request('DELETE', `/me/tokens/${created.id}`)).status).toBe(200);
+		expect(await expectOk<TokenMeta[]>(await request('GET', '/me/tokens'))).toEqual([]);
+	});
+
+	it('enforces the per-user cap with 429', async () => {
+		for (let i = 0; i < 20; i++) {
+			await request('POST', '/me/tokens', { name: `t${i}` });
+		}
+		await expectError(
+			await request('POST', '/me/tokens', { name: 'over' }),
+			429,
+			'RESOURCE_EXHAUSTED',
+		);
+	});
+
+	it('emits token.created / token.revoked audit events', async () => {
+		const { deps, request: req } = createTestApi({ bucket, userId: ACTOR });
+		await req('GET', '/me');
+		const created = await expectOk<TokenMeta>(
+			await req('POST', '/me/tokens', { name: 'audited' }),
+			201,
+		);
+		await req('DELETE', `/me/tokens/${created.id}`);
+
+		const day = new Date().toISOString().slice(0, 10);
+		const events = await deps.services.events.getEvents(day);
+		const tokenEvents = events.filter((e) => e.event.startsWith('token.'));
+		expect(tokenEvents.map((e) => e.event)).toEqual(['token.created', 'token.revoked']);
+		expect(tokenEvents[0]).toMatchObject({ actor: ACTOR, token_id: created.id });
+	});
+
+	describe('with the composed (PAT-aware) authenticator', () => {
+		let patRequest: (method: string, path: string, body?: unknown) => Promise<Response>;
+		let patRequestWith: (
+			scheme: string,
+		) => (method: string, path: string, body?: unknown) => Promise<Response>;
+		let token: string;
+
+		beforeEach(async () => {
+			// Wire the production composition: PAT bearer → TokenService, else stub SSO.
+			const session = createTestApi({ bucket, userId: ACTOR });
+			const composed = createApi({
+				...session.deps,
+				authenticator: composeAuthenticators(session.deps.services.tokens, {
+					authenticate: async () => null,
+				}),
+			});
+			await session.request('GET', '/me');
+			({ token } = await expectOk<{ token: string }>(
+				await session.request('POST', '/me/tokens', { name: 'ci' }),
+				201,
+			));
+			patRequestWith = (scheme) => async (method, path, body) =>
+				composed.request(`/api/v1${path}`, {
+					method,
+					headers: {
+						authorization: `${scheme} ${token}`,
+						...(body ? { 'content-type': 'application/json' } : {}),
+					},
+					...(body ? { body: JSON.stringify(body) } : {}),
+				});
+			patRequest = patRequestWith('Bearer');
+		});
+
+		it('a PAT authenticates as the issuing user', async () => {
+			const me = await expectOk<{ id: string; email: string }>(await patRequest('GET', '/me'));
+			expect(me.id).toBe(ACTOR);
+			expect(me.email).toBe(`${ACTOR}@example.com`);
+		});
+
+		it('a PAT may not create, list, or revoke tokens', async () => {
+			await expectError(await patRequest('POST', '/me/tokens', { name: 'sneaky' }), 403);
+			await expectError(await patRequest('GET', '/me/tokens'), 403);
+			await expectError(
+				await patRequest('DELETE', `/me/tokens/${'0'.repeat(26)}`),
+				403,
+				'FORBIDDEN',
+			);
+		});
+
+		// Regression: the guard must not re-parse the Authorization header with a
+		// stricter case rule than the authenticator. A differently-cased scheme
+		// (`BEARER`) still authenticates as the PAT, so it must still be barred from
+		// managing tokens — otherwise a leaked PAT escalates to minting/revoking.
+		it.each(['BEARER', 'bearer'])(
+			'a PAT presented with the %s scheme still cannot manage tokens',
+			async (scheme) => {
+				const req = patRequestWith(scheme);
+				// It authenticates (proving the case reaches the token path)...
+				expect((await req('GET', '/me')).status).toBe(200);
+				// ...yet is barred from every token-management route.
+				await expectError(await req('POST', '/me/tokens', { name: 'sneaky' }), 403, 'FORBIDDEN');
+				await expectError(await req('GET', '/me/tokens'), 403, 'FORBIDDEN');
+				await expectError(await req('DELETE', `/me/tokens/${'0'.repeat(26)}`), 403, 'FORBIDDEN');
+			},
+		);
+
+		it('an invalid PAT is 401, not a fall-through to SSO', async () => {
+			const composed = createApi({
+				...createTestApi({ bucket, userId: ACTOR }).deps,
+				authenticator: composeAuthenticators(
+					createTestApi({ bucket }).deps.services.tokens,
+					// An SSO adapter that would happily authenticate — must not be reached.
+					{ authenticate: async () => ({ id: ACTOR, email: 'sso@example.com' }) },
+				),
+			});
+			const res = await composed.request('/api/v1/me', {
+				headers: { authorization: `Bearer mhub_pat_${'0'.repeat(26)}_${'a'.repeat(32)}` },
+			});
+			await expectError(res, 401, 'UNAUTHORIZED');
+		});
+
+		it('a revoked PAT stops working', async () => {
+			const session = createTestApi({ bucket, userId: ACTOR }).request;
+			const [{ id }] = await expectOk<TokenMeta[]>(await session('GET', '/me/tokens'));
+			await session('DELETE', `/me/tokens/${id}`);
+			await expectError(await patRequest('GET', '/me'), 401, 'UNAUTHORIZED');
+		});
+	});
+});

--- a/packages/api/src/routes/tokens.ts
+++ b/packages/api/src/routes/tokens.ts
@@ -1,0 +1,168 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import { ForbiddenError, TokenId } from '@marimo-hub/core';
+import type { PublicToken } from '@marimo-hub/core';
+import type { Context } from 'hono';
+import type { HonoEnv } from '../context';
+import {
+	commonErrors,
+	createApp,
+	errorResponses,
+	jsonBody,
+	jsonContent,
+	SuccessResponseSchema,
+} from '../shared';
+
+// --- Schemas ---
+
+const TokenResponseSchema = z
+	.object({
+		id: z.string(),
+		name: z.string(),
+		created_at: z.string().openapi({ format: 'date-time' }),
+		expires_at: z.string().openapi({ format: 'date-time' }).optional(),
+		/** Coarse (daily) usage marker; absent until the token is first used. */
+		last_used_at: z.string().openapi({ format: 'date-time' }).optional(),
+	})
+	.openapi('ApiToken');
+
+const TokenCreatedResponseSchema = TokenResponseSchema.extend({
+	/** The plaintext token, returned exactly once — only its hash is stored. */
+	token: z.string(),
+}).openapi('ApiTokenCreated');
+
+const CreateTokenBodySchema = z.object({
+	name: z.string().min(1).max(100).openapi({ example: 'ci-deploy' }),
+	expires_in_days: z.number().int().min(1).max(3650).optional().openapi({
+		description: 'Days until expiry; omit for a non-expiring token.',
+		example: 90,
+	}),
+});
+
+const TokenIdParam = z.object({
+	tokenId: z
+		.string()
+		.regex(TokenId.regex)
+		.refine(TokenId.is)
+		.openapi({ param: { name: 'tokenId', in: 'path' }, example: '01HXY0S6GWMBASVAG3PZ7Y2K5T' }),
+});
+
+// --- Route definitions ---
+
+const createToken = createRoute({
+	method: 'post',
+	path: '/me/tokens',
+	tags: ['Auth'],
+	summary: 'Create a personal access token',
+	description:
+		'Mint a machine credential that acts as the calling user (CI, scripts, the CLI): send it as ' +
+		'`Authorization: Bearer mhub_pat_…`. The plaintext token is returned once, in this response, ' +
+		'and never again. Requires session (SSO) auth — a token cannot mint tokens.',
+	request: { body: jsonBody(CreateTokenBodySchema) },
+	responses: {
+		201: jsonContent(
+			z.object({ success: z.literal(true), data: TokenCreatedResponseSchema }),
+			'The new token — copy it now; it is never shown again',
+		),
+		...commonErrors(),
+		...errorResponses(403, 429),
+	},
+});
+
+const listTokens = createRoute({
+	method: 'get',
+	path: '/me/tokens',
+	tags: ['Auth'],
+	summary: "List the caller's personal access tokens",
+	description: 'Metadata only — the secret is never retrievable after creation.',
+	responses: {
+		200: jsonContent(
+			z.object({ success: z.literal(true), data: z.array(TokenResponseSchema) }),
+			'Tokens, newest first',
+		),
+		...commonErrors(),
+		...errorResponses(403),
+	},
+});
+
+const revokeToken = createRoute({
+	method: 'delete',
+	path: '/me/tokens/{tokenId}',
+	tags: ['Auth'],
+	summary: 'Revoke a personal access token',
+	description:
+		'Deletes the token; API requests using it fail within the verification-cache TTL ' +
+		'(~30 seconds) on other replicas, immediately on this one.',
+	request: { params: TokenIdParam },
+	responses: {
+		200: jsonContent(SuccessResponseSchema, 'Token revoked'),
+		...commonErrors(),
+		...errorResponses(403, 404),
+	},
+});
+
+// --- App ---
+
+/**
+ * Token-authenticated requests may not manage tokens: a leaked PAT must not
+ * mint replacements or revoke its neighbors. Gate on the `authMethod` flag the
+ * authN middleware set — not a re-parse of the Authorization header, which
+ * would risk disagreeing with the authenticator over scheme casing/whitespace.
+ */
+function assertSessionAuthenticated(c: Context<HonoEnv>): void {
+	if (c.get('authMethod') === 'pat') {
+		throw new ForbiddenError('Personal access tokens cannot manage tokens — sign in to do this');
+	}
+}
+
+// Explicit pick: the stored record also carries `user_id` (always the caller's
+// own id on these self-service routes), which the response contract omits.
+function toResponse(record: PublicToken) {
+	return {
+		id: record.id,
+		name: record.name,
+		created_at: record.created_at,
+		...(record.expires_at !== undefined ? { expires_at: record.expires_at } : {}),
+		...(record.last_used_at !== undefined ? { last_used_at: record.last_used_at } : {}),
+	};
+}
+
+const app = createApp();
+
+app.openapi(createToken, async (c) => {
+	assertSessionAuthenticated(c);
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { name, expires_in_days } = c.req.valid('json');
+
+	const { token, record } = await deps.services.tokens.create(
+		{ name, expiresInDays: expires_in_days },
+		user.id,
+	);
+	await deps.services.events
+		.append({ event: 'token.created', actor: user.id, token_id: record.id, token_name: name })
+		.catch(() => {});
+	return c.json({ success: true, data: { ...toResponse(record), token } }, 201);
+});
+
+app.openapi(listTokens, async (c) => {
+	assertSessionAuthenticated(c);
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const records = await deps.services.tokens.list(user.id);
+	return c.json({ success: true, data: records.map(toResponse) }, 200);
+});
+
+app.openapi(revokeToken, async (c) => {
+	assertSessionAuthenticated(c);
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { tokenId } = c.req.valid('param');
+
+	await deps.services.tokens.revoke(user.id, tokenId);
+	await deps.services.events
+		.append({ event: 'token.revoked', actor: user.id, token_id: tokenId })
+		.catch(() => {});
+	return c.json({ success: true }, 200);
+});
+
+export default app;

--- a/packages/api/src/routes/tokens.ts
+++ b/packages/api/src/routes/tokens.ts
@@ -31,7 +31,9 @@ const TokenCreatedResponseSchema = TokenResponseSchema.extend({
 }).openapi('ApiTokenCreated');
 
 const CreateTokenBodySchema = z.object({
-	name: z.string().min(1).max(100).openapi({ example: 'ci-deploy' }),
+	// Trim first so a whitespace-only name fails the non-empty check (mirrors the
+	// UI) and the stored name has no leading/trailing padding.
+	name: z.string().trim().min(1).max(100).openapi({ example: 'ci-deploy' }),
 	expires_in_days: z.number().int().min(1).max(3650).optional().openapi({
 		description: 'Days until expiry; omit for a non-expiring token.',
 		example: 90,
@@ -48,6 +50,12 @@ const TokenIdParam = z.object({
 
 // --- Route definitions ---
 
+// Token management is session-only: a PAT is rejected with 403 (see
+// assertSessionAuthenticated). Override the global disjunctive security so the
+// generated OpenAPI advertises ONLY cookieAuth for these routes — a client must
+// not pick a bearer token it can't use here.
+const SESSION_ONLY_SECURITY = [{ cookieAuth: [] }];
+
 const createToken = createRoute({
 	method: 'post',
 	path: '/me/tokens',
@@ -57,6 +65,7 @@ const createToken = createRoute({
 		'Mint a machine credential that acts as the calling user (CI, scripts, the CLI): send it as ' +
 		'`Authorization: Bearer mhub_pat_…`. The plaintext token is returned once, in this response, ' +
 		'and never again. Requires session (SSO) auth — a token cannot mint tokens.',
+	security: SESSION_ONLY_SECURITY,
 	request: { body: jsonBody(CreateTokenBodySchema) },
 	responses: {
 		201: jsonContent(
@@ -74,6 +83,7 @@ const listTokens = createRoute({
 	tags: ['Auth'],
 	summary: "List the caller's personal access tokens",
 	description: 'Metadata only — the secret is never retrievable after creation.',
+	security: SESSION_ONLY_SECURITY,
 	responses: {
 		200: jsonContent(
 			z.object({ success: z.literal(true), data: z.array(TokenResponseSchema) }),
@@ -92,6 +102,7 @@ const revokeToken = createRoute({
 	description:
 		'Deletes the token; API requests using it fail within the verification-cache TTL ' +
 		'(~30 seconds) on other replicas, immediately on this one.',
+	security: SESSION_ONLY_SECURITY,
 	request: { params: TokenIdParam },
 	responses: {
 		200: jsonContent(SuccessResponseSchema, 'Token revoked'),

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -35,6 +35,10 @@ export type NotebookVersion = components['schemas']['NotebookVersion'];
 export type DeploymentInfo = components['schemas']['DeploymentInfo'];
 /** A resolved user identity ({ id, email, name }) from `GET /api/v1/users`. */
 export type ResolvedUser = components['schemas']['User'];
+/** A personal access token's metadata (never the secret). */
+export type ApiToken = components['schemas']['ApiToken'];
+/** The create response: metadata plus the one-time plaintext `token`. */
+export type ApiTokenCreated = components['schemas']['ApiTokenCreated'];
 
 export interface ApiError {
 	code: string;

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -3171,6 +3171,263 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/me/tokens': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * List the caller's personal access tokens
+		 * @description Metadata only — the secret is never retrievable after creation.
+		 */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Tokens, newest first */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['ApiToken'][];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Insufficient role */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		/**
+		 * Create a personal access token
+		 * @description Mint a machine credential that acts as the calling user (CI, scripts, the CLI): send it as `Authorization: Bearer mhub_pat_…`. The plaintext token is returned once, in this response, and never again. Requires session (SSO) auth — a token cannot mint tokens.
+		 */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					'application/json': {
+						/** @example ci-deploy */
+						name: string;
+						/**
+						 * @description Days until expiry; omit for a non-expiring token.
+						 * @example 90
+						 */
+						expires_in_days?: number;
+					};
+				};
+			};
+			responses: {
+				/** @description The new token — copy it now; it is never shown again */
+				201: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['ApiTokenCreated'];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Insufficient role */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Resource limit reached */
+				429: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/me/tokens/{tokenId}': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		post?: never;
+		/**
+		 * Revoke a personal access token
+		 * @description Deletes the token; API requests using it fail within the verification-cache TTL (~30 seconds) on other replicas, immediately on this one.
+		 */
+		delete: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					tokenId: string;
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Token revoked */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['SuccessResponse'];
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Insufficient role */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -3509,6 +3766,19 @@ export interface components {
 			id: string;
 			email: string;
 			name: string;
+		};
+		ApiTokenCreated: components['schemas']['ApiToken'] & {
+			token: string;
+		};
+		ApiToken: {
+			id: string;
+			name: string;
+			/** Format: date-time */
+			created_at: string;
+			/** Format: date-time */
+			expires_at?: string;
+			/** Format: date-time */
+			last_used_at?: string;
 		};
 	};
 	responses: never;

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -44,6 +44,32 @@ describe('createFromEnv auth backend selection', () => {
 			/Unknown MARIMOHUB_AUTH_BACKEND/,
 		);
 	});
+
+	it('wraps the SSO adapter with personal-access-token support', async () => {
+		const deps = createFromEnv({
+			...baseEnv,
+			MARIMOHUB_AUTH_BACKEND: 'dev',
+			MARIMOHUB_AUTH_DEV_USER_ID: 'alice',
+			MARIMOHUB_AUTH_DEV_EMAIL: 'alice@example.com',
+		});
+		// A PAT resolves through the TokenService — issue one against the same
+		// bucket the deps were wired over.
+		const alice = (await deps.authenticator.authenticate(new Request('http://x')))!;
+		await deps.services.identities.upsert(alice);
+		const { token } = await deps.services.tokens.create({ name: 'ci' }, alice.id);
+
+		const viaPat = await deps.authenticator.authenticate(
+			new Request('http://x', { headers: { authorization: `Bearer ${token}` } }),
+		);
+		expect(viaPat?.id).toBe('alice');
+
+		// An invalid PAT is rejected outright — never a fall-through to the SSO
+		// adapter (which here would happily authenticate anyone).
+		const viaBadPat = await deps.authenticator.authenticate(
+			new Request('http://x', { headers: { authorization: 'Bearer mhub_pat_bogus' } }),
+		);
+		expect(viaBadPat).toBeNull();
+	});
 });
 
 describe('createFromEnv oidc email-domain allowlist', () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -13,6 +13,7 @@
  * examples/cloudflare-worker rather than here.
  */
 import {
+	composeAuthenticators,
 	createServices,
 	Millis,
 	ProxyExposure,
@@ -245,8 +246,9 @@ export function createFromEnv(env: Env = process.env, metrics?: Metrics): ApiDep
 	const { authenticator, authRoutes } = makeAuth(env);
 	const sessionLifetime = parseSessionLifetime(env);
 	const sandboxImages = resolveSandboxImages(env);
+	const services = createServices(bucket, metrics);
 	const deps: ApiDeps = {
-		services: createServices(bucket, metrics),
+		services,
 		bucket,
 		// The provider-side lifetime cap (CoreWeave/E2B) defaults to 2× the session
 		// TTL: an orphan backstop only, so the record-driven sweep always gets to
@@ -254,7 +256,9 @@ export function createFromEnv(env: Env = process.env, metrics?: Metrics): ApiDep
 		compute: makeCompute(env, {
 			sessionMaxLifetimeSeconds: Millis.toSeconds(sessionLifetime.maxLifetimeMs),
 		}),
-		authenticator,
+		// Personal access tokens ride on every deployment: a `mhub_pat_` bearer
+		// resolves through the TokenService, everything else through the SSO adapter.
+		authenticator: composeAuthenticators(services.tokens, authenticator),
 		authRoutes,
 		sandbox: {
 			bucket: makeSandboxBucketConfig(env),

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -12,6 +12,7 @@ export type NotebookId = string & { __brand: 'NotebookId' };
 export type SnapshotId = string & { __brand: 'SnapshotId' };
 export type VersionId = string & { __brand: 'VersionId' };
 export type SessionId = string & { __brand: 'SessionId' };
+export type TokenId = string & { __brand: 'TokenId' };
 
 // A user id is the opaque auth `sub` (OIDC / Cloudflare Access / dev). We do not
 // mint or format it, so unlike the ids above it is a *nominal* brand only — it
@@ -49,6 +50,10 @@ function randomBody(): string {
 // keeps the newest N versions by treating the lexicographically-largest ids as
 // newest, so non-monotonic ids would make pruning (and its tests) flaky.
 const nextVersionUlid = monotonicFactory();
+
+// Token ids are bare ULIDs (no `tok_` prefix): they ride inside the PAT string
+// (`mhub_pat_<tokenId>_<secret>`), where `_` is the field separator.
+const nextTokenUlid = monotonicFactory();
 
 // --- Id namespaces (guard / assert / parse / create) ---
 //
@@ -123,6 +128,7 @@ export const SessionId = defineId<SessionId>(
 	/^sess-[0-9a-z]{16}$/,
 	() => `sess-${randomBody()}`,
 );
+export const TokenId = defineId<TokenId>('TokenId', /^[0-9A-Z]{26}$/, () => nextTokenUlid());
 
 // A brand with no format/generator — `is` only checks "non-empty string". Used
 // for opaque provider ids (see UserId). `parse` brands a trusted value (e.g. an
@@ -166,6 +172,7 @@ export const createNotebookId = NotebookId.create;
 export const createSnapshotId = SnapshotId.create;
 export const createVersionId = VersionId.create;
 export const createSessionId = SessionId.create;
+export const createTokenId = TokenId.create;
 
 // Event object keys use a monotonic ULID so that, even when many events are
 // written within the same millisecond, the keys still sort in append order.

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,4 +1,12 @@
-import type { NotebookId, ProjectId, SessionId, SnapshotId, UserId, VersionId } from './ids';
+import type {
+	NotebookId,
+	ProjectId,
+	SessionId,
+	SnapshotId,
+	TokenId,
+	UserId,
+	VersionId,
+} from './ids';
 
 export interface VersionPaths {
 	code: string;
@@ -106,6 +114,10 @@ export const paths = {
 	sessionsForProject: (projectId: ProjectId) => `_system/sessions/${projectId}/`,
 	identity: (userId: UserId) => `_system/identities/${encodeURIComponent(userId)}.json`,
 	identitiesPrefix: '_system/identities/',
+	// One mutable record per personal access token, keyed by the id embedded in
+	// the presented token so verification is a single GET (no index object).
+	token: (tokenId: TokenId) => `_system/tokens/${tokenId}.json`,
+	tokensPrefix: '_system/tokens/',
 	eventsPrefix: '_system/events/',
 	eventsForDate: (date: string) => `_system/events/${date}/`,
 	event: (date: string, id: string) => `_system/events/${date}/${id}.json`,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -6,7 +6,16 @@ import {
 	SESSION_STATUSES,
 	SOURCE_TYPES,
 } from './constants';
-import { ProjectId, NotebookId, SnapshotId, VersionId, SessionId, SandboxId, UserId } from './ids';
+import {
+	ProjectId,
+	NotebookId,
+	SnapshotId,
+	VersionId,
+	SessionId,
+	SandboxId,
+	TokenId,
+	UserId,
+} from './ids';
 
 // --- Schema versioning ---
 //
@@ -71,6 +80,7 @@ export const SnapshotIdSchema = z.string().refine(SnapshotId.is);
 export const VersionIdSchema = z.string().refine(VersionId.is);
 export const SessionIdSchema = z.string().refine(SessionId.is);
 export const SandboxIdSchema = z.string().refine(SandboxId.is);
+export const TokenIdSchema = z.string().refine(TokenId.is);
 // User ids (`author`/`owner`/`user_id`/`actor` foreign keys) are the opaque auth
 // `sub`. UserId.is only checks non-empty, so this brands without imposing a
 // format the identity provider doesn't guarantee.
@@ -472,6 +482,32 @@ export const IdentitySchema = z.object({
 });
 
 export type Identity = z.infer<typeof IdentitySchema>;
+
+// --- Personal access token ---
+//
+// A machine credential acting as its issuing user (CI, scripts, the CLI). Only
+// the SHA-256 of the secret is stored. Like Identity, this is a mutable
+// last-writer-wins per-token object (the coarse `last_used_at` refresh
+// rewrites it), so it carries no `schema_version`.
+export const TokenSchema = z.object({
+	id: TokenIdSchema,
+	user_id: UserIdSchema,
+	name: z.string(),
+	/** Lowercase-hex SHA-256 of the token secret. Never leaves the server. */
+	hash: z.string(),
+	created_at: z.iso.datetime(),
+	expires_at: z.iso.datetime().optional(),
+	/** Daily-coalesced usage marker (last-writer-wins, like the identity directory). */
+	last_used_at: z.iso.datetime().optional(),
+});
+
+export type Token = z.infer<typeof TokenSchema>;
+
+export type PublicToken = Omit<Token, 'hash'>;
+export function toPublicToken(token: Token): PublicToken {
+	const { hash: _hash, ...rest } = token;
+	return rest;
+}
 
 // --- Event ---
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -486,10 +486,15 @@ export type Identity = z.infer<typeof IdentitySchema>;
 // --- Personal access token ---
 //
 // A machine credential acting as its issuing user (CI, scripts, the CLI). Only
-// the SHA-256 of the secret is stored. Like Identity, this is a mutable
-// last-writer-wins per-token object (the coarse `last_used_at` refresh
-// rewrites it), so it carries no `schema_version`.
-export const TokenSchema = z.object({
+// the SHA-256 of the secret is stored. A mutable per-token object (the coarse
+// `last_used_at` refresh rewrites it), so it carries no `schema_version`.
+//
+// `looseObject` for the same rolling-deploy reason as the snapshot schemas: the
+// `last_used_at` touch reads-modifies-writes the whole record, so a strict parse
+// would strip fields a newer replica added and silently downgrade the object.
+// The API projection (`toResponse` in routes/tokens.ts) is an explicit pick, so
+// preserved unknown keys never leak into a response.
+export const TokenSchema = z.looseObject({
 	id: TokenIdSchema,
 	user_id: UserIdSchema,
 	name: z.string(),
@@ -503,10 +508,23 @@ export const TokenSchema = z.object({
 
 export type Token = z.infer<typeof TokenSchema>;
 
-export type PublicToken = Omit<Token, 'hash'>;
+// Explicit Pick (not Omit): the schema is loose, so `Token` carries an index
+// signature; `Omit` would collapse the named keys under it (and preserved
+// unknown fields must never leak into a response anyway — same reasoning as
+// `toPublicProjectEntry`). The one field to hide is `hash`.
+export type PublicToken = Pick<
+	Token,
+	'id' | 'user_id' | 'name' | 'created_at' | 'expires_at' | 'last_used_at'
+>;
 export function toPublicToken(token: Token): PublicToken {
-	const { hash: _hash, ...rest } = token;
-	return rest;
+	return {
+		id: token.id,
+		user_id: token.user_id,
+		name: token.name,
+		created_at: token.created_at,
+		...(token.expires_at !== undefined ? { expires_at: token.expires_at } : {}),
+		...(token.last_used_at !== undefined ? { last_used_at: token.last_used_at } : {}),
+	};
 }
 
 // --- Event ---

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -11,6 +11,7 @@ import { MaintenanceService } from './catalog/MaintenanceService';
 import { NotebookService } from './content/NotebookService';
 import { ProjectService } from './content/ProjectService';
 import { SessionService } from './runtime/SessionService';
+import { TokenService } from './tokens/TokenService';
 
 export { CatalogService } from './catalog/CatalogService';
 export { EventService } from './catalog/EventService';
@@ -34,6 +35,16 @@ export type {
 	SessionLifecycleConfig,
 	SweepResult,
 } from './runtime/sessionLifecycle';
+export {
+	bearerToken,
+	hashPatSecret,
+	isPatRequest,
+	isPersonalAccessToken,
+	PAT_PREFIX,
+	TokenService,
+} from './tokens/TokenService';
+export type { CreatedToken, CreateTokenInput } from './tokens/TokenService';
+export { composeAuthenticators } from './tokens/composeAuthenticators';
 export { listAllKeys } from './catalog/storage';
 export { mutateObject, withCasRetry, type CasRetryOptions } from './catalog/cas';
 export { createWorkspaceLoadStrategies, SandboxProvisioner } from './runtime/SandboxProvisioner';
@@ -101,9 +112,20 @@ export function createServices(bucket: Bucket, metrics: Metrics = noopMetrics) {
 	const notebooks = new NotebookService(bucket, catalog, metrics);
 	const sessions = new SessionService(bucket, metrics);
 	const identities = new IdentityService(bucket);
+	const tokens = new TokenService(bucket, identities);
 	const maintenance = new MaintenanceService(bucket, metrics);
 	const idempotency = new IdempotencyService(bucket);
-	return { catalog, events, projects, notebooks, sessions, identities, maintenance, idempotency };
+	return {
+		catalog,
+		events,
+		projects,
+		notebooks,
+		sessions,
+		identities,
+		tokens,
+		maintenance,
+		idempotency,
+	};
 }
 
 /**

--- a/packages/core/src/services/tokens/TokenService.test.ts
+++ b/packages/core/src/services/tokens/TokenService.test.ts
@@ -93,6 +93,22 @@ describe('TokenService', () => {
 			await tokens.revoke(OWNER, TokenId.parse(created[0].record.id));
 			await expect(tokens.create({ name: 'now-fits' }, OWNER)).resolves.toBeTruthy();
 		});
+
+		it('does not count expired tokens toward the cap', async () => {
+			// Fill the cap with short-lived tokens...
+			for (let i = 0; i < TokenService.MAX_TOKENS_PER_USER; i++) {
+				await tokens.create({ name: `t${i}`, expiresInDays: 1 }, OWNER);
+			}
+			await expect(tokens.create({ name: 'blocked' }, OWNER)).rejects.toThrow(
+				ResourceExhaustedError,
+			);
+
+			// ...then let them all expire: minting a replacement must succeed even
+			// though the 20 expired records still exist (and still list).
+			advanceTime(2 * 24 * 60 * 60 * 1000);
+			await expect(tokens.create({ name: 'fits-now' }, OWNER)).resolves.toBeTruthy();
+			expect((await tokens.list(OWNER)).length).toBe(TokenService.MAX_TOKENS_PER_USER + 1);
+		});
 	});
 
 	describe('list', () => {
@@ -119,6 +135,14 @@ describe('TokenService', () => {
 			const listed = await tokens.list(OWNER);
 			expect(listed.map((t) => t.name)).toEqual(['good']);
 			expect(listed.map((t) => t.id)).toEqual([good.record.id]);
+		});
+
+		it('tolerates a non-JSON record instead of failing the whole list', async () => {
+			await tokens.create({ name: 'good' }, OWNER);
+			await bucket.put(paths.token(TokenId.parse('2'.repeat(26))), 'this is not json{{');
+
+			const listed = await tokens.list(OWNER);
+			expect(listed.map((t) => t.name)).toEqual(['good']);
 		});
 	});
 
@@ -162,6 +186,37 @@ describe('TokenService', () => {
 			// Overwrite with JSON that no longer matches the Token schema.
 			await bucket.put(paths.token(TokenId.parse(record.id)), JSON.stringify({ id: record.id }));
 			expect(await tokens.verify(token)).toBeNull();
+		});
+
+		it('returns null (does not throw) for a non-JSON stored record', async () => {
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			await bucket.put(paths.token(TokenId.parse(record.id)), 'not json at all');
+			await expect(tokens.verify(token)).resolves.toBeNull();
+		});
+
+		it('preserves unknown stored fields when it rewrites last_used_at', async () => {
+			// Forward-compat: an older replica touching last_used_at must not strip a
+			// field a newer replica added (TokenSchema is a looseObject).
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			const key = paths.token(TokenId.parse(record.id));
+			const stored = (await (await bucket.get(key))!.json()) as Record<string, unknown>;
+			await bucket.put(
+				key,
+				JSON.stringify({
+					...stored,
+					future_field: 'keep-me',
+					last_used_at: '2000-01-01T00:00:00.000Z',
+				}),
+			);
+
+			expect(await tokens.verify(token)).toBeTruthy(); // triggers a touch rewrite
+
+			const after = (await (await bucket.get(key))!.json()) as {
+				future_field?: string;
+				last_used_at?: string;
+			};
+			expect(after.future_field).toBe('keep-me'); // unknown key survived
+			expect(after.last_used_at).not.toBe('2000-01-01T00:00:00.000Z'); // and it did rewrite
 		});
 
 		it('rejects a revoked token immediately in the same process', async () => {
@@ -261,6 +316,12 @@ describe('TokenService', () => {
 		it('404s (not 500) on a schema-corrupt record', async () => {
 			const id = TokenId.parse('2'.repeat(26));
 			await bucket.put(paths.token(id), JSON.stringify({ id: 'nope' }));
+			await expect(tokens.revoke(OWNER, id)).rejects.toThrow(NotFoundError);
+		});
+
+		it('404s (not 500) on a non-JSON record', async () => {
+			const id = TokenId.parse('3'.repeat(26));
+			await bucket.put(paths.token(id), 'definitely not json');
 			await expect(tokens.revoke(OWNER, id)).rejects.toThrow(NotFoundError);
 		});
 	});

--- a/packages/core/src/services/tokens/TokenService.test.ts
+++ b/packages/core/src/services/tokens/TokenService.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { advanceTime, MemoryBucket, restoreClock, uid } from '../../testing';
+import { NotFoundError, ResourceExhaustedError } from '../../errors';
+import { TokenId } from '../../ids';
+import { paths } from '../../paths';
+import { IdentityService } from '../identity/IdentityService';
+import {
+	bearerToken,
+	hashPatSecret,
+	isPatRequest,
+	isPersonalAccessToken,
+	PAT_PREFIX,
+	TokenService,
+} from './TokenService';
+
+const withAuth = (value?: string): Request =>
+	new Request('https://hub.example/api/v1/me', {
+		headers: value === undefined ? {} : { authorization: value },
+	});
+
+const OWNER = uid('sub-owner');
+
+describe('TokenService', () => {
+	let bucket: MemoryBucket;
+	let identities: IdentityService;
+	let tokens: TokenService;
+
+	beforeEach(async () => {
+		bucket = new MemoryBucket();
+		identities = new IdentityService(bucket);
+		tokens = new TokenService(bucket, identities);
+		await identities.upsert({ id: OWNER, email: 'owner@x.io', name: 'Owner' });
+	});
+
+	afterEach(() => {
+		restoreClock();
+	});
+
+	describe('create', () => {
+		it('returns a well-formed plaintext token exactly once', async () => {
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+
+			expect(token).toMatch(/^mhub_pat_[0-9A-Z]{26}_[0-9a-z]{32}$/);
+			expect(token).toContain(record.id);
+			expect(record).not.toHaveProperty('hash');
+			expect(record.name).toBe('ci');
+			expect(record.expires_at).toBeUndefined();
+		});
+
+		it('stores only the SHA-256 of the secret, never the plaintext', async () => {
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			const secret = token.slice(token.lastIndexOf('_') + 1);
+
+			const stored = (await (await bucket.get(paths.token(TokenId.parse(record.id))))!.json()) as {
+				hash: string;
+			};
+			expect(stored.hash).toBe(await hashPatSecret(secret));
+			expect(JSON.stringify(stored)).not.toContain(secret);
+		});
+
+		it('stamps expires_at from expiresInDays', async () => {
+			const { record } = await tokens.create({ name: 'short', expiresInDays: 7 }, OWNER);
+			const expected = new Date(record.created_at).getTime() + 7 * 24 * 60 * 60 * 1000;
+			expect(new Date(record.expires_at!).getTime()).toBe(expected);
+		});
+
+		it('mints a distinct id and secret each time', async () => {
+			const a = await tokens.create({ name: 'a' }, OWNER);
+			const b = await tokens.create({ name: 'b' }, OWNER);
+			expect(a.record.id).not.toBe(b.record.id);
+			expect(a.token).not.toBe(b.token);
+		});
+
+		it('enforces the per-user cap', async () => {
+			for (let i = 0; i < TokenService.MAX_TOKENS_PER_USER; i++) {
+				await tokens.create({ name: `t${i}` }, OWNER);
+			}
+			await expect(tokens.create({ name: 'one-too-many' }, OWNER)).rejects.toThrow(
+				ResourceExhaustedError,
+			);
+			// The cap is per user, not global.
+			await identities.upsert({ id: uid('sub-other'), email: 'other@x.io', name: 'Other' });
+			await expect(tokens.create({ name: 'ok' }, uid('sub-other'))).resolves.toBeTruthy();
+		});
+
+		it('frees a slot when a token is revoked', async () => {
+			const created = [];
+			for (let i = 0; i < TokenService.MAX_TOKENS_PER_USER; i++) {
+				created.push(await tokens.create({ name: `t${i}` }, OWNER));
+			}
+			await expect(tokens.create({ name: 'over' }, OWNER)).rejects.toThrow(ResourceExhaustedError);
+
+			await tokens.revoke(OWNER, TokenId.parse(created[0].record.id));
+			await expect(tokens.create({ name: 'now-fits' }, OWNER)).resolves.toBeTruthy();
+		});
+	});
+
+	describe('list', () => {
+		it("returns only the user's tokens, newest first, without hashes", async () => {
+			const a = await tokens.create({ name: 'a' }, OWNER);
+			const b = await tokens.create({ name: 'b' }, OWNER);
+			await tokens.create({ name: 'theirs' }, uid('sub-other'));
+
+			const listed = await tokens.list(OWNER);
+			expect(listed.map((t) => t.name)).toEqual(['b', 'a']);
+			expect(listed.map((t) => t.id)).toEqual([b.record.id, a.record.id]);
+			for (const t of listed) expect(t).not.toHaveProperty('hash');
+		});
+
+		it('is empty for a user with no tokens', async () => {
+			expect(await tokens.list(OWNER)).toEqual([]);
+		});
+
+		it('tolerates a schema-invalid record instead of failing the whole list', async () => {
+			const good = await tokens.create({ name: 'good' }, OWNER);
+			// A record that parses as JSON but not as a Token (e.g. schema drift).
+			await bucket.put(paths.token(TokenId.parse('1'.repeat(26))), JSON.stringify({ id: 'nope' }));
+
+			const listed = await tokens.list(OWNER);
+			expect(listed.map((t) => t.name)).toEqual(['good']);
+			expect(listed.map((t) => t.id)).toEqual([good.record.id]);
+		});
+	});
+
+	describe('verify', () => {
+		it('resolves a valid token to the issuing user', async () => {
+			const { token } = await tokens.create({ name: 'ci' }, OWNER);
+			expect(await tokens.verify(token)).toEqual({
+				id: OWNER,
+				email: 'owner@x.io',
+				name: 'Owner',
+			});
+		});
+
+		it('rejects a wrong secret for a real token id', async () => {
+			const { record } = await tokens.create({ name: 'ci' }, OWNER);
+			expect(await tokens.verify(`${PAT_PREFIX}${record.id}_${'x'.repeat(32)}`)).toBeNull();
+		});
+
+		it('rejects malformed and unknown tokens', async () => {
+			expect(await tokens.verify('not-a-token')).toBeNull();
+			expect(await tokens.verify(`${PAT_PREFIX}garbage`)).toBeNull();
+			expect(await tokens.verify(`${PAT_PREFIX}${'0'.repeat(26)}_${'a'.repeat(32)}`)).toBeNull();
+		});
+
+		it('accepts a token whose expiry is still in the future', async () => {
+			const { token } = await tokens.create({ name: 'short', expiresInDays: 2 }, OWNER);
+			advanceTime(24 * 60 * 60 * 1000); // one day in — not yet past the 2-day expiry
+			expect(await tokens.verify(token)).toBeTruthy();
+		});
+
+		it('rejects an expired token', async () => {
+			const { token } = await tokens.create({ name: 'short', expiresInDays: 1 }, OWNER);
+			expect(await tokens.verify(token)).toBeTruthy();
+
+			advanceTime(2 * 24 * 60 * 60 * 1000);
+			expect(await tokens.verify(token)).toBeNull();
+		});
+
+		it('returns null for a schema-corrupt stored record', async () => {
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			// Overwrite with JSON that no longer matches the Token schema.
+			await bucket.put(paths.token(TokenId.parse(record.id)), JSON.stringify({ id: record.id }));
+			expect(await tokens.verify(token)).toBeNull();
+		});
+
+		it('rejects a revoked token immediately in the same process', async () => {
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			expect(await tokens.verify(token)).toBeTruthy(); // warm the cache
+			await tokens.revoke(OWNER, TokenId.parse(record.id));
+			expect(await tokens.verify(token)).toBeNull();
+		});
+
+		it('does not resurrect a token revoked between load and last_used_at write', async () => {
+			// A sporadically-used CI token whose last_used_at lags to a prior day, so
+			// the next verify triggers a real `touch` write.
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			const key = paths.token(TokenId.parse(record.id));
+			const stored = (await (await bucket.get(key))!.json()) as { last_used_at?: string };
+			await bucket.put(
+				key,
+				JSON.stringify({ ...stored, last_used_at: '2000-01-01T00:00:00.000Z' }),
+			);
+
+			// Delete the object mid-load (the identity lookup runs after the record is
+			// read, before `touch`) to model a concurrent revoke on another replica.
+			// The conditional `touch` must NOT recreate the just-deleted object.
+			vi.spyOn(identities, 'get').mockImplementation(async (id) => {
+				await bucket.delete(key);
+				return { id, email: 'owner@x.io', name: 'Owner', updated_at: '2026-07-24T00:00:00.000Z' };
+			});
+
+			expect(await tokens.verify(token)).toBeTruthy(); // this call still passes...
+			expect(await bucket.get(key)).toBeNull(); // ...but the object stays deleted.
+		});
+
+		it('serves from the positive cache within the TTL, refreshes past it', async () => {
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			expect(await tokens.verify(token)).toBeTruthy();
+
+			// Another replica revokes: this process keeps honoring the token until
+			// the cache entry ages out (the documented revocation lag)...
+			await bucket.delete(paths.token(TokenId.parse(record.id)));
+			expect(await tokens.verify(token)).toBeTruthy();
+
+			// ...and rejects it once the TTL forces a re-read.
+			advanceTime(TokenService.CACHE_TTL_MS + 1);
+			expect(await tokens.verify(token)).toBeNull();
+		});
+
+		it('fails closed when the issuing user has no identity record', async () => {
+			const ghost = uid('sub-ghost');
+			const { token } = await tokens.create({ name: 'ci' }, ghost);
+			expect(await tokens.verify(token)).toBeNull();
+		});
+
+		it('refreshes last_used_at at most once per day', async () => {
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			const key = paths.token(TokenId.parse(record.id));
+
+			await tokens.verify(token);
+			const first = ((await (await bucket.get(key))!.json()) as { last_used_at?: string })
+				.last_used_at;
+			expect(first).toBeTruthy();
+
+			const put = vi.spyOn(bucket, 'put');
+			await tokens.verify(token);
+			expect(put).not.toHaveBeenCalled(); // same UTC day → coalesced
+
+			advanceTime(24 * 60 * 60 * 1000);
+			await tokens.verify(token);
+			const later = ((await (await bucket.get(key))!.json()) as { last_used_at?: string })
+				.last_used_at;
+			expect(later).not.toBe(first);
+		});
+	});
+
+	describe('revoke', () => {
+		it('deletes an own token so it no longer lists or verifies', async () => {
+			const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+			await tokens.revoke(OWNER, TokenId.parse(record.id));
+			expect(await tokens.list(OWNER)).toEqual([]);
+			expect(await tokens.verify(token)).toBeNull();
+		});
+
+		it('404s for a nonexistent token', async () => {
+			await expect(tokens.revoke(OWNER, TokenId.parse('0'.repeat(26)))).rejects.toThrow(
+				NotFoundError,
+			);
+		});
+
+		it("404s for another user's token (no ownership disclosure)", async () => {
+			const { record } = await tokens.create({ name: 'ci' }, OWNER);
+			await expect(tokens.revoke(uid('sub-other'), TokenId.parse(record.id))).rejects.toThrow(
+				NotFoundError,
+			);
+			// Still present and usable by its owner.
+			expect(await tokens.list(OWNER)).toHaveLength(1);
+		});
+
+		it('404s (not 500) on a schema-corrupt record', async () => {
+			const id = TokenId.parse('2'.repeat(26));
+			await bucket.put(paths.token(id), JSON.stringify({ id: 'nope' }));
+			await expect(tokens.revoke(OWNER, id)).rejects.toThrow(NotFoundError);
+		});
+	});
+
+	describe('helpers', () => {
+		it('isPersonalAccessToken keys on the scanner prefix', () => {
+			expect(isPersonalAccessToken('mhub_pat_abc')).toBe(true);
+			expect(isPersonalAccessToken('some-session-jwt')).toBe(false);
+		});
+
+		it('hashPatSecret is deterministic and secret-sensitive', async () => {
+			expect(await hashPatSecret('s1')).toBe(await hashPatSecret('s1'));
+			expect(await hashPatSecret('s1')).not.toBe(await hashPatSecret('s2'));
+			expect(await hashPatSecret('s1')).toMatch(/^[0-9a-f]{64}$/);
+		});
+	});
+
+	// The bearer parser is security-critical: every consumer (authenticator +
+	// route guard) must see the SAME value, so its casing/whitespace handling is
+	// pinned here directly.
+	describe('bearerToken', () => {
+		it.each([
+			['Bearer abc', 'abc'],
+			['bearer abc', 'abc'],
+			['BEARER abc', 'abc'],
+			['BeArEr abc', 'abc'],
+			['Bearer   abc', 'abc'], // extra internal whitespace is collapsed
+			['Bearer abc ', 'abc'], // trailing whitespace trimmed
+		])('parses %j → %j', (header, expected) => {
+			expect(bearerToken(withAuth(header))).toBe(expected);
+		});
+
+		it('returns null for a missing header', () => {
+			expect(bearerToken(withAuth())).toBeNull();
+		});
+
+		it.each([
+			['Basic dXNlcjpwdw=='], // wrong scheme
+			['Bearer'], // scheme only, no credential
+			['Bearer '], // empty credential
+			['Token abc'], // unrelated scheme
+		])('returns null for %j', (header) => {
+			expect(bearerToken(withAuth(header))).toBeNull();
+		});
+	});
+
+	describe('isPatRequest', () => {
+		it('is true for a PAT-shaped bearer, regardless of scheme case', () => {
+			expect(isPatRequest(withAuth(`Bearer ${PAT_PREFIX}abc`))).toBe(true);
+			expect(isPatRequest(withAuth(`BEARER ${PAT_PREFIX}abc`))).toBe(true);
+		});
+
+		it('is false for a non-PAT bearer, a non-bearer scheme, or no header', () => {
+			expect(isPatRequest(withAuth('Bearer some-session-jwt'))).toBe(false);
+			expect(isPatRequest(withAuth('Basic dXNlcjpwdw=='))).toBe(false);
+			expect(isPatRequest(withAuth())).toBe(false);
+		});
+	});
+});

--- a/packages/core/src/services/tokens/TokenService.ts
+++ b/packages/core/src/services/tokens/TokenService.ts
@@ -1,0 +1,275 @@
+import type { Bucket } from '../../ports/bucket';
+import { mapWithConcurrency } from '../../concurrency';
+import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
+import { NotFoundError, ResourceExhaustedError } from '../../errors';
+import { createTokenId, TokenId } from '../../ids';
+import type { UserId } from '../../ids';
+import { timingSafeEqual } from '../../internal/hmac';
+import { toHex } from '../../internal/hex';
+import type { AuthUser } from '../../ports/auth';
+import { paths } from '../../paths';
+import { TokenSchema, toPublicToken } from '../../schema';
+import type { PublicToken, Token } from '../../schema';
+import { listAllKeys } from '../catalog/storage';
+import type { IdentityService } from '../identity/IdentityService';
+
+/**
+ * Personal access token format: `mhub_pat_<tokenId>_<secret>`. The fixed
+ * prefix exists for secret-scanner registration; the embedded ULID id makes
+ * verification a single GET (no scan, no index object); the 32-char base32
+ * secret carries 160 bits of entropy.
+ */
+export const PAT_PREFIX = 'mhub_pat_';
+
+const PAT_RE = /^mhub_pat_([0-9A-Z]{26})_([0-9a-z]{32})$/;
+
+/** Secret alphabet/length mirror the random ids in ids.ts: 32 chars × 5 bits = 160 bits. */
+const SECRET_ALPHABET = '0123456789abcdefghjkmnpqrstvwxyz';
+const SECRET_LENGTH = 32;
+
+/** Whether a bearer credential is (claims to be) a personal access token. */
+export function isPersonalAccessToken(bearer: string): boolean {
+	return bearer.startsWith(PAT_PREFIX);
+}
+
+/**
+ * The bearer credential from a request's `Authorization` header, or null. The
+ * scheme match is case-insensitive (`Bearer`/`bearer`/`BEARER` all parse), so
+ * every consumer sees the same value — anything that re-derives "is this a PAT
+ * request?" with a stricter rule would let a differently-cased scheme slip past.
+ */
+export function bearerToken(request: Request): string | null {
+	const header = request.headers.get('authorization');
+	if (!header) return null;
+	const [scheme, ...rest] = header.split(' ');
+	if (scheme.toLowerCase() !== 'bearer') return null;
+	const token = rest.join(' ').trim();
+	return token || null;
+}
+
+/** Whether a request authenticates with a personal access token. */
+export function isPatRequest(request: Request): boolean {
+	const bearer = bearerToken(request);
+	return bearer !== null && isPersonalAccessToken(bearer);
+}
+
+function generateSecret(): string {
+	const bytes = new Uint8Array(SECRET_LENGTH);
+	crypto.getRandomValues(bytes);
+	let out = '';
+	for (let i = 0; i < SECRET_LENGTH; i++) {
+		out += SECRET_ALPHABET[bytes[i] & 31];
+	}
+	return out;
+}
+
+/** Lowercase-hex SHA-256 of a token secret — the only form ever persisted. */
+export async function hashPatSecret(secret: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(secret));
+	return toHex(new Uint8Array(digest));
+}
+
+export interface CreateTokenInput {
+	name: string;
+	/** Days until expiry; omitted = the token never expires. */
+	expiresInDays?: number;
+}
+
+export interface CreatedToken {
+	/** The full plaintext token. Returned exactly once — it is never stored. */
+	token: string;
+	record: PublicToken;
+}
+
+/**
+ * Personal access tokens: bucket-only machine credentials that act as their
+ * issuing user. `verify` is the request hot path, so positive verifications are
+ * cached per process with a short TTL (the same doctrine as IdentityService's
+ * directory cache). Revocation deletes the per-token object; other replicas
+ * keep honoring a revoked token for at most the cache TTL.
+ */
+export class TokenService {
+	/** Per-user cap on live tokens — an abuse guard, not a capacity limit. */
+	static readonly MAX_TOKENS_PER_USER = 20;
+	/** Positive-cache TTL; bounds the cross-replica revocation lag. */
+	static readonly CACHE_TTL_MS = 30_000;
+
+	// Positive cache only: token id → verified record + resolved user + the object
+	// ETag at load time (so `touch` can write conditionally). Failed lookups are
+	// never cached, so garbage ids cannot grow the map.
+	private readonly cache = new Map<
+		TokenId,
+		{ record: Token; user: AuthUser; etag: string; at: number }
+	>();
+
+	constructor(
+		private bucket: Bucket,
+		private identities: IdentityService,
+	) {}
+
+	async create(input: CreateTokenInput, userId: UserId): Promise<CreatedToken> {
+		// Best-effort cap: concurrent mints can each read a below-limit count and
+		// race past it (no CAS on a fresh key). It's an abuse guard, not a quota.
+		const existing = await this.list(userId);
+		if (existing.length >= TokenService.MAX_TOKENS_PER_USER) {
+			throw new ResourceExhaustedError(
+				`Token limit reached (${TokenService.MAX_TOKENS_PER_USER} per user) — revoke an unused token first`,
+			);
+		}
+
+		const id = createTokenId();
+		const secret = generateSecret();
+		const now = new Date();
+		const record: Token = {
+			id,
+			user_id: userId,
+			name: input.name,
+			hash: await hashPatSecret(secret),
+			created_at: now.toISOString(),
+			...(input.expiresInDays !== undefined
+				? {
+						expires_at: new Date(
+							now.getTime() + input.expiresInDays * 24 * 60 * 60 * 1000,
+						).toISOString(),
+					}
+				: {}),
+		};
+		await this.bucket.put(paths.token(id), JSON.stringify(record));
+		return { token: `${PAT_PREFIX}${id}_${secret}`, record: toPublicToken(record) };
+	}
+
+	/**
+	 * A user's tokens (metadata only — never hashes), newest first. Cost is
+	 * O(all tokens in the deployment): the flat keyspace is keyed by token id so
+	 * `verify` is a single GET, which rules out a per-user prefix here without a
+	 * separate mutable index (which the store's single-CAS-object invariant
+	 * forbids). Acceptable because listing/creating are cold self-service paths,
+	 * bounded by users × MAX_TOKENS_PER_USER — not the request hot path.
+	 */
+	async list(userId: UserId): Promise<PublicToken[]> {
+		const keys = await listAllKeys(this.bucket, paths.tokensPrefix);
+		const records = await mapWithConcurrency(keys, BUCKET_SCAN_CONCURRENCY, async (key) => {
+			const obj = await this.bucket.get(key);
+			if (!obj) return null;
+			// Tolerate a corrupt record: it must not take down the whole list.
+			const parsed = TokenSchema.safeParse(await obj.json());
+			return parsed.success ? parsed.data : null;
+		});
+		return records
+			.filter((r): r is Token => r?.user_id === userId)
+			.sort((a, b) => b.id.localeCompare(a.id)) // ULID ids sort by creation time
+			.map(toPublicToken);
+	}
+
+	/**
+	 * Revoke one of `userId`'s tokens. 404 for a token that does not exist OR
+	 * belongs to someone else — ownership of other users' token ids is not
+	 * disclosed.
+	 */
+	async revoke(userId: UserId, tokenId: TokenId): Promise<void> {
+		const obj = await this.bucket.get(paths.token(tokenId));
+		// safeParse (like `list`): a corrupt record can't prove ownership, and it
+		// already fails `verify`, so treat it as not-found rather than 500ing a
+		// security-relevant "make it stop working" call.
+		const parsed = obj ? TokenSchema.safeParse(await obj.json()) : null;
+		const record = parsed?.success ? parsed.data : null;
+		if (!record || record.user_id !== userId) {
+			throw new NotFoundError(`Token ${tokenId} not found`);
+		}
+		await this.bucket.delete(paths.token(tokenId));
+		// Same-process revocation is immediate; other replicas age out via the TTL.
+		this.cache.delete(tokenId);
+	}
+
+	/**
+	 * Resolve a presented bearer credential to its issuing user, or null for
+	 * anything invalid (malformed, unknown, wrong secret, expired, revoked, or an
+	 * issuer with no identity record). Never throws — the auth middleware maps
+	 * null to 401.
+	 */
+	async verify(bearer: string): Promise<AuthUser | null> {
+		const match = PAT_RE.exec(bearer);
+		if (!match) return null;
+		const tokenId = TokenId.parse(match[1]);
+		const secret = match[2];
+
+		const entry = await this.load(tokenId);
+		if (!entry) return null;
+		const { record, user } = entry;
+
+		// Constant-time compare of the secret's hash. An unknown token id returns
+		// earlier (id-existence is not hidden), but the 160-bit secret is what
+		// gates access, and comparing it in constant time defeats a timing probe.
+		const encoder = new TextEncoder();
+		const presented = encoder.encode(await hashPatSecret(secret));
+		if (!timingSafeEqual(presented, encoder.encode(record.hash))) return null;
+
+		// Expired when the deadline is now or already past.
+		if (record.expires_at !== undefined && new Date(record.expires_at).getTime() <= Date.now()) {
+			this.cache.delete(tokenId);
+			return null;
+		}
+
+		await this.touch(entry);
+		return user;
+	}
+
+	/** Cached entry for a token id, refreshing from the bucket past the TTL. */
+	private async load(tokenId: TokenId): Promise<CacheEntry | null> {
+		const cached = this.cache.get(tokenId);
+		if (cached && Date.now() - cached.at < TokenService.CACHE_TTL_MS) return cached;
+
+		const obj = await this.bucket.get(paths.token(tokenId));
+		if (!obj) {
+			this.cache.delete(tokenId);
+			return null;
+		}
+		const parsed = TokenSchema.safeParse(await obj.json());
+		if (!parsed.success) return null;
+		const record = parsed.data;
+
+		// Resolve `{email, name}` through the identity directory — every issuer has
+		// signed in at least once, which recorded them. Fail closed if it's gone.
+		const identity = await this.identities.get(record.user_id);
+		if (!identity) return null;
+		const entry: CacheEntry = {
+			record,
+			user: { id: identity.id, email: identity.email, name: identity.name },
+			etag: obj.etag,
+			at: Date.now(),
+		};
+		this.cache.set(tokenId, entry);
+		return entry;
+	}
+
+	/**
+	 * Refresh `last_used_at`, coalesced to once per UTC day so the hot path is
+	 * not a bucket PUT per request. The write is conditional on the ETag read at
+	 * load time (`If-Match`): if the token was revoked (deleted) or rewritten
+	 * concurrently, the CAS fails and we do NOT recreate the object — an
+	 * unconditional PUT here would resurrect a just-revoked token. Best-effort: a
+	 * failed write (incl. the lost CAS) must never fail an otherwise-valid auth.
+	 */
+	private async touch(entry: CacheEntry): Promise<void> {
+		const now = new Date().toISOString();
+		if (entry.record.last_used_at?.slice(0, 10) === now.slice(0, 10)) return;
+		const updated: Token = { ...entry.record, last_used_at: now };
+		try {
+			const written = await this.bucket.put(paths.token(entry.record.id), JSON.stringify(updated), {
+				onlyIfEtagMatches: entry.etag,
+			});
+			// Keep the cache coherent so a same-process re-verify uses the new ETag.
+			entry.record = updated;
+			entry.etag = written.etag;
+		} catch {
+			// Usage bookkeeping only — swallow and keep serving the request.
+		}
+	}
+}
+
+interface CacheEntry {
+	record: Token;
+	user: AuthUser;
+	etag: string;
+	at: number;
+}

--- a/packages/core/src/services/tokens/TokenService.ts
+++ b/packages/core/src/services/tokens/TokenService.ts
@@ -1,4 +1,4 @@
-import type { Bucket } from '../../ports/bucket';
+import type { Bucket, BucketObjectBody } from '../../ports/bucket';
 import { mapWithConcurrency } from '../../concurrency';
 import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
 import { NotFoundError, ResourceExhaustedError } from '../../errors';
@@ -69,6 +69,27 @@ export async function hashPatSecret(secret: string): Promise<string> {
 	return toHex(new Uint8Array(digest));
 }
 
+/**
+ * Parse a stored token object, tolerating BOTH non-JSON bytes and schema drift —
+ * a single corrupt record must never take down verify/list/revoke (it just reads
+ * as an invalid credential). Returns null on any failure.
+ */
+async function parseTokenBody(obj: BucketObjectBody): Promise<Token | null> {
+	let raw: unknown;
+	try {
+		raw = await obj.json();
+	} catch {
+		return null;
+	}
+	const parsed = TokenSchema.safeParse(raw);
+	return parsed.success ? parsed.data : null;
+}
+
+/** Whether a token is still live at `nowMs` (a missing expiry never expires). */
+function isLive(token: { expires_at?: string }, nowMs: number): boolean {
+	return token.expires_at === undefined || new Date(token.expires_at).getTime() > nowMs;
+}
+
 export interface CreateTokenInput {
 	name: string;
 	/** Days until expiry; omitted = the token never expires. */
@@ -108,10 +129,13 @@ export class TokenService {
 	) {}
 
 	async create(input: CreateTokenInput, userId: UserId): Promise<CreatedToken> {
-		// Best-effort cap: concurrent mints can each read a below-limit count and
-		// race past it (no CAS on a fresh key). It's an abuse guard, not a quota.
-		const existing = await this.list(userId);
-		if (existing.length >= TokenService.MAX_TOKENS_PER_USER) {
+		const nowMs = Date.now();
+		// The cap counts only LIVE tokens — an expired record still lists (as
+		// metadata) but must not block minting a replacement. Best-effort: concurrent
+		// mints can each read a below-limit count and race past it (no CAS on a fresh
+		// key). It's an abuse guard, not a quota.
+		const live = (await this.list(userId)).filter((t) => isLive(t, nowMs));
+		if (live.length >= TokenService.MAX_TOKENS_PER_USER) {
 			throw new ResourceExhaustedError(
 				`Token limit reached (${TokenService.MAX_TOKENS_PER_USER} per user) — revoke an unused token first`,
 			);
@@ -119,7 +143,7 @@ export class TokenService {
 
 		const id = createTokenId();
 		const secret = generateSecret();
-		const now = new Date();
+		const now = new Date(nowMs);
 		const record: Token = {
 			id,
 			user_id: userId,
@@ -150,10 +174,7 @@ export class TokenService {
 		const keys = await listAllKeys(this.bucket, paths.tokensPrefix);
 		const records = await mapWithConcurrency(keys, BUCKET_SCAN_CONCURRENCY, async (key) => {
 			const obj = await this.bucket.get(key);
-			if (!obj) return null;
-			// Tolerate a corrupt record: it must not take down the whole list.
-			const parsed = TokenSchema.safeParse(await obj.json());
-			return parsed.success ? parsed.data : null;
+			return obj ? parseTokenBody(obj) : null;
 		});
 		return records
 			.filter((r): r is Token => r?.user_id === userId)
@@ -168,11 +189,10 @@ export class TokenService {
 	 */
 	async revoke(userId: UserId, tokenId: TokenId): Promise<void> {
 		const obj = await this.bucket.get(paths.token(tokenId));
-		// safeParse (like `list`): a corrupt record can't prove ownership, and it
-		// already fails `verify`, so treat it as not-found rather than 500ing a
-		// security-relevant "make it stop working" call.
-		const parsed = obj ? TokenSchema.safeParse(await obj.json()) : null;
-		const record = parsed?.success ? parsed.data : null;
+		// A corrupt record can't prove ownership and already fails `verify`, so treat
+		// it as not-found rather than 500ing a security-relevant "make it stop
+		// working" call.
+		const record = obj ? await parseTokenBody(obj) : null;
 		if (!record || record.user_id !== userId) {
 			throw new NotFoundError(`Token ${tokenId} not found`);
 		}
@@ -224,9 +244,8 @@ export class TokenService {
 			this.cache.delete(tokenId);
 			return null;
 		}
-		const parsed = TokenSchema.safeParse(await obj.json());
-		if (!parsed.success) return null;
-		const record = parsed.data;
+		const record = await parseTokenBody(obj);
+		if (!record) return null;
 
 		// Resolve `{email, name}` through the identity directory — every issuer has
 		// signed in at least once, which recorded them. Fail closed if it's gone.

--- a/packages/core/src/services/tokens/composeAuthenticators.test.ts
+++ b/packages/core/src/services/tokens/composeAuthenticators.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MemoryBucket, uid } from '../../testing';
+import { TokenId } from '../../ids';
+import { paths } from '../../paths';
+import type { Authenticator, AuthUser } from '../../ports/auth';
+import { IdentityService } from '../identity/IdentityService';
+import { composeAuthenticators } from './composeAuthenticators';
+import { PAT_PREFIX, TokenService } from './TokenService';
+
+const OWNER = uid('sub-owner');
+const SSO_USER: AuthUser = { id: uid('sub-sso'), email: 'sso@x.io' };
+
+function req(headers: Record<string, string> = {}): Request {
+	return new Request('https://hub.example/api/v1/me', { headers });
+}
+
+const makeSsoMock = () =>
+	vi.fn((_request: Request): Promise<AuthUser | null> => Promise.resolve(SSO_USER));
+
+describe('composeAuthenticators', () => {
+	let bucket: MemoryBucket;
+	let tokens: TokenService;
+	let ssoAuthenticate: ReturnType<typeof makeSsoMock>;
+	let sso: Authenticator;
+
+	beforeEach(async () => {
+		bucket = new MemoryBucket();
+		const identities = new IdentityService(bucket);
+		tokens = new TokenService(bucket, identities);
+		await identities.upsert({ id: OWNER, email: 'owner@x.io', name: 'Owner' });
+		ssoAuthenticate = makeSsoMock();
+		sso = { authenticate: ssoAuthenticate };
+	});
+
+	it('resolves a valid PAT without consulting SSO', async () => {
+		const { token } = await tokens.create({ name: 'ci' }, OWNER);
+		const auth = composeAuthenticators(tokens, sso);
+
+		const user = await auth.authenticate(req({ authorization: `Bearer ${token}` }));
+		expect(user?.id).toBe(OWNER);
+		expect(ssoAuthenticate).not.toHaveBeenCalled();
+	});
+
+	it('an invalid PAT yields null — it never falls through to SSO', async () => {
+		const auth = composeAuthenticators(tokens, sso);
+		const bad = `${PAT_PREFIX}${'0'.repeat(26)}_${'a'.repeat(32)}`;
+
+		expect(await auth.authenticate(req({ authorization: `Bearer ${bad}` }))).toBeNull();
+		expect(
+			await auth.authenticate(req({ authorization: `Bearer ${PAT_PREFIX}mangled` })),
+		).toBeNull();
+		expect(ssoAuthenticate).not.toHaveBeenCalled();
+	});
+
+	it('a revoked but well-formed PAT yields null, never SSO', async () => {
+		const { token, record } = await tokens.create({ name: 'ci' }, OWNER);
+		await bucket.delete(paths.token(TokenId.parse(record.id))); // revoked
+		const auth = composeAuthenticators(tokens, sso);
+		expect(await auth.authenticate(req({ authorization: `Bearer ${token}` }))).toBeNull();
+		expect(ssoAuthenticate).not.toHaveBeenCalled();
+	});
+
+	it('delegates non-PAT requests to SSO', async () => {
+		const auth = composeAuthenticators(tokens, sso);
+
+		expect(await auth.authenticate(req())).toBe(SSO_USER);
+		expect(await auth.authenticate(req({ authorization: 'Bearer some-other-token' }))).toBe(
+			SSO_USER,
+		);
+		expect(await auth.authenticate(req({ authorization: 'Basic dXNlcjpwdw==' }))).toBe(SSO_USER);
+		expect(ssoAuthenticate).toHaveBeenCalledTimes(3);
+	});
+
+	// The scheme match must be case-insensitive — a stricter parse anywhere
+	// downstream (the token-management guard) would then disagree and leak.
+	it.each(['Bearer', 'bearer', 'BEARER', 'BeArEr'])(
+		'resolves the PAT under the %s scheme',
+		async (scheme) => {
+			const { token } = await tokens.create({ name: 'ci' }, OWNER);
+			const auth = composeAuthenticators(tokens, sso);
+			const user = await auth.authenticate(req({ authorization: `${scheme} ${token}` }));
+			expect(user?.id).toBe(OWNER);
+			expect(ssoAuthenticate).not.toHaveBeenCalled();
+		},
+	);
+
+	it('surfaces logoutUrl only when the SSO adapter has one', () => {
+		expect(composeAuthenticators(tokens, sso).logoutUrl).toBeUndefined();
+
+		const withLogout = composeAuthenticators(tokens, {
+			authenticate: async () => null,
+			logoutUrl: () => 'https://idp.example/logout',
+		});
+		expect(withLogout.logoutUrl?.()).toBe('https://idp.example/logout');
+	});
+});

--- a/packages/core/src/services/tokens/composeAuthenticators.ts
+++ b/packages/core/src/services/tokens/composeAuthenticators.ts
@@ -1,0 +1,25 @@
+import type { Authenticator } from '../../ports/auth';
+import { bearerToken, isPersonalAccessToken } from './TokenService';
+import type { TokenService } from './TokenService';
+
+/**
+ * Wrap an SSO `Authenticator` with personal-access-token support. A request
+ * carrying `Authorization: Bearer mhub_pat_…` is resolved by the TokenService
+ * ALONE — a malformed or invalid PAT yields null (401), never a fall-through to
+ * SSO, so a leaked-but-revoked token can't silently downgrade to cookie auth.
+ * Everything else (cookies, no credential) delegates to the SSO adapter
+ * unchanged. The `Authenticator` port itself is untouched.
+ */
+export function composeAuthenticators(tokens: TokenService, sso: Authenticator): Authenticator {
+	const logoutUrl = sso.logoutUrl?.bind(sso);
+	return {
+		async authenticate(request) {
+			const bearer = bearerToken(request);
+			if (bearer !== null && isPersonalAccessToken(bearer)) {
+				return tokens.verify(bearer);
+			}
+			return sso.authenticate(request);
+		},
+		...(logoutUrl ? { logoutUrl } : {}),
+	};
+}

--- a/packages/core/src/testing/bucketContract.ts
+++ b/packages/core/src/testing/bucketContract.ts
@@ -95,6 +95,17 @@ export function bucketContract(name: string, makeBucket: () => Bucket | Promise<
 			).rejects.toBeInstanceOf(PreconditionFailedError);
 		});
 
+		// A conditional put against an ABSENT key must fail, never create. This is
+		// the invariant TokenService.touch relies on to avoid resurrecting a token
+		// deleted (revoked) between load and the last_used_at write — an adapter that
+		// treated a missing object as "matches" would silently reintroduce that bug.
+		it('conditional put throws PreconditionFailedError on an absent key (no create)', async () => {
+			await expect(
+				bucket.put('cas-absent.json', 'x', { onlyIfEtagMatches: 'any-etag' }),
+			).rejects.toBeInstanceOf(PreconditionFailedError);
+			expect(await bucket.get('cas-absent.json')).toBeNull();
+		});
+
 		it('create-if-absent put succeeds when the key is absent', async () => {
 			const put = await bucket.put('cia.json', '1', { onlyIfNotExists: true });
 			expect(put.etag).toBeTruthy();

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -27,6 +27,8 @@ import type {
 	ServerVersion,
 	Session,
 	SecretEntry,
+	ApiToken,
+	ApiTokenCreated,
 } from '../types';
 
 /** How often the notebook table re-polls runtime status, in ms. */
@@ -45,6 +47,44 @@ export function useUserQuery() {
 		queryFn: () => apiFetch<User>('/api/v1/me'),
 		staleTime: Number.POSITIVE_INFINITY,
 		retry: false,
+	});
+}
+
+// Personal access tokens (self-service, on the account menu)
+
+/** The caller's API tokens, newest first — metadata only, never a secret. */
+export function useApiTokensQuery(enabled = true) {
+	return useQuery({
+		queryKey: userKeys.tokens(),
+		queryFn: () => apiFetch<ApiToken[]>('/api/v1/me/tokens'),
+		enabled,
+	});
+}
+
+/** Mint a token. The response's `token` is shown once and never retrievable again. */
+export function useCreateApiToken() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (body: { name: string; expires_in_days?: number }) =>
+			apiFetch<ApiTokenCreated>('/api/v1/me/tokens', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body),
+			}),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: userKeys.tokens() });
+		},
+	});
+}
+
+export function useRevokeApiToken() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (tokenId: string) =>
+			apiFetch<void>(`/api/v1/me/tokens/${tokenId}`, { method: 'DELETE' }),
+		onSuccess: () => {
+			void queryClient.invalidateQueries({ queryKey: userKeys.tokens() });
+		},
 	});
 }
 

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -5,6 +5,7 @@ export const userKeys = {
 	// the caller's ordering.
 	resolve: (ids: readonly string[]) => [...userKeys.all, 'resolve', ids] as const,
 	search: (query: string) => [...userKeys.all, 'search', query] as const,
+	tokens: () => [...userKeys.all, 'tokens'] as const,
 };
 
 export const projectKeys = {

--- a/packages/web/src/components/Account/ApiTokensDialog.test.tsx
+++ b/packages/web/src/components/Account/ApiTokensDialog.test.tsx
@@ -1,0 +1,193 @@
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Toaster } from 'sonner';
+import { ApiTokensDialog } from './ApiTokensDialog';
+import type { ApiToken } from '@/types';
+
+const TOKEN_ID = '01HXY0S6GWMBASVAG3PZ7Y2K5T';
+const PLAINTEXT = `mhub_pat_${TOKEN_ID}_${'a'.repeat(32)}`;
+
+const tokenMeta = (over: Partial<ApiToken> = {}): ApiToken => ({
+	id: TOKEN_ID,
+	name: 'ci-deploy',
+	created_at: '2026-07-01T00:00:00.000Z',
+	...over,
+});
+
+function ok(data: unknown, status = 200) {
+	return new Response(JSON.stringify({ success: true, data }), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+}
+
+/** Route the dialog's requests; the GET list serves `tokens` (mutable). */
+function makeFetch(tokens: ApiToken[]) {
+	const calls: { url: string; method: string; body: unknown }[] = [];
+	const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(input);
+		const method = init?.method ?? 'GET';
+		const body = init?.body ? JSON.parse(init.body as string) : undefined;
+		if (method !== 'GET') calls.push({ url, method, body });
+
+		if (url.includes('/me/tokens')) {
+			if (method === 'GET') return ok(tokens);
+			if (method === 'POST') {
+				return ok(
+					{ ...tokenMeta({ name: (body as { name: string }).name }), token: PLAINTEXT },
+					201,
+				);
+			}
+			if (method === 'DELETE') return ok(undefined);
+		}
+		throw new Error(`unexpected fetch: ${method} ${url}`);
+	});
+	vi.stubGlobal('fetch', impl);
+	return calls;
+}
+
+function setup(tokens: ApiToken[] = []) {
+	const calls = makeFetch(tokens);
+	const onClose = vi.fn();
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>
+			{children}
+			<Toaster />
+		</QueryClientProvider>
+	);
+	render(<ApiTokensDialog isOpen onClose={onClose} />, { wrapper });
+	return { calls, onClose };
+}
+
+beforeEach(() => {
+	// jsdom has no matchMedia; Tooltip's mobile check needs it.
+	vi.stubGlobal('matchMedia', (query: string) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		addListener: () => {},
+		removeListener: () => {},
+		dispatchEvent: () => false,
+	}));
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('ApiTokensDialog', () => {
+	it('shows the empty state when the user has no tokens', async () => {
+		setup([]);
+		expect(await screen.findByText('No tokens yet.')).toBeInTheDocument();
+	});
+
+	it('lists existing tokens with metadata', async () => {
+		setup([
+			tokenMeta(),
+			tokenMeta({
+				id: '01HXY0S6GWMBASVAG3PZ7Y2K5V',
+				name: 'laptop',
+				last_used_at: '2026-07-20T00:00:00.000Z',
+			}),
+		]);
+
+		const rows = await screen.findAllByTestId('token-row');
+		expect(rows).toHaveLength(2);
+		expect(screen.getByText('ci-deploy')).toBeInTheDocument();
+		expect(screen.getByText('laptop')).toBeInTheDocument();
+		expect(screen.getAllByText(/never used/)).toHaveLength(1);
+	});
+
+	it('creates a token and shows the plaintext once with a copy-now warning', async () => {
+		const user = userEvent.setup();
+		const { calls } = setup([]);
+
+		await user.type(await screen.findByLabelText('Name'), 'ci-deploy');
+		await user.type(screen.getByLabelText('Expires in days'), '90');
+		await user.click(screen.getByRole('button', { name: /create token/i }));
+
+		expect(await screen.findByLabelText('API token')).toHaveValue(PLAINTEXT);
+		expect(screen.getByText(/shown once and cannot be retrieved later/i)).toBeInTheDocument();
+		expect(calls).toEqual([
+			{
+				url: '/api/v1/me/tokens',
+				method: 'POST',
+				body: { name: 'ci-deploy', expires_in_days: 90 },
+			},
+		]);
+	});
+
+	it('rejects a blank name without calling the API', async () => {
+		const user = userEvent.setup();
+		const { calls } = setup([]);
+
+		await screen.findByText('No tokens yet.');
+		await user.click(screen.getByRole('button', { name: /create token/i }));
+
+		expect(await screen.findByText(/name the token/i)).toBeInTheDocument();
+		expect(calls).toEqual([]);
+	});
+
+	it('rejects a non-numeric expiry without calling the API', async () => {
+		const user = userEvent.setup();
+		const { calls } = setup([]);
+
+		await user.type(await screen.findByLabelText('Name'), 'ci');
+		await user.type(screen.getByLabelText('Expires in days'), 'soon');
+		await user.click(screen.getByRole('button', { name: /create token/i }));
+
+		expect(await screen.findByText(/whole number of days/i)).toBeInTheDocument();
+		expect(calls).toEqual([]);
+	});
+
+	it('surfaces a server error when creation fails', async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const method = init?.method ?? 'GET';
+				if (String(input).includes('/me/tokens') && method === 'GET') return ok([]);
+				return new Response(
+					JSON.stringify({
+						success: false,
+						error: { code: 'RESOURCE_EXHAUSTED', message: 'Token limit reached' },
+					}),
+					{ status: 429, headers: { 'content-type': 'application/json' } },
+				);
+			}),
+		);
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const wrapper = ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={client}>
+				{children}
+				<Toaster />
+			</QueryClientProvider>
+		);
+		render(<ApiTokensDialog isOpen onClose={vi.fn()} />, { wrapper });
+
+		await user.type(await screen.findByLabelText('Name'), 'ci');
+		await user.click(screen.getByRole('button', { name: /create token/i }));
+
+		expect(await screen.findByText('Token limit reached')).toBeInTheDocument();
+		// The one-time-plaintext panel must NOT appear on a failed create.
+		expect(screen.queryByLabelText('API token')).not.toBeInTheDocument();
+	});
+
+	it('revokes a token after confirmation', async () => {
+		const user = userEvent.setup();
+		const { calls } = setup([tokenMeta()]);
+
+		await user.click(await screen.findByRole('button', { name: 'Revoke ci-deploy' }));
+		await user.click(await screen.findByRole('button', { name: 'Revoke' }));
+
+		await waitFor(() =>
+			expect(calls).toEqual([
+				{ url: `/api/v1/me/tokens/${TOKEN_ID}`, method: 'DELETE', body: undefined },
+			]),
+		);
+	});
+});

--- a/packages/web/src/components/Account/ApiTokensDialog.test.tsx
+++ b/packages/web/src/components/Account/ApiTokensDialog.test.tsx
@@ -102,6 +102,21 @@ describe('ApiTokensDialog', () => {
 		expect(screen.getAllByText(/never used/)).toHaveLength(1);
 	});
 
+	it('shows remaining time for a future expiry and elapsed time for a past one', async () => {
+		const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+		const past = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString();
+		setup([
+			tokenMeta({ id: '01HXY0S6GWMBASVAG3PZ7Y2K5V', name: 'live', expires_at: future }),
+			tokenMeta({ name: 'dead', expires_at: past }),
+		]);
+
+		await screen.findAllByTestId('token-row');
+		// The fix: a future deadline shows a real remaining span, not "just now".
+		expect(screen.getByText(/expires in \d+[dhm]/)).toBeInTheDocument();
+		expect(screen.queryByText(/expires just now/)).not.toBeInTheDocument();
+		expect(screen.getByText(/expired 3d ago/)).toBeInTheDocument();
+	});
+
 	it('creates a token and shows the plaintext once with a copy-now warning', async () => {
 		const user = userEvent.setup();
 		const { calls } = setup([]);

--- a/packages/web/src/components/Account/ApiTokensDialog.tsx
+++ b/packages/web/src/components/Account/ApiTokensDialog.tsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 import { AlertTriangle, Check, Copy, Plus, Trash2 } from 'lucide-react';
 import { Button, ConfirmDialog, DialogModal, IconButton, TextField } from '@/components/ui';
 import { useApiTokensQuery, useCreateApiToken, useRevokeApiToken } from '@/api/hooks';
-import { formatRelative } from '@/lib/time';
+import { formatDuration, formatRelative } from '@/lib/time';
 import type { ApiToken, ApiTokenCreated } from '@/types';
 
 export interface ApiTokensDialogProps {
@@ -40,9 +40,16 @@ function CopyTokenField({ value }: { value: string }) {
 	);
 }
 
-/** "expires <in 30 days>" / "expired <3 days ago>" from the ISO deadline. */
-function expiryLabel(iso: string): string {
-	return `${iso <= new Date().toISOString() ? 'expired' : 'expires'} ${formatRelative(iso)}`;
+/**
+ * "expires in 30d" / "expired 3d ago" from the ISO deadline. A future deadline
+ * needs the remaining span (`formatRelative` flattens all future times to "just
+ * now"); a past one reads naturally as a relative phrase.
+ */
+function expiryLabel(iso: string, now: number = Date.now()): string {
+	const deadline = new Date(iso).getTime();
+	if (Number.isNaN(deadline)) return '';
+	if (deadline <= now) return `expired ${formatRelative(iso, now)}`;
+	return `expires in ${formatDuration(new Date(now).toISOString(), deadline)}`;
 }
 
 /**

--- a/packages/web/src/components/Account/ApiTokensDialog.tsx
+++ b/packages/web/src/components/Account/ApiTokensDialog.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { AlertTriangle, Check, Copy, Plus, Trash2 } from 'lucide-react';
+import { Button, ConfirmDialog, DialogModal, IconButton, TextField } from '@/components/ui';
+import { useApiTokensQuery, useCreateApiToken, useRevokeApiToken } from '@/api/hooks';
+import { formatRelative } from '@/lib/time';
+import type { ApiToken, ApiTokenCreated } from '@/types';
+
+export interface ApiTokensDialogProps {
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+function CopyTokenField({ value }: { value: string }) {
+	const [copied, setCopied] = useState(false);
+
+	const copy = async () => {
+		try {
+			await navigator.clipboard.writeText(value);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			toast.error('Could not copy to clipboard');
+		}
+	};
+
+	return (
+		<div className="flex items-center gap-2">
+			<input
+				readOnly
+				aria-label="API token"
+				value={value}
+				onFocus={(e) => e.target.select()}
+				className="h-9 w-full rounded-md border border-input bg-muted/40 px-3 font-mono text-xs text-foreground outline-none"
+			/>
+			<IconButton label={copied ? 'Copied' : 'Copy token'} onPress={() => void copy()}>
+				{copied ? <Check className="size-4 text-primary" /> : <Copy className="size-4" />}
+			</IconButton>
+		</div>
+	);
+}
+
+/** "expires <in 30 days>" / "expired <3 days ago>" from the ISO deadline. */
+function expiryLabel(iso: string): string {
+	return `${iso <= new Date().toISOString() ? 'expired' : 'expires'} ${formatRelative(iso)}`;
+}
+
+/**
+ * Self-service personal access tokens for the API (CI, scripts, the CLI). The
+ * plaintext is server-side hashed, so it is shown exactly once, right after
+ * creation — the list only ever carries metadata.
+ */
+export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
+	const { data: tokens } = useApiTokensQuery(isOpen);
+	const createToken = useCreateApiToken();
+	const revokeToken = useRevokeApiToken();
+
+	const [name, setName] = useState('');
+	const [expiresInDays, setExpiresInDays] = useState('');
+	const [created, setCreated] = useState<ApiTokenCreated | null>(null);
+	const [revokeTarget, setRevokeTarget] = useState<ApiToken | null>(null);
+
+	const handleCreate = async () => {
+		const trimmed = name.trim();
+		if (!trimmed) {
+			toast.error('Name the token (e.g. "ci-deploy") so you can recognize it later.');
+			return;
+		}
+		const days = expiresInDays.trim();
+		if (days && !/^\d+$/.test(days)) {
+			toast.error('Expiry must be a whole number of days.');
+			return;
+		}
+		try {
+			const result = await createToken.mutateAsync({
+				name: trimmed,
+				...(days ? { expires_in_days: Number(days) } : {}),
+			});
+			setCreated(result);
+			setName('');
+			setExpiresInDays('');
+		} catch (err) {
+			toast.error((err as Error).message);
+		}
+	};
+
+	const handleRevoke = () => {
+		if (!revokeTarget) return;
+		revokeToken.mutate(revokeTarget.id, {
+			onSuccess: () => {
+				toast.success('Token revoked');
+				setRevokeTarget(null);
+			},
+			onError: (err) => toast.error(err.message),
+		});
+	};
+
+	const close = () => {
+		setCreated(null);
+		onClose();
+	};
+
+	return (
+		<DialogModal isOpen={isOpen} onClose={close} title="API tokens" width="md">
+			<div className="flex flex-col gap-4 text-sm">
+				<p className="text-muted-foreground">
+					Personal access tokens let CI, scripts, and the CLI call the API as you: send one as{' '}
+					<code className="text-xs">Authorization: Bearer …</code>. Tokens cannot manage other
+					tokens.
+				</p>
+
+				{created && (
+					<div className="flex flex-col gap-2 rounded-md border p-3">
+						<span className="text-xs font-semibold">{created.name}</span>
+						<CopyTokenField value={created.token} />
+						<div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+							<AlertTriangle className="mt-px size-4 shrink-0" />
+							<span>Copy this token now — it is shown once and cannot be retrieved later.</span>
+						</div>
+					</div>
+				)}
+
+				{tokens &&
+					(tokens.length === 0 ? (
+						!created && <p className="text-muted-foreground">No tokens yet.</p>
+					) : (
+						<ul className="flex flex-col divide-y">
+							{tokens.map((token) => (
+								<li
+									key={token.id}
+									data-testid="token-row"
+									className="flex items-center justify-between gap-3 py-2"
+								>
+									<span className="flex min-w-0 flex-col">
+										<span className="truncate text-xs font-medium">{token.name}</span>
+										<span className="truncate text-xs text-muted-foreground">
+											created {formatRelative(token.created_at)}
+											{token.expires_at ? ` · ${expiryLabel(token.expires_at)}` : ''}
+											{token.last_used_at
+												? ` · last used ${formatRelative(token.last_used_at)}`
+												: ' · never used'}
+										</span>
+									</span>
+									<IconButton
+										label={`Revoke ${token.name}`}
+										tooltip="Revoke token"
+										tone="danger"
+										onPress={() => setRevokeTarget(token)}
+									>
+										<Trash2 className="size-4" />
+									</IconButton>
+								</li>
+							))}
+						</ul>
+					))}
+
+				<form
+					onSubmit={(e) => {
+						e.preventDefault();
+						void handleCreate();
+					}}
+					className="flex flex-col gap-3 border-t pt-4"
+				>
+					<span className="text-xs font-semibold">Create a token</span>
+					<div className="flex gap-2">
+						<div className="flex-1">
+							<TextField label="Name" placeholder="ci-deploy" value={name} onChange={setName} />
+						</div>
+						<div className="w-36 shrink-0">
+							<TextField
+								label="Expires in days"
+								placeholder="never"
+								value={expiresInDays}
+								onChange={setExpiresInDays}
+							/>
+						</div>
+					</div>
+					<div className="flex justify-end">
+						<Button type="submit" variant="primary" isDisabled={createToken.isPending}>
+							<Plus className="size-4" />
+							{createToken.isPending ? 'Creating...' : 'Create token'}
+						</Button>
+					</div>
+				</form>
+
+				<ConfirmDialog
+					isOpen={!!revokeTarget}
+					onClose={() => setRevokeTarget(null)}
+					title="Revoke token"
+					description={`Revoke "${revokeTarget?.name}"? Anything still using it will stop authenticating within about a minute.`}
+					confirmLabel="Revoke"
+					pendingLabel="Revoking..."
+					isPending={revokeToken.isPending}
+					onConfirm={handleRevoke}
+				/>
+			</div>
+		</DialogModal>
+	);
+}

--- a/packages/web/src/components/Header/Header.tsx
+++ b/packages/web/src/components/Header/Header.tsx
@@ -1,14 +1,17 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { MenuTrigger, Button, Popover, Menu, MenuItem, Separator } from 'react-aria-components';
-import { ChevronDown, Copy, Moon, Sun } from 'lucide-react';
+import { ChevronDown, Copy, KeyRound, Moon, Sun } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/context/ThemeContext';
 import { Brand } from '@/components/ui';
+import { ApiTokensDialog } from '@/components/Account/ApiTokensDialog';
 
 export function Header() {
 	const { user, signOut } = useAuth();
 	const { theme, toggleTheme } = useTheme();
+	const [tokensOpen, setTokensOpen] = useState(false);
 
 	return (
 		<header className="sticky top-0 z-40 flex h-14 shrink-0 items-center justify-between border-b bg-background/85 px-4 backdrop-blur-md max-md:px-3">
@@ -51,7 +54,7 @@ export function Header() {
 									else if (key === 'copy-id') {
 										void navigator.clipboard.writeText(user.id);
 										toast.success('User id copied');
-									}
+									} else if (key === 'api-tokens') setTokensOpen(true);
 								}}
 							>
 								<MenuItem
@@ -72,6 +75,13 @@ export function Header() {
 									<Copy className="size-3.5" />
 									Copy user id
 								</MenuItem>
+								<MenuItem
+									id="api-tokens"
+									className="flex cursor-pointer items-center gap-2 px-3 py-2 text-[13px] outline-none transition-colors focus:bg-muted max-md:min-h-11"
+								>
+									<KeyRound className="size-3.5" />
+									API tokens
+								</MenuItem>
 								<Separator className="h-px bg-border" />
 								<MenuItem
 									id="signout"
@@ -84,6 +94,8 @@ export function Header() {
 					</MenuTrigger>
 				)}
 			</div>
+
+			<ApiTokensDialog isOpen={tokensOpen} onClose={() => setTokensOpen(false)} />
 		</header>
 	);
 }

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -19,6 +19,8 @@ import type {
 	Session as ClientSession,
 	SecretEntry as ClientSecretEntry,
 	ResolvedUser as ClientResolvedUser,
+	ApiToken as ClientApiToken,
+	ApiTokenCreated as ClientApiTokenCreated,
 	ApiResponse as ClientApiResponse,
 	ApiError as ClientApiError,
 } from '@marimo-hub/client';
@@ -50,6 +52,10 @@ export type Session = ClientSession;
 export type SecretEntry = ClientSecretEntry;
 /** A resolved user identity ({ id, email, name }) from `GET /api/v1/users`. */
 export type ResolvedUser = ClientResolvedUser;
+/** A personal access token's metadata (never the secret). */
+export type ApiToken = ClientApiToken;
+/** The token-create response: metadata plus the one-time plaintext `token`. */
+export type ApiTokenCreated = ClientApiTokenCreated;
 export type ApiResponse<T> = ClientApiResponse<T>;
 export type ApiError = ClientApiError;
 


### PR DESCRIPTION

## Summary 
Add self-service personal access tokens (`mhub_pat_…`) so CI, scripts, and the CLI can call the API via Authorization: Bearer and act as the issuing user. Includes secure token storage, revocation, last-used tracking, docs, and a web UI to create/list/revoke tokens.

- **New Features**
  - API: POST/GET/DELETE `/api/v1/me/tokens`; PATs cannot manage tokens; OpenAPI updates; client types `ApiToken` and `ApiTokenCreated` in `@marimo-hub/client`.
  - Core (`@marimo-hub/core`): `TokenService` (create/list/revoke/verify) storing only SHA-256; short-TTL positive cache; safe `last_used_at` touch via ETag; `composeAuthenticators` routes PATs without SSO fallback.
  - Web (`@marimo-hub/web`): Account menu → API Tokens dialog to create, copy-once, list, and revoke; new React Query hooks.
  - Config/Examples: All deployments wrap SSO with `composeAuthenticators`; Cloudflare Worker wired. Docs: new “API tokens” page and API doc updates; bucket spec adds `_system/tokens/`.

- **Migration**
  - No changes for default setups. For custom deployments, wrap your SSO authenticator with `composeAuthenticators(tokens, sso)` so PATs are handled and never fall through to SSO.

<sup>Written for commit abbc7df4607476633bebd8971f5c5977de6505c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

