### PR TITLE
test: negative/edge/security tests + fix 20 surfaced bugs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,7 @@ Any S3-compatible store: CoreWeave CAIOS, AWS S3, MinIO, Tigris, Ceph, or Cloudf
 | `MARIMOHUB_STORAGE_S3_BUCKET` | Name of the bucket that backs the hub. | Yes | — | `orgname-marimohub` |
 | `MARIMOHUB_STORAGE_S3_ENDPOINT` | Custom endpoint for non-AWS providers (MinIO, Tigris, Ceph, R2-via-S3). Omit for AWS. | — | — | `https://s3.us-east-1.amazonaws.com` |
 | `MARIMOHUB_STORAGE_S3_REGION` | AWS region for the bucket. | — | `auto (SDK default)` | `us-east-1` |
-| `MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID` 🔒 | Access key id. Both key id and secret must be set together, otherwise the SDK default credential chain is used. | — | — | — |
+| `MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID` 🔒 | Access key id. Set both key id and secret together to use static credentials, or neither to use the SDK default credential chain. Setting only one is rejected at startup. | — | — | — |
 | `MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY` 🔒 | Secret access key (paired with the access key id above). | — | — | — |
 | `MARIMOHUB_STORAGE_S3_FORCE_PATH_STYLE` | Use path-style bucket addressing (required by MinIO/Ceph). | — | `false` | `true` |
 

--- a/packages/api/src/bodyLimit.test.ts
+++ b/packages/api/src/bodyLimit.test.ts
@@ -13,6 +13,22 @@ describe('request body limit', () => {
 		await expectError(res, 413, 'PAYLOAD_TOO_LARGE');
 	});
 
+	it('rejects an oversized /api/sync/* push with a 413 envelope', async () => {
+		const { app } = createTestApi();
+		// A body comfortably over the cap pushed at the git-sync endpoint (its own
+		// bodyLimit, separate from the /api/v1 one).
+		const huge = new Uint8Array(MAX_REQUEST_BYTES + 1024);
+		const res = await app.request(
+			'/api/sync/git/v1/projects/proj-0000000000000000/notebooks/nb-0000000000000000',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/zip' },
+				body: huge,
+			},
+		);
+		await expectError(res, 413, 'PAYLOAD_TOO_LARGE');
+	});
+
 	it('lets a normal-sized body through', async () => {
 		const { request } = createTestApi();
 

--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -1,13 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { HTTPException } from 'hono/http-exception';
 import {
 	ConflictError,
+	createServices,
 	ForbiddenError,
 	NotFoundError,
 	NotInitializedError,
 	PreconditionFailedError,
 	UnavailableError,
 } from '@marimo-hub/core';
-import { createTestApi } from './testing';
+import { createInitializedBucket, createTestApi, expectPage } from './testing';
 
 // Each row drives exactly one branch of the real `createApi` onError handler.
 // The message is the class name so the snapshot stays readable and deterministic.
@@ -38,5 +40,30 @@ describe('createApi onError mapping', () => {
 			table.push({ thrown: c.name, status: res.status, body: await res.json() });
 		}
 		expect(table).toMatchSnapshot();
+	});
+
+	// A thrown HTTPException carries its own Response; onError must honor it rather
+	// than swallowing it into a generic 500.
+	it('honors a thrown HTTPException instead of masking it as a 500', async () => {
+		const { app } = createTestApi();
+		app.get('/_throw', () => {
+			throw new HTTPException(418, { message: "I'm a teapot" });
+		});
+		const res = await app.request('/_throw');
+		expect(res.status).toBe(418);
+		expect(await res.text()).toContain('teapot');
+	});
+});
+
+describe('createApi identity refresh is best-effort', () => {
+	it('serves an authenticated request even when identities.upsert throws', async () => {
+		const bucket = await createInitializedBucket();
+		const services = createServices(bucket);
+		// The best-effort identity-directory refresh must never 500 a request.
+		vi.spyOn(services.identities, 'upsert').mockRejectedValue(new Error('directory down'));
+
+		const { request } = createTestApi({ bucket, deps: { services } });
+		const res = await request('GET', '/projects');
+		expect(await expectPage(res)).toEqual([]);
 	});
 });

--- a/packages/api/src/csrf.test.ts
+++ b/packages/api/src/csrf.test.ts
@@ -72,4 +72,34 @@ describe('CSRF / Origin guard', () => {
 		});
 		expect(res.status).not.toBe(403);
 	});
+
+	it('allows a cross-origin request from a policy.allowedOrigins origin (both signals)', async () => {
+		const allowedApp = createTestApi({
+			deps: { policy: { allowedOrigins: ['https://trusted.example.com'] } },
+		}).app;
+		const res = await allowedApp.request('/api/v1/projects', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Origin: 'https://trusted.example.com',
+				// Both the Sec-Fetch-Site cross-site branch and the Origin/Host branch
+				// must clear via the allowlist.
+				'Sec-Fetch-Site': 'cross-site',
+				Host: 'hub.example.com',
+			},
+			body: JSON.stringify({ name: 'P', description: 'd' }),
+		});
+		expect(res.status).not.toBe(403);
+	});
+
+	it('rejects a state-changing request with a malformed/unparseable Origin (403)', async () => {
+		// `garbage` is not a parseable URL → no host derived → not same-origin, not
+		// allowlisted → rejected.
+		const res = await post({
+			headers: { 'Content-Type': 'application/json', Origin: 'garbage', Host: 'localhost' },
+			body: JSON.stringify({ name: 'x', description: 'y' }),
+		});
+		expect(res.status).toBe(403);
+		expect(((await res.json()) as { error: { code: string } }).error.code).toBe('FORBIDDEN');
+	});
 });

--- a/packages/api/src/routes/ai.test.ts
+++ b/packages/api/src/routes/ai.test.ts
@@ -63,6 +63,40 @@ describe('POST /api/ai/v1/chat/completions', () => {
 		expect(res.status).toBe(404);
 	});
 
+	it('returns 400 for an invalid JSON body (valid token)', async () => {
+		const headers: Record<string, string> = {
+			'content-type': 'application/json',
+			authorization: `Bearer ${await token()}`,
+		};
+		const res = await app().request('/api/ai/v1/chat/completions', {
+			method: 'POST',
+			headers,
+			body: '{ this is not json',
+		});
+		expect(res.status).toBe(400);
+		const json = (await res.json()) as { error: { type: string } };
+		expect(json.error.type).toBe('invalid_request_error');
+	});
+
+	it('returns 502 when the upstream provider is unreachable', async () => {
+		vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+		const res = await post(await token(), { model: 'm', messages: [] });
+		expect(res.status).toBe(502);
+		const json = (await res.json()) as { error: { type: string } };
+		expect(json.error.type).toBe('api_error');
+	});
+
+	it('rejects a well-formed but expired session token with 401', async () => {
+		// Mint the token as if issued 2h ago (default TTL is 1h) so it is already expired.
+		const expired = await mintAiSessionToken(
+			SECRET,
+			{ projectId: 'proj-1', notebookId: 'nb-1', sessionId: 'sess-1', userId: 'u-1' },
+			{ now: () => Date.now() - 2 * 60 * 60 * 1000 },
+		);
+		const res = await post(expired, { model: 'm', messages: [] });
+		expect(res.status).toBe(401);
+	});
+
 	it('forwards to the upstream with the real key and streams back', async () => {
 		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
 			new Response('data: {"x":1}\n\ndata: [DONE]\n\n', {

--- a/packages/api/src/routes/gitSync.test.ts
+++ b/packages/api/src/routes/gitSync.test.ts
@@ -122,6 +122,21 @@ describe('Git sync routes', () => {
 		expect(content.code).toBe('print("synced")');
 	});
 
+	it("rejects a valid sync token used against a DIFFERENT notebook's path (401 IDOR)", async () => {
+		// Two independently-synced notebooks, each with its own per-notebook token.
+		const a = await createSyncedNotebook();
+		const b = await createSyncedNotebook();
+		expect(a.notebookId).not.toBe(b.notebookId);
+
+		// A's token presented on B's path must not authenticate (tokens are scoped
+		// per-notebook, so one notebook's token can't push to another's workspace).
+		await expectError(
+			await syncRequest({ notebookId: b.notebookId, headers: requiredHeaders(a.syncToken) }),
+			401,
+			'UNAUTHORIZED',
+		);
+	});
+
 	it('rejects a request missing a required header, naming it (400)', async () => {
 		const { notebookId, syncToken } = await createSyncedNotebook();
 		const headers = requiredHeaders(syncToken);

--- a/packages/api/src/routes/notebooks.test.ts
+++ b/packages/api/src/routes/notebooks.test.ts
@@ -521,6 +521,28 @@ describe('Notebook routes', () => {
 		await expectError(await request('GET', nb('/nb-0000000000000000/workspace.zip')), 404);
 	});
 
+	it('GET /{nid}/workspace.zip 404s for a malformed (path-traversal-shaped) notebook id', async () => {
+		// `bad..id` fails NotebookId.is → NotFound, never reaching a store read.
+		await expectError(await request('GET', nb('/bad..id/workspace.zip')), 404, 'NOT_FOUND');
+	});
+
+	it('GET /{nid} (and /content, /html) 404s for a notebook in a DIFFERENT project', async () => {
+		// Notebook lives in `projectId`; a second project the caller also owns does not.
+		const created = await expectOk<any>(
+			await request('POST', nb(''), { title: 'NB', description: 'D', code: 'v1' }),
+			201,
+		);
+		const other = await createServices(bucket).projects.createProject(
+			{ name: 'Other', description: 'd' },
+			ACTOR,
+		);
+		const foreign = (path: string) => `/projects/${other.id}/notebooks/${created.id}${path}`;
+
+		await expectError(await request('GET', foreign('')), 404, 'NOT_FOUND');
+		await expectError(await request('GET', foreign('/content')), 404, 'NOT_FOUND');
+		await expectError(await request('GET', foreign('/html')), 404, 'NOT_FOUND');
+	});
+
 	it('GET /{nid}/versions/{vid} returns specific version', async () => {
 		const created = await expectOk<any>(
 			await request('POST', nb(''), { title: 'NB', description: 'D', code: 'v1' }),

--- a/packages/api/src/routes/projects.test.ts
+++ b/packages/api/src/routes/projects.test.ts
@@ -91,6 +91,17 @@ describe('Project routes', () => {
 		expect(await expectPage(await request('GET', '/projects'))).toHaveLength(0);
 	});
 
+	it('GET /projects/{pid} 404s for a soft-deleted project', async () => {
+		const created = await expectOk<any>(
+			await request('POST', '/projects', { name: 'Doomed', description: 'd' }),
+			201,
+		);
+		await expectOk(await request('DELETE', `/projects/${created.id}`));
+
+		// The bytes linger until GC, but a soft-deleted project reads as gone.
+		await expectError(await request('GET', `/projects/${created.id}`), 404, 'NOT_FOUND');
+	});
+
 	it('PUT/DELETE return 403 for a non-member', async () => {
 		const created = await expectOk<any>(
 			await request('POST', '/projects', { name: 'Owned', description: 'd' }),

--- a/packages/api/src/routes/secrets.test.ts
+++ b/packages/api/src/routes/secrets.test.ts
@@ -55,6 +55,51 @@ describe('Secrets routes', () => {
 		expect(JSON.stringify(list)).not.toContain('value');
 	});
 
+	it('stores a managed secret without ever returning or auditing its value', async () => {
+		const pid = await createProject();
+		const SECRET_VALUE = 'sk-super-secret-managed-value';
+
+		// A managed codec (encrypted-in-bucket) so `kind: 'managed'` is accepted.
+		const codec = {
+			encrypt: async (plaintext: string) => ({
+				kek_id: 'test',
+				alg: 'A256GCM' as const,
+				iv: 'aXY=',
+				ciphertext: Buffer.from(plaintext).toString('base64'),
+			}),
+			decrypt: async (env: { ciphertext: string }) =>
+				Buffer.from(env.ciphertext, 'base64').toString('utf8'),
+		};
+		const managedReq = createTestApi({
+			bucket,
+			userId: ACTOR,
+			deps: {
+				secrets: new ProjectSecretsStore({ bucket, resolvers: [stubResolver], managed: codec }),
+			},
+		}).request;
+
+		const put = await expectOk<Record<string, unknown>>(
+			await managedReq('PUT', `/projects/${pid}/secrets/MANAGED_KEY`, {
+				kind: 'managed',
+				value: SECRET_VALUE,
+			}),
+		);
+		// The PUT response is metadata only — never the value.
+		expect(put).toMatchObject({ name: 'MANAGED_KEY', kind: 'managed' });
+		expect(JSON.stringify(put)).not.toContain(SECRET_VALUE);
+
+		// Neither does the list.
+		const list = await expectOk<any[]>(await request('GET', `/projects/${pid}/secrets`));
+		expect(list).toHaveLength(1);
+		expect(list[0]).toMatchObject({ name: 'MANAGED_KEY', kind: 'managed' });
+		expect(JSON.stringify(list)).not.toContain(SECRET_VALUE);
+
+		// Nor the audit trail.
+		const events = await expectOk<any[]>(await request('GET', `/projects/${pid}/events`));
+		expect(events.map((e) => e.event)).toContain('secret.put');
+		expect(JSON.stringify(events)).not.toContain(SECRET_VALUE);
+	});
+
 	it('rejects an unknown backend (422) and a bad name (422)', async () => {
 		const pid = await createProject();
 		await expectError(

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -237,6 +237,47 @@ describe('Session routes', () => {
 		expect(stillThere.status).toBe('starting');
 	});
 
+	it('GET /sessions/{sid} 404s for a session under a DIFFERENT notebook in the same project', async () => {
+		// A second notebook in the SAME project, with its own session.
+		const otherNb = await createServices(bucket).notebooks.createNotebook(
+			pid,
+			{ title: 'NB2', description: 'd', code: 'import marimo as mo' },
+			ACTOR,
+		);
+		const otherSession = await createServices(bucket).sessions.createSession({
+			notebook_id: otherNb.id,
+			project_id: pid,
+			user_id: ACTOR,
+		});
+
+		// Fetch it through the FIRST notebook's path — project-scoped lookup finds it,
+		// but the notebook_id mismatch must keep it out of scope (404).
+		await expectError(
+			await owner('GET', sessionsPath(`/${otherSession.session_id}`)),
+			404,
+			'NOT_FOUND',
+		);
+	});
+
+	it('POST /sessions/{sid}/heartbeat 404s for a session under a DIFFERENT notebook', async () => {
+		const otherNb = await createServices(bucket).notebooks.createNotebook(
+			pid,
+			{ title: 'NB2', description: 'd', code: 'import marimo as mo' },
+			ACTOR,
+		);
+		const otherSession = await createServices(bucket).sessions.createSession({
+			notebook_id: otherNb.id,
+			project_id: pid,
+			user_id: ACTOR,
+		});
+
+		await expectError(
+			await owner('POST', sessionsPath(`/${otherSession.session_id}/heartbeat`)),
+			404,
+			'NOT_FOUND',
+		);
+	});
+
 	it('POST /sessions/{sid}/heartbeat as a non-member returns 403', async () => {
 		const sid = await startSession();
 		await expectError(await stranger('POST', sessionsPath(`/${sid}/heartbeat`)), 403, 'FORBIDDEN');

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -119,6 +119,36 @@ describe('authorizeProxyRequest', () => {
 		const d = await authorizeProxyRequest(req(`/proxy/${token}/`), deps(ACTOR));
 		expect(d).toMatchObject({ kind: 'reject', status: 410 });
 	});
+
+	it('rejects 404 when the token references a session that does not exist', async () => {
+		// A validly-signed token for a session id that was never created.
+		const ghost = 'sess-0000000000000000';
+		const ghostToken = await signProxyToken(pid, ghost as never, SECRET);
+		const d = await authorizeProxyRequest(req(`/proxy/${ghostToken}/`), deps(ACTOR));
+		expect(d).toMatchObject({ kind: 'reject', status: 404 });
+	});
+
+	it('rejects 503 when a running session has no sandbox_origin_url', async () => {
+		// A running session provisioned under a different exposure mode records no
+		// origin — it is authorized but not reachable via the proxy.
+		const services = createServices(bucket);
+		const notebook = await services.notebooks.createNotebook(
+			pid,
+			{ title: 'NB2', description: 'd', code: 'import marimo as mo' },
+			ACTOR,
+		);
+		const session = await services.sessions.createSession({
+			notebook_id: notebook.id,
+			project_id: pid,
+			user_id: ACTOR,
+		});
+		// setRunning WITHOUT an origin url (5th arg omitted).
+		await services.sessions.setRunning(pid, session.session_id, '/proxy/x/', false);
+		const noOriginToken = await signProxyToken(pid, session.session_id as never, SECRET);
+
+		const d = await authorizeProxyRequest(req(`/proxy/${noOriginToken}/`), deps(ACTOR));
+		expect(d).toMatchObject({ kind: 'reject', status: 503 });
+	});
 });
 
 describe('forwardHttp', () => {

--- a/packages/auth-cloudflare-access/src/index.test.ts
+++ b/packages/auth-cloudflare-access/src/index.test.ts
@@ -84,4 +84,19 @@ describe('CloudflareAccessAuthenticator', () => {
 			'https://myteam.cloudflareaccess.com/cdn-cgi/access/logout',
 		);
 	});
+
+	// The audience boundary is enforced by jose: assert the configured aud is passed,
+	// and that a token jose rejects for a mismatched audience yields no user.
+	it('rejects a token whose audience does not match (aud enforced by jose)', async () => {
+		const auth = makeAuth();
+		// Real jose throws JWTClaimValidationFailed when `aud` != the expected audience.
+		jwtVerify.mockRejectedValue(new Error('unexpected "aud" claim value'));
+		expect(await auth.authenticate(requestWithJwt('a.b.c'))).toBeNull();
+		expect(jwtVerify).toHaveBeenCalledWith('a.b.c', { __mockJwks: true }, { audience: 'my-aud' });
+	});
+
+	// Can't be driven hermetically (jose is fully mocked). Latent gap worth pinning:
+	// the adapter passes neither an `algorithms` nor an `issuer` pin to jwtVerify,
+	// leaning entirely on jose's key-derived defaults and the team JWKS URL.
+	it.skip('does not accept a token signed with an unexpected algorithm (no algorithms/issuer pin)', () => {});
 });

--- a/packages/auth-dev/src/index.test.ts
+++ b/packages/auth-dev/src/index.test.ts
@@ -19,4 +19,23 @@ describe('DevAuthenticator', () => {
 	it('has no logout URL', () => {
 		expect(new DevAuthenticator().logoutUrl()).toBeNull();
 	});
+
+	// The dev bypass has no production refusal: under NODE_ENV=production it still
+	// authenticates every request as a fixed user, and config/src/auth.ts accepts
+	// MARIMOHUB_AUTH_BACKEND=dev unconditionally. This pins the current (unsafe)
+	// behavior; flip it to `.toThrow()` once a production gate exists.
+	it('is NOT blocked in a production configuration (invariant currently unenforced)', async () => {
+		const prev = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'production';
+		try {
+			const auth = new DevAuthenticator();
+			await expect(auth.authenticate()).resolves.toEqual({
+				id: 'user',
+				email: 'user@localhost',
+				name: 'Local Dev',
+			});
+		} finally {
+			process.env.NODE_ENV = prev;
+		}
+	});
 });

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -479,4 +479,103 @@ describe('OIDC authenticate (cookie session)', () => {
 		const auth = makeAuthenticator();
 		expect(await auth.authenticate(new Request('http://x'))).toBeNull();
 	});
+
+	// An unsigned alg:none token must never authenticate. The adapter passes no
+	// `algorithms` pin, so this relies on jose restricting a symmetric key to HS*.
+	it('rejects an unsigned alg:none session cookie', async () => {
+		const auth = makeAuthenticator();
+		const b64url = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+		const header = b64url({ alg: 'none', typ: 'JWT' });
+		const payload = b64url({
+			sub: 'user-1',
+			email: 'attacker@example.com',
+			exp: Math.floor(Date.now() / 1000) + 3600,
+		});
+		// alg:none carries an empty signature segment.
+		const unsigned = `${header}.${payload}.`;
+		expect(await auth.authenticate(requestWithCookie(unsigned))).toBeNull();
+	});
+});
+
+describe('OIDC callback integrity (security)', () => {
+	/** Mint a transaction cookie the way `/api/auth/login` does, with a chosen secret. */
+	async function signTxn(opts: { secret: string; verifier?: string; state?: string }) {
+		const secret = new TextEncoder().encode(opts.secret);
+		return new SignJWT({
+			verifier: opts.verifier ?? 'verifier-1',
+			state: opts.state ?? 'state-1',
+			nonce: 'nonce-1',
+		})
+			.setProtectedHeader({ alg: 'HS256' })
+			.setIssuedAt()
+			.setExpirationTime('10m')
+			.sign(secret);
+	}
+
+	// CSRF/PKCE integrity: a txn cookie forged/signed with a foreign secret must not
+	// be trusted — its verifier+state would let an attacker complete another user's
+	// authorization-code exchange.
+	it('redirects session_expired when the txn cookie is signed with a different secret', async () => {
+		const { routes } = makeOidc();
+		const forgedTxn = await signTxn({ secret: 'a-totally-different-secret-32-bytes!!' });
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: `${TXN_COOKIE}=${forgedTxn}` },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/?auth_error=session_expired');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('fails auth_failed when the ID token has a sub but no email', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({ sub: 'user-1', email_verified: true });
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('fails auth_failed when the ID token email is a non-string', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 12345,
+			email_verified: true,
+		});
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+});
+
+describe('OIDC login discovery failure', () => {
+	it('returns 500 OIDC_ERROR when the discovered AS has no authorization_endpoint', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			// authorization_endpoint intentionally omitted
+		});
+		const { routes } = makeOidc();
+
+		const res = await routes.request('/api/auth/login');
+
+		expect(res.status).toBe(500);
+		const body = (await res.json()) as { success: boolean; error: { code: string } };
+		expect(body.success).toBe(false);
+		expect(body.error.code).toBe('OIDC_ERROR');
+	});
 });

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -84,4 +84,51 @@ describe('apiFetch', () => {
 		expect(err.code).toBe('PARSE_ERROR');
 		expect(err.message).toContain('502');
 	});
+
+	it('throws NETWORK_ERROR when fetch rejects (no HTTP response)', async () => {
+		stubFetch(async () => {
+			throw new Error('Failed to fetch');
+		});
+		await expect(apiFetch('/api/projects')).rejects.toMatchObject({
+			name: 'ApiRequestError',
+			code: 'NETWORK_ERROR',
+		});
+	});
+
+	it('throws NETWORK_ERROR on a timeout (retry:0, aborts the request)', async () => {
+		// Never resolves on its own; rejects only when ofetch aborts on the timeout.
+		stubFetch(
+			(_input?: unknown, init?: RequestInit) =>
+				new Promise<Response>((_resolve, reject) => {
+					init?.signal?.addEventListener('abort', () =>
+						reject(new DOMException('The operation was aborted', 'AbortError')),
+					);
+				}),
+		);
+		await expect(apiFetch('/api/projects', { timeout: 5 })).rejects.toMatchObject({
+			code: 'NETWORK_ERROR',
+		});
+	});
+
+	it.each([null, [1, 2], 'plain', 42])(
+		'throws PARSE_ERROR for a valid-JSON body that is not an envelope object (%o)',
+		async (body) => {
+			stubFetch(async () => jsonResponse(body));
+			const err = (await apiFetch('/api/projects').catch((e) => e)) as ApiRequestError;
+			expect(err).toBeInstanceOf(ApiRequestError);
+			expect(err.code).toBe('PARSE_ERROR');
+		},
+	);
+
+	it('honors the envelope over the HTTP status (a 2xx { success:false } still throws)', async () => {
+		stubFetch(async () =>
+			jsonResponse({ success: false, error: { code: 'CONFLICT', message: 'stale' } }, 200),
+		);
+		await expect(apiFetch('/api/projects')).rejects.toMatchObject({ code: 'CONFLICT' });
+	});
+
+	it('returns undefined data when success is true but data is absent', async () => {
+		stubFetch(async () => jsonResponse({ success: true }));
+		expect(await apiFetch('/api/projects')).toBeUndefined();
+	});
 });

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -75,6 +75,39 @@ describe('CloudflareSandboxProvider', () => {
 			expect(fakeSandbox.exec).toHaveBeenCalledWith('echo ok');
 			expect(result).toEqual({ success: true, stdout: 'ok', stderr: '' });
 		});
+
+		it('surfaces success:false from the SDK exec result', async () => {
+			fakeSandbox.exec.mockResolvedValueOnce({ success: false, stdout: '', stderr: 'boom' });
+			const res = await makeProvider().create(SANDBOX_ID).exec('bad');
+			expect(res).toEqual({ success: false, stdout: '', stderr: 'boom' });
+		});
+	});
+
+	describe('instance.writeFiles() bytes', () => {
+		it('base64-armors non-string bytes via writeFile({encoding:base64}), never an inline argv (ARG_MAX)', async () => {
+			fakeSandbox.writeFile.mockClear();
+			fakeSandbox.writeFile.mockResolvedValueOnce(undefined);
+			const big = new Uint8Array(512 * 1024);
+			for (let i = 0; i < big.length; i++) big[i] = i % 256;
+
+			await makeProvider()
+				.create(SANDBOX_ID)
+				.writeFiles([{ path: '/f.bin', content: big }]);
+
+			const [path, armored, opts] = fakeSandbox.writeFile.mock.calls.at(-1)!;
+			expect(path).toBe('/f.bin');
+			expect(opts).toEqual({ encoding: 'base64' });
+			// The payload is base64 TEXT that decodes back to the original bytes.
+			expect(typeof armored).toBe('string');
+			expect(atob(armored as string).length).toBe(big.length);
+		});
+
+		it('destroy is idempotent (each call delegates to the SDK)', async () => {
+			fakeSandbox.destroy.mockResolvedValue(undefined);
+			const instance = makeProvider().create(SANDBOX_ID);
+			await instance.destroy();
+			await expect(instance.destroy()).resolves.toBeUndefined();
+		});
 	});
 
 	describe('instance.exposePort()', () => {
@@ -114,6 +147,46 @@ describe('CloudflareSandboxProvider', () => {
 					expect.objectContaining({ method: 'GET' }),
 				);
 				expect(result).toEqual({ url: 'https://random-words.trycloudflare.com' });
+			} finally {
+				vi.unstubAllGlobals();
+			}
+		});
+
+		it('stops polling and returns at the cap when the tunnel URL never resolves', async () => {
+			fakeSandbox.tunnels.get.mockResolvedValueOnce({ url: 'https://never.trycloudflare.com' });
+			const instance = new CloudflareSandboxProvider(fakeNamespace, { useTunnel: true }).create(
+				SANDBOX_ID,
+			);
+			const fetchSpy = vi.fn().mockRejectedValue(new Error('ENOTFOUND'));
+			vi.stubGlobal('fetch', fetchSpy);
+			// Jump Date.now past the readiness cap after the first probe so the poll
+			// terminates without a real 10s wait.
+			const now = vi.spyOn(Date, 'now');
+			now.mockReturnValueOnce(0).mockReturnValue(1_000_000);
+			try {
+				const result = await instance.exposePort(8080, { hostname: 'ignored' });
+				expect(fetchSpy).toHaveBeenCalledTimes(1);
+				expect(result).toEqual({ url: 'https://never.trycloudflare.com' });
+			} finally {
+				now.mockRestore();
+				vi.unstubAllGlobals();
+			}
+		});
+
+		it('keeps polling while the probe returns 5xx, then returns on success', async () => {
+			fakeSandbox.tunnels.get.mockResolvedValueOnce({ url: 'https://slow.trycloudflare.com' });
+			const instance = new CloudflareSandboxProvider(fakeNamespace, { useTunnel: true }).create(
+				SANDBOX_ID,
+			);
+			const fetchSpy = vi
+				.fn()
+				.mockResolvedValueOnce({ status: 503 })
+				.mockResolvedValueOnce({ status: 200 });
+			vi.stubGlobal('fetch', fetchSpy);
+			try {
+				const result = await instance.exposePort(8080, { hostname: 'ignored' });
+				expect(fetchSpy).toHaveBeenCalledTimes(2);
+				expect(result).toEqual({ url: 'https://slow.trycloudflare.com' });
 			} finally {
 				vi.unstubAllGlobals();
 			}

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
+	base64Encode,
 	buildFindFilesCommand,
 	buildGitCloneCommand,
 	iterableToStream,
+	mapWithConcurrency,
 	parseFindFilesOutput,
 	pollUntilReady,
 	removeUndefined,
@@ -162,6 +164,20 @@ describe('parseFindFilesOutput', () => {
 			absolutePath: '/workspace/has\ttab.py',
 		});
 	});
+
+	it('passes an absolute path outside rootPath through unchanged as relativePath', () => {
+		// A row whose path is NOT under rootPath keeps its absolute path as the
+		// relativePath (no accidental prefix-stripping of an unrelated dir).
+		expect(parseFindFilesOutput('f\t3\t/etc/passwd\n', '/workspace')).toEqual([
+			{
+				name: 'passwd',
+				absolutePath: '/etc/passwd',
+				relativePath: '/etc/passwd',
+				type: 'file',
+				size: 3,
+			},
+		]);
+	});
 });
 
 async function* gen(values: string[], opts: { throwAt?: number } = {}) {
@@ -275,5 +291,82 @@ describe('pollUntilReady', () => {
 			),
 		).rejects.toThrow('process exited');
 		expect(calls).toBe(1);
+	});
+
+	it('throws without ever probing when timeoutMs is 0', async () => {
+		let calls = 0;
+		await expect(
+			pollUntilReady(
+				() => {
+					calls += 1;
+					return true;
+				},
+				{ timeoutMs: 0 },
+			),
+		).rejects.toThrow(/timed out after 0ms/);
+		expect(calls).toBe(0);
+	});
+});
+
+describe('mapWithConcurrency', () => {
+	it('never runs more than `concurrency` fns in flight', async () => {
+		let inFlight = 0;
+		let maxInFlight = 0;
+		const items = Array.from({ length: 20 }, (_, i) => i);
+		await mapWithConcurrency(items, 3, async (n) => {
+			inFlight += 1;
+			maxInFlight = Math.max(maxInFlight, inFlight);
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			inFlight -= 1;
+			return n;
+		});
+		expect(maxInFlight).toBe(3);
+	});
+
+	it('preserves result order despite out-of-order completion', async () => {
+		const items = [30, 5, 20, 1];
+		const results = await mapWithConcurrency(items, 4, async (ms) => {
+			await new Promise((resolve) => setTimeout(resolve, ms));
+			return ms;
+		});
+		expect(results).toEqual([30, 5, 20, 1]);
+	});
+
+	it('rejects when an item fn rejects', async () => {
+		await expect(
+			mapWithConcurrency([1, 2, 3], 2, async (n) => {
+				if (n === 2) throw new Error('item boom');
+				return n;
+			}),
+		).rejects.toThrow('item boom');
+	});
+
+	it('processes every item even when concurrency is 0 (no silent data loss)', async () => {
+		// A misconfigured concurrency of 0 must not silently write nothing — an
+		// adapter routing writeFiles through this would drop every file.
+		const seen: number[] = [];
+		const results = await mapWithConcurrency([1, 2, 3], 0, async (n) => {
+			seen.push(n);
+			return n * 2;
+		});
+		expect(seen.sort((a, b) => a - b)).toEqual([1, 2, 3]);
+		expect(results).toEqual([2, 4, 6]);
+	});
+});
+
+describe('base64Encode', () => {
+	it('encodes a payload larger than the 0x8000 chunk boundary', () => {
+		const bytes = new Uint8Array(0x8000 * 2 + 123);
+		for (let i = 0; i < bytes.length; i++) bytes[i] = i % 256;
+		const decoded = atob(base64Encode(bytes));
+		expect(decoded.length).toBe(bytes.length);
+		for (let i = 0; i < bytes.length; i++) {
+			expect(decoded.charCodeAt(i)).toBe(bytes[i]);
+		}
+	});
+
+	it('round-trips arbitrary bytes including a NUL and high bytes', () => {
+		const bytes = new Uint8Array([0x00, 0xff, 0xfe, 0x80, 0x7f]);
+		expect(base64Encode(bytes)).toBe(btoa('\x00\xff\xfe\x80\x7f'));
 	});
 });

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -220,10 +220,11 @@ export async function mapWithConcurrency<T, R>(
 			results[i] = await fn(items[i]);
 		}
 	};
-	// Floor the pool at 1 so a caller passing 0 (or a negative) still drains every
-	// item serially rather than silently processing nothing — every adapter's
+	// Floor the pool at 1 so a caller passing 0, a negative, or NaN still drains
+	// every item serially rather than silently processing nothing — every adapter's
 	// writeFiles rides this, and a no-op there would drop files with no error.
-	const pool = Math.max(1, Math.min(concurrency, items.length));
+	const requested = Number.isNaN(concurrency) ? 1 : concurrency;
+	const pool = Math.max(1, Math.min(requested, items.length));
 	await Promise.all(Array.from({ length: pool }, worker));
 	return results;
 }

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -220,7 +220,11 @@ export async function mapWithConcurrency<T, R>(
 			results[i] = await fn(items[i]);
 		}
 	};
-	await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+	// Floor the pool at 1 so a caller passing 0 (or a negative) still drains every
+	// item serially rather than silently processing nothing — every adapter's
+	// writeFiles rides this, and a no-op there would drop files with no error.
+	const pool = Math.max(1, Math.min(concurrency, items.length));
+	await Promise.all(Array.from({ length: pool }, worker));
 	return results;
 }
 

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -544,6 +544,91 @@ describe('CoreWeaveCompute', () => {
 		});
 	});
 
+	describe('gateway failures & orphan cleanup', () => {
+		it('create propagates a gateway create rejection (e.g. org wif-config NOT_FOUND)', async () => {
+			const client: CoreWeaveClient = {
+				create: async () => {
+					throw new Error('NOT_FOUND: org wif-config not configured');
+				},
+				fromId: async () => {
+					throw new Error('unused');
+				},
+				list: async () => ({ sandboxes: [] }),
+				delete: async () => {},
+			};
+			await expect(
+				new CoreWeaveCompute(baseConfig, client).create(SANDBOX_ID).exec('true'),
+			).rejects.toThrow(/NOT_FOUND/);
+		});
+
+		it('writeFiles sends a large file via files.write and never places its bytes in an exec argv (ARG_MAX)', async () => {
+			const world = makeWorld();
+			const inst = makeCompute(world).create(SANDBOX_ID, { reuse: false });
+			const big = new Uint8Array(1024 * 1024).fill(7);
+
+			await inst.writeFiles([{ path: '/w/big.bin', content: big }]);
+
+			const fake = [...world.registry.values()][0].fake;
+			// The bytes ride the SDK write API verbatim…
+			expect(fake.batchWrites.at(-1)![0].content).toBe(big);
+			// …and no exec argv (only the small mkdir) carries them.
+			for (const call of fake.runCalls) {
+				expect(call[2].length).toBeLessThan(big.length);
+			}
+		});
+
+		it('exposePort rejects when resolveExposedUrl throws', async () => {
+			const world = makeWorld();
+			const inst = makeCompute(world, {
+				...baseConfig,
+				resolveExposedUrl: async () => {
+					throw new Error('gateway ip unavailable');
+				},
+			}).create(SANDBOX_ID);
+			await inst.exec('true');
+			await expect(inst.exposePort(2718, { hostname: 'h' })).rejects.toThrow(
+				/gateway ip unavailable/,
+			);
+		});
+
+		it('destroy deletes every sandbox tagged with our id (no orphan)', async () => {
+			const world = makeWorld();
+			const compute = makeCompute(world);
+			// Two fresh provisions create two sandboxes carrying the same id tag.
+			await compute.create(SANDBOX_ID, { reuse: false }).exec('true'); // cw-1
+			await compute.create(SANDBOX_ID, { reuse: false }).exec('true'); // cw-2
+			expect(world.created).toHaveLength(2);
+
+			// A re-resolved instance (no cached handle) must delete BOTH.
+			await compute.create(SANDBOX_ID).destroy();
+			expect(world.deleted).toEqual(expect.arrayContaining(['cw-1', 'cw-2']));
+		});
+
+		it('destroy rethrows a non-NotFound delete error', async () => {
+			const client: CoreWeaveClient = {
+				create: async () => ({
+					sandboxId: 'cw-x',
+					commands: { run: async () => procResult(), start: async () => fakeProcess() },
+					files: { readText: async () => '', write: async () => {} },
+					delete: async () => {
+						throw new Error('gRPC unavailable');
+					},
+				}),
+				fromId: async (id) => ({
+					sandboxId: id,
+					commands: { run: async () => procResult(), start: async () => fakeProcess() },
+					files: { readText: async () => '', write: async () => {} },
+					delete: async () => {},
+				}),
+				list: async () => ({ sandboxes: [] }),
+				delete: async () => {},
+			};
+			const inst = new CoreWeaveCompute(baseConfig, client).create(SANDBOX_ID);
+			await inst.exec('true'); // caches the cw-x handle
+			await expect(inst.destroy()).rejects.toThrow(/gRPC unavailable/);
+		});
+	});
+
 	describe('reconnect / dead-status handling', () => {
 		const bareSandbox = (sandboxId: string) => ({
 			sandboxId,

--- a/packages/compute-docker/src/index.test.ts
+++ b/packages/compute-docker/src/index.test.ts
@@ -118,8 +118,11 @@ describe('DockerCompute', () => {
 		expect(write).toBeDefined();
 		// The bytes ride stdin verbatim…
 		expect(write!.stdin).toBe(big);
-		// …and never appear on the argv (which stays tiny regardless of payload size).
-		expect(write!.args.join(' ').length).toBeLessThan(big.length);
+		// …and the argv is the fixed redirect command with no payload interpolated:
+		// the last arg is exactly `cat > <path>` and none of the payload bytes (the
+		// repeated 0x41 'A') appear anywhere in the argv.
+		expect(write!.args.at(-1)).toBe("cat > '/workspace/big.bin'");
+		expect(write!.args.join(' ')).not.toContain('AAAAAAAAAA');
 	});
 
 	it('writeFiles shell-quotes a file path containing a single quote', async () => {
@@ -231,8 +234,18 @@ describe('DockerCompute', () => {
 		expect(rm!.args).toEqual(['rm', '-f', '-v', NAME]);
 	});
 
-	it('destroy is idempotent when called twice', async () => {
-		const { runner, calls } = fakeRunner(defaultHandler);
+	it('destroy is idempotent when called twice (even if the second rm fails)', async () => {
+		let rmCount = 0;
+		const { runner, calls } = fakeRunner((args) => {
+			if (args[0] === 'rm') {
+				rmCount++;
+				// The second removal fails (container already gone); destroy must swallow it.
+				return rmCount >= 2
+					? { stdout: '', stderr: 'No such container', exitCode: 1 }
+					: { stdout: '', stderr: '', exitCode: 0 };
+			}
+			return defaultHandler(args);
+		});
 		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
 		await sb.destroy();
 		await expect(sb.destroy()).resolves.toBeUndefined();

--- a/packages/compute-docker/src/index.test.ts
+++ b/packages/compute-docker/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { SandboxId } from '@marimo-hub/core';
 import { expectListFilesResult } from '@marimo-hub/core/testing';
 import { computeContract } from '@marimo-hub/core/testing/compute-contract';
-import { DockerCompute } from './index';
+import { DockerCompute, spawnDockerRunner } from './index';
 import type { DockerRunner, DockerRunResult } from './index';
 
 /**
@@ -107,6 +107,31 @@ describe('DockerCompute', () => {
 		);
 	});
 
+	it('writeFiles streams a large payload via stdin, never in the argv (ARG_MAX)', async () => {
+		const { runner, calls } = fakeRunner(defaultHandler);
+		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
+
+		const big = new Uint8Array(1024 * 1024).fill(65); // 1 MiB
+		await sb.writeFiles([{ path: '/workspace/big.bin', content: big }]);
+
+		const write = calls.find((c) => c.args.includes('-i') && c.args.join(' ').includes('cat >'));
+		expect(write).toBeDefined();
+		// The bytes ride stdin verbatim…
+		expect(write!.stdin).toBe(big);
+		// …and never appear on the argv (which stays tiny regardless of payload size).
+		expect(write!.args.join(' ').length).toBeLessThan(big.length);
+	});
+
+	it('writeFiles shell-quotes a file path containing a single quote', async () => {
+		const { runner, calls } = fakeRunner(defaultHandler);
+		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
+
+		await sb.writeFiles([{ path: "/workspace/it's a file.py", content: 'x' }]);
+
+		const write = calls.find((c) => c.args.includes('-i') && c.args.join(' ').includes('cat >'));
+		expect(write!.args.at(-1)).toBe("cat > '/workspace/it'\\''s a file.py'");
+	});
+
 	it('writeFiles throws when the stdin write fails', async () => {
 		const { runner } = fakeRunner((args) => {
 			const base = defaultHandler(args);
@@ -204,6 +229,49 @@ describe('DockerCompute', () => {
 		await sb.destroy();
 		const rm = calls.find((c) => c.args[0] === 'rm');
 		expect(rm!.args).toEqual(['rm', '-f', '-v', NAME]);
+	});
+
+	it('destroy is idempotent when called twice', async () => {
+		const { runner, calls } = fakeRunner(defaultHandler);
+		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
+		await sb.destroy();
+		await expect(sb.destroy()).resolves.toBeUndefined();
+		expect(calls.filter((c) => c.args[0] === 'rm')).toHaveLength(2);
+	});
+
+	it('startProcess throws when the container create (docker run) fails', async () => {
+		const { runner } = fakeRunner((args) => {
+			if (args[0] === 'inspect') return { stdout: 'false', stderr: '', exitCode: 1 };
+			if (args[0] === 'run') return { stdout: '', stderr: 'no such image', exitCode: 125 };
+			return;
+		});
+		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
+		await expect(sb.startProcess('uv run marimo edit')).rejects.toThrow(
+			/docker run failed.*no such image/,
+		);
+	});
+
+	it('startProcess throws when the detached launch fails', async () => {
+		const { runner } = fakeRunner((args) => {
+			const base = defaultHandler(args);
+			if (base) return base;
+			// The `exec -d` detached launch fails; ordinary execs still succeed.
+			if (args[0] === 'exec' && args.includes('-d')) {
+				return { stdout: '', stderr: 'exec denied', exitCode: 1 };
+			}
+			return;
+		});
+		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
+		await expect(sb.startProcess('uv run marimo edit')).rejects.toThrow(
+			/startProcess failed.*exec denied/,
+		);
+	});
+
+	it('spawnDockerRunner maps a missing docker binary to exitCode 127 with stderr', async () => {
+		const runner = spawnDockerRunner('marimohub-no-such-docker-binary-xyz');
+		const res = await runner.run(['ps']);
+		expect(res.exitCode).toBe(127);
+		expect(res.stderr).toBeTruthy();
 	});
 
 	it('listActive: parses container names into sandbox ids', async () => {

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -451,10 +451,13 @@ describe('createE2bClient', () => {
 		await expect(handle.kill()).resolves.toBeUndefined();
 	});
 
-	it('defaultLoadSdk throws a clear install error when the e2b SDK is not installed', async () => {
-		// No injected loader → the default runtime import('e2b') fails (SDK unbundled).
-		const client = createE2bClient(baseConfig);
-		await expect(client.create({})).rejects.toThrow(/requires the 'e2b' SDK/);
+	it('surfaces a loadSdk failure (e.g. the e2b SDK is not installed)', async () => {
+		// Inject a deterministic failing loader instead of relying on `e2b` being absent
+		// from the environment, and assert the failure reaches the caller.
+		const client = createE2bClient(baseConfig, async () => {
+			throw new Error("Cannot find package 'e2b'");
+		});
+		await expect(client.create({})).rejects.toThrow(/Cannot find package 'e2b'/);
 	});
 
 	it('surfaces CommandExitError-like SDK failures as command results', async () => {

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -212,6 +212,35 @@ describe('E2bCompute', () => {
 		).rejects.toThrow();
 	});
 
+	it('writeFiles sends a Uint8Array subarray as its own byte range only', async () => {
+		const fake = new FakeE2b();
+		const backing = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+		const view = backing.subarray(2, 5); // bytes [2,3,4]
+		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+		await sb.writeFiles([{ path: '/a.bin', content: view }]);
+		const stored = [...fake.sandboxes.values()][0].files.get('/a.bin') as unknown as ArrayBuffer;
+		expect(stored.byteLength).toBe(3);
+		expect([...new Uint8Array(stored)]).toEqual([2, 3, 4]);
+	});
+
+	it('batches bytes via files.write (ArrayBuffer), never a shell argv (ARG_MAX)', async () => {
+		const fake = new FakeE2b();
+		const big = new Uint8Array(1024 * 1024);
+		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+		await sb.writeFiles([{ path: '/big.bin', content: big }]);
+		// Bytes go over the files API — no exec/command is used to write them.
+		expect(fake.runCalls).toEqual([]);
+		const stored = [...fake.sandboxes.values()][0].files.get('/big.bin') as unknown as ArrayBuffer;
+		expect(stored.byteLength).toBe(big.length);
+	});
+
+	it('destroy resolves as a no-op when no handle and no matching sandbox exist', async () => {
+		const fake = new FakeE2b();
+		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+		await expect(sb.destroy()).resolves.toBeUndefined();
+		expect([...fake.sandboxes.values()].some((s) => s.killed)).toBe(false);
+	});
+
 	it('destroy kills the sandbox', async () => {
 		const fake = new FakeE2b();
 		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
@@ -375,6 +404,59 @@ describe('E2bCompute', () => {
 });
 
 describe('createE2bClient', () => {
+	it('threads apiKey (and domain) into every SDK call', async () => {
+		const handle = {
+			sandboxId: 'e2b-1',
+			commands: { run: vi.fn(), kill: vi.fn() },
+			files: { write: vi.fn(), read: vi.fn() },
+			getHost: vi.fn(),
+			kill: vi.fn(),
+		};
+		const create = vi.fn(async () => handle);
+		const connect = vi.fn(async () => handle);
+		const list = vi.fn(() => []);
+		const sdk: E2bSdk = { Sandbox: { create, connect, list } };
+		const client = createE2bClient(
+			{ apiKey: 'my-key', template: 'tpl', domain: 'e2b.internal' },
+			async () => sdk,
+		);
+
+		await client.create({});
+		await client.connect('e2b-1');
+		await client.list();
+
+		expect(create).toHaveBeenCalledWith(expect.anything(), {
+			apiKey: 'my-key',
+			domain: 'e2b.internal',
+		});
+		expect(connect).toHaveBeenCalledWith('e2b-1', { apiKey: 'my-key', domain: 'e2b.internal' });
+		expect(list).toHaveBeenCalledWith({ apiKey: 'my-key', domain: 'e2b.internal' });
+	});
+
+	it('runBackground does not throw when the SDK exposes no commands.kill', async () => {
+		const sdk: E2bSdk = {
+			Sandbox: {
+				connect: vi.fn(async () => ({
+					sandboxId: 'e2b-1',
+					commands: { run: vi.fn(async () => ({ pid: 'p1' })) }, // no kill
+					files: { write: vi.fn(), read: vi.fn() },
+					getHost: vi.fn(),
+					kill: vi.fn(),
+				})),
+			},
+		};
+		const client = createE2bClient(baseConfig, async () => sdk);
+		const sb = await client.connect('e2b-1');
+		const handle = await sb.commands.runBackground('sleep 1');
+		await expect(handle.kill()).resolves.toBeUndefined();
+	});
+
+	it('defaultLoadSdk throws a clear install error when the e2b SDK is not installed', async () => {
+		// No injected loader → the default runtime import('e2b') fails (SDK unbundled).
+		const client = createE2bClient(baseConfig);
+		await expect(client.create({})).rejects.toThrow(/requires the 'e2b' SDK/);
+	});
+
 	it('surfaces CommandExitError-like SDK failures as command results', async () => {
 		const sdk: E2bSdk = {
 			Sandbox: {

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -224,6 +224,8 @@ describe('createK8sClient', () => {
 	it('streams a Uint8Array stdin as raw bytes to the pod (objectMode:false)', async () => {
 		const client = createK8sClient({ namespace: 'kernels' });
 		const received: Buffer[] = [];
+		let objectMode: boolean | undefined;
+		let everyChunkWasRawBytes = true;
 		k8sMock.exec.mockImplementation(
 			async (
 				_namespace: string,
@@ -237,7 +239,13 @@ describe('createK8sClient', () => {
 				statusCallback: (status: unknown) => void,
 			) => {
 				const socket = new EventEmitter();
-				stdin?.on('data', (chunk) => received.push(Buffer.from(chunk)));
+				objectMode = stdin?.readableObjectMode;
+				stdin?.on('data', (chunk) => {
+					// In object mode the whole Uint8Array would arrive as one non-Buffer
+					// object chunk; a byte stream delivers Buffer chunks.
+					if (!Buffer.isBuffer(chunk)) everyChunkWasRawBytes = false;
+					received.push(Buffer.from(chunk));
+				});
 				stdin?.on('end', () => {
 					statusCallback({ status: 'Success' });
 					setTimeout(() => socket.emit('close'), 0);
@@ -248,11 +256,19 @@ describe('createK8sClient', () => {
 
 		const bytes = new Uint8Array([0xff, 0x00, 0x80, 0x7f]);
 		const res = await client.exec('pod-1', ['sh', '-lc', 'cat'], bytes);
+		expect(objectMode).toBe(false);
+		expect(everyChunkWasRawBytes).toBe(true);
 		expect(Array.from(Buffer.concat(received))).toEqual([0xff, 0x00, 0x80, 0x7f]);
 		expect(res.exitCode).toBe(0);
 	});
 
-	it('defaults a Failure status with a missing/non-numeric ExitCode to exit code 1', async () => {
+	it.each([
+		['a missing ExitCode cause', { status: 'Failure' }],
+		[
+			'a non-numeric ExitCode cause',
+			{ status: 'Failure', details: { causes: [{ reason: 'ExitCode', message: 'boom' }] } },
+		],
+	])('defaults a Failure status with %s to exit code 1', async (_label, status) => {
 		const client = createK8sClient({ namespace: 'kernels' });
 		k8sMock.exec.mockImplementation(
 			async (
@@ -267,7 +283,7 @@ describe('createK8sClient', () => {
 				statusCallback: (status: unknown) => void,
 			) => {
 				stdin?.resume();
-				statusCallback({ status: 'Failure' }); // no details.causes → ExitCode unknown
+				statusCallback(status);
 				const socket = new EventEmitter();
 				setTimeout(() => socket.emit('close'), 0);
 				return socket;

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -198,6 +198,87 @@ describe('createK8sClient', () => {
 		]);
 	});
 
+	it('rethrows a 403 RBAC-forbidden pod create (only 409 is tolerated)', async () => {
+		k8sMock.core.createNamespacedPod.mockRejectedValueOnce({ code: 403 });
+		const client = createK8sClient({ namespace: 'kernels' });
+
+		await expect(
+			client.ensure({
+				name: 'mh-sb',
+				sandboxId: SANDBOX_ID,
+				host: '',
+				image: 'kernel-image',
+				port: 2718,
+				namespace: 'kernels',
+			}),
+		).rejects.toMatchObject({ code: 403 });
+	});
+
+	it('rethrows a non-404 delete error (e.g. 403)', async () => {
+		k8sMock.net.deleteNamespacedIngress.mockRejectedValueOnce({ code: 403 });
+		const client = createK8sClient({ namespace: 'kernels' });
+
+		await expect(client.delete('mh-sb')).rejects.toMatchObject({ code: 403 });
+	});
+
+	it('streams a Uint8Array stdin as raw bytes to the pod (objectMode:false)', async () => {
+		const client = createK8sClient({ namespace: 'kernels' });
+		const received: Buffer[] = [];
+		k8sMock.exec.mockImplementation(
+			async (
+				_namespace: string,
+				_name: string,
+				_container: string,
+				_command: string[],
+				_stdout: Writable,
+				_stderr: Writable,
+				stdin: Readable | null,
+				_tty: boolean,
+				statusCallback: (status: unknown) => void,
+			) => {
+				const socket = new EventEmitter();
+				stdin?.on('data', (chunk) => received.push(Buffer.from(chunk)));
+				stdin?.on('end', () => {
+					statusCallback({ status: 'Success' });
+					setTimeout(() => socket.emit('close'), 0);
+				});
+				return socket;
+			},
+		);
+
+		const bytes = new Uint8Array([0xff, 0x00, 0x80, 0x7f]);
+		const res = await client.exec('pod-1', ['sh', '-lc', 'cat'], bytes);
+		expect(Array.from(Buffer.concat(received))).toEqual([0xff, 0x00, 0x80, 0x7f]);
+		expect(res.exitCode).toBe(0);
+	});
+
+	it('defaults a Failure status with a missing/non-numeric ExitCode to exit code 1', async () => {
+		const client = createK8sClient({ namespace: 'kernels' });
+		k8sMock.exec.mockImplementation(
+			async (
+				_namespace: string,
+				_name: string,
+				_container: string,
+				_command: string[],
+				_stdout: Writable,
+				_stderr: Writable,
+				stdin: Readable | null,
+				_tty: boolean,
+				statusCallback: (status: unknown) => void,
+			) => {
+				stdin?.resume();
+				statusCallback({ status: 'Failure' }); // no details.causes → ExitCode unknown
+				const socket = new EventEmitter();
+				setTimeout(() => socket.emit('close'), 0);
+				return socket;
+			},
+		);
+
+		await expect(client.exec('pod-1', ['sh', '-lc', 'cmd'])).resolves.toMatchObject({
+			exitCode: 1,
+		});
+	});
+
 	it('deletes ingress, service, and pod while tolerating 404s', async () => {
 		k8sMock.net.deleteNamespacedIngress.mockRejectedValueOnce({ code: 404 });
 		const client = createK8sClient({ namespace: 'kernels' });

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -168,6 +168,14 @@ describe('KubernetesCompute', () => {
 				/entered terminal phase Failed/,
 			);
 		});
+
+		it('times out when the Pod stays Pending (never reaches Running)', async () => {
+			const world = makeWorld({ phase: 'Pending' });
+			const compute = makeCompute(world, { ...baseConfig, podReadyTimeout: Millis.of(30) });
+			await expect(compute.create(SANDBOX_ID).exec('true')).rejects.toThrow(
+				/timed out waiting for pod .* to reach Running/,
+			);
+		});
 	});
 
 	describe('writeFile() / readFile()', () => {
@@ -205,6 +213,19 @@ describe('KubernetesCompute', () => {
 				.readFile('/workspace/notebooks/missing.py');
 
 			expect(res).toEqual({ success: false, content: '' });
+		});
+
+		it('writeFile streams a large file via stdin, never into the exec argv (ARG_MAX)', async () => {
+			const world = makeWorld();
+			const big = new Uint8Array(1024 * 1024).fill(65);
+			await makeCompute(world)
+				.create(SANDBOX_ID)
+				.writeFiles([{ path: '/workspace/big.bin', content: big }]);
+			const call = world.execCalls.at(-1)!;
+			// The bytes ride stdin verbatim…
+			expect(call.stdin).toBe(big);
+			// …and the argv (mkdir && cat > path) never carries them.
+			expect(shCmd(call).length).toBeLessThan(big.length);
 		});
 
 		it('writeFile throws when the in-pod write command fails', async () => {

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -1,3 +1,6 @@
+import { access, rm } from 'node:fs/promises';
+import net from 'node:net';
+import os from 'node:os';
 import path from 'node:path';
 import type { SandboxId } from '@marimo-hub/core';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -198,6 +201,61 @@ describe('LocalCompute process lifecycle', () => {
 		} finally {
 			await sb.destroy();
 		}
+	});
+});
+
+describe('LocalCompute security & limits', () => {
+	it('writeFiles must not allow path traversal outside the sandbox root', async () => {
+		// The sandbox root sits one level under os.tmpdir(), so a single `..` in the
+		// write path escapes it (mapPath is a bare path.join with no containment check).
+		const rand = Math.random().toString(36).slice(2, 10);
+		const escaped = path.join(os.tmpdir(), `mh-traversal-${rand}.txt`);
+		const sb = newSandbox();
+		try {
+			await sb.writeFiles([{ path: `/../mh-traversal-${rand}.txt`, content: 'pwned' }]);
+			// Secure behaviour: the traversal must NOT have written outside the root.
+			await expect(access(escaped)).rejects.toThrow();
+		} finally {
+			await rm(escaped, { force: true });
+		}
+	});
+
+	it('startProcess throws when the configured port range is exhausted', async () => {
+		// Occupy a single-port range so allocatePort scans it and finds nothing free.
+		const srv = net.createServer();
+		const port = await new Promise<number>((resolve) => {
+			srv.listen(0, '127.0.0.1', () => {
+				const addr = srv.address();
+				resolve(typeof addr === 'object' && addr ? addr.port : 0);
+			});
+		});
+		const ranged = new LocalCompute({ ports: { start: port, end: port } });
+		const id = `sb-exhaust-${Math.random().toString(36).slice(2, 10)}` as SandboxId;
+		const sb = ranged.create(id);
+		try {
+			await expect(sb.startProcess(SERVER_CMD, { cwd: '/workspace' })).rejects.toThrow(
+				/no free port/,
+			);
+		} finally {
+			await sb.destroy();
+			srv.close();
+		}
+	});
+
+	it('destroy is idempotent when called twice and after never starting', async () => {
+		const id = `sb-idempotent-${Math.random().toString(36).slice(2, 10)}` as SandboxId;
+		const sb = compute.create(id);
+		await expect(sb.destroy()).resolves.toBeUndefined();
+		await expect(sb.destroy()).resolves.toBeUndefined();
+	});
+
+	it('exposePort ignores the app-provided hostname (kernel host is the configured host)', async () => {
+		// Documents that the local backend serves the kernel on its own host and does
+		// NOT honour the hostname passed for cross-origin isolation (dev-only backend).
+		const sb = newSandbox();
+		const { url } = await sb.exposePort(2718, { hostname: 'kernels.example.com' });
+		expect(url).not.toContain('kernels.example.com');
+		expect(url.startsWith('http://localhost:')).toBe(true);
 	});
 });
 

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -238,7 +238,9 @@ describe('LocalCompute security & limits', () => {
 			);
 		} finally {
 			await sb.destroy();
-			srv.close();
+			// close() is fire-and-forget (returns the server, not a promise); await the
+			// actual close so the port is freed before teardown to avoid cross-test flakes.
+			await new Promise<void>((resolve) => srv.close(() => resolve()));
 		}
 	});
 

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -180,9 +180,24 @@ class LocalSandboxInstance implements SandboxInstance {
 		this.ports = opts.ports;
 	}
 
-	/** Map an absolute sandbox path (e.g. /workspace/...) under this sandbox root. */
+	/**
+	 * Resolve an absolute sandbox path (e.g. /workspace/...) under this sandbox
+	 * root, or `null` if it would escape the root. path.join normalizes, so a `..`
+	 * in a notebook-controlled path could otherwise read/write anywhere the server
+	 * user can.
+	 */
+	private resolveContained(p: string): string | null {
+		const abs = path.join(this.root, p);
+		const rootPrefix = this.root.endsWith(path.sep) ? this.root : this.root + path.sep;
+		if (abs !== this.root && !abs.startsWith(rootPrefix)) return null;
+		return abs;
+	}
+
+	/** Map a sandbox path under the root, throwing if it escapes. */
 	private mapPath(p: string): string {
-		return path.join(this.root, p);
+		const abs = this.resolveContained(p);
+		if (abs === null) throw new Error(`sandbox path escapes the sandbox root: ${p}`);
+		return abs;
 	}
 
 	/** Rewrite `/workspace` references in a shell command to the real root. */
@@ -264,7 +279,11 @@ class LocalSandboxInstance implements SandboxInstance {
 	async writeFiles(files: readonly SandboxFileWrite[]): Promise<void> {
 		// Local writes are cheap (no round-trip), so a plain bounded loop is enough.
 		await mapWithConcurrency(files, WRITE_CONCURRENCY, async (f) => {
-			const abs = this.mapPath(f.path);
+			const abs = this.resolveContained(f.path);
+			if (abs === null) {
+				console.warn(`writeFiles: skipping path outside sandbox root: ${f.path}`);
+				return;
+			}
 			await mkdir(path.dirname(abs), { recursive: true });
 			// `encoding` applies to string content only; bytes are written verbatim.
 			await writeFile(abs, f.content, typeof f.content === 'string' ? 'utf-8' : null);

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -210,6 +210,15 @@ describe('ModalCompute', () => {
 			expect(String(url)).toBe(`${API_BASE}/v1/sandboxes/${SANDBOX_ID}/tunnels`);
 			expect(parseBody(init?.body as string).port).toBe(2718);
 		});
+
+		it('rejects when the tunnels response is missing a url', async () => {
+			// A parseable kernel URL is part of the exposePort contract; a tunnels
+			// response with no `url` must not slip through as `{ url: undefined }`.
+			mockFetch.mockResolvedValueOnce(mockOkResponse({}));
+			await expect(
+				makeCompute().create(SANDBOX_ID).exposePort(2718, { hostname: 'ignored' }),
+			).rejects.toThrow();
+		});
 	});
 
 	describe('create().destroy()', () => {
@@ -296,6 +305,29 @@ describe('ModalCompute', () => {
 			);
 		});
 
+		it('writeFiles throws when the parent mkdir exec fails', async () => {
+			mockFetch.mockResolvedValueOnce(
+				mockOkResponse({ exit_code: 1, stdout: '', stderr: 'permission denied' }),
+			);
+			await expect(
+				makeCompute()
+					.create(SANDBOX_ID)
+					.writeFiles([{ path: '/d/f.txt', content: 'x' }]),
+			).rejects.toThrow(/writeFiles mkdir failed.*permission denied/);
+		});
+
+		it('writeFiles throws when the in-sandbox base64 decode exec fails', async () => {
+			mockFetch
+				.mockResolvedValueOnce(mockOkResponse({ exit_code: 0, stdout: '', stderr: '' })) // mkdir
+				.mockResolvedValueOnce(mockOkResponse({})) // files/write (tmp)
+				.mockResolvedValueOnce(mockOkResponse({ exit_code: 1, stdout: '', stderr: 'bad base64' })); // decode
+			await expect(
+				makeCompute()
+					.create(SANDBOX_ID)
+					.writeFiles([{ path: '/f.bin', content: new Uint8Array([1, 2, 3]) }]),
+			).rejects.toThrow(/writeFile \/f\.bin failed.*bad base64/);
+		});
+
 		it('listFiles returns files, defaulting a missing array to []', async () => {
 			mockFetch.mockResolvedValueOnce(mockOkResponse({}));
 			expect(await makeCompute().create(SANDBOX_ID).listFiles('/')).toEqual({
@@ -333,6 +365,39 @@ describe('ModalCompute', () => {
 
 		it('proxy returns null (Modal kernels are reached directly)', async () => {
 			expect(await makeCompute().proxy(new Request('https://x/'))).toBeNull();
+		});
+	});
+
+	describe('request behaviour', () => {
+		it('exec opts out of the control-plane timeout (no abort signal), unlike short calls', async () => {
+			mockFetch.mockResolvedValue(mockOkResponse({ exit_code: 0, stdout: '', stderr: '' }));
+			await makeCompute().create(SANDBOX_ID).exec('slow-cmd');
+			const execInit = mockFetch.mock.calls.at(-1)![1];
+			expect(execInit?.signal == null).toBe(true);
+
+			mockFetch.mockReset();
+			mockFetch.mockResolvedValue(mockOkResponse({}));
+			await makeCompute().create(SANDBOX_ID).setEnvVars({ A: '1' });
+			const envInit = mockFetch.mock.calls.at(-1)![1];
+			expect(envInit?.signal).toBeInstanceOf(AbortSignal);
+		});
+
+		it('does not retry a non-idempotent exec POST on a 5xx', async () => {
+			mockFetch.mockResolvedValue(mockErrorResponse(500));
+			await expect(makeCompute().create(SANDBOX_ID).exec('cmd')).rejects.toThrow(/Modal API/);
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+		});
+
+		it('passes a network-level (non-response) error through, not wrapped as a Modal API failure', async () => {
+			mockFetch.mockRejectedValue(new TypeError('network down'));
+			const err: unknown = await makeCompute()
+				.create(SANDBOX_ID)
+				.exec('cmd')
+				.catch((e: unknown) => e);
+			// toModalError only builds the `Modal API … failed: <status>` shape for a
+			// FetchError with a response; a bare network error passes through untouched.
+			expect(err).toBeInstanceOf(Error);
+			expect(String((err as Error).message)).not.toContain('Modal API');
 		});
 	});
 

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -277,6 +277,11 @@ class ModalSandboxInstance implements SandboxInstance {
 		// Modal returns a public tunnel URL for the exposed port — used directly by
 		// the client, so the API's proxy() is a no-op for this backend.
 		const res = await this.modal<{ url: string }>(`/v1/sandboxes/${this.id}/tunnels`, { port });
+		// A parseable absolute URL is part of the exposePort contract; never let a
+		// malformed tunnels response slip through as `{ url: undefined }`.
+		if (!res.url || typeof res.url !== 'string') {
+			throw new Error(`Modal tunnels response for sandbox ${this.id} is missing a url`);
+		}
 		return { url: res.url };
 	}
 

--- a/packages/config/src/ai.test.ts
+++ b/packages/config/src/ai.test.ts
@@ -37,4 +37,31 @@ describe('makeAi', () => {
 	it('does not validate the TTL when the AI backend is disabled', () => {
 		expect(makeAi({ MARIMOHUB_AI_TOKEN_TTL_SECONDS: '0' })).toEqual({});
 	});
+
+	it('throws when the backend is enabled but MARIMOHUB_AUTH_SESSION_SECRET is unset', () => {
+		const { MARIMOHUB_AUTH_SESSION_SECRET: _omit, ...env } = aiEnv;
+		expect(() => makeAi(env)).toThrow(/MARIMOHUB_AUTH_SESSION_SECRET/);
+	});
+
+	it('rejects an unknown MARIMOHUB_AI_BACKEND', () => {
+		expect(() => makeAi({ ...aiEnv, MARIMOHUB_AI_BACKEND: 'anthropic' })).toThrow(
+			/Unknown MARIMOHUB_AI_BACKEND/,
+		);
+	});
+
+	it.each([
+		'MARIMOHUB_AI_UPSTREAM_BASE_URL',
+		'MARIMOHUB_AI_UPSTREAM_API_KEY',
+		'MARIMOHUB_AI_MODEL',
+	])('requires %s', (key) => {
+		const env: Record<string, string | undefined> = { ...aiEnv };
+		delete env[key];
+		expect(() => makeAi(env)).toThrow(new RegExp(key));
+	});
+
+	it('rejects a non-integer MARIMOHUB_AI_MAX_TOKENS', () => {
+		expect(() => makeAi({ ...aiEnv, MARIMOHUB_AI_MAX_TOKENS: '1.5' })).toThrow(
+			/MARIMOHUB_AI_MAX_TOKENS/,
+		);
+	});
 });

--- a/packages/config/src/auth.test.ts
+++ b/packages/config/src/auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { makeAuth } from './auth';
+import { ConfigError } from './errors';
+
+/**
+ * `makeAuth` selector tests. The oidc backend requires a full set of vars; each
+ * must fail closed when missing rather than construct a half-configured
+ * authenticator.
+ */
+const oidcEnv = {
+	MARIMOHUB_AUTH_BACKEND: 'oidc',
+	MARIMOHUB_AUTH_OIDC_ISSUER: 'https://accounts.example.com',
+	MARIMOHUB_AUTH_OIDC_CLIENT_ID: 'client',
+	MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: 'secret',
+	MARIMOHUB_AUTH_OIDC_REDIRECT_URI: 'https://hub.example.com/api/auth/callback',
+	MARIMOHUB_AUTH_SESSION_SECRET: 'x'.repeat(48),
+	MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: 'example.com',
+};
+
+describe('makeAuth oidc required vars', () => {
+	it('throws when MARIMOHUB_AUTH_SESSION_SECRET is missing', () => {
+		const { MARIMOHUB_AUTH_SESSION_SECRET: _omit, ...env } = oidcEnv;
+		expect(() => makeAuth(env)).toThrow(/MARIMOHUB_AUTH_SESSION_SECRET/);
+	});
+
+	it.each([
+		'MARIMOHUB_AUTH_OIDC_ISSUER',
+		'MARIMOHUB_AUTH_OIDC_CLIENT_ID',
+		'MARIMOHUB_AUTH_OIDC_CLIENT_SECRET',
+		'MARIMOHUB_AUTH_OIDC_REDIRECT_URI',
+	])('throws when %s is missing', (key) => {
+		const env: Record<string, string | undefined> = { ...oidcEnv };
+		delete env[key];
+		expect(() => makeAuth(env)).toThrow(new RegExp(key));
+	});
+});
+
+describe('makeAuth cloudflare-access', () => {
+	it('refuses the cloudflare-access backend outside Workers', () => {
+		expect(() => makeAuth({ MARIMOHUB_AUTH_BACKEND: 'cloudflare-access' })).toThrow(ConfigError);
+		expect(() => makeAuth({ MARIMOHUB_AUTH_BACKEND: 'cloudflare-access' })).toThrow(
+			/cloudflare-worker/,
+		);
+	});
+});

--- a/packages/config/src/compute.test.ts
+++ b/packages/config/src/compute.test.ts
@@ -4,6 +4,7 @@ import { ModalCompute } from '@marimo-hub/compute-modal';
 import { LocalCompute } from '@marimo-hub/compute-local';
 import { DockerCompute } from '@marimo-hub/compute-docker';
 import { CoreWeaveCompute } from '@marimo-hub/compute-coreweave';
+import { KubernetesCompute } from '@marimo-hub/compute-kubernetes';
 import {
 	makeCompute,
 	resolveLifetimeBackstop,
@@ -82,6 +83,32 @@ describe('makeCompute fail-fast', () => {
 	it('requires the modal token id', () => {
 		expect(() => makeCompute({ MARIMOHUB_COMPUTE_BACKEND: 'modal' })).toThrow(
 			/MARIMOHUB_COMPUTE_MODAL_TOKEN_ID/,
+		);
+	});
+
+	it('requires the modal token secret', () => {
+		expect(() =>
+			makeCompute({
+				MARIMOHUB_COMPUTE_BACKEND: 'modal',
+				MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: 'tid',
+				MARIMOHUB_COMPUTE_IMAGE: 'img',
+			}),
+		).toThrow(/MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET/);
+	});
+
+	it('requires a modal image', () => {
+		expect(() =>
+			makeCompute({
+				MARIMOHUB_COMPUTE_BACKEND: 'modal',
+				MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: 'tid',
+				MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: 'tsecret',
+			}),
+		).toThrow(/MARIMOHUB_COMPUTE_IMAGE/);
+	});
+
+	it('selects kubernetes', () => {
+		expect(makeCompute({ MARIMOHUB_COMPUTE_BACKEND: 'kubernetes' })).toBeInstanceOf(
+			KubernetesCompute,
 		);
 	});
 

--- a/packages/config/src/hostIsolation.test.ts
+++ b/packages/config/src/hostIsolation.test.ts
@@ -31,5 +31,17 @@ describe('checkSandboxHostIsolation', () => {
 			MARIMOHUB_AUTH_OIDC_REDIRECT_URI: 'not-a-valid-url',
 		});
 		expect(result.isolated).toBe(false);
+		expect(result.reason).toBe('unverifiable-redirect');
+	});
+
+	// A hostless-but-parseable scheme (e.g. mailto:) yields an empty hostname, which
+	// must be treated as unverifiable too — not silently isolated.
+	it('fails closed when the redirect parses but yields no host (mailto:)', () => {
+		const result = checkSandboxHostIsolation({
+			MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: 'hub.example.com',
+			MARIMOHUB_AUTH_OIDC_REDIRECT_URI: 'mailto:admin@example.com',
+		});
+		expect(result.isolated).toBe(false);
+		expect(result.reason).toBe('unverifiable-redirect');
 	});
 });

--- a/packages/config/src/hostIsolation.test.ts
+++ b/packages/config/src/hostIsolation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { checkSandboxHostIsolation } from './hostIsolation';
+
+/**
+ * Isolation guard: when a sandbox host is configured, the guard derives the app
+ * host from the OIDC redirect URI and refuses a same-origin/parent-domain
+ * sandbox (untrusted kernels must not share an origin with the control plane).
+ */
+describe('checkSandboxHostIsolation', () => {
+	it('flags a same-origin sandbox host as non-isolated', () => {
+		const result = checkSandboxHostIsolation({
+			MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: 'hub.example.com',
+			MARIMOHUB_AUTH_OIDC_REDIRECT_URI: 'https://hub.example.com/api/auth/callback',
+		});
+		expect(result.isolated).toBe(false);
+	});
+
+	it('treats a distinct-domain sandbox host as isolated', () => {
+		const result = checkSandboxHostIsolation({
+			MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: 'sandboxes.example.net',
+			MARIMOHUB_AUTH_OIDC_REDIRECT_URI: 'https://hub.example.com/api/auth/callback',
+		});
+		expect(result.isolated).toBe(true);
+	});
+
+	// A malformed redirect is configured-but-unparseable, not absent: the app host
+	// can't be derived, so isolation is unverifiable and must fail closed.
+	it('fails closed when the OIDC redirect URI is malformed (isolation unverifiable)', () => {
+		const result = checkSandboxHostIsolation({
+			MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: 'hub.example.com',
+			MARIMOHUB_AUTH_OIDC_REDIRECT_URI: 'not-a-valid-url',
+		});
+		expect(result.isolated).toBe(false);
+	});
+});

--- a/packages/config/src/hostIsolation.ts
+++ b/packages/config/src/hostIsolation.ts
@@ -1,10 +1,16 @@
 import type { Env } from './env';
 
 export interface SandboxHostIsolation {
-	/** False only when both hosts are known AND they share an origin/parent domain. */
+	/** False when the hosts share an origin/parent domain OR isolation can't be verified. */
 	isolated: boolean;
 	sandboxHost?: string;
 	appHost?: string;
+	/**
+	 * Present only when `isolated` is false, so the caller can word the error:
+	 * `shared-origin` (hosts overlap) vs `unverifiable-redirect` (the redirect is
+	 * set but yields no usable app host).
+	 */
+	reason?: 'shared-origin' | 'unverifiable-redirect';
 }
 
 /**
@@ -28,12 +34,18 @@ export function checkSandboxHostIsolation(env: Env): SandboxHostIsolation {
 	try {
 		appHost = new URL(redirect).hostname.toLowerCase();
 	} catch {
-		// A redirect WAS configured but is unparseable, so the app host is unknown
-		// and isolation can't be verified. Fail closed — a bad redirect must not
-		// silently green-light a potentially same-origin untrusted kernel.
-		return { isolated: false, sandboxHost };
+		appHost = '';
 	}
+	// A redirect WAS configured but yields no usable app host — either unparseable,
+	// or a hostless scheme like `mailto:` (empty hostname). Isolation can't be
+	// verified, so fail closed: a bad redirect must not silently green-light a
+	// potentially same-origin untrusted kernel.
+	if (!appHost) return { isolated: false, sandboxHost, reason: 'unverifiable-redirect' };
+
 	const sameOrigin = sandboxHost === appHost;
 	const sharesParent = sandboxHost.endsWith(`.${appHost}`) || appHost.endsWith(`.${sandboxHost}`);
-	return { isolated: !(sameOrigin || sharesParent), sandboxHost, appHost };
+	if (sameOrigin || sharesParent) {
+		return { isolated: false, sandboxHost, appHost, reason: 'shared-origin' };
+	}
+	return { isolated: true, sandboxHost, appHost };
 }

--- a/packages/config/src/hostIsolation.ts
+++ b/packages/config/src/hostIsolation.ts
@@ -10,8 +10,10 @@ export interface SandboxHostIsolation {
 /**
  * Pure check (no throw) reused by the wiring guard (index.ts) and the preflight
  * report. Returns `isolated: true` when there's nothing to compare (no sandbox
- * host, or no app host to derive from the OIDC redirect) — the wiring guard only
- * applies in `subdomain` mode, so a missing signal can't weaken `proxy` mode.
+ * host, or no redirect at all to derive an app host from) — the wiring guard only
+ * applies in `subdomain` mode, so a missing signal can't weaken `proxy` mode. But
+ * a redirect that IS set yet unparseable fails closed (`isolated: false`): the app
+ * host is then unknowable and isolation can't be verified.
  *
  * Why this matters: notebook kernels run untrusted user code. If they share an
  * origin/parent domain with the control plane, a malicious notebook can escape the
@@ -26,7 +28,10 @@ export function checkSandboxHostIsolation(env: Env): SandboxHostIsolation {
 	try {
 		appHost = new URL(redirect).hostname.toLowerCase();
 	} catch {
-		return { isolated: true, sandboxHost };
+		// A redirect WAS configured but is unparseable, so the app host is unknown
+		// and isolation can't be verified. Fail closed — a bad redirect must not
+		// silently green-light a potentially same-origin untrusted kernel.
+		return { isolated: false, sandboxHost };
 	}
 	const sameOrigin = sandboxHost === appHost;
 	const sharesParent = sandboxHost.endsWith(`.${appHost}`) || appHost.endsWith(`.${sandboxHost}`);

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -463,4 +463,67 @@ describe('createFromEnv session lifetime', () => {
 			createFromEnv({ ...baseEnv, MARIMOHUB_SESSION_MAX_LIFETIME_SECONDS: '0' }),
 		).toThrow(/MARIMOHUB_SESSION_MAX_LIFETIME_SECONDS/);
 	});
+
+	it.each([
+		'MARIMOHUB_SESSION_IDLE_TIMEOUT_SECONDS',
+		'MARIMOHUB_SESSION_LIFETIME_EXTENSION_SECONDS',
+		'MARIMOHUB_SESSION_SWEEP_INTERVAL_SECONDS',
+	])('rejects a zero %s (only the snapshot interval may be 0)', (key) => {
+		expect(() => createFromEnv({ ...baseEnv, [key]: '0' })).toThrow(new RegExp(key));
+	});
+
+	it.each([
+		'MARIMOHUB_SESSION_IDLE_TIMEOUT_SECONDS',
+		'MARIMOHUB_SESSION_LIFETIME_EXTENSION_SECONDS',
+		'MARIMOHUB_SESSION_SWEEP_INTERVAL_SECONDS',
+	])('rejects a negative %s', (key) => {
+		expect(() => createFromEnv({ ...baseEnv, [key]: '-1' })).toThrow(new RegExp(key));
+	});
+});
+
+describe('createFromEnv concurrent-session cap', () => {
+	const baseEnv = {
+		MARIMOHUB_STORAGE_BACKEND: 'memory',
+		MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: 'true',
+		MARIMOHUB_COMPUTE_BACKEND: 'none',
+		MARIMOHUB_AUTH_BACKEND: 'dev',
+	};
+
+	it('defaults to 10 when unset', () => {
+		expect(createFromEnv({ ...baseEnv }).policy.maxConcurrentSessionsPerUser).toBe(10);
+	});
+
+	it('treats 0 as unlimited (undefined)', () => {
+		expect(
+			createFromEnv({ ...baseEnv, MARIMOHUB_MAX_SESSIONS_PER_USER: '0' }).policy
+				.maxConcurrentSessionsPerUser,
+		).toBeUndefined();
+	});
+
+	it.each(['-1', '2.5', 'abc'])('rejects the invalid cap %o', (raw) => {
+		expect(() => createFromEnv({ ...baseEnv, MARIMOHUB_MAX_SESSIONS_PER_USER: raw })).toThrow(
+			/MARIMOHUB_MAX_SESSIONS_PER_USER/,
+		);
+	});
+});
+
+describe('createFromEnv allowed origins', () => {
+	const baseEnv = {
+		MARIMOHUB_STORAGE_BACKEND: 'memory',
+		MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: 'true',
+		MARIMOHUB_COMPUTE_BACKEND: 'none',
+		MARIMOHUB_AUTH_BACKEND: 'dev',
+	};
+
+	it('parses MARIMOHUB_ALLOWED_ORIGINS into a trimmed list', () => {
+		const deps = createFromEnv({
+			...baseEnv,
+			MARIMOHUB_ALLOWED_ORIGINS: 'https://a.example.com, https://b.example.com',
+		});
+		expect(deps.policy.allowedOrigins).toEqual(['https://a.example.com', 'https://b.example.com']);
+	});
+
+	it('leaves allowed origins undefined when unset', () => {
+		expect(createFromEnv({ ...baseEnv }).policy.allowedOrigins).toBeUndefined();
+	});
 });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -180,13 +180,19 @@ function parsePersistWorkspace(env: Env): 'source' | 'workspace' {
  * the hosts so neither is a dotted suffix of the other.
  */
 function assertSandboxHostIsolated(env: Env): void {
-	const { isolated, sandboxHost, appHost } = checkSandboxHostIsolation(env);
+	const { isolated, sandboxHost, appHost, reason } = checkSandboxHostIsolation(env);
 	if (isolated) return;
+	const detail =
+		reason === 'unverifiable-redirect'
+			? `MARIMOHUB_AUTH_OIDC_REDIRECT_URI does not yield a usable app host, so isolation of ` +
+				`MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME (${sandboxHost}) cannot be verified. Set a valid ` +
+				`absolute http(s) redirect URI.`
+			: `MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME (${sandboxHost}) shares an origin/parent domain with the ` +
+				`app host (${appHost}).`;
 	throw new ConfigError(
-		`MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME (${sandboxHost}) shares an origin/parent domain with the ` +
-			`app host (${appHost}). Notebook kernels run untrusted code and must be isolated on a separate ` +
-			`domain (e.g. sandboxes.example.net) so a malicious notebook cannot escape the iframe sandbox ` +
-			`into the control plane or set cookies on the shared domain.`,
+		`${detail} Notebook kernels run untrusted code and must be isolated on a separate domain ` +
+			`(e.g. sandboxes.example.net) so a malicious notebook cannot escape the iframe sandbox into ` +
+			`the control plane or set cookies on the shared domain.`,
 		{
 			variable: 'MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME',
 			remediation: 'Serve kernels from a separate domain (e.g. sandboxes.example.net).',

--- a/packages/config/src/secrets.test.ts
+++ b/packages/config/src/secrets.test.ts
@@ -46,4 +46,25 @@ describe('makeSecrets', () => {
 		const { secrets } = makeSecrets({ MARIMOHUB_SECRETS_BACKEND: 'bucket' }, bucket);
 		expect(secrets).toBeDefined();
 	});
+
+	it('enables aws-sm via the flag even with no region', () => {
+		const { secrets } = makeSecrets(
+			{ MARIMOHUB_SECRETS_BACKEND: 'bucket', MARIMOHUB_SECRETS_AWS: 'true' },
+			bucket,
+		);
+		expect(secrets).toBeDefined();
+	});
+
+	it('rejects a non-integer aws cache TTL', () => {
+		expect(() =>
+			makeSecrets(
+				{
+					MARIMOHUB_SECRETS_BACKEND: 'bucket',
+					MARIMOHUB_SECRETS_AWS_REGION: 'us-east-1',
+					MARIMOHUB_SECRETS_AWS_CACHE_TTL_SECONDS: '1.5',
+				},
+				bucket,
+			),
+		).toThrow(/MARIMOHUB_SECRETS_AWS_CACHE_TTL_SECONDS/);
+	});
 });

--- a/packages/config/src/secrets.test.ts
+++ b/packages/config/src/secrets.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryBucket } from '@marimo-hub/core/testing';
+import { createAwsSecretsManagerResolver } from '@marimo-hub/secrets-aws';
 import { makeSecrets } from './secrets';
 import { ConfigError } from './errors';
 
+// Mock the resolver factory so we can assert whether the aws-sm resolver is
+// actually registered (not just that a store came back).
+vi.mock('@marimo-hub/secrets-aws', () => ({
+	createAwsSecretsManagerResolver: vi.fn(() => ({ backend: 'aws-sm', resolve: async () => '' })),
+}));
+
 const bucket = new MemoryBucket();
+
+beforeEach(() => vi.mocked(createAwsSecretsManagerResolver).mockClear());
 
 describe('makeSecrets', () => {
 	it('is disabled when the backend is unset or none', () => {
@@ -42,9 +51,9 @@ describe('makeSecrets', () => {
 	});
 
 	it('does not enable AWS when neither region nor the enable flag is set', () => {
-		// bucket-only: provider present, but no aws-sm resolver constructed.
 		const { secrets } = makeSecrets({ MARIMOHUB_SECRETS_BACKEND: 'bucket' }, bucket);
 		expect(secrets).toBeDefined();
+		expect(createAwsSecretsManagerResolver).not.toHaveBeenCalled();
 	});
 
 	it('enables aws-sm via the flag even with no region', () => {
@@ -53,6 +62,10 @@ describe('makeSecrets', () => {
 			bucket,
 		);
 		expect(secrets).toBeDefined();
+		// The flag alone (no region) must still construct the resolver.
+		expect(createAwsSecretsManagerResolver).toHaveBeenCalledWith(
+			expect.objectContaining({ region: undefined }),
+		);
 	});
 
 	it('rejects a non-integer aws cache TTL', () => {

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -86,7 +86,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						id: 'MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID',
 						name: 'S3 access key id',
 						description:
-							'Access key id. Both key id and secret must be set together, otherwise the SDK default credential chain is used.',
+							'Access key id. Set both key id and secret together to use static credentials, or neither to use the SDK default credential chain. Setting only one is rejected at startup.',
 						secret: true,
 					},
 					{

--- a/packages/config/src/storage.test.ts
+++ b/packages/config/src/storage.test.ts
@@ -87,6 +87,28 @@ describe('makeStorage backend selection', () => {
 			/Unknown MARIMOHUB_STORAGE_BACKEND/,
 		);
 	});
+
+	// `env.MARIMOHUB_STORAGE_BACKEND ?? 's3'` only coalesces null/undefined, so an
+	// explicit empty string is NOT treated as unset — it falls through to the
+	// unknown-backend error rather than defaulting to s3.
+	it('rejects an empty-string backend (does not default to s3)', () => {
+		expect(() =>
+			makeStorage({ MARIMOHUB_STORAGE_BACKEND: '', MARIMOHUB_STORAGE_S3_BUCKET: 'b' }),
+		).toThrow(/Unknown MARIMOHUB_STORAGE_BACKEND/);
+	});
+
+	// A partially-configured static credential (key id without the matching secret)
+	// is an operator mistake: it should fail closed like the secrets-aws all-or-
+	// nothing check, not silently drop the credential and fall back to the ambient
+	// AWS provider chain (a different, possibly unintended identity).
+	it('rejects partial S3 static credentials (key id without secret)', () => {
+		expect(() =>
+			makeStorage({
+				MARIMOHUB_STORAGE_S3_BUCKET: 'b',
+				MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID: 'akid',
+			}),
+		).toThrow();
+	});
 });
 
 describe('makeSandboxBucketConfig', () => {

--- a/packages/config/src/storage.ts
+++ b/packages/config/src/storage.ts
@@ -22,6 +22,20 @@ export function makeStorage(env: Env): Bucket {
 	const backend = env.MARIMOHUB_STORAGE_BACKEND ?? 's3';
 	switch (backend) {
 		case 's3':
+			// Static creds are all-or-nothing. If only one half is set, silently
+			// dropping it (and falling back to the ambient AWS chain — a different
+			// identity) is a misconfiguration that fails in confusing ways at runtime.
+			// Fail closed at boot instead.
+			if (
+				Boolean(env.MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID) !==
+				Boolean(env.MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY)
+			) {
+				throw new ConfigError(
+					'Partial S3 credentials: set BOTH MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID and ' +
+						'MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY, or neither (to use the ambient AWS credential chain).',
+					{ variable: 'MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID', docs: 'docs/configuration.md#storage' },
+				);
+			}
 			return new S3Storage({
 				bucket: requiredVar(env, 'MARIMOHUB_STORAGE_S3_BUCKET', {
 					remediation:

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
+	assertVersionMatch,
+	BadRequestError,
 	ConflictError,
 	ForbiddenError,
 	NotFoundError,
@@ -7,6 +9,7 @@ import {
 	PreconditionFailedError,
 	ResourceExhaustedError,
 	UnavailableError,
+	ValidationError,
 } from './errors';
 
 // The HTTP status carried by each domain error is load-bearing: `packages/api`
@@ -65,5 +68,33 @@ describe('domain errors', () => {
 			throw new Err();
 		}).toThrow(Error);
 		expect(typeof new Err().stack).toBe('string');
+	});
+
+	it('BadRequestError carries 400 / BAD_REQUEST and its name', () => {
+		const e = new BadRequestError();
+		expect(e.status).toBe(400);
+		expect(e.code).toBe('BAD_REQUEST');
+		expect(e.name).toBe('BadRequestError');
+	});
+
+	it('ValidationError carries 422 / VALIDATION_ERROR and its name', () => {
+		const e = new ValidationError();
+		expect(e.status).toBe(422);
+		expect(e.code).toBe('VALIDATION_ERROR');
+		expect(e.name).toBe('ValidationError');
+	});
+});
+
+describe('assertVersionMatch', () => {
+	it('is a no-op when the caller sent no precondition (expected undefined)', () => {
+		expect(() => assertVersionMatch('etag-1', undefined)).not.toThrow();
+	});
+
+	it('passes when expected matches current', () => {
+		expect(() => assertVersionMatch('etag-1', 'etag-1')).not.toThrow();
+	});
+
+	it('throws PreconditionFailedError on a stale precondition', () => {
+		expect(() => assertVersionMatch('etag-2', 'etag-1')).toThrow(PreconditionFailedError);
 	});
 });

--- a/packages/core/src/ids.test.ts
+++ b/packages/core/src/ids.test.ts
@@ -4,11 +4,13 @@ import {
 	createProjectId,
 	createSandboxId,
 	createSessionId,
+	createVersionId,
 	NotebookId,
 	ProjectId,
 	SandboxId,
 	SessionId,
 	SnapshotId,
+	UserId,
 	VersionId,
 } from './ids';
 import type { IdBrand } from './ids';
@@ -111,5 +113,27 @@ describe('VersionId namespace', () => {
 		const valid = VersionId.create();
 		expect(VersionId.parse(valid)).toBe(valid);
 		expect(() => VersionId.parse('ver_lowercase')).toThrow('VersionId');
+	});
+
+	it('createVersionId sorts monotonically for ids minted within the same millisecond', () => {
+		// The monotonic factory guarantees strictly-increasing (lexicographic) ids even
+		// under a frozen clock — version pruning treats the largest id as newest.
+		const ids = Array.from({ length: 50 }, () => createVersionId());
+		const sorted = [...ids].sort();
+		expect(ids).toEqual(sorted);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});
+
+describe('UserId (opaque brand)', () => {
+	it('rejects the empty string', () => {
+		expect(UserId.is('')).toBe(false);
+		expect(() => UserId.assert('')).toThrow('UserId');
+		expect(() => UserId.parse('')).toThrow('UserId');
+	});
+
+	it('accepts a non-empty opaque sub like "system"', () => {
+		expect(UserId.is('system')).toBe(true);
+		expect(UserId.parse('system')).toBe('system');
 	});
 });

--- a/packages/core/src/integrations/remoteWorkspace.test.ts
+++ b/packages/core/src/integrations/remoteWorkspace.test.ts
@@ -78,4 +78,20 @@ describe('remote workspace helpers', () => {
 			]),
 		).toThrow(BadRequestError);
 	});
+
+	it('isSafeWorkspacePath rejects a null byte, a backslash, and a single-dot segment', () => {
+		expect(isSafeWorkspacePath('data/\0.csv')).toBe(false);
+		expect(isSafeWorkspacePath('data\\cars.csv')).toBe(false);
+		expect(isSafeWorkspacePath('data/./cars.csv')).toBe(false);
+		expect(isSafeWorkspacePath('.')).toBe(false);
+	});
+
+	it('normalizeEntryNotebook rejects a non-.py path', () => {
+		expect(() => normalizeEntryNotebook('apps/main.txt')).toThrow(BadRequestError);
+		expect(() => normalizeEntryNotebook('apps/main')).toThrow(BadRequestError);
+	});
+
+	it('toSyncedWorkspaceFileMap rejects an empty archive', () => {
+		expect(() => toSyncedWorkspaceFileMap([])).toThrow(BadRequestError);
+	});
 });

--- a/packages/core/src/internal/base64url.test.ts
+++ b/packages/core/src/internal/base64url.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { fromBase64Url, toBase64Url } from './base64url';
+
+describe('base64url', () => {
+	it('round-trips at every len%3 boundary (0, 1, 2 trailing bytes)', () => {
+		for (const len of [0, 1, 2, 3, 4, 5, 6]) {
+			const bytes = new Uint8Array(len).map((_, i) => (i * 37 + 11) & 0xff);
+			const encoded = toBase64Url(bytes);
+			// padding-free + URL-safe alphabet only
+			expect(encoded).not.toMatch(/[+/=]/);
+			expect(Array.from(fromBase64Url(encoded))).toEqual(Array.from(bytes));
+		}
+	});
+
+	it('throws on invalid input rather than returning garbage', () => {
+		// A single stray base64 char has no valid decoding.
+		expect(() => fromBase64Url('a')).toThrow();
+	});
+});

--- a/packages/core/src/internal/hex.test.ts
+++ b/packages/core/src/internal/hex.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { toHex } from './hex';
+
+describe('toHex', () => {
+	it('pads each byte to two chars, including leading zeros', () => {
+		expect(toHex(new Uint8Array([0, 1, 15, 16, 255]))).toBe('00010f10ff');
+	});
+
+	it('renders an empty input as an empty string', () => {
+		expect(toHex(new Uint8Array([]))).toBe('');
+	});
+});

--- a/packages/core/src/internal/hmac.test.ts
+++ b/packages/core/src/internal/hmac.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { hmacSha256, timingSafeEqual } from './hmac';
+
+describe('timingSafeEqual', () => {
+	it('returns false on a length mismatch (never index out of the shorter array)', () => {
+		expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2]))).toBe(false);
+		expect(timingSafeEqual(new Uint8Array([]), new Uint8Array([0]))).toBe(false);
+	});
+
+	it('returns true for equal contents and false for a single differing byte', () => {
+		expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).toBe(true);
+		expect(timingSafeEqual(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 4]))).toBe(false);
+	});
+});
+
+describe('hmacSha256', () => {
+	it('is key-dependent: the same payload under different secrets does not match', async () => {
+		const a = await hmacSha256('secret-a', 'payload');
+		const b = await hmacSha256('secret-b', 'payload');
+		expect(a).toHaveLength(32);
+		expect(timingSafeEqual(a, b)).toBe(false);
+	});
+
+	it('is deterministic for the same secret + payload', async () => {
+		const a = await hmacSha256('secret', 'payload');
+		const b = await hmacSha256('secret', 'payload');
+		expect(timingSafeEqual(a, b)).toBe(true);
+	});
+});

--- a/packages/core/src/paths.test.ts
+++ b/packages/core/src/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { NotebookId, ProjectId, SessionId, SnapshotId, VersionId } from './ids';
+import type { NotebookId, ProjectId, SessionId, SnapshotId, UserId, VersionId } from './ids';
 import { paths } from './paths';
 
 const pid = 'proj_01HXY11111ABCDEFGHJKMN' as ProjectId;
@@ -64,6 +64,21 @@ describe('paths', () => {
 			  "workspacePrefix": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/workspace/",
 			}
 		`);
+	});
+
+	it('secret() encodes a name so a "/" or ".." segment cannot escape the secrets prefix', () => {
+		const proj = paths.project(pid);
+		const key = proj.secret('../../etc/passwd');
+		expect(key.startsWith(proj.secretsPrefix)).toBe(true);
+		// The path separators are percent-encoded, so the name stays a single object
+		// under `secrets/` and cannot traverse into a parent directory.
+		expect(key.slice(proj.secretsPrefix.length)).not.toContain('/');
+	});
+
+	it('identity() encodes a user id so a "/" or ".." segment cannot escape the identities prefix', () => {
+		const key = paths.identity('../../evil' as UserId);
+		expect(key.startsWith(paths.identitiesPrefix)).toBe(true);
+		expect(key.slice(paths.identitiesPrefix.length)).not.toContain('/');
 	});
 
 	it('composability — intermediate objects are reusable', () => {

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -123,6 +123,15 @@ export const paths = {
 	event: (date: string, id: string) => `_system/events/${date}/${id}.json`,
 	idempotencyPrefix: '_system/idempotency/',
 	idempotencyKey: (digest: string) => `_system/idempotency/${digest}.json`,
+	/**
+	 * First-seen marker for a recordless sandbox the compute provider reports
+	 * without a `createdAt`. Written once when the reconciler first observes such an
+	 * orphan and deleted when it is reaped or vanishes — an append-only bound on how
+	 * long a timestamp-less orphan can leak (see ReconciliationService Rule 3).
+	 */
+	reconcileOrphansPrefix: '_system/reconcile/orphans/',
+	reconcileOrphan: (sandboxId: string) =>
+		`_system/reconcile/orphans/${encodeURIComponent(sandboxId)}.json`,
 	/** Advisory lease guarding the single-writer maintenance sweep (see MaintenanceLock). */
 	maintenanceLock: '_system/_maintenance.lock',
 	/** Advisory lease for the session-lifecycle sweep — its own key, so the two loops

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,6 +1,7 @@
 import type {
 	NotebookId,
 	ProjectId,
+	SandboxId,
 	SessionId,
 	SnapshotId,
 	TokenId,
@@ -130,7 +131,7 @@ export const paths = {
 	 * long a timestamp-less orphan can leak (see ReconciliationService Rule 3).
 	 */
 	reconcileOrphansPrefix: '_system/reconcile/orphans/',
-	reconcileOrphan: (sandboxId: string) =>
+	reconcileOrphan: (sandboxId: SandboxId) =>
 		`_system/reconcile/orphans/${encodeURIComponent(sandboxId)}.json`,
 	/** Advisory lease guarding the single-writer maintenance sweep (see MaintenanceLock). */
 	maintenanceLock: '_system/_maintenance.lock',

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -8,11 +8,13 @@ import {
 } from './ids';
 import { z } from 'zod';
 import {
+	CatalogSchema,
 	EventSchema,
 	NotebookIdSchema,
 	parseStored,
 	ProjectIdSchema,
 	ProjectMemberSchema,
+	ProjectSchema,
 	SessionIdSchema,
 	SnapshotIdSchema,
 	SnapshotProjectEntrySchema,
@@ -22,7 +24,14 @@ import {
 	toPublicNotebookEntry,
 	toPublicProjectEntry,
 } from './schema';
-import { makeSnapshotNotebookEntry, makeSnapshotProjectEntry, ACTOR, NOW } from './testing';
+import {
+	makeCatalog,
+	makeProject,
+	makeSnapshotNotebookEntry,
+	makeSnapshotProjectEntry,
+	ACTOR,
+	NOW,
+} from './testing';
 
 describe('parseStored', () => {
 	const schema = z.object({ a: z.number() });
@@ -237,11 +246,50 @@ describe('ProjectMemberSchema', () => {
 	});
 });
 
+describe('CatalogSchema', () => {
+	it('parses a well-formed v1 catalog', () => {
+		const catalog = makeCatalog(createSnapshotId());
+		expect(CatalogSchema.parse(catalog).version).toBe(1);
+	});
+
+	it('rejects a catalog whose version is not 1 (strict literal, not forward-tolerant)', () => {
+		const catalog = { ...makeCatalog(createSnapshotId()), version: 2 };
+		expect(CatalogSchema.safeParse(catalog).success).toBe(false);
+	});
+});
+
+describe('status defaulting', () => {
+	it('SnapshotProjectEntrySchema defaults status to "active" when omitted', () => {
+		const entry: Record<string, unknown> = {
+			...makeSnapshotProjectEntry({ id: createProjectId() }),
+		};
+		delete entry.status;
+		expect(SnapshotProjectEntrySchema.parse(entry).status).toBe('active');
+	});
+
+	it('ProjectSchema defaults status to "active" when omitted', () => {
+		const project: Record<string, unknown> = { ...makeProject() };
+		delete project.status;
+		expect(ProjectSchema.parse(project).status).toBe('active');
+	});
+});
+
 describe('SnapshotProjectEntrySchema (rolling-deploy tolerance)', () => {
 	it('preserves unknown entry fields across a parse round-trip', () => {
 		const entry = { ...makeSnapshotProjectEntry({ id: createProjectId() }), future_field: 'kept' };
 		const parsed = SnapshotProjectEntrySchema.parse(entry);
 		expect((parsed as Record<string, unknown>).future_field).toBe('kept');
+	});
+
+	// authz compares member_emails against subject.email.toLowerCase(), so the schema
+	// must lowercase on parse or a mixed-case invite email would never match.
+	it('lowercases member_emails on parse (so authz email matching holds)', () => {
+		const entry = {
+			...makeSnapshotProjectEntry({ id: createProjectId() }),
+			member_emails: ['Alice@Example.COM'],
+		};
+		const parsed = SnapshotProjectEntrySchema.parse(entry);
+		expect(parsed.member_emails).toEqual(['alice@example.com']);
 	});
 
 	it('toPublicProjectEntry never leaks preserved unknown fields', () => {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -144,7 +144,9 @@ export const SnapshotProjectEntrySchema = z.looseObject({
 	// Companion roster for pending email invites (lowercased). Unlike a missing
 	// `member_ids`, a missing `member_emails` does NOT trigger the project.json
 	// fallback — see canSeeProjectEntry for why it fails closed instead.
-	member_emails: z.array(z.string()).optional(),
+	// Lowercased on parse so authz matching against a lowercased subject email holds
+	// regardless of the case an invite was stored in.
+	member_emails: z.array(z.string().transform((e) => e.toLowerCase())).optional(),
 });
 
 export type SnapshotProjectEntry = z.infer<typeof SnapshotProjectEntrySchema>;

--- a/packages/core/src/services/ai/aiSessionConfig.test.ts
+++ b/packages/core/src/services/ai/aiSessionConfig.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Seconds } from '../../duration';
+import { toBase64Url, utf8ToBase64Url } from '../../internal/base64url';
+import { hmacSha256 } from '../../internal/hmac';
 import {
 	aiConfigToSessionEnv,
 	buildMarimoAiToml,
@@ -10,6 +12,16 @@ import {
 import type { AiTokenClaims } from './aiSessionConfig';
 
 const SECRET = 'test-session-secret';
+
+/** Mint an HS256 token over an arbitrary payload, signed with `secret`. */
+async function mintRaw(secret: string, payload: Record<string, unknown>): Promise<string> {
+	const header = { alg: 'HS256', typ: 'JWT' };
+	const signingInput = `${utf8ToBase64Url(JSON.stringify(header))}.${utf8ToBase64Url(
+		JSON.stringify(payload),
+	)}`;
+	const sig = await hmacSha256(secret, signingInput);
+	return `${signingInput}.${toBase64Url(sig)}`;
+}
 const CLAIMS: AiTokenClaims = {
 	projectId: 'proj-1',
 	notebookId: 'nb-1',
@@ -46,6 +58,24 @@ describe('buildMarimoAiToml', () => {
 		const toml = buildMarimoAiToml({ baseUrl: 'u', apiKey: 'k', model: 'm' });
 		expect(toml).not.toContain('max_tokens');
 		expect(toml).not.toContain('rules');
+	});
+
+	it('emits enabled = false when enabled is false (does not silently force-enable)', () => {
+		const toml = buildMarimoAiToml({ baseUrl: 'u', apiKey: 'k', model: 'm', enabled: false });
+		expect(toml).toContain('enabled = false');
+		expect(toml).not.toContain('enabled = true');
+	});
+
+	it('escapes newline, carriage-return, and tab in rules (no TOML string break-out)', () => {
+		const toml = buildMarimoAiToml({
+			baseUrl: 'u',
+			apiKey: 'k',
+			model: 'm',
+			rules: 'line1\nline2\rline3\tcol',
+		});
+		expect(toml).toContain('rules = "line1\\nline2\\rline3\\tcol"');
+		// The raw control chars must NOT appear inside the emitted rules string.
+		expect(toml).not.toContain('line1\nline2');
 	});
 });
 
@@ -91,5 +121,39 @@ describe('AI session token', () => {
 		});
 		const later = () => start + 61_000;
 		expect(await verifyAiSessionToken(SECRET, token, later)).toBeNull();
+	});
+
+	it('rejects a well-formed, correctly-signed token that is missing exp', async () => {
+		const token = await mintRaw(SECRET, {
+			sub: 'sess-1',
+			project_id: 'proj-1',
+			notebook_id: 'nb-1',
+			user_id: 'user-1',
+			iat: 1_000_000_000,
+			// exp deliberately omitted — an unexpiring token must be rejected.
+		});
+		expect(await verifyAiSessionToken(SECRET, token)).toBeNull();
+	});
+
+	it('rejects a correctly-signed token missing a required claim (project_id)', async () => {
+		const token = await mintRaw(SECRET, {
+			sub: 'sess-1',
+			notebook_id: 'nb-1',
+			user_id: 'user-1',
+			iat: 1_000_000_000,
+			exp: 9_999_999_999,
+		});
+		expect(await verifyAiSessionToken(SECRET, token)).toBeNull();
+	});
+
+	it('treats exp exactly equal to now as still valid (boundary)', async () => {
+		const start = 1_000_000_000_000;
+		const token = await mintAiSessionToken(SECRET, CLAIMS, {
+			ttlSeconds: Seconds.of(60),
+			now: () => start,
+		});
+		// now (in seconds) === exp: the token expires strictly after this instant.
+		const atExpiry = () => start + 60_000;
+		expect(await verifyAiSessionToken(SECRET, token, atExpiry)).toEqual(CLAIMS);
 	});
 });

--- a/packages/core/src/services/catalog/CatalogService.test.ts
+++ b/packages/core/src/services/catalog/CatalogService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ACTOR, makeCatalog, makeSnapshot, MemoryBucket, setupTestEnv } from '../../testing';
 import { ConflictError, NotInitializedError, PreconditionFailedError } from '../../errors';
+import { createSnapshotId } from '../../ids';
 import { paths } from '../../paths';
 import { noopMetrics } from '../../ports/metrics';
 import { EventSchema, SnapshotSchema } from '../../schema';
@@ -75,6 +76,18 @@ describe('CatalogService', () => {
 			const snaps = await bucket.list({ prefix: '_system/snapshots/' });
 			expect(snaps.objects.length).toBeLessThanOrEqual(2);
 		});
+
+		it('propagates a non-precondition error from the create-if-absent put', async () => {
+			const originalPut = bucket.put.bind(bucket);
+			bucket.put = async (key, value, opts) => {
+				if (key === paths.catalog && opts?.onlyIfNotExists) {
+					throw new Error('catalog put boom');
+				}
+				return originalPut(key, value, opts);
+			};
+
+			await expect(catalog.initialize(ACTOR)).rejects.toThrow('catalog put boom');
+		});
 	});
 
 	describe('getCurrentSnapshot', () => {
@@ -90,6 +103,16 @@ describe('CatalogService', () => {
 			const init = await catalog.initialize(ACTOR);
 			const current = await catalog.getCurrentSnapshot();
 			expect(current.snapshot_id).toBe(init.snapshot_id);
+		});
+
+		it('throws NotInitializedError when the catalog points at a missing snapshot', async () => {
+			await bucket.put(paths.catalog, JSON.stringify(makeCatalog(createSnapshotId())));
+			await expect(catalog.getCurrentSnapshot()).rejects.toBeInstanceOf(NotInitializedError);
+		});
+
+		it('throws a corrupted-object error on malformed catalog JSON', async () => {
+			await bucket.put(paths.catalog, JSON.stringify({ bad: true }));
+			await expect(catalog.getCurrentSnapshot()).rejects.toThrow(/Corrupted stored object/);
 		});
 	});
 
@@ -165,6 +188,104 @@ describe('CatalogService', () => {
 			};
 
 			await expect(catalog.mutateSnapshot('test', ACTOR, (s) => s)).rejects.toThrow(ConflictError);
+		});
+
+		it('deletes the orphan snapshot it wrote when the CAS swap loses the race', async () => {
+			const snapshotPuts: string[] = [];
+			let raced = false;
+			const originalPut = bucket.put.bind(bucket);
+			bucket.put = async (key, value, opts) => {
+				if (key.startsWith(paths.snapshotsPrefix)) snapshotPuts.push(key);
+				if (key === paths.catalog && opts?.onlyIfEtagMatches && !raced) {
+					raced = true;
+					// Bump the catalog ETag so the retry re-reads and can commit.
+					const current = await bucket.get(paths.catalog);
+					await originalPut(key, await current!.text());
+					throw new PreconditionFailedError('simulated race');
+				}
+				return originalPut(key, value, opts);
+			};
+
+			await catalog.mutateSnapshot('test', ACTOR, (s) => s);
+
+			// The losing attempt's orphan + the winning commit.
+			expect(snapshotPuts).toHaveLength(2);
+			// The orphan was cleaned up; the committed snapshot remains.
+			expect(await bucket.get(snapshotPuts[0])).toBeNull();
+			expect(await bucket.get(snapshotPuts[1])).not.toBeNull();
+		});
+
+		it('propagates immediately (no retry, no orphan) when the snapshot put fails', async () => {
+			const increment = vi.fn();
+			const svc = new CatalogService(bucket, { increment, gauge: vi.fn() });
+			const before = (await bucket.list({ prefix: paths.snapshotsPrefix })).objects.length;
+
+			const originalPut = bucket.put.bind(bucket);
+			bucket.put = async (key, value, opts) => {
+				if (key.startsWith(paths.snapshotsPrefix)) throw new Error('snapshot put boom');
+				return originalPut(key, value, opts);
+			};
+
+			await expect(svc.mutateSnapshot('test', ACTOR, (s) => s)).rejects.toThrow(
+				'snapshot put boom',
+			);
+
+			// A non-precondition error is not retried.
+			expect(increment.mock.calls.filter(([n]) => n === 'catalog.cas.attempt')).toHaveLength(1);
+			// Nothing was written (the failed put left no orphan).
+			expect((await bucket.list({ prefix: paths.snapshotsPrefix })).objects.length).toBe(before);
+		});
+
+		it('does not retry and writes nothing when mutateFn throws', async () => {
+			const increment = vi.fn();
+			const svc = new CatalogService(bucket, { increment, gauge: vi.fn() });
+			const before = (await bucket.list({ prefix: paths.snapshotsPrefix })).objects.length;
+
+			const boom = new Error('mutate boom');
+			await expect(
+				svc.mutateSnapshot('test', ACTOR, () => {
+					throw boom;
+				}),
+			).rejects.toBe(boom);
+
+			expect(increment.mock.calls.filter(([n]) => n === 'catalog.cas.attempt')).toHaveLength(1);
+			expect((await bucket.list({ prefix: paths.snapshotsPrefix })).objects.length).toBe(before);
+		});
+
+		it('throws NotInitializedError without retrying when the snapshot pointer dangles', async () => {
+			const increment = vi.fn();
+			const svc = new CatalogService(bucket, { increment, gauge: vi.fn() });
+			const current = await svc.getCurrentSnapshot();
+			// Leave the catalog pointing at a snapshot that no longer exists.
+			await bucket.delete(paths.snapshot(current.snapshot_id));
+
+			await expect(svc.mutateSnapshot('test', ACTOR, (s) => s)).rejects.toBeInstanceOf(
+				NotInitializedError,
+			);
+			expect(increment.mock.calls.filter(([n]) => n === 'catalog.cas.attempt')).toHaveLength(1);
+		});
+
+		it('throws a corrupted-object error on malformed catalog JSON', async () => {
+			await bucket.put(paths.catalog, JSON.stringify({ not: 'a catalog' }));
+			await expect(catalog.mutateSnapshot('test', ACTOR, (s) => s)).rejects.toThrow(
+				/Corrupted stored object/,
+			);
+		});
+
+		it('throws a corrupted-object error on a malformed snapshot object', async () => {
+			const current = await catalog.getCurrentSnapshot();
+			await bucket.put(paths.snapshot(current.snapshot_id), JSON.stringify({ nope: true }));
+			await expect(catalog.mutateSnapshot('test', ACTOR, (s) => s)).rejects.toThrow(
+				/Corrupted stored object/,
+			);
+		});
+
+		it('ignores a mutateFn-lowered schema_version (stamps the read version)', async () => {
+			const result = await catalog.mutateSnapshot('test', ACTOR, (s) => ({
+				...s,
+				schema_version: 0 as unknown as 1,
+			}));
+			expect(result.schema_version).toBe(1);
 		});
 	});
 

--- a/packages/core/src/services/catalog/EventService.test.ts
+++ b/packages/core/src/services/catalog/EventService.test.ts
@@ -1,7 +1,18 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { MemoryBucket, uid } from '../../testing';
+import type { BucketListOptions } from '../../ports/bucket';
 import { paths } from '../../paths';
 import { EventService } from './EventService';
+
+/** Forces a tiny list page so getEvents' cursor loop spans multiple pages. */
+class SmallPageBucket extends MemoryBucket {
+	constructor(private readonly pageSize: number) {
+		super();
+	}
+	override list(options?: BucketListOptions) {
+		return super.list({ ...options, limit: options?.limit ?? this.pageSize });
+	}
+}
 
 describe('EventService', () => {
 	let bucket: MemoryBucket;
@@ -78,6 +89,27 @@ describe('EventService', () => {
 			const evts = await events.getEvents('2025-03-05');
 			expect(evts).toHaveLength(3);
 			expect(evts.map((e) => e.event)).toEqual(['a', 'b', 'c']);
+		});
+
+		it('skips a corrupt event object rather than throwing', async () => {
+			await events.append({ event: 'a', actor: uid('x') });
+			await events.append({ event: 'b', actor: uid('y') });
+			// A corrupt object under the same day prefix (sorts after the ULID keys).
+			await bucket.put(paths.event('2025-03-05', 'zzz-corrupt'), 'not-json{');
+
+			const evts = await events.getEvents('2025-03-05');
+			expect(evts.map((e) => e.event).sort()).toEqual(['a', 'b']);
+		});
+
+		it('pages across multiple truncated list pages', async () => {
+			const small = new SmallPageBucket(2);
+			const svc = new EventService(small);
+			for (let i = 0; i < 5; i++) {
+				await svc.append({ event: `e${i}`, actor: uid('a') });
+			}
+
+			const evts = await svc.getEvents('2025-03-05');
+			expect(evts).toHaveLength(5);
 		});
 	});
 

--- a/packages/core/src/services/catalog/EventService.ts
+++ b/packages/core/src/services/catalog/EventService.ts
@@ -43,7 +43,15 @@ export class EventService {
 				BUCKET_SCAN_CONCURRENCY,
 				async (obj) => {
 					const body = await this.bucket.get(obj.key);
-					return body ? EventSchema.parse(await body.json()) : undefined;
+					if (!body) return;
+					// One corrupt/legacy event object must not make the whole day's audit
+					// log unreadable — skip it (logged) rather than throwing.
+					try {
+						return EventSchema.parse(await body.json());
+					} catch (err) {
+						console.warn(`getEvents: skipping unreadable event ${obj.key}: ${String(err)}`);
+						return;
+					}
 				},
 			);
 			for (const event of page) {

--- a/packages/core/src/services/catalog/IdempotencyService.test.ts
+++ b/packages/core/src/services/catalog/IdempotencyService.test.ts
@@ -48,6 +48,30 @@ describe('IdempotencyService', () => {
 		expect(await svc.lookup('u1:POST /projects', 'fresh')).toEqual({ data: { id: 'fresh' } });
 	});
 
+	it('lookup returns null when the stored record scope does not match (hash-collision guard)', async () => {
+		const bucket = new MemoryBucket();
+		const svc = new IdempotencyService(bucket);
+		await svc.record('u1:POST /projects', 'k1', { id: 'proj-1' });
+
+		// Tamper the stored record's scope in place, simulating a digest collision
+		// where a record for a different scope lands at the same object key.
+		const { objects } = await bucket.list({ prefix: paths.idempotencyPrefix });
+		const key = objects[0].key;
+		const record = await (await bucket.get(key))!.json<any>();
+		await bucket.put(key, JSON.stringify({ ...record, scope: 'u2:POST /other' }));
+
+		expect(await svc.lookup('u1:POST /projects', 'k1')).toBeNull();
+	});
+
+	it('record rethrows a non-PreconditionFailed error from put', async () => {
+		const bucket = new MemoryBucket();
+		const boom = new Error('put boom');
+		vi.spyOn(bucket, 'put').mockRejectedValue(boom);
+		const svc = new IdempotencyService(bucket);
+
+		await expect(svc.record('u1:POST /projects', 'k1', { id: 'x' })).rejects.toBe(boom);
+	});
+
 	it('prune writes under the _system/idempotency/ prefix', async () => {
 		const bucket = new MemoryBucket();
 		await new IdempotencyService(bucket).record('u1:POST /projects', 'k1', { id: 'proj-1' });

--- a/packages/core/src/services/catalog/MaintenanceLock.test.ts
+++ b/packages/core/src/services/catalog/MaintenanceLock.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MemoryBucket, useFakeClock } from '../../testing';
+import { PreconditionFailedError } from '../../errors';
 import { paths } from '../../paths';
 import { MaintenanceLock } from './MaintenanceLock';
 
@@ -55,5 +56,39 @@ describe('MaintenanceLock', () => {
 		await lock.release('B'); // not the holder
 		expect(await bucket.get(paths.maintenanceLock)).not.toBeNull();
 		expect(await lock.acquire('B', 10_000)).toBe(false); // A still holds it
+	});
+
+	it('steals a lock whose stored record is malformed', async () => {
+		await bucket.put(paths.maintenanceLock, 'not-json');
+
+		expect(await lock.acquire('A', 1000)).toBe(true);
+		const stored = await bucket.get(paths.maintenanceLock);
+		expect((await stored!.json<{ holder: string }>()).holder).toBe('A');
+	});
+
+	it('returns false when it loses the CAS on a contended steal', async () => {
+		expect(await lock.acquire('A', 1000)).toBe(true);
+		clock.set(2000); // A's lease expired → eligible to steal
+
+		const originalPut = bucket.put.bind(bucket);
+		vi.spyOn(bucket, 'put').mockImplementation(async (key, value, opts) => {
+			// Another writer wins the steal first: the conditional CAS fails.
+			if (opts?.onlyIfEtagMatches) throw new PreconditionFailedError('lost the steal');
+			return originalPut(key, value, opts);
+		});
+
+		expect(await lock.acquire('B', 1000)).toBe(false);
+	});
+
+	it('release does not delete a lease another holder stole after a TTL overrun', async () => {
+		expect(await lock.acquire('A', 1000)).toBe(true);
+		clock.set(2000); // A overran its TTL
+		expect(await lock.acquire('B', 10_000)).toBe(true); // B steals the expired lease
+
+		await lock.release('A'); // must not delete B's freshly-acquired lease
+
+		const stored = await bucket.get(paths.maintenanceLock);
+		expect(stored).not.toBeNull();
+		expect((await stored!.json<{ holder: string }>()).holder).toBe('B');
 	});
 });

--- a/packages/core/src/services/catalog/MaintenanceService.test.ts
+++ b/packages/core/src/services/catalog/MaintenanceService.test.ts
@@ -91,6 +91,46 @@ describe('MaintenanceService', () => {
 			expect(await maintenance.expireSnapshots({ retentionMs: 0, keepLast: 20 })).toBe(0);
 		});
 
+		it('does not delete anything when catalog.json is corrupt', async () => {
+			const old1 = createSnapshotId();
+			const old2 = createSnapshotId();
+			await putSnapshotAt(old1, 0);
+			await putSnapshotAt(old2, 0);
+			await bucket.put(paths.catalog, JSON.stringify({ not: 'a catalog' }));
+			const delSpy = vi.spyOn(bucket, 'delete');
+
+			clock.set(500 * DAY_MS);
+			// The corrupt catalog means current/previous can't be identified, so
+			// nothing may be deleted (else the live pointer could be orphaned).
+			await maintenance.expireSnapshots({ retentionMs: 0, keepLast: 0 }).catch(() => {});
+
+			expect(delSpy).not.toHaveBeenCalled();
+			expect(await bucket.get(paths.snapshot(old1))).not.toBeNull();
+			expect(await bucket.get(paths.snapshot(old2))).not.toBeNull();
+		});
+
+		it('protects current/previous even when outside keepLast AND older than retention', async () => {
+			const previous = createSnapshotId();
+			const current = createSnapshotId();
+			const newer1 = createSnapshotId();
+			const newer2 = createSnapshotId();
+			// current/previous are the OLDEST — outside a keepLast floor and past retention.
+			await putSnapshotAt(previous, 0);
+			await putSnapshotAt(current, 1 * DAY_MS);
+			await putSnapshotAt(newer1, 10 * DAY_MS);
+			await putSnapshotAt(newer2, 11 * DAY_MS);
+			await bucket.put(
+				paths.catalog,
+				JSON.stringify({ ...makeCatalog(current), previous_snapshot_id: previous }),
+			);
+
+			clock.set(500 * DAY_MS);
+			await maintenance.expireSnapshots({ retentionMs: 90 * DAY_MS, keepLast: 2 });
+
+			expect(await bucket.get(paths.snapshot(current))).not.toBeNull();
+			expect(await bucket.get(paths.snapshot(previous))).not.toBeNull();
+		});
+
 		it('emits snapshot count/size gauges', async () => {
 			const gauge = vi.fn();
 			const svc = new MaintenanceService(bucket, { increment: vi.fn(), gauge });
@@ -122,6 +162,32 @@ describe('MaintenanceService', () => {
 
 		it('returns 0 when there are no events', async () => {
 			expect(await maintenance.pruneEvents()).toBe(0);
+		});
+
+		it('skips a non-date folder under the events prefix', async () => {
+			clock.set(Date.parse('2025-06-17T00:00:00.000Z'));
+			await bucket.put(paths.event('2020-01-01', 'e1'), '{}'); // old day → pruned
+			await bucket.put('_system/events/not-a-date/x.json', '{}'); // not a date folder
+
+			const deleted = await maintenance.pruneEvents({ retentionMs: 90 * DAY_MS });
+
+			expect(deleted).toBe(1); // only the old day folder
+			expect(await bucket.get('_system/events/not-a-date/x.json')).not.toBeNull();
+		});
+
+		it('keeps a day folder whose end is exactly at the retention boundary', async () => {
+			// Choose `now` so cutoff (now - retention) lands exactly on the day's end.
+			// The documented rule keeps a day "until the end predates the cutoff"; at
+			// end === cutoff the end does not predate, so the folder must survive.
+			const retentionMs = 90 * DAY_MS;
+			const dayEnd = Date.parse('2020-01-02T00:00:00.000Z');
+			clock.set(dayEnd + retentionMs); // cutoff === dayEnd
+			await bucket.put(paths.event('2020-01-01', 'e1'), '{}');
+
+			const deleted = await maintenance.pruneEvents({ retentionMs });
+
+			expect(deleted).toBe(0);
+			expect(await bucket.get(paths.event('2020-01-01', 'e1'))).not.toBeNull();
 		});
 	});
 });

--- a/packages/core/src/services/catalog/MaintenanceService.ts
+++ b/packages/core/src/services/catalog/MaintenanceService.ts
@@ -109,8 +109,9 @@ export class MaintenanceService {
 			const dateStr = dayPrefix.slice(paths.eventsPrefix.length).replace(/\/$/, '');
 			const dayStart = Date.parse(`${dateStr}T00:00:00.000Z`);
 			if (Number.isNaN(dayStart)) continue; // not a date folder — leave it alone
-			// Keep the whole day until the end of that day predates the cutoff.
-			if (dayStart + DAY_MS > cutoff) continue;
+			// Keep the whole day until the end of that day predates the cutoff. "Predates"
+			// is strictly-before, so a day whose end lands exactly on the cutoff is kept.
+			if (dayStart + DAY_MS >= cutoff) continue;
 
 			const dayObjects = await listAllObjects(this.bucket, dayPrefix);
 			if (dayObjects.length === 0) continue;

--- a/packages/core/src/services/catalog/MigrationService.test.ts
+++ b/packages/core/src/services/catalog/MigrationService.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createNotebookId, createProjectId } from '../../ids';
 import { MemoryBucket, makeNotebookMeta } from '../../testing';
+import type { BucketListOptions } from '../../ports/bucket';
 import { paths } from '../../paths';
 import { EventService } from './EventService';
 import { MigrationService, exampleMigrateV1toV2 } from './MigrationService';
+import type { MigrateFn } from './MigrationService';
+
+/** Forces a tiny list page so the cursor loop is exercised without 1000+ objects. */
+class SmallPageBucket extends MemoryBucket {
+	constructor(private readonly pageSize: number) {
+		super();
+	}
+	override list(options?: BucketListOptions) {
+		return super.list({ ...options, limit: options?.limit ?? this.pageSize });
+	}
+}
 
 describe('MigrationService (prototype, unwired)', () => {
 	let bucket: MemoryBucket;
@@ -97,6 +109,68 @@ describe('MigrationService (prototype, unwired)', () => {
 		expect((run as any).from_version).toBe(1);
 		expect((run as any).to_version).toBe(2);
 		expect((run as any).migrated).toBe(2);
+	});
+
+	it('leaves already-migrated objects intact when migrateFn throws mid-run', async () => {
+		await seedMeta(3);
+		let n = 0;
+		const migrateThrows: MigrateFn = (data) => {
+			if (n++ === 1) throw new Error('mid-run boom');
+			return { ...data, migrated_marker: true };
+		};
+
+		await expect(migrations.runMigration(1, 2, 'meta', migrateThrows)).rejects.toThrow(
+			'mid-run boom',
+		);
+
+		// The object migrated before the throw stays at v2 (not rolled back).
+		const metas = await Promise.all(
+			(await bucket.list({ prefix: 'projects/' })).objects.map(async (o) =>
+				(await bucket.get(o.key))!.json<any>(),
+			),
+		);
+		expect(metas.filter((m) => m.schema_version === 2)).toHaveLength(1);
+	});
+
+	it('does not abort the whole run on one malformed object', async () => {
+		const validKeys = await seedMeta(2);
+		// A corrupt meta.json (invalid JSON) under the scanned prefix/suffix.
+		const projectId = createProjectId();
+		const notebookId = createNotebookId();
+		const badKey = paths.project(projectId).notebook(notebookId).meta;
+		await bucket.put(badKey, 'not-json{');
+
+		const result = await migrations.runMigration(1, 2, 'meta', exampleMigrateV1toV2);
+
+		// The two valid objects should migrate despite the corrupt sibling.
+		expect(result.migrated).toBe(2);
+		for (const key of validKeys) {
+			expect((await (await bucket.get(key))!.json<any>()).schema_version).toBe(2);
+		}
+	});
+
+	it('resumes across multiple cursor pages', async () => {
+		const small = new SmallPageBucket(2);
+		const svc = new MigrationService(small);
+		const projectId = createProjectId();
+		const keys: string[] = [];
+		for (let i = 0; i < 5; i++) {
+			const notebookId = createNotebookId();
+			const key = paths.project(projectId).notebook(notebookId).meta;
+			await small.put(
+				key,
+				JSON.stringify(makeNotebookMeta({ id: notebookId, project_id: projectId })),
+			);
+			keys.push(key);
+		}
+
+		const result = await svc.runMigration(1, 2, 'meta', exampleMigrateV1toV2);
+
+		expect(result.scanned).toBe(5);
+		expect(result.migrated).toBe(5);
+		for (const key of keys) {
+			expect((await (await small.get(key))!.json<any>()).schema_version).toBe(2);
+		}
 	});
 
 	it('exampleMigrateV1toV2 is pure and leaves schema_version to the runner', () => {

--- a/packages/core/src/services/catalog/MigrationService.test.ts
+++ b/packages/core/src/services/catalog/MigrationService.test.ts
@@ -149,6 +149,21 @@ describe('MigrationService (prototype, unwired)', () => {
 		}
 	});
 
+	it('skips a JSON-valid but non-object record (e.g. null) without aborting', async () => {
+		const validKeys = await seedMeta(2);
+		// Valid JSON, but `null` — reading `.schema_version` off it would throw.
+		const badKey = paths.project(createProjectId()).notebook(createNotebookId()).meta;
+		await bucket.put(badKey, 'null');
+
+		const result = await migrations.runMigration(1, 2, 'meta', exampleMigrateV1toV2);
+
+		expect(result.migrated).toBe(2);
+		expect(result.skipped).toBe(1);
+		for (const key of validKeys) {
+			expect((await (await bucket.get(key))!.json<any>()).schema_version).toBe(2);
+		}
+	});
+
 	it('resumes across multiple cursor pages', async () => {
 		const small = new SmallPageBucket(2);
 		const svc = new MigrationService(small);

--- a/packages/core/src/services/catalog/MigrationService.ts
+++ b/packages/core/src/services/catalog/MigrationService.ts
@@ -81,12 +81,18 @@ export class MigrationService {
 				const body = await this.bucket.get(obj.key);
 				if (!body) continue;
 
-				// A single corrupt/unparseable object must not abort the whole run and
-				// strand its valid siblings unmigrated. Count it as skipped (logged) and
-				// move on; a re-run after the object is repaired will pick it up.
+				// A single corrupt object must not abort the whole run and strand its
+				// valid siblings unmigrated. Count it as skipped (logged) and move on; a
+				// re-run after the object is repaired will pick it up. This covers both
+				// unparseable JSON and JSON that isn't a non-null object (e.g. `null`,
+				// which would otherwise throw on the schema_version read below).
 				let data: Migratable;
 				try {
-					data = (await body.json()) as Migratable;
+					const parsed = await body.json();
+					if (parsed === null || typeof parsed !== 'object') {
+						throw new Error('not a JSON object');
+					}
+					data = parsed as Migratable;
 				} catch (err) {
 					console.warn(`runMigration: skipping unreadable object ${obj.key}: ${String(err)}`);
 					result.skipped++;

--- a/packages/core/src/services/catalog/MigrationService.ts
+++ b/packages/core/src/services/catalog/MigrationService.ts
@@ -81,7 +81,17 @@ export class MigrationService {
 				const body = await this.bucket.get(obj.key);
 				if (!body) continue;
 
-				const data = (await body.json()) as Migratable;
+				// A single corrupt/unparseable object must not abort the whole run and
+				// strand its valid siblings unmigrated. Count it as skipped (logged) and
+				// move on; a re-run after the object is repaired will pick it up.
+				let data: Migratable;
+				try {
+					data = (await body.json()) as Migratable;
+				} catch (err) {
+					console.warn(`runMigration: skipping unreadable object ${obj.key}: ${String(err)}`);
+					result.skipped++;
+					continue;
+				}
 
 				// Idempotency guard: only objects still at fromVersion are migrated.
 				// Re-running after a partial run skips everything already at toVersion.

--- a/packages/core/src/services/catalog/cas.test.ts
+++ b/packages/core/src/services/catalog/cas.test.ts
@@ -41,6 +41,12 @@ describe('withCasRetry', () => {
 		await expect(withCasRetry(attempt, { backoffMs: () => 0 })).rejects.toBeInstanceOf(TypeError);
 		expect(attempt).toHaveBeenCalledTimes(1);
 	});
+
+	it('throws ConflictError immediately when retries is 0 (attempt never runs)', async () => {
+		const attempt = vi.fn();
+		await expect(withCasRetry(attempt, { retries: 0 })).rejects.toBeInstanceOf(ConflictError);
+		expect(attempt).not.toHaveBeenCalled();
+	});
 });
 
 describe('mutateObject', () => {
@@ -70,6 +76,46 @@ describe('mutateObject', () => {
 				notFound: () => new NotFoundError('nope'),
 			}),
 		).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	it('throws the default NotFoundError when no notFound option is given', async () => {
+		const bucket = new MemoryBucket();
+		await expect(mutateObject(bucket, 'missing', parse, (c) => c)).rejects.toBeInstanceOf(
+			NotFoundError,
+		);
+	});
+
+	it('exhausts retries and throws ConflictError under perpetual conflict', async () => {
+		const bucket = new MemoryBucket();
+		await bucket.put('k', JSON.stringify({ n: 1 }));
+		vi.spyOn(bucket, 'put').mockRejectedValue(new PreconditionFailedError('always'));
+
+		await expect(
+			mutateObject(bucket, 'k', parse, (cur) => ({ n: cur.n + 1 }), {
+				retries: 3,
+				backoffMs: () => 0,
+			}),
+		).rejects.toBeInstanceOf(ConflictError);
+	});
+
+	it('propagates a parse error without retrying', async () => {
+		const bucket = new MemoryBucket();
+		await bucket.put('k', JSON.stringify({ n: 1 }));
+		const getSpy = vi.spyOn(bucket, 'get');
+		const boom = new Error('parse boom');
+
+		await expect(
+			mutateObject(
+				bucket,
+				'k',
+				() => {
+					throw boom;
+				},
+				(c) => c,
+				{ backoffMs: () => 0 },
+			),
+		).rejects.toBe(boom);
+		expect(getSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it('CAS: a racing write makes apply re-run against the fresh value', async () => {

--- a/packages/core/src/services/catalog/storage.test.ts
+++ b/packages/core/src/services/catalog/storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { MemoryBucket } from '../../testing';
 import type { BucketListOptions } from '../../ports/bucket';
-import { listAllKeys, listAllObjects } from './storage';
+import { deleteByPrefix, listAllKeys, listAllObjects } from './storage';
 
 /**
  * MemoryBucket pages at `limit` (default 1000). These helpers never pass a
@@ -92,5 +92,26 @@ describe('listAllKeys', () => {
 
 		const got = await listAllKeys(bucket, 'projects/p/');
 		expect(got.sort()).toEqual([...keys].sort());
+	});
+});
+
+describe('deleteByPrefix', () => {
+	it('deletes every key under the prefix and returns the count', async () => {
+		const bucket = new MemoryBucket();
+		await seed(bucket, ['p/a', 'p/b', 'p/c', 'other/x']);
+
+		const count = await deleteByPrefix(bucket, 'p/');
+
+		expect(count).toBe(3);
+		expect(await listAllKeys(bucket, 'p/')).toEqual([]);
+		expect(await listAllKeys(bucket, 'other/')).toEqual(['other/x']);
+	});
+
+	it('no-ops (returns 0, never calls bucket.delete) for an empty prefix', async () => {
+		const bucket = new MemoryBucket();
+		const delSpy = vi.spyOn(bucket, 'delete');
+
+		expect(await deleteByPrefix(bucket, 'nothing/')).toBe(0);
+		expect(delSpy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -1441,16 +1441,24 @@ describe('NotebookService', () => {
 				return realGet(key);
 			});
 
-			const result = await notebooks.commitSession(
-				projectId,
-				created.id,
-				{ code: 'v1', html: '<html>x</html>' },
-				ACTOR,
-			);
-			spy.mockRestore();
+			let result: Awaited<ReturnType<typeof notebooks.commitSession>>;
+			try {
+				result = await notebooks.commitSession(
+					projectId,
+					created.id,
+					{ code: 'v1', html: '<html>x</html>' },
+					ACTOR,
+				);
+			} finally {
+				// Restore in finally so a failed assertion/throw can't leak the forced-null
+				// get spy into later tests.
+				spy.mockRestore();
+			}
 
 			expect(result).not.toBeNull();
 			expect(result!.newVersion).toBe(false);
+			// The whole attach was skipped, so no orphan html sidecar was left behind.
+			expect(await bucket.get(ver.html)).toBeNull();
 		});
 
 		it('skips the descriptor attach entirely when version.json is missing', async () => {

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { MemoryBucket } from '../../testing';
-import { BadRequestError, NotFoundError } from '../../errors';
+import { BadRequestError, DomainError, NotFoundError, PreconditionFailedError } from '../../errors';
 import { createNotebookId, createVersionId } from '../../ids';
 import type { NotebookId, ProjectId } from '../../ids';
 import { paths } from '../../paths';
@@ -486,6 +486,45 @@ describe('NotebookService', () => {
 	});
 
 	describe('updateNotebook', () => {
+		it('rejects a stale expectedVersion with PreconditionFailedError', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+
+			await expect(
+				notebooks.updateNotebook(
+					projectId,
+					created.id,
+					{ title: 'New' },
+					ACTOR,
+					'2000-01-01T00:00:00.000Z',
+				),
+			).rejects.toThrow(PreconditionFailedError);
+		});
+
+		it('rejects code/deps changes on a git-backed notebook', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{
+					title: 'Git NB',
+					description: 'from repo',
+					repo: 'org/repo',
+					branch: 'main',
+					entry_notebook: 'app.py',
+				},
+				ACTOR,
+			);
+
+			await expect(
+				notebooks.updateNotebook(projectId, meta.id, { code: 'hacked' }, ACTOR),
+			).rejects.toThrow(BadRequestError);
+			await expect(
+				notebooks.updateNotebook(projectId, meta.id, { deps: 'hacked' }, ACTOR),
+			).rejects.toThrow(BadRequestError);
+		});
+
 		it('updates metadata without creating a version when no code change', async () => {
 			const created = await notebooks.createNotebook(
 				projectId,
@@ -751,7 +790,86 @@ describe('NotebookService', () => {
 		});
 	});
 
+	describe('restoreVersion', () => {
+		it('rejects a non-local (git) notebook with BadRequestError', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{
+					title: 'Git NB',
+					description: 'from repo',
+					repo: 'org/repo',
+					branch: 'main',
+					entry_notebook: 'app.py',
+				},
+				ACTOR,
+			);
+
+			await expect(
+				notebooks.restoreVersion(projectId, meta.id, createVersionId(), ACTOR),
+			).rejects.toThrow(BadRequestError);
+		});
+
+		it('throws NotFoundError when the version folder does not exist', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+
+			await expect(
+				notebooks.restoreVersion(projectId, created.id, createVersionId(), ACTOR),
+			).rejects.toThrow(NotFoundError);
+		});
+
+		it('cuts a new version carrying the restored code, leaving history intact', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const original = (await notebooks.listVersions(projectId, created.id))[0];
+
+			await notebooks.updateNotebook(
+				projectId,
+				created.id,
+				{ code: 'v2', message: 'second' },
+				ACTOR,
+			);
+
+			// Restore the ORIGINAL version: a restore is another save, so it cuts a NEW
+			// version carrying v1 rather than rewinding history.
+			await notebooks.restoreVersion(projectId, created.id, original.version_id, ACTOR);
+
+			expect(await notebooks.getNotebookContent(projectId, created.id)).toBe('v1');
+			const versions = await notebooks.listVersions(projectId, created.id);
+			expect(versions).toHaveLength(3);
+			// The original version is still present — history was preserved.
+			expect(versions.map((v) => v.version_id)).toContain(original.version_id);
+			// The restore version chains onto the most recent (v2) version.
+			const restore = versions.find((v) => v.message === `Restore version ${original.version_id}`);
+			expect(restore).toBeDefined();
+			expect(restore!.version_id).not.toBe(original.version_id);
+		});
+	});
+
 	describe('deleteNotebook', () => {
+		it('rejects a stale expectedVersion with PreconditionFailedError', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'code' },
+				ACTOR,
+			);
+
+			await expect(
+				notebooks.deleteNotebook(projectId, created.id, ACTOR, '2000-01-01T00:00:00.000Z'),
+			).rejects.toThrow(PreconditionFailedError);
+
+			// The stale precondition must abort the delete: the notebook is still active.
+			const snap = await catalog.getCurrentSnapshot();
+			const proj = snap.projects.find((p) => p.id === projectId)!;
+			expect(proj.notebooks[0].status).toBe('active');
+		});
+
 		it('soft-deletes — sets status to deleted in snapshot and meta', async () => {
 			const created = await notebooks.createNotebook(
 				projectId,
@@ -849,6 +967,20 @@ describe('NotebookService', () => {
 
 			expect(version.message).toBe('Initial version');
 			expect(code).toBe('v1');
+		});
+
+		it('getVersion maps a malformed version id to a domain error, not a raw 500', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'c' },
+				ACTOR,
+			);
+
+			// A malformed version id is a client mistake: it must surface as a 4xx domain
+			// error (400/404), never a raw parse Error that the API renders as a 500.
+			await expect(
+				notebooks.getVersion(projectId, created.id, 'not-a-valid-version-id'),
+			).rejects.toBeInstanceOf(DomainError);
 		});
 
 		it('getVersion throws NotFoundError for missing version', async () => {
@@ -1277,6 +1409,79 @@ describe('NotebookService', () => {
 			const version = (await (await bucket.get(ver.meta))!.json()) as any;
 			expect(version.html_snapshot.size_bytes).toBe(new TextEncoder().encode(html).length);
 			expect(version.html_snapshot.size_bytes).toBeGreaterThan(html.length);
+		});
+
+		it('swallows a NotFoundError when version.json is deleted mid-CAS', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const before = await notebooks.getNotebook(projectId, created.id);
+			const currentVid = (before.source as { current_version_id: string }).current_version_id;
+			const ver = paths
+				.project(projectId)
+				.notebook(created.id)
+				.version(currentVid as any);
+
+			// Unchanged code + a fresh html snapshot takes the "attach to existing version"
+			// path. The existence check reads version.json (present); then between that
+			// read and the CAS re-read (inside mutateObject), a concurrent purge deletes
+			// version.json. mutateObject throws NotFoundError, which commitSession must
+			// swallow rather than surface.
+			const realGet = bucket.get.bind(bucket);
+			let metaGets = 0;
+			const spy = vi.spyOn(bucket, 'get').mockImplementation(async (key) => {
+				if (key === ver.meta) {
+					metaGets++;
+					// First read (existence check) returns the object; the CAS re-read sees
+					// it deleted.
+					if (metaGets >= 2) return null;
+				}
+				return realGet(key);
+			});
+
+			const result = await notebooks.commitSession(
+				projectId,
+				created.id,
+				{ code: 'v1', html: '<html>x</html>' },
+				ACTOR,
+			);
+			spy.mockRestore();
+
+			expect(result).not.toBeNull();
+			expect(result!.newVersion).toBe(false);
+		});
+
+		it('skips the descriptor attach entirely when version.json is missing', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const before = await notebooks.getNotebook(projectId, created.id);
+			const currentVid = (before.source as { current_version_id: string }).current_version_id;
+			const ver = paths
+				.project(projectId)
+				.notebook(created.id)
+				.version(currentVid as any);
+
+			// Drop the current version's version.json (keep its code so the session reads
+			// as unchanged). With no version.json to record a descriptor against, the
+			// attach is skipped — no sidecar html is written that we could never track.
+			await bucket.delete(ver.meta);
+
+			const result = await notebooks.commitSession(
+				projectId,
+				created.id,
+				{ code: 'v1', html: '<html>x</html>' },
+				ACTOR,
+			);
+
+			expect(result).not.toBeNull();
+			expect(result!.newVersion).toBe(false);
+			// The sidecar html was NOT written because the descriptor could not be recorded.
+			expect(await bucket.get(ver.html)).toBeNull();
 		});
 	});
 

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -687,7 +687,14 @@ export class NotebookService {
 		notebookId: NotebookId,
 		versionId: string,
 	): Promise<{ version: Version; code: string }> {
-		const vid = VersionId.parse(versionId);
+		// A malformed id is a client mistake, not a server fault: map the bare parse
+		// Error to a domain 404 so the API renders a 4xx instead of a raw 500.
+		let vid: VersionId;
+		try {
+			vid = VersionId.parse(versionId);
+		} catch {
+			throw new NotFoundError(`Version ${versionId} not found`);
+		}
 		const { source } = await this.getNotebook(projectId, notebookId);
 		const ver = paths.project(projectId).notebook(notebookId).version(vid);
 		const entryNotebook = remoteWorkspaceEntry(source);

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -617,8 +617,15 @@ export class NotebookService {
 					);
 				} catch (err) {
 					// version.json deleted between the read above and the CAS write
-					// (e.g. concurrent notebook purge) — skip, matching the read-first check.
+					// (e.g. concurrent notebook purge). Best-effort remove the sidecars we
+					// just wrote so we don't leak untracked artifacts no descriptor points
+					// at — matching the read-first "skip the whole attach" contract.
 					if (!(err instanceof NotFoundError)) throw err;
+					const orphans = [
+						input.html !== undefined ? ver.html : undefined,
+						input.session !== undefined ? ver.session : undefined,
+					].filter((k): k is string => k !== undefined);
+					if (orphans.length > 0) await this.bucket.delete(orphans).catch(() => {});
 				}
 			}
 		}

--- a/packages/core/src/services/content/ProjectService.test.ts
+++ b/packages/core/src/services/content/ProjectService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { NotFoundError } from '../../errors';
+import { NotFoundError, PreconditionFailedError } from '../../errors';
 import { UserId } from '../../ids';
 import type { ProjectId } from '../../ids';
 import { ACTOR, setupTestEnv } from '../../testing';
@@ -150,6 +150,21 @@ describe('ProjectService', () => {
 			const list = await projects.listProjects({ subject: STRANGER, defaultRole: null });
 			expect(list.map((e) => e.id)).toEqual([p.id]);
 		});
+
+		it('hides the project from a stranger via the project.json deny fallback', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			// Simulate an old snapshot entry (no denormalized roster) so visibility is
+			// indeterminate from the snapshot and must fall back to project.json.
+			await catalog.updateProjectEntry('test.strip', ACTOR, p.id, () => ({
+				member_ids: undefined,
+			}));
+			expect((await catalog.getCurrentSnapshot()).projects[0].member_ids).toBeUndefined();
+
+			// The stranger is neither owner nor a member, so the deny branch of
+			// canSeeProject hides the project entirely.
+			const list = await projects.listProjects({ subject: STRANGER, defaultRole: null });
+			expect(list).toEqual([]);
+		});
 	});
 
 	describe('membership', () => {
@@ -289,6 +304,20 @@ describe('ProjectService', () => {
 				projects.updateProject('proj_01HXY00000000000000000000' as ProjectId, { name: 'X' }, ACTOR),
 			).rejects.toThrow(NotFoundError);
 		});
+
+		it('rejects a stale expectedVersion with PreconditionFailedError (If-Match)', async () => {
+			const created = await projects.createProject({ name: 'P', description: 'd' }, ACTOR);
+
+			// A precondition that no longer matches the resource's current version.
+			await expect(
+				projects.updateProject(created.id, { name: 'X' }, ACTOR, 'stale-version-token'),
+			).rejects.toThrow(PreconditionFailedError);
+
+			// The matching version is accepted, proving the guard checks the token
+			// rather than rejecting every precondition.
+			const ok = await projects.updateProject(created.id, { name: 'X' }, ACTOR, created.updated_at);
+			expect(ok.name).toBe('X');
+		});
 	});
 
 	describe('deleteProject (soft-delete)', () => {
@@ -323,6 +352,17 @@ describe('ProjectService', () => {
 			await expect(
 				projects.deleteProject('proj_01HXY00000000000000000000' as ProjectId, ACTOR),
 			).rejects.toThrow(NotFoundError);
+		});
+
+		it('rejects a stale expectedVersion with PreconditionFailedError (If-Match)', async () => {
+			const created = await projects.createProject({ name: 'Doomed', description: 'D' }, ACTOR);
+
+			await expect(
+				projects.deleteProject(created.id, ACTOR, 'stale-version-token'),
+			).rejects.toThrow(PreconditionFailedError);
+
+			// The project was NOT deleted: a failed precondition must be a no-op.
+			expect((await projects.getProject(created.id)).status).toBe('active');
 		});
 	});
 
@@ -392,6 +432,25 @@ describe('ProjectService', () => {
 			expect(await listAllKeys(bucket, survivorPrefix)).toEqual(survivorKeysBefore);
 			expect((await projects.listProjects()).map((p) => p.id)).toContain(survivor.id);
 			expect(await notebooks.getNotebookContent(survivor.id, survivorNb.id)).toBe('s1');
+		});
+
+		// Skipped: the NaN branch in the sweep filter is unreachable. updated_at is
+		// typed z.iso.datetime(), so a garbage value throws in getCurrentSnapshot's
+		// parseStored before the sweep runs — it exercises the schema guard, not a
+		// ProjectService defect.
+		it.skip('still purges a soft-deleted project whose updated_at is unparseable', async () => {
+			const doomed = await projects.createProject({ name: 'Doomed', description: 'D' }, ACTOR);
+			await projects.deleteProject(doomed.id, ACTOR);
+
+			await catalog.updateProjectEntry('test.corrupt', ACTOR, doomed.id, () => ({
+				updated_at: 'not-a-real-date',
+			}));
+
+			expect(await projects.sweepDeletedProjects(0)).toBe(1);
+			expect(await listAllKeys(bucket, `projects/${doomed.id}/`)).toEqual([]);
+			expect((await catalog.getCurrentSnapshot()).projects.map((p) => p.id)).not.toContain(
+				doomed.id,
+			);
 		});
 	});
 });

--- a/packages/core/src/services/content/ProjectService.test.ts
+++ b/packages/core/src/services/content/ProjectService.test.ts
@@ -313,6 +313,9 @@ describe('ProjectService', () => {
 				projects.updateProject(created.id, { name: 'X' }, ACTOR, 'stale-version-token'),
 			).rejects.toThrow(PreconditionFailedError);
 
+			// The rejection must be a no-op: the stored project is untouched.
+			expect((await projects.getProject(created.id)).name).toBe('P');
+
 			// The matching version is accepted, proving the guard checks the token
 			// rather than rejecting every precondition.
 			const ok = await projects.updateProject(created.id, { name: 'X' }, ACTOR, created.updated_at);
@@ -432,25 +435,6 @@ describe('ProjectService', () => {
 			expect(await listAllKeys(bucket, survivorPrefix)).toEqual(survivorKeysBefore);
 			expect((await projects.listProjects()).map((p) => p.id)).toContain(survivor.id);
 			expect(await notebooks.getNotebookContent(survivor.id, survivorNb.id)).toBe('s1');
-		});
-
-		// Skipped: the NaN branch in the sweep filter is unreachable. updated_at is
-		// typed z.iso.datetime(), so a garbage value throws in getCurrentSnapshot's
-		// parseStored before the sweep runs — it exercises the schema guard, not a
-		// ProjectService defect.
-		it.skip('still purges a soft-deleted project whose updated_at is unparseable', async () => {
-			const doomed = await projects.createProject({ name: 'Doomed', description: 'D' }, ACTOR);
-			await projects.deleteProject(doomed.id, ACTOR);
-
-			await catalog.updateProjectEntry('test.corrupt', ACTOR, doomed.id, () => ({
-				updated_at: 'not-a-real-date',
-			}));
-
-			expect(await projects.sweepDeletedProjects(0)).toBe(1);
-			expect(await listAllKeys(bucket, `projects/${doomed.id}/`)).toEqual([]);
-			expect((await catalog.getCurrentSnapshot()).projects.map((p) => p.id)).not.toContain(
-				doomed.id,
-			);
 		});
 	});
 });

--- a/packages/core/src/services/content/SyncedNotebookService.test.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ACTOR, setupTestEnv } from '../../testing';
 import type { ProjectId } from '../../ids';
+import { noopMetrics } from '../../ports/metrics';
 import type { CatalogService } from '../catalog/CatalogService';
 import type { NotebookService } from './NotebookService';
 import type { ProjectService } from './ProjectService';
+import { SyncedNotebookService } from './SyncedNotebookService';
 import type { CreateSyncedNotebookInput } from '../../integrations/syncedSource';
 
 const enc = (s: string) => new TextEncoder().encode(s);
@@ -16,6 +18,16 @@ const CREATE_INPUT: CreateSyncedNotebookInput = {
 	entry_notebook: 'app.py',
 	root_path: '',
 };
+
+function syncInput(commit: string) {
+	return {
+		repo: 'owner/repo',
+		branch: 'main',
+		root_path: '',
+		commit,
+		files: [{ path: 'app.py', bytes: enc('import marimo') }],
+	};
+}
 
 describe('SyncedNotebookService', () => {
 	let notebooks: NotebookService;
@@ -78,16 +90,6 @@ describe('SyncedNotebookService', () => {
 	});
 
 	describe('sync', () => {
-		function syncInput(commit: string) {
-			return {
-				repo: 'owner/repo',
-				branch: 'main',
-				root_path: '',
-				commit,
-				files: [{ path: 'app.py', bytes: enc('import marimo') }],
-			};
-		}
-
 		it('advances the source to a new version and flips status to active', async () => {
 			const { meta } = await notebooks.synced.create(projectId, CREATE_INPUT, ACTOR);
 
@@ -126,6 +128,75 @@ describe('SyncedNotebookService', () => {
 					repo: 'other/repo',
 				}),
 			).rejects.toThrow();
+		});
+
+		// A stale-source push whose commit was already claimed by a concurrent push
+		// must lose its CAS and skip, leaving the winner's version as the pointer —
+		// its own freshly-written version is a harmless orphan.
+		it('leaves the concurrent winner in place when a push already claimed the commit', async () => {
+			const env = await setupTestEnv();
+			const project = await env.projects.createProject({ name: 'P', description: 'd' }, ACTOR);
+			const pid = project.id;
+			const { meta } = await env.notebooks.synced.create(pid, CREATE_INPUT, ACTOR);
+
+			// First push claims commit A; capture that source as the "stale" read.
+			await env.notebooks.synced.sync(pid, meta.id, syncInput('commit-aaaa'));
+			const stale = await env.notebooks.getNotebook(pid, meta.id);
+
+			// A concurrent push claims commit B and advances the pointer to its version.
+			await env.notebooks.synced.sync(pid, meta.id, syncInput('commit-bbbb'));
+			const winner = await env.notebooks.getNotebook(pid, meta.id);
+			const winnerVersionId =
+				winner.source.type === 'git' ? winner.source.current_version_id : null;
+
+			const versionsBefore = await env.notebooks.listVersions(pid, meta.id);
+
+			// Our push also targets commit B, but started from the stale (commit-A) source.
+			// Its CAS re-reads the pointer (now commit B) and must no-op rather than clobber.
+			const racing = new SyncedNotebookService(env.bucket, env.catalog, noopMetrics, {
+				getNotebook: async () => ({ meta: stale.meta, source: stale.source }),
+				pruneVersions: async () => {},
+			});
+			await expect(racing.sync(pid, meta.id, syncInput('commit-bbbb'))).resolves.toBeDefined();
+
+			const after = await env.notebooks.getNotebook(pid, meta.id);
+			expect(after.source.type).toBe('git');
+			if (after.source.type === 'git') {
+				expect(after.source.commit).toBe('commit-bbbb');
+				expect(after.source.current_version_id).toBe(winnerVersionId);
+			}
+			// The losing push's version is left behind as a harmless orphan.
+			const versionsAfter = await env.notebooks.listVersions(pid, meta.id);
+			expect(versionsAfter.length).toBe(versionsBefore.length + 1);
+		});
+	});
+
+	describe('non-synced (local) notebooks', () => {
+		async function createLocal() {
+			return notebooks.createNotebook(
+				projectId,
+				{ title: 'Local', description: 'd', code: 'import marimo' },
+				ACTOR,
+			);
+		}
+
+		it('rotateToken rejects a local (non-git) notebook', async () => {
+			const local = await createLocal();
+			await expect(notebooks.synced.rotateToken(projectId, local.id)).rejects.toThrow();
+		});
+
+		it('sync rejects a local (non-git) notebook', async () => {
+			const local = await createLocal();
+			await expect(
+				notebooks.synced.sync(projectId, local.id, syncInput('commit-aaaa')),
+			).rejects.toThrow();
+		});
+
+		it('verifyToken returns false when no sync-token sidecar exists', async () => {
+			const local = await createLocal();
+			expect(await notebooks.synced.verifyToken(projectId, local.id, 'mhsync_anything')).toBe(
+				false,
+			);
 		});
 	});
 });

--- a/packages/core/src/services/content/filesystemSnapshots.test.ts
+++ b/packages/core/src/services/content/filesystemSnapshots.test.ts
@@ -210,6 +210,28 @@ describe('filesystemSnapshots', () => {
 			expect((await env.notebooks.getFsSnapshot(project.id, nb.id))?.snapshot_id).toBe('snap_old');
 			expect(provider.deleted).toEqual([]);
 		});
+
+		it('swallows a setFsSnapshot bucket failure without throwing or GCing', async () => {
+			const { instance } = makeFakeSandbox();
+			const provider = snapshotProvider(instance, { captureId: 'snap_new' });
+			// The capture succeeds but persisting the new pointer blows up.
+			const notebooks = {
+				setFsSnapshot: async () => {
+					throw new Error('bucket write failed');
+				},
+			} as unknown as NotebookService;
+			await expect(
+				captureFilesystemSnapshot(
+					provider,
+					notebooks,
+					instance,
+					createProjectId(),
+					createNotebookId(),
+				),
+			).resolves.toBeUndefined();
+			// The GC delete must not run when the pointer write never landed.
+			expect(provider.deleted).toEqual([]);
+		});
 	});
 
 	describe('reapFilesystemSnapshots', () => {
@@ -221,6 +243,32 @@ describe('filesystemSnapshots', () => {
 			]);
 			expect(reaped).toBe(2);
 			expect(provider.deleted).toEqual(['a', 'b']);
+		});
+
+		it('continues past a failing deleteSnapshot and reaps the rest', async () => {
+			const { instance } = makeFakeSandbox();
+			const deleted: string[] = [];
+			const provider: SandboxProvider & FilesystemSnapshots = {
+				filesystemSnapshotsEnabled: true,
+				create: () => instance,
+				proxy: async () => null,
+				createFromSnapshot: () => instance,
+				async captureSnapshot() {
+					return { snapshotId: 'x', sizeBytes: 0 };
+				},
+				async deleteSnapshot(id) {
+					if (id === 'bad') throw new Error('delete failed');
+					deleted.push(id);
+				},
+			};
+			// The failing id is FIRST: if the loop did not swallow-and-continue, 'good'
+			// would never be deleted.
+			const reaped = await reapFilesystemSnapshots(provider, [
+				{ snapshot_id: 'bad', captured_at: '2020-01-01T00:00:00.000Z' },
+				{ snapshot_id: 'good', captured_at: '2020-01-02T00:00:00.000Z' },
+			]);
+			expect(reaped).toBe(1);
+			expect(deleted).toEqual(['good']);
 		});
 
 		it('reaps nothing on a provider without the capability', async () => {

--- a/packages/core/src/services/identity/WorkloadIdentityIssuer.test.ts
+++ b/packages/core/src/services/identity/WorkloadIdentityIssuer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Seconds } from '../../duration';
-import { fromBase64Url } from '../../internal/base64url';
+import { fromBase64Url, utf8ToBase64Url } from '../../internal/base64url';
 import { WorkloadIdentityIssuer } from './WorkloadIdentityIssuer';
 
 const RS256_ALG = { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' } as const;
@@ -88,6 +88,46 @@ describe('WorkloadIdentityIssuer', () => {
 		expect(payload.iss).toBe(claims.iss);
 		expect(payload.sub).toBe(claims.sub);
 		expect(payload.custom).toBe('ok');
+	});
+
+	it('does not let extraClaims override the computed iat/nbf/exp', async () => {
+		const { pem } = await generatePkcs8Pem();
+		const fixedNow = 1_700_000_000_000;
+		const issuer = new WorkloadIdentityIssuer(pem, 'kid-1', () => fixedNow);
+		const iat = Math.floor(fixedNow / 1000);
+		const jwt = await issuer.mint({
+			...claims,
+			// An attacker-supplied far-future exp / zeroed nbf must be ignored.
+			extraClaims: { iat: 1, nbf: 0, exp: 9_999_999_999 },
+		});
+		const payload = decodeSegment(jwt.split('.')[1]);
+		expect(payload.iat).toBe(iat);
+		expect(payload.nbf).toBe(iat - 60);
+		expect(payload.exp).toBe(iat + 3600);
+	});
+
+	it('rejects a tampered token: a mutated claim invalidates the RS256 signature', async () => {
+		const { pem } = await generatePkcs8Pem();
+		const issuer = new WorkloadIdentityIssuer(pem, 'kid-1');
+		const jwt = await issuer.mint(claims);
+		const [headerB64, payloadB64, sigB64] = jwt.split('.');
+
+		// Escalate the subject, keeping the original signature.
+		const payload = decodeSegment(payloadB64);
+		payload.sub = 'attacker-controlled';
+		const forgedPayloadB64 = utf8ToBase64Url(JSON.stringify(payload));
+		const forged = `${headerB64}.${forgedPayloadB64}.${sigB64}`;
+
+		const { keys } = await issuer.jwks();
+		const pub = await crypto.subtle.importKey('jwk', { ...keys[0] }, RS256_ALG, false, ['verify']);
+		const [h, p, s] = forged.split('.');
+		const ok = await crypto.subtle.verify(
+			RS256_ALG,
+			pub,
+			fromBase64Url(s) as unknown as ArrayBuffer,
+			new TextEncoder().encode(`${h}.${p}`),
+		);
+		expect(ok).toBe(false);
 	});
 
 	it('publishes a public-only JWKS (no private material)', async () => {

--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -145,4 +145,64 @@ describe('ReconciliationService', () => {
 		expect(result.orphansReaped).toBe(0);
 		expect(compute.destroyed).toEqual([]);
 	});
+
+	it('Rule 3: applies the grace window to an orphan with no createdAt', async () => {
+		// Provisioning writes the record before creating the sandbox, so a brand-new
+		// sandbox the provider has not yet timestamped is an in-flight provision, not
+		// a leak. With unknown age we cannot prove it is older than the grace window,
+		// so it must be left alone — not reaped on sight.
+		compute.active = [{ id: inflightId }];
+
+		const result = await reconciler.reconcile({ orphanGraceMs: 1_000 });
+
+		expect(result.orphansReaped).toBe(0);
+		expect(compute.destroyed).toEqual([]);
+	});
+
+	it('Rule 1: force-destroys and still counts reclaimed when teardown throws', async () => {
+		const session = await createSession(terminalId);
+		await sessions.terminate(projectId, session.session_id);
+		compute.active = [{ id: terminalId }];
+
+		// Save-on-reap can reject (bucket/sandbox RPC failure); the reconciler must
+		// still guarantee the sandbox dies and count it reclaimed.
+		const provisioner = (
+			reconciler as unknown as { provisioner: { teardown: () => Promise<void> } }
+		).provisioner;
+		vi.spyOn(provisioner, 'teardown').mockRejectedValue(new Error('teardown boom'));
+
+		const result = await reconciler.reconcile();
+
+		expect(result.reclaimed).toBe(1);
+		expect(compute.destroyed).toEqual([terminalId]);
+	});
+
+	it('Rule 1: reclaims a lingering sandbox behind a terminating record', async () => {
+		const session = await createSession(goneId);
+		await sessions.heartbeat(projectId, session.session_id); // -> running
+		await sessions.beginTerminating(projectId, session.session_id); // -> terminating
+		// Teardown stalled/crashed: the sandbox is still live and billing while the
+		// record sits in `terminating`. The provider-truth net must destroy it.
+		compute.active = [{ id: goneId }];
+
+		const result = await reconciler.reconcile();
+
+		expect(result.reclaimed).toBe(1);
+		expect(compute.destroyed).toEqual([goneId]);
+	});
+
+	it('Rule 2 does not misfire on a terminating record whose sandbox vanished', async () => {
+		const session = await createSession(healthyId);
+		await sessions.heartbeat(projectId, session.session_id); // -> running
+		await sessions.beginTerminating(projectId, session.session_id); // -> terminating
+		compute.active = []; // sandbox already gone
+
+		const result = await reconciler.reconcile();
+
+		// An explicit stop must not be downgraded to `failed`.
+		expect(result.markedDead).toBe(0);
+		expect(compute.destroyed).toEqual([]);
+		const stored = await sessions.getSession(projectId, session.session_id);
+		expect(stored.status).toBe('terminating');
+	});
 });

--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createNotebookId, createProjectId, createSandboxId, createVersionId } from '../../ids';
 import type { SandboxId } from '../../ids';
+import { paths } from '../../paths';
 import type { SandboxInstance, SandboxProvider } from '../../ports/sandbox';
 import { ACTOR, makeLocalSource, MemoryBucket, RecordingCompute } from '../../testing';
 import { CatalogService } from '../catalog/CatalogService';
@@ -157,6 +158,25 @@ describe('ReconciliationService', () => {
 
 		expect(result.orphansReaped).toBe(0);
 		expect(compute.destroyed).toEqual([]);
+		// First sighting is recorded durably so the grace is anchored, not forgotten.
+		expect(await bucket.get(paths.reconcileOrphan(inflightId))).not.toBeNull();
+	});
+
+	it('Rule 3: reaps a timestamp-less orphan once its first-seen marker exceeds the grace', async () => {
+		compute.active = [{ id: inflightId }]; // no createdAt
+		// A prior sighting old enough that the grace has since elapsed — the leak is
+		// bounded, not indefinite.
+		await bucket.put(
+			paths.reconcileOrphan(inflightId),
+			JSON.stringify({ first_seen: Date.now() - 60_000 }),
+		);
+
+		const result = await reconciler.reconcile({ orphanGraceMs: 1_000 });
+
+		expect(result.orphansReaped).toBe(1);
+		expect(compute.destroyed).toEqual([inflightId]);
+		// The marker is cleaned up after the orphan is reaped.
+		expect(await bucket.get(paths.reconcileOrphan(inflightId))).toBeNull();
 	});
 
 	it('Rule 1: force-destroys and still counts reclaimed when teardown throws', async () => {

--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -179,6 +179,26 @@ describe('ReconciliationService', () => {
 		expect(await bucket.get(paths.reconcileOrphan(inflightId))).toBeNull();
 	});
 
+	it('Rule 3: resets a future-dated marker so a bad clock cannot defer reaping forever', async () => {
+		compute.active = [{ id: inflightId }]; // no createdAt
+		// A marker dated in the future (clock skew / tampering) would otherwise push
+		// the grace out indefinitely.
+		await bucket.put(
+			paths.reconcileOrphan(inflightId),
+			JSON.stringify({ first_seen: Date.now() + 3_600_000 }),
+		);
+
+		const result = await reconciler.reconcile({ orphanGraceMs: 1_000 });
+
+		// Not reaped on sight, but the marker is rewritten to a non-future time so a
+		// later sweep will reap it within one grace window.
+		expect(result.orphansReaped).toBe(0);
+		const marker = await (await bucket.get(paths.reconcileOrphan(inflightId)))!.json<{
+			first_seen: number;
+		}>();
+		expect(marker.first_seen).toBeLessThanOrEqual(Date.now());
+	});
+
 	it('Rule 1: force-destroys and still counts reclaimed when teardown throws', async () => {
 		const session = await createSession(terminalId);
 		await sessions.terminate(projectId, session.session_id);

--- a/packages/core/src/services/runtime/ReconciliationService.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.ts
@@ -1,5 +1,6 @@
 import type { Bucket } from '../../ports/bucket';
 import { Millis } from '../../duration';
+import type { SandboxId } from '../../ids';
 import { paths } from '../../paths';
 import type { SandboxProvider } from '../../ports/sandbox';
 import type { NotebookService } from '../content/NotebookService';
@@ -173,16 +174,20 @@ export class ReconciliationService {
 
 	/**
 	 * First-seen epoch (ms) for a timestamp-less orphan: read the durable marker, or
-	 * create it at `now` on first sighting. A corrupt/absent marker resets to `now`,
-	 * so the worst case is one extra grace window — never an unbounded leak.
+	 * create it at `now` on first sighting. A marker that is absent, corrupt, or dated
+	 * in the FUTURE (clock skew / tampering — which would otherwise defer reaping
+	 * indefinitely) resets to `now`, so the worst case is one extra grace window —
+	 * never an unbounded leak.
 	 */
-	private async firstSeenOrphan(sandboxId: string, now: number): Promise<number> {
+	private async firstSeenOrphan(sandboxId: SandboxId, now: number): Promise<number> {
 		const key = paths.reconcileOrphan(sandboxId);
 		const existing = await this.bucket.get(key);
 		if (existing) {
 			try {
 				const { first_seen } = await existing.json<{ first_seen: number }>();
-				if (typeof first_seen === 'number' && Number.isFinite(first_seen)) return first_seen;
+				if (typeof first_seen === 'number' && Number.isFinite(first_seen) && first_seen <= now) {
+					return first_seen;
+				}
 			} catch {
 				// Corrupt marker — fall through and rewrite it below.
 			}

--- a/packages/core/src/services/runtime/ReconciliationService.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.ts
@@ -1,8 +1,10 @@
 import type { Bucket } from '../../ports/bucket';
 import { Millis } from '../../duration';
+import { paths } from '../../paths';
 import type { SandboxProvider } from '../../ports/sandbox';
 import type { NotebookService } from '../content/NotebookService';
 import { SandboxProvisioner } from './SandboxProvisioner';
+import { listAllKeys } from '../catalog/storage';
 import type { SessionService } from './SessionService';
 
 /**
@@ -129,27 +131,75 @@ export class ReconciliationService {
 			}
 		}
 
+		// Ids for which we hold (or just wrote) a first-seen marker this pass, so the
+		// stale ones (reaped / recorded / vanished) can be pruned below.
+		const pendingUndated = new Set<string>();
+
 		for (const sandbox of active) {
 			if (recordedSandboxIds.has(sandbox.id)) continue; // owned by a record above
 
 			// Rule 3 — a live sandbox with no record at all is an invisible orphan that
 			// leaks billable compute forever. Reap it once past the grace window.
-			// Without a creation timestamp we can't prove the sandbox is old enough to be
-			// a leaked orphan (vs. an in-flight provision the record just hasn't caught up
-			// to), so the grace window applies and we leave it for a later sweep.
-			if (!sandbox.createdAt) continue;
-			const ageMs = now - new Date(sandbox.createdAt).getTime();
+			let ageMs: number;
+			if (sandbox.createdAt) {
+				ageMs = now - new Date(sandbox.createdAt).getTime();
+			} else {
+				// The provider gave no creation timestamp, so we can't tell an in-flight
+				// provision (record not yet visible) from a leaked orphan on a single
+				// snapshot. Anchor the grace to a durable first-seen marker so it's left
+				// alone at first sighting but still reaped a bounded time later — never
+				// leaking forever, never reaped on sight.
+				const firstSeen = await this.firstSeenOrphan(sandbox.id, now);
+				pendingUndated.add(sandbox.id);
+				ageMs = now - firstSeen;
+			}
 			if (ageMs < orphanGraceMs) continue;
 
 			try {
 				await this.compute.create(sandbox.id).destroy();
 				orphansReaped++;
 				orphanSandboxIds.push(sandbox.id);
+				pendingUndated.delete(sandbox.id);
+				await this.bucket.delete(paths.reconcileOrphan(sandbox.id)).catch(() => {});
 			} catch {
 				// Best-effort: a later sweep will retry.
 			}
 		}
 
+		await this.pruneOrphanMarkers(pendingUndated);
+
 		return { skipped: false, reclaimed, markedDead, orphansReaped, orphanSandboxIds };
+	}
+
+	/**
+	 * First-seen epoch (ms) for a timestamp-less orphan: read the durable marker, or
+	 * create it at `now` on first sighting. A corrupt/absent marker resets to `now`,
+	 * so the worst case is one extra grace window — never an unbounded leak.
+	 */
+	private async firstSeenOrphan(sandboxId: string, now: number): Promise<number> {
+		const key = paths.reconcileOrphan(sandboxId);
+		const existing = await this.bucket.get(key);
+		if (existing) {
+			try {
+				const { first_seen } = await existing.json<{ first_seen: number }>();
+				if (typeof first_seen === 'number' && Number.isFinite(first_seen)) return first_seen;
+			} catch {
+				// Corrupt marker — fall through and rewrite it below.
+			}
+		}
+		await this.bucket.put(key, JSON.stringify({ first_seen: now })).catch(() => {});
+		return now;
+	}
+
+	/** Drop first-seen markers for orphans that are no longer pending (reaped, recorded, or gone). */
+	private async pruneOrphanMarkers(keep: ReadonlySet<string>): Promise<void> {
+		const keys = await listAllKeys(this.bucket, paths.reconcileOrphansPrefix).catch(() => []);
+		const stale = keys.filter((k) => {
+			const id = decodeURIComponent(
+				k.slice(paths.reconcileOrphansPrefix.length).replace(/\.json$/, ''),
+			);
+			return !keep.has(id);
+		});
+		if (stale.length > 0) await this.bucket.delete(stale).catch(() => {});
 	}
 }

--- a/packages/core/src/services/runtime/ReconciliationService.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.ts
@@ -3,7 +3,6 @@ import { Millis } from '../../duration';
 import type { SandboxProvider } from '../../ports/sandbox';
 import type { NotebookService } from '../content/NotebookService';
 import { SandboxProvisioner } from './SandboxProvisioner';
-import { isTerminal } from './sessionState';
 import type { SessionService } from './SessionService';
 
 /**
@@ -88,11 +87,13 @@ export class ReconciliationService {
 			const sandboxId = session.sandbox_id;
 			if (!sandboxId) continue;
 
-			const terminal = isTerminal(session.status);
 			const isLive = session.status === 'running' || session.status === 'starting';
 
-			if (terminal && activeIds.has(sandboxId)) {
-				// Rule 1 — terminal record, sandbox still alive (and billing). Save edits
+			if (!isLive && activeIds.has(sandboxId)) {
+				// Rule 1 — record is terminal OR mid-teardown (`terminating`) but the
+				// sandbox is still alive (and billing). A `terminating` record whose
+				// teardown never finished would otherwise leak the sandbox forever, since
+				// it is neither live (Rule 2) nor an unrecorded orphan (Rule 3). Save edits
 				// back when reachable, then guarantee the sandbox dies.
 				const sandbox = this.compute.create(sandboxId);
 				try {
@@ -133,10 +134,12 @@ export class ReconciliationService {
 
 			// Rule 3 — a live sandbox with no record at all is an invisible orphan that
 			// leaks billable compute forever. Reap it once past the grace window.
-			if (sandbox.createdAt) {
-				const ageMs = now - new Date(sandbox.createdAt).getTime();
-				if (ageMs < orphanGraceMs) continue;
-			}
+			// Without a creation timestamp we can't prove the sandbox is old enough to be
+			// a leaked orphan (vs. an in-flight provision the record just hasn't caught up
+			// to), so the grace window applies and we leave it for a later sweep.
+			if (!sandbox.createdAt) continue;
+			const ageMs = now - new Date(sandbox.createdAt).getTime();
+			if (ageMs < orphanGraceMs) continue;
 
 			try {
 				await this.compute.create(sandbox.id).destroy();

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -356,6 +356,29 @@ describe('SandboxProvisioner', () => {
 			expect(calls.mountBucket).toHaveLength(0);
 			expect(calls.startProcess).toHaveLength(0);
 		});
+
+		it('rethrows the original provisioning error when the cleanup destroy also throws', async () => {
+			const { instance: base } = makeFakeSandbox({ failExec: 'true' });
+			// Provisioning fails at reachability; the compensating destroy then also
+			// throws. The caller must see the original failure, not the destroy error.
+			const instance = {
+				...base,
+				destroy: async () => {
+					throw new Error('destroy boom');
+				},
+			} as unknown as SandboxInstance;
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			await expect(
+				provisioner.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				}),
+			).rejects.toThrow(/not available/i);
+		});
 	});
 
 	describe('teardown', () => {
@@ -558,6 +581,34 @@ describe('SandboxProvisioner', () => {
 				notebookId,
 				ACTOR,
 				'workspace',
+			);
+
+			expect(calls.destroy).toBe(1);
+		});
+
+		it('still destroys the sandbox when captureFilesystemSnapshot fails (best-effort)', async () => {
+			const env = await setupTestEnv();
+			const project = await env.projects.createProject({ name: 'P', description: 'd' }, ACTOR);
+			const created = await env.notebooks.createNotebook(
+				project.id,
+				{ title: 'NB', description: 'd', code: 'print(1)' },
+				ACTOR,
+			);
+			const { instance, calls } = makeFakeSandbox({
+				files: { [`${MOUNT_PATH}/notebook.py`]: 'print(2)  # edited' },
+			});
+			// The snapshot capture API is down; teardown must swallow it and still destroy.
+			const compute = makeSnapshotCompute(instance, { failCapture: true });
+			const provisioner = new SandboxProvisioner(compute);
+
+			await provisioner.teardown(
+				instance,
+				env.notebooks,
+				env.bucket,
+				project.id,
+				created.id,
+				ACTOR,
+				'source',
 			);
 
 			expect(calls.destroy).toBe(1);
@@ -770,6 +821,53 @@ describe('SandboxProvisioner', () => {
 			).rejects.toThrow('metadata unavailable');
 			expect(commitSession).not.toHaveBeenCalled();
 			expect(calls.destroy).toBe(0);
+		});
+
+		it('throws the workspace error and logs the commit error when both reject', async () => {
+			const { instance: base, calls } = makeFakeSandbox();
+			// Fail the workspace capture (listFiles without includeHidden); the commit
+			// (readSessionArtifacts passes includeHidden:true) is failed via commitSession.
+			const instance = {
+				...base,
+				listFiles: async (_path: string, options?: { includeHidden?: boolean }) => {
+					if (options?.includeHidden) return { success: true, files: [] };
+					throw new Error('workspace list boom');
+				},
+			} as unknown as SandboxInstance;
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+			const failingNotebooks = {
+				getNotebook: async () => ({ source: makeLocalSource() }),
+				commitSession: async () => {
+					throw new Error('commit boom');
+				},
+			} as unknown as NotebookService;
+			const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			// The workspace error is surfaced to the caller...
+			await expect(
+				provisioner.captureSession(
+					instance,
+					failingNotebooks,
+					new MemoryBucket(),
+					projectId,
+					notebookId,
+					ACTOR,
+					'workspace',
+				),
+			).rejects.toThrow('workspace list boom');
+
+			// ...and the otherwise-masked commit failure is logged, not dropped.
+			expect(
+				errorSpy.mock.calls.some(
+					([msg, err]) =>
+						typeof msg === 'string' &&
+						msg.includes('commitSession failed') &&
+						err instanceof Error &&
+						err.message === 'commit boom',
+				),
+			).toBe(true);
+			expect(calls.destroy).toBe(0);
+			errorSpy.mockRestore();
 		});
 
 		it('includeWorkspace: false saves the source but never touches the workspace mirror', async () => {

--- a/packages/core/src/services/runtime/SessionService.countActive.test.ts
+++ b/packages/core/src/services/runtime/SessionService.countActive.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { ACTOR, MemoryBucket, uid } from '../../testing';
+import { ACTOR, advanceTime, MemoryBucket, restoreClock, uid } from '../../testing';
 import { createNotebookId, createProjectId } from '../../ids';
 import type { UserId } from '../../ids';
 import { SessionService } from './SessionService';
@@ -40,5 +40,31 @@ describe('SessionService.countActiveForUser', () => {
 		expect(await sessions.countActiveForUser(ACTOR)).toBe(2);
 		expect(await sessions.countActiveForUser(OTHER)).toBe(1);
 		expect(await sessions.countActiveForUser(uid('nobody'))).toBe(0);
+	});
+
+	it('excludes terminating, failed, and expired sessions', async () => {
+		// expired: reaped by the TTL sweep — terminal, must not count. Driven to
+		// `expired` first, in isolation, so the time-advance doesn't reap the others.
+		const gone = await create(ACTOR);
+		await sessions.heartbeat(projectId, gone.session_id); // -> running
+		advanceTime(6 * 60 * 1000);
+		expect(await sessions.expireStale()).toBe(1); // -> expired
+		restoreClock();
+
+		// One genuinely-active session that must be counted.
+		const live = await create(ACTOR);
+		await sessions.heartbeat(projectId, live.session_id); // -> running
+
+		// terminating: on its way out — a stop should immediately free the slot.
+		const stopping = await create(ACTOR);
+		await sessions.setRunning(projectId, stopping.session_id, 'https://sandbox.example');
+		await sessions.beginTerminating(projectId, stopping.session_id); // -> terminating
+
+		// failed: provision/runtime error — terminal, must not count.
+		const broken = await create(ACTOR);
+		await sessions.markFailed(projectId, broken.session_id); // -> failed
+
+		// Only the single live (running) session should be counted.
+		expect(await sessions.countActiveForUser(ACTOR)).toBe(1);
 	});
 });

--- a/packages/core/src/services/runtime/SessionService.test.ts
+++ b/packages/core/src/services/runtime/SessionService.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../testing';
 import { createNotebookId, createProjectId } from '../../ids';
 import type { SessionId } from '../../ids';
+import { paths } from '../../paths';
 import { SessionService } from './SessionService';
 
 describe('SessionService', () => {
@@ -460,6 +461,24 @@ describe('SessionService', () => {
 			const list = await sessions.listSessions();
 			expect(list).toEqual([]);
 		});
+
+		it('does not let one corrupt session record abort the whole scan', async () => {
+			const valid = await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+			});
+
+			// A garbage record under the sessions prefix (e.g. a partial/legacy write)
+			// must not blow up a deployment-wide scan — the good record should survive.
+			await bucket.put(
+				`${paths.sessionsForProject(projectId)}corrupt.json`,
+				JSON.stringify({ session_id: 'not-a-valid-id', status: 'bogus' }),
+			);
+
+			const list = await sessions.listSessions();
+			expect(list.map((s) => s.session_id)).toEqual([valid.session_id]);
+		});
 	});
 
 	describe('listActiveByProject', () => {
@@ -573,6 +592,35 @@ describe('SessionService', () => {
 			expect(await sessions.findReusable(projectId, notebookId, ACTOR)).toBeUndefined();
 			expect(await sessions.findReusable(projectId, createNotebookId(), ACTOR)).toBeUndefined();
 		});
+
+		it('does not reuse a wedged starting session past the provision window', async () => {
+			await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+			});
+
+			// The provision never resolved (still `starting`) and the window elapsed —
+			// reusing it would attach a client to a dead provision forever.
+			advanceTime(6 * 60 * 1000); // past HEARTBEAT_TTL_MS (5m)
+			const found = await sessions.findReusable(projectId, notebookId, ACTOR);
+			restoreClock();
+
+			expect(found).toBeUndefined();
+		});
+
+		it('does not reuse a running session that has no sandbox_url', async () => {
+			const created = await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+			});
+			// A heartbeat promotes starting → running WITHOUT stamping a sandbox_url;
+			// there is no live kernel to reconnect to, so it must not be reused.
+			await sessions.heartbeat(projectId, created.session_id);
+
+			expect(await sessions.findReusable(projectId, notebookId, ACTOR)).toBeUndefined();
+		});
 	});
 
 	describe('expireStale', () => {
@@ -629,6 +677,41 @@ describe('SessionService', () => {
 			}
 
 			restoreClock();
+		});
+
+		it('skips a session whose ETag changed between scan and conditional PUT', async () => {
+			const created = await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+			});
+			await sessions.setRunning(projectId, created.session_id, 'https://sandbox.example');
+			const running = await sessions.getSession(projectId, created.session_id);
+
+			advanceTime(6 * 60 * 1000); // heartbeat now stale → reaper wants to expire it
+
+			// Sneak a concurrent transition in *between* the reaper's scan (which captured
+			// the old ETag) and its conditional PUT. That other write wins; the reaper's
+			// stale-ETag PUT must fail its precondition and be skipped, not clobbered.
+			const realPut = bucket.put.bind(bucket);
+			let raced = false;
+			const putSpy = vi.spyOn(bucket, 'put').mockImplementation(async (key, value, opts) => {
+				if (opts?.onlyIfEtagMatches && !raced) {
+					raced = true;
+					await realPut(key, JSON.stringify({ ...running, status: 'terminated' }));
+				}
+				return realPut(key, value, opts);
+			});
+
+			const expired = await sessions.expireStale();
+
+			putSpy.mockRestore();
+			restoreClock();
+
+			// The concurrent terminate must stand; the reaper must not have expired it.
+			expect(expired).toBe(0);
+			const stored = await sessions.getSession(projectId, created.session_id);
+			expect(stored.status).toBe('terminated');
 		});
 	});
 

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -230,7 +230,15 @@ export class SessionService {
 		const scanned = await mapWithConcurrency(objects, BUCKET_SCAN_CONCURRENCY, async (obj) => {
 			const body = await this.bucket.get(obj.key);
 			if (!body) return SKIP;
-			const session = SessionSchema.parse(await body.json());
+			// A single corrupt/legacy record must not abort a deployment-wide scan
+			// (listing, reuse, reaper). Skip it (logged) so the good records survive.
+			let session: Session;
+			try {
+				session = SessionSchema.parse(await body.json());
+			} catch (err) {
+				console.warn(`scanPrefix: skipping unreadable session ${obj.key}: ${String(err)}`);
+				return SKIP;
+			}
 			return handle(session, obj, body.etag);
 		});
 		return scanned.filter((r): r is Awaited<T> => r !== SKIP);

--- a/packages/core/src/services/runtime/proxyToken.test.ts
+++ b/packages/core/src/services/runtime/proxyToken.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ProjectId, SessionId } from '../../ids';
+import { toBase64Url } from '../../internal/base64url';
+import { hmacSha256 } from '../../internal/hmac';
 import { signProxyToken, verifyProxyToken } from './proxyToken';
 
 const SECRET = 'a-test-signing-secret-at-least-32-bytes-long!!';
@@ -48,5 +50,21 @@ describe('proxy routing token', () => {
 		const token = await signProxyToken(PROJECT, SESSION, SECRET);
 		const sig = token.slice(token.lastIndexOf('.') + 1);
 		expect(await verifyProxyToken(`${SESSION}.${sig}`, SECRET)).toBeNull();
+	});
+
+	it('rejects a valid-base64url signature of the wrong byte length', async () => {
+		// Decodes cleanly (so it passes the fromBase64Url guard) but is 16 bytes, not
+		// the 32-byte HMAC digest — timingSafeEqual must reject on the length branch
+		// rather than reading past the shorter array.
+		const shortSig = toBase64Url(new Uint8Array(16));
+		expect(await verifyProxyToken(`${PROJECT}.${SESSION}.${shortSig}`, SECRET)).toBeNull();
+	});
+
+	it('rejects a token whose payload has more than two id segments (a.b.c.<sig>)', async () => {
+		// Sign a legitimately-3-segment payload so the signature check passes; the
+		// boundary parse (`parts.length !== 2`) must still reject it.
+		const payload = `${PROJECT}.${SESSION}.${SESSION}`;
+		const sig = toBase64Url(await hmacSha256(SECRET, payload));
+		expect(await verifyProxyToken(`${payload}.${sig}`, SECRET)).toBeNull();
 	});
 });

--- a/packages/core/src/services/runtime/sandboxExposure.test.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.test.ts
@@ -48,4 +48,13 @@ describe('ProxyExposure', () => {
 		const token = await signProxyToken(ctx.projectId, ctx.sessionId, SECRET);
 		expect(result.clientUrl).toBe(`https://hub.example.com/proxy/${token}/`);
 	});
+
+	it('collapses multiple trailing slashes on the app base url (no `//proxy`)', async () => {
+		const result = await exposure.finalize('http://kernel:2718', {
+			...ctx,
+			appBaseUrl: 'https://hub.example.com//',
+		});
+		const token = await signProxyToken(ctx.projectId, ctx.sessionId, SECRET);
+		expect(result.clientUrl).toBe(`https://hub.example.com/proxy/${token}/`);
+	});
 });

--- a/packages/core/src/services/runtime/sandboxExposure.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.ts
@@ -10,9 +10,9 @@ import type {
 } from '../../ports/sandboxExposure';
 import { signProxyToken } from './proxyToken';
 
-/** Strip a single trailing slash so we can join path segments cleanly. */
+/** Strip any trailing slashes so we can join path segments cleanly (no `//proxy`). */
 function trimTrailingSlash(s: string): string {
-	return s.endsWith('/') ? s.slice(0, -1) : s;
+	return s.replace(/\/+$/, '');
 }
 
 /**

--- a/packages/core/src/services/runtime/sandboxFiles.test.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.test.ts
@@ -457,3 +457,79 @@ describe('readSessionArtifacts', () => {
 		warn.mockRestore();
 	});
 });
+
+describe('sandboxFiles security', () => {
+	it('restoreWorkspace never writes outside workingDir when a bucket key contains ".."', async () => {
+		const { nb } = nbCtx();
+		const bucket = new MemoryBucket();
+		// A poisoned object key (e.g. from a compromised/synced source) that would
+		// resolve to a path above the working dir if concatenated naively.
+		await bucket.put(`${nb.workspacePrefix}../../etc/pwned.txt`, 'owned');
+		await bucket.put(nb.workspaceFile('safe.txt'), 'ok');
+		const { instance, calls } = makeFsSandbox();
+
+		await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT);
+
+		// Every written path MUST stay under the working dir — no `..` escape.
+		for (const batch of calls.writeFiles) {
+			for (const f of batch) {
+				expect(f.path.startsWith(`${MOUNT}/`)).toBe(true);
+				expect(f.path).not.toContain('/../');
+			}
+		}
+		// The mkdir prep must likewise not create a directory above the working dir.
+		for (const cmd of calls.exec) {
+			if (cmd.startsWith('mkdir -p ')) expect(cmd).not.toContain('/../');
+		}
+	});
+
+	it('captureWorkspace shell-safely handles a filename with shell metacharacters', async () => {
+		const { projectId, notebookId, nb } = nbCtx();
+		const bucket = new MemoryBucket();
+		// `$(id)` would execute if the filename were interpolated unquoted into `sh -lc`.
+		const { instance } = makeFsSandbox({ files: { '$(id).csv': 'a,b\n1,2\n' } });
+
+		await captureWorkspace(instance, bucket, projectId, notebookId, MOUNT, 'workspace');
+
+		const stored = await bucket.get(nb.workspaceFile('$(id).csv'));
+		expect(decode(await stored!.bytes())).toBe('a,b\n1,2\n');
+	});
+
+	it('restoreWorkspace retries a transient writeFiles fault, then succeeds', async () => {
+		const { nb } = nbCtx();
+		const bucket = new MemoryBucket();
+		await bucket.put(nb.workspaceFile('a.txt'), 'hi');
+		const { instance: base, fs } = makeFsSandbox();
+		let attempts = 0;
+		const instance = {
+			...base,
+			writeFiles: async (files: Parameters<typeof base.writeFiles>[0]) => {
+				attempts++;
+				if (attempts < 2) throw new Error('ECONNRESET');
+				return base.writeFiles(files);
+			},
+		} as unknown as typeof base;
+
+		await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT);
+
+		expect(attempts).toBe(2);
+		expect(decode(fs.get('a.txt')!)).toBe('hi');
+	});
+
+	it('restoreWorkspace throws after exhausting write attempts', async () => {
+		const { nb } = nbCtx();
+		const bucket = new MemoryBucket();
+		await bucket.put(nb.workspaceFile('a.txt'), 'hi');
+		const { instance: base } = makeFsSandbox();
+		const instance = {
+			...base,
+			writeFiles: async () => {
+				throw new Error('ECONNRESET');
+			},
+		} as unknown as typeof base;
+
+		await expect(restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT)).rejects.toThrow(
+			'ECONNRESET',
+		);
+	});
+});

--- a/packages/core/src/services/runtime/sandboxFiles.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.ts
@@ -5,6 +5,7 @@ import { paths } from '../../paths';
 import type { SandboxInstance } from '../../ports/sandbox';
 import { MAX_ARTIFACT_BYTES, MAX_WORKSPACE_FILE_BYTES } from '../../constants';
 import { shellQuote } from './shell';
+import { isSafeWorkspacePath } from '../../integrations/remoteWorkspace';
 import { listAllKeys, listAllObjects } from '../catalog/storage';
 import type { CommitSessionInput } from '../content/NotebookService';
 
@@ -121,6 +122,13 @@ export async function restoreWorkspace(
 	for (const obj of objects) {
 		const rel = obj.key.slice(sourcePrefix.length);
 		if (!rel) continue;
+		// A poisoned key (e.g. from a compromised/synced source) whose relative path
+		// carries `..`/absolute/backslash segments would escape workingDir once
+		// concatenated. Skip it — the sandbox working dir is a hard boundary.
+		if (!isSafeWorkspacePath(rel)) {
+			console.warn(`restoreWorkspace: unsafe workspace path; skipping ${rel}`);
+			continue;
+		}
 		if (obj.size > MAX_WORKSPACE_FILE_BYTES) {
 			console.warn(
 				`restoreWorkspace: per-file cap (${MAX_WORKSPACE_FILE_BYTES}) exceeded; skipping ${rel} (${obj.size} bytes)`,

--- a/packages/core/src/services/runtime/sessionLifecycle.test.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createNotebookId, createProjectId, createSandboxId } from '../../ids';
 import { paths } from '../../paths';
 import type { SandboxInstance } from '../../ports/sandbox';
@@ -58,6 +58,12 @@ describe('SessionLifecycleService', () => {
 		sandboxCalls = fake.calls;
 		compute = fakeComputeFrom(fake.instance);
 		probe = vi.fn(async () => 0);
+	});
+
+	afterEach(() => {
+		// Restore prototype spies (e.g. SandboxProvisioner.teardown) so a per-test
+		// mock never leaks into a sibling; beforeEach re-establishes the fixtures.
+		vi.restoreAllMocks();
 	});
 
 	const makeService = (overrides: Partial<SessionLifecycleConfig> = {}) =>
@@ -161,6 +167,22 @@ describe('SessionLifecycleService', () => {
 			expect(probe).not.toHaveBeenCalled();
 			expect(result.reapedExpired).toBe(1);
 			expect(sandboxCalls.destroy).toBe(1);
+		});
+
+		it('force-destroys and still marks terminated when live teardown throws', async () => {
+			// A save that throws must never leave the sandbox running and billing: the
+			// catch force-destroys, and the record is still stamped terminated.
+			const teardownSpy = vi
+				.spyOn(SandboxProvisioner.prototype, 'teardown')
+				.mockRejectedValue(new Error('save failed'));
+			const s = await putSession({ expires_at: iso(-1000), last_snapshot_at: iso(0) });
+
+			const result = await makeService().sweep(now);
+
+			expect(teardownSpy).toHaveBeenCalled();
+			expect(result.reapedExpired).toBe(1);
+			expect(sandboxCalls.destroy).toBe(1); // force-destroy in the catch
+			expect((await getStored(s)).status).toBe('terminated');
 		});
 	});
 

--- a/packages/core/src/services/runtime/sessionState.test.ts
+++ b/packages/core/src/services/runtime/sessionState.test.ts
@@ -50,4 +50,11 @@ describe('sessionState', () => {
 		expect(nextStatus('terminating', 'running')).toBeNull();
 		expect(nextStatus('terminating', 'heartbeat')).toBeNull();
 	});
+
+	it('does not downgrade a terminating session to failed (an explicit stop wins)', () => {
+		// Mirrors SessionService.markFailed, which refuses to fail a `terminating`
+		// session, and the state-table comment: once terminating, only `terminated`
+		// (or the `expire` teardown-hang fallback) applies.
+		expect(nextStatus('terminating', 'fail')).toBeNull();
+	});
 });

--- a/packages/core/src/services/runtime/sessionState.ts
+++ b/packages/core/src/services/runtime/sessionState.ts
@@ -37,7 +37,9 @@ const machine = createStateMachine<SessionStatus, SessionEvent>({
 		running: { heartbeat: 'running', terminate: 'terminating', fail: 'failed', expire: 'expired' },
 		// A stop wins over a still-resolving provision; once terminating, only the
 		// teardown's `terminated` (or an `expire` fallback if teardown hangs) applies.
-		terminating: { terminated: 'terminated', expire: 'terminated', fail: 'failed' },
+		// A `fail` must NOT downgrade it — mirrors SessionService.markFailed, which
+		// refuses to fail a terminating session.
+		terminating: { terminated: 'terminated', expire: 'terminated' },
 		terminated: {},
 		failed: {},
 		expired: {},

--- a/packages/core/src/services/secrets/ProjectSecretsStore.test.ts
+++ b/packages/core/src/services/secrets/ProjectSecretsStore.test.ts
@@ -3,6 +3,7 @@ import { ValidationError } from '../../errors';
 import { createProjectId } from '../../ids';
 import type { ProjectId } from '../../ids';
 import type { ManagedSecretCodec, SecretResolver } from '../../ports/secrets';
+import { paths } from '../../paths';
 import { ACTOR, MemoryBucket } from '../../testing';
 import { ProjectSecretsStore } from './ProjectSecretsStore';
 
@@ -247,5 +248,78 @@ describe('ProjectSecretsStore', () => {
 		expect(JSON.stringify(list)).not.toContain('hunter2');
 
 		expect(await store.resolve(pid)).toEqual({ DB_PASSWORD: 'hunter2' });
+	});
+
+	it('fails closed when an expanded key collides with a RESERVED env var name', async () => {
+		const store = new ProjectSecretsStore({
+			bucket,
+			resolvers: [stubResolver({ bundle: JSON.stringify({ PATH: '/evil/bin' }) })],
+		});
+		await store.put(
+			pid,
+			'APP',
+			{ kind: 'reference', ref: { backend: 'stub', locator: 'bundle', expand: 'json' } },
+			ACTOR,
+		);
+		// A fan-out that materialized PATH would let a secret shadow the sandbox's PATH.
+		await expect(store.resolve(pid)).rejects.toThrow(ValidationError);
+	});
+
+	it.each([
+		['a JSON array', JSON.stringify([1, 2])],
+		['a JSON primitive', '42'],
+	])('fails closed when an expand payload is %s (not an object)', async (_label, payload) => {
+		const store = new ProjectSecretsStore({
+			bucket,
+			resolvers: [stubResolver({ bad: payload })],
+		});
+		await store.put(
+			pid,
+			'APP',
+			{ kind: 'reference', ref: { backend: 'stub', locator: 'bad', expand: 'json' } },
+			ACTOR,
+		);
+		await expect(store.resolve(pid)).rejects.toThrow(/APP/);
+	});
+
+	it('binds a managed envelope to its object path — decrypt at a different key fails', async () => {
+		// A codec that authenticates the object path (path-as-AAD): decrypt throws
+		// unless it is handed the exact path the envelope was encrypted under. A real
+		// AEAD codec behaves this way, so this proves the store threads `path` through
+		// both encrypt and decrypt (defeating a cut-and-paste of one secret's
+		// ciphertext into another secret's key).
+		const aadCodec: ManagedSecretCodec = {
+			encrypt: async (plaintext, ctx) => ({
+				kek_id: 'test',
+				alg: 'A256GCM',
+				iv: 'aXY=',
+				ciphertext: btoa(`${ctx.path} ${plaintext}`),
+			}),
+			decrypt: async (envelope, ctx) => {
+				const [boundPath, ...rest] = atob(envelope.ciphertext).split(' ');
+				if (boundPath !== ctx.path) throw new Error('AAD mismatch: envelope moved to a new key');
+				return rest.join(' ');
+			},
+		};
+		const store = new ProjectSecretsStore({ bucket, managed: aadCodec });
+		await store.put(pid, 'DB_PASSWORD', { kind: 'managed', value: 'hunter2' }, ACTOR);
+
+		// Relocate the stored envelope under a DIFFERENT secret's object key.
+		const src = paths.project(pid).secret('DB_PASSWORD');
+		const dst = paths.project(pid).secret('MOVED_PASSWORD');
+		const body = await bucket.get(src);
+		const raw = JSON.parse(await body!.text()) as Record<string, unknown>;
+		await bucket.put(dst, JSON.stringify({ ...raw, name: 'MOVED_PASSWORD' }));
+		await bucket.delete(src);
+
+		await expect(store.resolve(pid)).rejects.toThrow(/AAD mismatch/);
+	});
+
+	it('rejects a managed secret it can no longer decrypt (codec dropped)', async () => {
+		const withCodec = new ProjectSecretsStore({ bucket, managed: fakeCodec });
+		await withCodec.put(pid, 'DB_PASSWORD', { kind: 'managed', value: 'hunter2' }, ACTOR);
+
+		const withoutCodec = new ProjectSecretsStore({ bucket });
+		await expect(withoutCodec.resolve(pid)).rejects.toThrow(/DB_PASSWORD/);
 	});
 });

--- a/packages/core/src/services/secrets/secretName.test.ts
+++ b/packages/core/src/services/secrets/secretName.test.ts
@@ -30,4 +30,23 @@ describe('assertValidSecretName', () => {
 	it.each(['MARIMO_FOO', 'MARIMOHUB_ANYTHING'])('rejects reserved prefix %o', (name) => {
 		expect(() => assertValidSecretName(name)).toThrow(ValidationError);
 	});
+
+	// A newline-bearing name that slipped through would let an attacker inject a
+	// second `KEY=value` line when the env is materialized as text.
+	it.each(['FOO\n', 'FOO\nBAR', '\nFOO'])('rejects a name with a newline %o', (name) => {
+		expect(() => assertValidSecretName(name)).toThrow(ValidationError);
+	});
+
+	it.each(['IFS', 'ENV', 'DYLD_INSERT_LIBRARIES', 'PYTHONPATH', 'AWS_SECRET_ACCESS_KEY'])(
+		'rejects the reserved injection/credential name %o',
+		(name) => {
+			expect(() => assertValidSecretName(name)).toThrow(ValidationError);
+		},
+	);
+
+	// RESERVED_PREFIXES uses startsWith, so the bare token and no-underscore
+	// variants must be caught too (not just `MARIMO_...`).
+	it.each(['MARIMO', 'MARIMOS'])('rejects the bare/glued reserved prefix %o', (name) => {
+		expect(() => assertValidSecretName(name)).toThrow(ValidationError);
+	});
 });

--- a/packages/credentials-aws/src/index.test.ts
+++ b/packages/credentials-aws/src/index.test.ts
@@ -195,4 +195,54 @@ describe('AwsStsWifBroker', () => {
 			/not a URL/,
 		);
 	});
+
+	// Retry invariant (avoid double-minting): only 429/503/504 are retried; a 500/502
+	// may mean the mint partially succeeded, so it must NOT be replayed.
+	it.each([500, 502])('does not retry a %d (mint may have partially succeeded)', async (status) => {
+		const fetchFn = stubFetch(() => jsonResponse({ Error: { Code: 'InternalError' } }, status));
+		const broker = new AwsStsWifBroker({ roleArn: ROLE_ARN });
+		await exchangeError(broker, fakeJwt({ sub: 'proj-x1' }));
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([429, 503])('retries a %d then exhausts to an error', async (status) => {
+		const fetchFn = stubFetch(() => jsonResponse({ Error: { Code: 'Throttling' } }, status));
+		const broker = new AwsStsWifBroker({ roleArn: ROLE_ARN });
+		const message = await exchangeError(broker, fakeJwt({ sub: 'proj-x1' }));
+		// retry: 2 → the original call plus two retries.
+		expect(fetchFn).toHaveBeenCalledTimes(3);
+		expect(message).toContain(`HTTP ${status}`);
+	});
+
+	it('surfaces a bare failure on a network error without leaking the JWT', async () => {
+		stubFetch(() => {
+			throw new Error('ECONNRESET tunnel closed');
+		});
+		const broker = new AwsStsWifBroker({ roleArn: ROLE_ARN });
+		const secretJwt = fakeJwt({ sub: 'proj-super-secret' });
+		const message = await exchangeError(broker, secretJwt);
+		expect(message).toContain('STS credential exchange failed');
+		expect(message).not.toContain(secretJwt);
+	});
+
+	it.each(['12345678901', '1234567890123'])('rejects a non-12-digit account id (%s)', (account) => {
+		expect(
+			() => new AwsStsWifBroker({ roleArn: `arn:aws:iam::${account}:role/marimohub-wif` }),
+		).toThrow(/MARIMOHUB_WIF_AWS_ROLE_ARN/);
+	});
+
+	it.each(['aws-cn', 'aws-us-gov'])('accepts the %s partition', (partition) => {
+		expect(
+			() =>
+				new AwsStsWifBroker({ roleArn: `arn:${partition}:iam::123456789012:role/marimohub-wif` }),
+		).not.toThrow();
+	});
+
+	it('rejects a success body whose Expiration is neither number nor string', async () => {
+		stubFetch(() => jsonResponse(stsSuccess(true as unknown as number)));
+		const broker = new AwsStsWifBroker({ roleArn: ROLE_ARN });
+		const message = await exchangeError(broker, fakeJwt({ sub: 'proj-x1' }));
+		expect(message).toContain('unexpected response shape');
+		expect(message).toContain('Expiration');
+	});
 });

--- a/packages/credentials-coreweave/src/index.test.ts
+++ b/packages/credentials-coreweave/src/index.test.ts
@@ -107,4 +107,52 @@ describe('CoreWeaveWifBroker', () => {
 	it('fails fast when given a non-URL', () => {
 		expect(() => new CoreWeaveWifBroker({ exchangeUrl: 'not-a-url' })).toThrow(/not a URL/);
 	});
+
+	// Retry invariant (avoid orphaning a credential): only 429/503/504 are retried;
+	// a 500/502 may mean the mint partially succeeded and must NOT be replayed.
+	it.each([500, 502])('does not retry a %d (mint may have partially succeeded)', async (status) => {
+		const fetchFn = stubFetch(() => jsonResponse({ message: 'internal' }, status));
+		const broker = new CoreWeaveWifBroker({ exchangeUrl: EXCHANGE_URL });
+		await exchangeError(broker, 'jwt');
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([429, 503])('retries a %d then exhausts to an error', async (status) => {
+		const fetchFn = stubFetch(() => jsonResponse({ message: 'throttled' }, status));
+		const broker = new CoreWeaveWifBroker({ exchangeUrl: EXCHANGE_URL });
+		const message = await exchangeError(broker, 'jwt');
+		expect(fetchFn).toHaveBeenCalledTimes(3);
+		expect(message).toContain(`HTTP ${status}`);
+	});
+
+	it('surfaces a bare failure on a network timeout without leaking the JWT', async () => {
+		stubFetch(() => {
+			throw new Error('network timeout after 10000ms');
+		});
+		const broker = new CoreWeaveWifBroker({ exchangeUrl: EXCHANGE_URL });
+		const secretJwt = 'eyJ.super-secret-jwt.sig';
+		const message = await exchangeError(broker, secretJwt);
+		expect(message).toContain('CAIOS credential exchange failed');
+		expect(message).not.toContain(secretJwt);
+	});
+
+	it('accepts a legitimate custom exchange host', () => {
+		expect(
+			() =>
+				new CoreWeaveWifBroker({
+					exchangeUrl: 'https://api.coreweave.com/v1/cwobject/temporary-credentials/oidc/org',
+				}),
+		).not.toThrow();
+	});
+
+	// The issuer-host guard is an EXACT hostname match, so a host that merely embeds
+	// the issuer label (a different, non-issuer host) is allowed through.
+	it('allows a host that only embeds the issuer label (guard is exact-match)', () => {
+		expect(
+			() =>
+				new CoreWeaveWifBroker({
+					exchangeUrl: 'https://oidc.cks.coreweave.com.attacker.test/v1/exchange',
+				}),
+		).not.toThrow();
+	});
 });

--- a/packages/secrets-aws/src/index.test.ts
+++ b/packages/secrets-aws/src/index.test.ts
@@ -102,4 +102,49 @@ describe('AwsSecretsManagerResolver', () => {
 		await r.resolve(ref('k'));
 		expect(fetch).toHaveBeenCalledTimes(2);
 	});
+
+	it('does not memoize a failed fetch (a later attempt can still succeed)', async () => {
+		let calls = 0;
+		const fetch = vi.fn(async () => {
+			calls += 1;
+			if (calls === 1) throw Object.assign(new Error('flaky'), { name: 'ThrottlingException' });
+			return { SecretString: SECRET };
+		});
+		const r = resolver(fetch, 1000, () => 1000);
+
+		await expect(r.resolve(ref('k'))).rejects.toThrow(/ThrottlingException/);
+		expect(await r.resolve(ref('k'))).toBe(SECRET);
+		expect(fetch).toHaveBeenCalledTimes(2);
+	});
+
+	it('serves a stale value within the TTL after the underlying secret rotates', async () => {
+		let current = 'v1';
+		const fetch = vi.fn(async () => ({ SecretString: current }));
+		const r = resolver(fetch, 100, () => 1000);
+
+		expect(await r.resolve(ref('k'))).toBe('v1');
+		current = 'v2'; // rotate underneath, still within TTL
+		expect(await r.resolve(ref('k'))).toBe('v1');
+		expect(fetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('rejects a locator with a trailing # (empty json key)', async () => {
+		const r = resolver(async () => ({ SecretString: JSON.stringify({ k: 'v' }) }));
+		await expect(r.resolve(ref('db#'))).rejects.toThrow(/no JSON key/);
+	});
+
+	it('passes an empty-string locator through to the fetcher (no validation)', async () => {
+		const seen: string[] = [];
+		const r = resolver(async (id) => {
+			seen.push(id);
+			return { SecretString: SECRET };
+		});
+		expect(await r.resolve(ref(''))).toBe(SECRET);
+		expect(seen[0]).toBe('');
+	});
+
+	it('stringifies a null JSON field value', async () => {
+		const r = resolver(async () => ({ SecretString: JSON.stringify({ k: null }) }));
+		expect(await r.resolve(ref('db#k'))).toBe('null');
+	});
 });

--- a/packages/storage-fs/src/index.test.ts
+++ b/packages/storage-fs/src/index.test.ts
@@ -1,4 +1,13 @@
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -261,5 +270,84 @@ describe('FsStorage', () => {
 			await bucket.verifyConditionalWrites();
 			expect((await bucket.list()).objects).toEqual([]);
 		});
+	});
+});
+
+describe('FsStorage negative / edge cases', () => {
+	const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+
+	it('does not follow an intermediate symlink dir that escapes the root', async () => {
+		const parent = makeRoot();
+		const root = path.join(parent, 'store');
+		const external = path.join(parent, 'external');
+		mkdirSync(external);
+		writeFileSync(path.join(external, 'passwd'), 'root:x:0:0');
+
+		const bucket = new FsStorage({ root });
+		// An intermediate symlink dir (proj -> /external) escapes the root; O_NOFOLLOW
+		// only guards the final path component, and containment is a lexical prefix
+		// check, so this must not leak the external file.
+		symlinkSync(external, path.join(root, 'proj'));
+
+		expect(await bucket.get('proj/passwd')).toBeNull();
+		expect(await bucket.head('proj/passwd')).toBeNull();
+	});
+
+	it('rejects put when both onlyIfEtagMatches and onlyIfNotExists are supplied', async () => {
+		const bucket = new FsStorage({ root: makeRoot() });
+		await expect(
+			bucket.put('k', 'v', { onlyIfEtagMatches: 'x', onlyIfNotExists: true }),
+		).rejects.toThrow(/mutually exclusive/);
+	});
+
+	it('get and head return null for a key that resolves to a directory', async () => {
+		const bucket = new FsStorage({ root: makeRoot() });
+		await bucket.put('dir/child.txt', 'x');
+		expect(await bucket.get('dir')).toBeNull();
+		expect(await bucket.head('dir')).toBeNull();
+	});
+
+	it('delete is a no-op for a key that resolves to a directory', async () => {
+		const bucket = new FsStorage({ root: makeRoot() });
+		await bucket.put('dir/child.txt', 'x');
+		// The key has no object (get('dir') is null), so delete must be idempotent
+		// like a missing key rather than surfacing a raw EISDIR/EPERM.
+		await expect(bucket.delete('dir')).resolves.toBeUndefined();
+	});
+
+	it.skipIf(isRoot)('put surfaces EACCES on an unwritable staging dir', async () => {
+		const root = makeRoot();
+		const bucket = new FsStorage({ root });
+		chmodSync(path.join(root, '.tmp'), 0o500);
+		try {
+			await expect(bucket.put('x.txt', 'data')).rejects.toThrow();
+		} finally {
+			chmodSync(path.join(root, '.tmp'), 0o700);
+		}
+	});
+
+	it('get returns null (not a raw ENAMETOOLONG) for an over-long key segment', async () => {
+		const bucket = new FsStorage({ root: makeRoot() });
+		const longKey = 'a'.repeat(300);
+		expect(await bucket.get(longKey)).toBeNull();
+	});
+
+	it('constructor fails cleanly when the root points at an existing regular file', () => {
+		const parent = makeRoot();
+		const file = path.join(parent, 'not-a-dir');
+		writeFileSync(file, 'x');
+		expect(() => new FsStorage({ root: file })).toThrow();
+	});
+
+	it('list returns empty for an empty root and for a non-matching prefix', async () => {
+		const bucket = new FsStorage({ root: makeRoot() });
+		const empty = await bucket.list();
+		expect(empty.objects).toEqual([]);
+		expect(empty.truncated).toBe(false);
+
+		await bucket.put('a/1', 'x');
+		const none = await bucket.list({ prefix: 'zzz/' });
+		expect(none.objects).toEqual([]);
+		expect(none.truncated).toBe(false);
 	});
 });

--- a/packages/storage-fs/src/index.ts
+++ b/packages/storage-fs/src/index.ts
@@ -124,9 +124,22 @@ export class FsStorage implements Bucket {
 			// O_NOFOLLOW only guards the final component; an intermediate symlinked
 			// directory can still escape the root. Re-resolve the real path and treat
 			// anything outside the root as absent, so a link can't exfiltrate a file
-			// from elsewhere on the host.
-			const real = await fsp.realpath(filePath);
-			if (real !== this.root && !real.startsWith(this.rootPrefix)) return null;
+			// from elsewhere on the host. Tie the check to the OPEN fd's inode (compare
+			// dev+ino) so a symlink swapped in between open() and realpath() can't make
+			// an external fd pass the containment check.
+			let real: string;
+			let realStat: Awaited<ReturnType<typeof fsp.stat>>;
+			try {
+				real = await fsp.realpath(filePath);
+				if (real !== this.root && !real.startsWith(this.rootPrefix)) return null;
+				realStat = await fsp.stat(real);
+			} catch (err) {
+				// The path vanished (or a segment did) after open — treat as absent so
+				// list()'s concurrent-delete behavior stays intact.
+				if (NOT_FOUND_CODES.has(errCode(err) ?? '')) return null;
+				throw err;
+			}
+			if (realStat.ino !== stat.ino || realStat.dev !== stat.dev) return null;
 			return { body: await handle.readFile(), uploaded: stat.mtime };
 		} finally {
 			await handle.close();

--- a/packages/storage-fs/src/index.ts
+++ b/packages/storage-fs/src/index.ts
@@ -4,10 +4,10 @@
  * Keys map 1:1 to relative paths under the root, so operators can browse the
  * tree directly. Traversal is blocked by key validation plus a resolved-path
  * containment check, and reads refuse a symlink as the final path component
- * (O_NOFOLLOW). Intermediate directories are the operator's own layout: the
- * API only ever creates real directories, so a symlinked subdirectory can only
- * come from the operator (e.g. a mounted volume) and is followed. Writes stage
- * into a reserved `.tmp/` dir (fsync, then rename into place — atomic on a
+ * (O_NOFOLLOW). Reads additionally re-resolve the real path and refuse anything
+ * that escapes the root through an intermediate symlinked directory — a link
+ * pointing outside the root reads as absent, not as the external file. Writes
+ * stage into a reserved `.tmp/` dir (fsync, then rename into place — atomic on a
  * single filesystem).
  *
  * ETags are the sha-256 of the content, so they survive restarts (the catalog
@@ -44,10 +44,12 @@ const TMP_DIR = '.tmp';
 
 /**
  * open() failures that mean "no object at this key": missing file, a file
- * where a directory was expected (ENOTDIR), a directory itself (EISDIR), or a
- * symlink refused by O_NOFOLLOW (ELOOP on linux, EMLINK on darwin).
+ * where a directory was expected (ENOTDIR), a directory itself (EISDIR), a
+ * symlink refused by O_NOFOLLOW (ELOOP on linux, EMLINK on darwin), or a key
+ * segment longer than the filesystem name limit (ENAMETOOLONG — no such object
+ * could ever exist, so treat it as absent rather than surfacing a raw errno).
  */
-const NOT_FOUND_CODES = new Set(['ENOENT', 'ENOTDIR', 'EISDIR', 'ELOOP', 'EMLINK']);
+const NOT_FOUND_CODES = new Set(['ENOENT', 'ENOTDIR', 'EISDIR', 'ELOOP', 'EMLINK', 'ENAMETOOLONG']);
 
 /**
  * put() serialization shared by every instance in this process, keyed by
@@ -119,6 +121,12 @@ export class FsStorage implements Bucket {
 		try {
 			const stat = await handle.stat();
 			if (!stat.isFile()) return null;
+			// O_NOFOLLOW only guards the final component; an intermediate symlinked
+			// directory can still escape the root. Re-resolve the real path and treat
+			// anything outside the root as absent, so a link can't exfiltrate a file
+			// from elsewhere on the host.
+			const real = await fsp.realpath(filePath);
+			if (real !== this.root && !real.startsWith(this.rootPrefix)) return null;
 			return { body: await handle.readFile(), uploaded: stat.mtime };
 		} finally {
 			await handle.close();
@@ -219,7 +227,16 @@ export class FsStorage implements Bucket {
 			try {
 				await fsp.unlink(filePath);
 			} catch (err) {
-				if (errCode(err) === 'ENOENT' || errCode(err) === 'ENOTDIR') continue;
+				const code = errCode(err);
+				if (code === 'ENOENT' || code === 'ENOTDIR') continue;
+				// A key that resolves to a directory holds no object (get/head return
+				// null), so deleting it is an idempotent no-op rather than a raw
+				// EISDIR (linux) / EPERM (darwin). Only skip when it really is a dir —
+				// a genuine permission fault on a file must still surface.
+				if (code === 'EISDIR' || code === 'EPERM') {
+					const st = await fsp.lstat(filePath).catch(() => null);
+					if (!st || st.isDirectory()) continue;
+				}
 				throw err;
 			}
 			// Best-effort prune of now-empty parent dirs, stopping at the root.

--- a/packages/storage-fs/src/index.ts
+++ b/packages/storage-fs/src/index.ts
@@ -122,11 +122,16 @@ export class FsStorage implements Bucket {
 			const stat = await handle.stat();
 			if (!stat.isFile()) return null;
 			// O_NOFOLLOW only guards the final component; an intermediate symlinked
-			// directory can still escape the root. Re-resolve the real path and treat
-			// anything outside the root as absent, so a link can't exfiltrate a file
-			// from elsewhere on the host. Tie the check to the OPEN fd's inode (compare
-			// dev+ino) so a symlink swapped in between open() and realpath() can't make
-			// an external fd pass the containment check.
+			// directory can still escape the root. Re-resolve the real path, refuse
+			// anything outside the root, and require the opened fd to still be that same
+			// inode (dev+ino) — so a static escaping symlink reads as absent.
+			//
+			// Threat model: this is defense-in-depth against a MISCONFIGURED tree (e.g.
+			// an operator-mounted symlink escaping the root), NOT a race-free guarantee.
+			// Node exposes no beneath-resolving open (openat2/RESOLVE_BENEATH), so an
+			// attacker able to swap symlinks inside the root *concurrently* could still
+			// win the open→realpath→stat window — but such an attacker already has write
+			// access to the hub's private storage tree and has fully compromised it.
 			let real: string;
 			let realStat: Awaited<ReturnType<typeof fsp.stat>>;
 			try {

--- a/packages/storage-gcs/src/index.test.ts
+++ b/packages/storage-gcs/src/index.test.ts
@@ -442,6 +442,104 @@ describe('GcsStorage auth and request mapping', () => {
 	});
 });
 
+describe('GcsStorage error propagation and edge cases', () => {
+	it('percent-encodes slashes in the object key path segment', async () => {
+		let seenUrl = '';
+		const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+			seenUrl = String(input);
+			return new Response('payload', {
+				status: 200,
+				headers: { 'x-goog-generation': '7', 'content-length': '7' },
+			});
+		});
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		await bucket.get('dir/nb.py');
+		expect(seenUrl).toContain('/o/dir%2Fnb.py');
+	});
+
+	it('list reports truncated=false and no cursor when nextPageToken is absent', async () => {
+		const fetchImpl = vi.fn(async () =>
+			json({
+				items: [{ name: 'a', generation: '1', size: '1', updated: '2025-03-05T14:00:00.000Z' }],
+			}),
+		);
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		const res = await bucket.list();
+		expect(res.truncated).toBe(false);
+		expect(res.cursor).toBeUndefined();
+	});
+
+	it('get falls back to bodyBytes.length when content-length is missing', async () => {
+		const fetchImpl = vi.fn(
+			async () => new Response('payload!', { status: 200, headers: { 'x-goog-generation': '9' } }),
+		);
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		const body = await bucket.get('k');
+		expect(body?.size).toBe(8);
+	});
+
+	it('put sends ifGenerationMatch=0 for onlyIfNotExists', async () => {
+		let seenUrl: URL | undefined;
+		const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+			seenUrl = new URL(String(input));
+			return json({ name: 'k', generation: '10', size: '1', updated: '2025-03-05T14:00:00.000Z' });
+		});
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		await bucket.put('k', 'v', { onlyIfNotExists: true });
+		expect(seenUrl?.searchParams.get('ifGenerationMatch')).toBe('0');
+	});
+
+	it('put coerces a bogus etag to generation 1 for ifGenerationMatch', async () => {
+		let seenUrl: URL | undefined;
+		const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+			seenUrl = new URL(String(input));
+			return json({ name: 'k', generation: '11', size: '1', updated: '2025-03-05T14:00:00.000Z' });
+		});
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		await bucket.put('k', 'v', { onlyIfEtagMatches: 'not-a-number' });
+		expect(seenUrl?.searchParams.get('ifGenerationMatch')).toBe('1');
+	});
+
+	it('does not retry an upload on a transient network error', async () => {
+		let calls = 0;
+		const fetchImpl = vi.fn(async () => {
+			calls += 1;
+			throw Object.assign(new Error('network down'), { name: 'FetchError' });
+		});
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		await expect(bucket.put('k', 'v')).rejects.toThrow();
+		expect(calls).toBe(1);
+	});
+
+	it('get throws on a 500 response', async () => {
+		const fetchImpl = vi.fn(async () => new Response('boom', { status: 500 }));
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		await expect(bucket.get('k')).rejects.toThrow(/GCS get failed/);
+	});
+
+	it('head throws on a 403 response', async () => {
+		const fetchImpl = vi.fn(async () => new Response('denied', { status: 403 }));
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		await expect(bucket.head('k')).rejects.toThrow(/GCS head failed/);
+	});
+
+	it('list throws on a 500 response', async () => {
+		const fetchImpl = vi.fn(async () => new Response('boom', { status: 500 }));
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		await expect(bucket.list()).rejects.toThrow(/GCS list failed/);
+	});
+
+	it('delete throws on a non-404 error', async () => {
+		const fetchImpl = vi.fn(async () => new Response('denied', { status: 403 }));
+		const bucket = new GcsStorage({ bucket: 'test', accessToken: 't', fetchImpl });
+		await expect(bucket.delete('k')).rejects.toThrow(/GCS delete failed/);
+	});
+
+	// SKIP: the adapter reads the whole body via `res.arrayBuffer()` in get(), so
+	// "does not buffer an unbounded body" is not expressible against this code.
+	it.skip('get does not buffer an unbounded object body into memory', () => {});
+});
+
 describe('GcsStorage conditional-write verification', () => {
 	it('passes against a store that enforces ifGenerationMatch atomically', async () => {
 		const bucket = new GcsStorage({ bucket: 'test', fetchImpl: makeFakeGcsFetch() });

--- a/packages/storage-r2/src/index.test.ts
+++ b/packages/storage-r2/src/index.test.ts
@@ -193,3 +193,90 @@ describe('R2BucketAdapter CAS error mapping', () => {
 		);
 	});
 });
+
+describe('R2BucketAdapter list / put forwarding', () => {
+	function makeR2Object2(key: string): R2Object {
+		return {
+			key,
+			etag: 'e',
+			size: 1,
+			uploaded: new Date(),
+		} as unknown as R2Object;
+	}
+
+	it('surfaces a cursor only when the result is truncated', async () => {
+		let toReturn: unknown;
+		const r2 = {
+			list: async () => toReturn,
+		} as unknown as R2Bucket;
+		const adapter = new R2BucketAdapter(r2);
+
+		toReturn = { objects: [], truncated: false, cursor: 'leftover', delimitedPrefixes: [] };
+		expect((await adapter.list()).cursor).toBeUndefined();
+
+		toReturn = { objects: [], truncated: true, cursor: 'more', delimitedPrefixes: [] };
+		const truncated = await adapter.list();
+		expect(truncated.truncated).toBe(true);
+		expect(truncated.cursor).toBe('more');
+	});
+
+	it('forwards prefix/delimiter/cursor/limit/startAfter to r2.list', async () => {
+		let seen: R2ListOptions | undefined;
+		const r2 = {
+			list: async (opts?: R2ListOptions) => {
+				seen = opts;
+				return { objects: [], truncated: false, delimitedPrefixes: [] };
+			},
+		} as unknown as R2Bucket;
+		const adapter = new R2BucketAdapter(r2);
+
+		await adapter.list({
+			prefix: 'p/',
+			delimiter: '/',
+			cursor: 'tok',
+			limit: 42,
+			startAfter: 'p/0',
+		});
+
+		expect(seen).toMatchObject({
+			prefix: 'p/',
+			delimiter: '/',
+			cursor: 'tok',
+			limit: 42,
+			startAfter: 'p/0',
+		});
+	});
+
+	it('passes through delimitedPrefixes from r2.list', async () => {
+		const r2 = {
+			list: async () => ({
+				objects: [makeR2Object2('a/1')],
+				truncated: false,
+				delimitedPrefixes: ['a/', 'b/'],
+			}),
+		} as unknown as R2Bucket;
+		const adapter = new R2BucketAdapter(r2);
+
+		const res = await adapter.list({ delimiter: '/' });
+		expect(res.delimitedPrefixes).toEqual(['a/', 'b/']);
+	});
+
+	it('forwards httpMetadata and customMetadata to r2.put', async () => {
+		let seen: R2PutOptions | undefined;
+		const r2 = {
+			put: async (key: string, _value: unknown, opts?: R2PutOptions) => {
+				seen = opts;
+				return makeR2Object2(key);
+			},
+		} as unknown as R2Bucket;
+		const adapter = new R2BucketAdapter(r2);
+
+		await adapter.put('k', 'v', {
+			httpMetadata: { contentType: 'text/x-python' },
+			customMetadata: { source: 'git' },
+		});
+
+		expect(seen?.httpMetadata).toEqual({ contentType: 'text/x-python' });
+		expect(seen?.customMetadata).toEqual({ source: 'git' });
+	});
+});

--- a/packages/storage-s3/src/index.test.ts
+++ b/packages/storage-s3/src/index.test.ts
@@ -292,6 +292,96 @@ describe('S3Storage error classification', () => {
 		const s3 = new S3Storage(CFG);
 		await expect(s3.get('k')).rejects.toThrow('AccessDenied');
 	});
+
+	it('propagates a non-NotFound error from head rather than returning null', async () => {
+		vi.spyOn(S3Client.prototype, 'send').mockRejectedValue(
+			Object.assign(new Error('AccessDenied'), {
+				name: 'AccessDenied',
+				$metadata: { httpStatusCode: 403 },
+			}),
+		);
+		const s3 = new S3Storage(CFG);
+		await expect(s3.head('k')).rejects.toThrow('AccessDenied');
+	});
+
+	it('treats a status-404 error with a non-NoSuchKey name as not-found (get and head)', async () => {
+		vi.spyOn(S3Client.prototype, 'send').mockRejectedValue(
+			Object.assign(new Error('SomethingWeird'), {
+				name: 'SomethingWeird',
+				$metadata: { httpStatusCode: 404 },
+			}),
+		);
+		const s3 = new S3Storage(CFG);
+		expect(await s3.get('k')).toBeNull();
+		expect(await s3.head('k')).toBeNull();
+	});
+
+	it('maps a status-412 error with a non-PreconditionFailed name to PreconditionFailedError', async () => {
+		vi.spyOn(S3Client.prototype, 'send').mockRejectedValue(
+			Object.assign(new Error('SomeOtherName'), {
+				name: 'SomeOtherName',
+				$metadata: { httpStatusCode: 412 },
+			}),
+		);
+		const s3 = new S3Storage(CFG);
+		await expect(s3.put('k', 'v', { onlyIfEtagMatches: 'x' })).rejects.toBeInstanceOf(
+			PreconditionFailedError,
+		);
+	});
+});
+
+describe('S3Storage list truncation and delete edge cases', () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it('maps IsTruncated/NextContinuationToken and clears the cursor when not truncated', async () => {
+		const spy = vi.spyOn(S3Client.prototype, 'send');
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		spy.mockResolvedValueOnce({
+			Contents: [],
+			IsTruncated: true,
+			NextContinuationToken: 'next-tok',
+		} as any);
+		const truncated = await new S3Storage(CFG).list();
+		expect(truncated.truncated).toBe(true);
+		expect(truncated.cursor).toBe('next-tok');
+
+		// A store that returns a token but reports IsTruncated=false must not leak a cursor.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		spy.mockResolvedValueOnce({
+			Contents: [],
+			IsTruncated: false,
+			NextContinuationToken: 'leftover',
+		} as any);
+		const done = await new S3Storage(CFG).list();
+		expect(done.truncated).toBe(false);
+		expect(done.cursor).toBeUndefined();
+	});
+
+	it('sends no command for an empty key array delete', async () => {
+		const spy = vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({} as never);
+		await new S3Storage(CFG).delete([]);
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('surfaces per-object errors in a DeleteObjects batch response (HTTP 200 with Errors[])', async () => {
+		// The real S3 batch delete returns HTTP 200 with a per-key Errors[] array; a
+		// key that failed (e.g. AccessDenied) must not be silently reported as deleted.
+		vi.spyOn(S3Client.prototype, 'send').mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			async (command: any) => {
+				if (command.constructor.name === 'DeleteObjectsCommand') {
+					return {
+						Deleted: [],
+						Errors: [{ Key: 'k/1', Code: 'AccessDenied', Message: 'Access Denied' }],
+					} as never;
+				}
+				return {} as never;
+			},
+		);
+		const s3 = new S3Storage(CFG);
+		await expect(s3.delete(['k/1', 'k/2'])).rejects.toThrow();
+	});
 });
 
 describe('S3Storage.verifyConditionalWrites', () => {

--- a/packages/storage-s3/src/index.test.ts
+++ b/packages/storage-s3/src/index.test.ts
@@ -382,6 +382,27 @@ describe('S3Storage list truncation and delete edge cases', () => {
 		const s3 = new S3Storage(CFG);
 		await expect(s3.delete(['k/1', 'k/2'])).rejects.toThrow();
 	});
+
+	it('attempts every batch before rejecting, even when an early batch has an error', async () => {
+		let deleteCalls = 0;
+		vi.spyOn(S3Client.prototype, 'send').mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			async (command: any) => {
+				if (command.constructor.name === 'DeleteObjectsCommand') {
+					deleteCalls++;
+					// The first batch has a failing key; the second must still be attempted.
+					return deleteCalls === 1
+						? { Deleted: [], Errors: [{ Key: 'k/0', Code: 'AccessDenied' }] }
+						: ({ Deleted: [], Errors: [] } as never);
+				}
+				return {} as never;
+			},
+		);
+		// 1500 keys → two 1000-max batches.
+		const keys = Array.from({ length: 1500 }, (_, i) => `k/${i}`);
+		await expect(new S3Storage(CFG).delete(keys)).rejects.toThrow(/AccessDenied/);
+		expect(deleteCalls).toBe(2);
+	});
 });
 
 describe('S3Storage.verifyConditionalWrites', () => {

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -165,12 +165,22 @@ export class S3Storage implements Bucket {
 		if (Array.isArray(key)) {
 			for (const batch of chunk(key, 1000)) {
 				if (batch.length === 0) continue;
-				await this.client.send(
+				const res = await this.client.send(
 					new DeleteObjectsCommand({
 						Bucket: this.bucket,
 						Delete: { Objects: batch.map((Key) => ({ Key })) },
 					}),
 				);
+				// A batch delete returns HTTP 200 even when individual keys fail; the
+				// per-key failures come back in Errors[]. Don't report a partial failure
+				// as a clean delete — a swallowed AccessDenied leaves the object behind.
+				if (res.Errors && res.Errors.length > 0) {
+					const first = res.Errors[0];
+					throw new Error(
+						`S3 batch delete failed for ${res.Errors.length} object(s): ` +
+							`${first.Key} — ${first.Code}: ${first.Message}`,
+					);
+				}
 			}
 			return;
 		}

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -163,6 +163,11 @@ export class S3Storage implements Bucket {
 
 	async delete(key: string | string[]): Promise<void> {
 		if (Array.isArray(key)) {
+			// A batch delete returns HTTP 200 even when individual keys fail; the per-key
+			// failures come back in Errors[]. Collect them across ALL chunks (never abort
+			// early — one inaccessible object must not block retention cleanup for the
+			// rest) and reject only once every batch has been attempted.
+			const errors: { Key?: string; Code?: string; Message?: string }[] = [];
 			for (const batch of chunk(key, 1000)) {
 				if (batch.length === 0) continue;
 				const res = await this.client.send(
@@ -171,16 +176,14 @@ export class S3Storage implements Bucket {
 						Delete: { Objects: batch.map((Key) => ({ Key })) },
 					}),
 				);
-				// A batch delete returns HTTP 200 even when individual keys fail; the
-				// per-key failures come back in Errors[]. Don't report a partial failure
-				// as a clean delete — a swallowed AccessDenied leaves the object behind.
-				if (res.Errors && res.Errors.length > 0) {
-					const first = res.Errors[0];
-					throw new Error(
-						`S3 batch delete failed for ${res.Errors.length} object(s): ` +
-							`${first.Key} — ${first.Code}: ${first.Message}`,
-					);
-				}
+				if (res.Errors && res.Errors.length > 0) errors.push(...res.Errors);
+			}
+			if (errors.length > 0) {
+				const first = errors[0];
+				throw new Error(
+					`S3 batch delete failed for ${errors.length} object(s): ` +
+						`${first.Key} — ${first.Code}: ${first.Message}`,
+				);
 			}
 			return;
 		}


### PR DESCRIPTION
Adds ~189 negative test cases (edge cases, security guards, conflicts) across every package. 20 surfaced real bugs, all fixed in this PR.

**Highlights**
- **Security:** sandbox path-traversal writes, storage-fs symlink escape, config host-isolation fail-open
- **Resilience:** one corrupt record no longer aborts a whole scan (sessions/events/migrations); s3 batch-delete surfaces per-key errors; `mapWithConcurrency(0)` no longer silently drops
- **Lifecycle/correctness:** reconciler orphan-grace + terminating-sandbox leak, `member_emails` lowercasing, retention off-by-one, `getVersion` 404-not-500, `//proxy` slash, modal missing-url guard, partial-S3-cred fail-closed

Full suite green (2125 tests), typecheck + lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ~189 negative/edge/security tests and fixes 20 bugs across API, core, compute, storage, and config. Hardens sandbox/storage security, improves resiliency, and tightens lifecycle and error handling.

- **Bug Fixes**
  - Block path traversal in workspace restore and `@marimo-hub/compute-local`; unsafe workspace paths are skipped.
  - `@marimo-hub/storage-fs`: prevent escaping the bucket root via intermediate symlinks; reads tie containment to the opened fd (close TOCTOU) and treat concurrent deletes as absent.
  - S3: fail closed on partial static creds in `@marimo-hub/config`; `@marimo-hub/storage-s3` batch deletes attempt all chunks and then surface per-key errors.
  - Skip corrupt records instead of aborting scans in sessions, events, and migrations (including JSON-valid but non-object records).
  - `@marimo-hub/compute-commons` `mapWithConcurrency(0/NaN)` now runs serially (no dropped work).
  - Reconciler: adds a durable first-seen marker for timestamp-less orphans, clamps future-dated markers to now, applies grace before reaping; honors `terminating` sessions, and the FSM no longer downgrades `terminating` to `failed`.
  - Event retention off-by-one fixed: keeps a day whose end lands on the cutoff.
  - Tighter input/ID validation: `getVersion` returns 404 for malformed ids; `member_emails` lowercased on parse; stricter secret names and encoded secret/identity keys.
  - Proxy/tunnel hardening: trim trailing slashes to avoid `//proxy`; require a `url` in Modal tunnels responses.
  - Notebook versions: clean up html/session sidecars if the descriptor CAS loses to a concurrent version purge.
  - Host isolation: `@marimo-hub/config` distinguishes shared-origin vs unverifiable redirect; hostless redirects (e.g. `mailto:`) are rejected.
  - API: onError honors thrown `HTTPException` responses; tighter CSRF allowlist and ID/token scoping; 413 handling for oversized sync pushes.

<sup>Written for commit 5a9e2370697dae8811e78904157c17d6627d32ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

