### PR TITLE
feat: add workflow to publish sandbox image and Dockerfile for marimo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,28 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["local>marimo-team/.github:renovate-config", "config:recommended", "schedule:monthly"]
+	"extends": [
+		"local>marimo-team/.github:renovate-config",
+		"config:recommended",
+		"schedule:monthly"
+	],
+	"timezone": "America/New_York",
+	"customManagers": [
+		{
+			"customType": "regex",
+			"managerFilePatterns": ["/^images\\/marimo-sandbox\\/Dockerfile$/"],
+			"matchStrings": ["ARG MARIMO_VERSION=(?<currentValue>\\S+)"],
+			"depNameTemplate": "marimo",
+			"datasourceTemplate": "pypi",
+			"versioningTemplate": "pep440"
+		}
+	],
+	"packageRules": [
+		{
+			"description": "Check the sandbox image for marimo updates daily",
+			"matchDatasources": ["pypi"],
+			"matchPackageNames": ["marimo"],
+			"matchFileNames": ["images/marimo-sandbox/Dockerfile"],
+			"schedule": ["* 0-4 * * *"]
+		}
+	]
 }

--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -1,0 +1,64 @@
+name: Publish sandbox image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/marimo-sandbox/Dockerfile'
+  pull_request:
+    paths:
+      - 'images/marimo-sandbox/Dockerfile'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  image:
+    name: Build, test, and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Read marimo version
+        id: version
+        run: |
+          VERSION="$(sed -n 's/^ARG MARIMO_VERSION=//p' images/marimo-sandbox/Dockerfile)"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid MARIMO_VERSION: $VERSION"
+            exit 1
+          fi
+          echo "marimo=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build and run acceptance tests
+        run: examples/sandbox-image/acceptance-test.sh marimo-sandbox:ci images/marimo-sandbox
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        if: github.event_name == 'push'
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: images/marimo-sandbox
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:latest
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:py3.13-marimo${{ steps.version.outputs.marimo }}
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:sha-${{ github.sha }}

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.13-slim
+
+ARG MARIMO_VERSION=0.23.11
+ENV MARIMO_VERSION=${MARIMO_VERSION}
+
+COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /usr/local/bin/
+
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates locales \
+ && sed -i 's/^# *en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+ && locale-gen \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    UV_PROJECT_ENVIRONMENT=/opt/venv \
+    UV_CACHE_DIR=/opt/uv-cache \
+    MARIMO_SKIP_UPDATE_CHECK=1 \
+    _MARIMO_APP_OVERLOAD_AUTO_DOWNLOAD=[html]
+
+RUN useradd -m appuser \
+ && mkdir -p /workspace/notebooks \
+ && chown -R appuser:appuser /workspace
+
+# Retaining uv's cache makes overlapping per-notebook dependency installs cache hits.
+RUN cd /tmp \
+ && uv init --bare --no-readme base \
+ && cd base \
+ && uv add --compile-bytecode \
+      "marimo[recommended]==${MARIMO_VERSION}" \
+      polars \
+      narwhals \
+      numpy \
+      pandas \
+      pyarrow \
+      duckdb \
+      altair \
+      matplotlib \
+      plotly \
+      anywidget \
+      moutils \
+      scikit-learn \
+      scipy \
+      requests \
+      httpx \
+      openpyxl \
+      sqlglot \
+ && rm -rf /tmp/base \
+ && chown -R appuser:appuser /opt/venv /opt/uv-cache
+
+# uv compiles installed packages, but not the interpreter's standard library.
+RUN python3 -m compileall -j 0 -q /usr/local/lib/python3.13 || true
+
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:$PATH
+
+USER appuser
+WORKDIR /workspace/notebooks
+
+CMD ["uv", "run", "--no-sync", "marimo", "edit", "notebook.py", "--convert", "--headless", "--no-token", "--host", "0.0.0.0", "--port", "2718"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Dockerfile and CI workflow to build, test, and publish a `marimo` sandbox image to `ghcr.io`, with automated version bumps via Renovate.

- **New Features**
  - Dockerfile for `python:3.13-slim` with `uv` and preinstalled data/science libs; defaults to running `marimo` headless on port 2718.
  - GitHub Action builds and runs acceptance tests on PRs; publishes on `main` with tags: `latest`, `py3.13-marimo<version>`, and `sha-<commit>`.
  - Validates `MARIMO_VERSION` and compiles Python stdlib bytecode to speed startup.

- **Dependencies**
  - Renovate custom manager tracks `ARG MARIMO_VERSION` in `images/marimo-sandbox/Dockerfile` and checks `pypi` for `marimo` updates daily (timezone `America/New_York`).

<sup>Written for commit b962c9b6f02fcc9bb766920ac589eaa92815d603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

