### PR TITLE
deps: match npm min release

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,12 @@
 	],
 	"packageRules": [
 		{
+			"description": "Match pnpm's 14-day minimum release age for npm packages",
+			"matchDatasources": ["npm"],
+			"minimumReleaseAge": "14 days",
+			"internalChecksFilter": "strict"
+		},
+		{
 			"description": "Check the sandbox image for marimo updates daily",
 			"matchDatasources": ["pypi"],
 			"matchPackageNames": ["marimo"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update Renovate to delay `npm` updates until releases are at least 14 days old, matching `pnpm`’s minimum release age. Uses strict internal checks to avoid early, unstable updates and reduce noise.

<sup>Written for commit 4d0a15be92bcb08e4d06d2fa57bec289d752487d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

