### PR TITLE
refactor(web): consolidate hooks behind shared primitives, +131 tests

### DIFF
--- a/packages/web/src/api/hooks.test.tsx
+++ b/packages/web/src/api/hooks.test.tsx
@@ -1,0 +1,406 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { jsonError, jsonOk, renderHookWithClient } from '@/test/render';
+import { notebookKeys, projectKeys, sessionKeys } from './queryKeys';
+import {
+	useCapabilitiesQuery,
+	useDownloadWorkspace,
+	useNotebookHtmlQuery,
+	useProjectSecretsQuery,
+	useRestartApp,
+	useStartSession,
+	useUpdateNotebook,
+	useUpdateProject,
+	useUserQuery,
+	useUsersQuery,
+	useUserSearchQuery,
+	useVersionQuery,
+} from './hooks';
+
+const PID = 'proj-1';
+const NID = 'nb-1';
+
+type FetchHandler = (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/** Stub the network with a URL/method router; anything unrouted is a test bug. */
+function stubFetch(handler: FetchHandler) {
+	const fetchMock = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => handler(url, init));
+	vi.stubGlobal('fetch', fetchMock);
+	return fetchMock;
+}
+
+const urlsOf = (fetchMock: ReturnType<typeof stubFetch>) =>
+	fetchMock.mock.calls.map(([url]) => String(url));
+
+/** The query keys passed to `invalidateQueries`, in call order. */
+function invalidatedKeys(spy: { mock: { calls: unknown[][] } }): unknown[] {
+	return spy.mock.calls.map((call) => (call[0] as { queryKey: unknown }).queryKey);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('useUsersQuery', () => {
+	it('dedupes and sorts ids so any input ordering shares one cache entry', async () => {
+		const fetchMock = stubFetch(async () => jsonOk({ a: { id: 'a' }, b: { id: 'b' } }));
+
+		const { result } = renderHookWithClient(
+			() => ({
+				first: useUsersQuery(['b', 'a']),
+				second: useUsersQuery(['a', 'b', 'a']),
+			}),
+			{ toaster: false },
+		);
+
+		await waitFor(() => expect(result.current.first.data).toBeDefined());
+		expect(result.current.second.data).toBe(result.current.first.data);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('filters out undefined ids and encodes the joined list', async () => {
+		const fetchMock = stubFetch(async () => jsonOk({}));
+
+		renderHookWithClient(() => useUsersQuery(['u2', undefined, 'u1', undefined]), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+		expect(urlsOf(fetchMock)[0]).toBe('/api/v1/users?ids=u1%2Cu2');
+	});
+
+	it('does not fetch for an empty or all-undefined list', async () => {
+		const fetchMock = stubFetch(async () => jsonOk({}));
+
+		const { result } = renderHookWithClient(
+			() => ({ empty: useUsersQuery([]), blank: useUsersQuery([undefined, undefined]) }),
+			{ toaster: false },
+		);
+
+		await act(async () => {});
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result.current.empty.data).toBeUndefined();
+		expect(result.current.blank.data).toBeUndefined();
+	});
+});
+
+describe('useUserSearchQuery', () => {
+	it('is disabled below two characters after trimming, and enabled at two', async () => {
+		const fetchMock = stubFetch(async () => jsonOk([]));
+
+		const { rerender } = renderHookWithClient(({ q }: { q: string }) => useUserSearchQuery(q), {
+			initialProps: { q: ' a ' },
+			toaster: false,
+		});
+
+		await act(async () => {});
+		expect(fetchMock).not.toHaveBeenCalled();
+
+		rerender({ q: ' ab ' });
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		expect(urlsOf(fetchMock)[0]).toBe('/api/v1/users/search?q=ab');
+	});
+
+	it('keeps the previous results while a new query is in flight', async () => {
+		let releaseSecond!: () => void;
+		const secondInFlight = new Promise<void>((resolve) => {
+			releaseSecond = resolve;
+		});
+		stubFetch(async (url) => {
+			const q = new URL(String(url), 'http://test.local').searchParams.get('q');
+			if (q === 'ab') return jsonOk([{ id: 'u1', email: 'a@b.c', name: 'Ada' }]);
+			await secondInFlight;
+			return jsonOk([{ id: 'u2', email: 'b@b.c', name: 'Bob' }]);
+		});
+
+		const { result, rerender } = renderHookWithClient(
+			({ q }: { q: string }) => useUserSearchQuery(q),
+			{ initialProps: { q: 'ab' }, toaster: false },
+		);
+		await waitFor(() => expect(result.current.data?.[0]?.id).toBe('u1'));
+
+		rerender({ q: 'abc' });
+		await waitFor(() => expect(result.current.isPlaceholderData).toBe(true));
+		// The option list must not blank out between keystrokes.
+		expect(result.current.data?.[0]?.id).toBe('u1');
+
+		releaseSecond();
+		await waitFor(() => expect(result.current.data?.[0]?.id).toBe('u2'));
+		expect(result.current.isPlaceholderData).toBe(false);
+	});
+});
+
+describe('useProjectSecretsQuery', () => {
+	it('resolves null (not an error) when the route 404s as NOT_FOUND', async () => {
+		const fetchMock = stubFetch(async () => jsonError('NOT_FOUND', 'secrets disabled', 404));
+
+		const { result } = renderHookWithClient(() => useProjectSecretsQuery(PID), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toBeNull();
+		expect(result.current.error).toBeNull();
+		// A disabled feature is a settled answer — it must not be retried.
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('surfaces any other error', async () => {
+		stubFetch(async () => jsonError('INTERNAL_ERROR', 'boom', 500));
+
+		const { result } = renderHookWithClient(() => useProjectSecretsQuery(PID), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5_000 });
+		expect(result.current.error?.message).toBe('boom');
+	}, 10_000);
+
+	it('does not fetch while disabled', async () => {
+		const fetchMock = stubFetch(async () => jsonOk([]));
+
+		renderHookWithClient(() => useProjectSecretsQuery(PID, false), { toaster: false });
+
+		await act(async () => {});
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('useNotebookHtmlQuery', () => {
+	const htmlPath = `/api/v1/projects/${PID}/notebooks/${NID}/html`;
+
+	it('resolves null when the notebook simply has no snapshot yet', async () => {
+		const fetchMock = stubFetch(async () => jsonError('NO_HTML_SNAPSHOT', 'no outputs', 404));
+
+		const { result } = renderHookWithClient(() => useNotebookHtmlQuery(PID, NID), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(result.current.data).toBeNull();
+		expect(urlsOf(fetchMock)[0]).toBe(htmlPath);
+	});
+
+	it('throws when the notebook itself is gone', async () => {
+		stubFetch(async () => jsonError('NOT_FOUND', 'gone', 404));
+
+		const { result } = renderHookWithClient(() => useNotebookHtmlQuery(PID, NID), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(result.current.error?.message).toBe('Notebook not found');
+	});
+
+	it('throws with the status on a server error', async () => {
+		stubFetch(async () => new Response('nope', { status: 500 }));
+
+		const { result } = renderHookWithClient(() => useNotebookHtmlQuery(PID, NID), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(result.current.error?.message).toBe('Failed to load notebook outputs (HTTP 500)');
+	});
+
+	it('returns the html and the captured-at header', async () => {
+		stubFetch(
+			async () =>
+				new Response('<h1>out</h1>', {
+					status: 200,
+					headers: {
+						'content-type': 'text/html',
+						'X-Marimohub-Captured-At': '2025-03-05T14:00:00Z',
+					},
+				}),
+		);
+
+		const { result } = renderHookWithClient(() => useNotebookHtmlQuery(PID, NID), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(result.current.data).toBeTruthy());
+		expect(result.current.data).toEqual({
+			html: '<h1>out</h1>',
+			capturedAt: '2025-03-05T14:00:00Z',
+		});
+	});
+
+	it('reports a null capturedAt when the header is absent', async () => {
+		stubFetch(
+			async () =>
+				new Response('<h1>out</h1>', { status: 200, headers: { 'content-type': 'text/html' } }),
+		);
+
+		const { result } = renderHookWithClient(() => useNotebookHtmlQuery(PID, NID), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(result.current.data).toBeTruthy());
+		expect(result.current.data?.capturedAt).toBeNull();
+	});
+});
+
+describe('useStartSession', () => {
+	const sessionsPath = `/api/v1/projects/${PID}/notebooks/${NID}/sessions`;
+
+	it('creates an edit session with no body at all', async () => {
+		const fetchMock = stubFetch(async () => jsonOk({ session_id: 'sess-1' }));
+
+		const { result } = renderHookWithClient(() => useStartSession(PID, NID), { toaster: false });
+		await act(async () => {
+			await result.current.mutateAsync();
+		});
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toBe(sessionsPath);
+		expect(init?.method).toBe('POST');
+		expect(init?.body ?? undefined).toBeUndefined();
+	});
+
+	it('creates an app session with a JSON mode body', async () => {
+		const fetchMock = stubFetch(async () => jsonOk({ session_id: 'sess-1', mode: 'app' }));
+
+		const { result } = renderHookWithClient(() => useStartSession(PID, NID, 'app'), {
+			toaster: false,
+		});
+		await act(async () => {
+			await result.current.mutateAsync();
+		});
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toBe(sessionsPath);
+		expect(init?.method).toBe('POST');
+		expect(String(init?.body)).toBe('{"mode":"app"}');
+		expect(new Headers(init?.headers).get('content-type')).toBe('application/json');
+	});
+});
+
+describe('useRestartApp', () => {
+	const sessionsPath = `/api/v1/projects/${PID}/notebooks/${NID}/sessions`;
+
+	function restartFetch(stop: () => Promise<Response>) {
+		return stubFetch(async (url, init) => {
+			const method = init?.method ?? 'GET';
+			if (method === 'DELETE' && String(url) === `${sessionsPath}/sess-1`) return stop();
+			if (method === 'POST' && String(url) === sessionsPath) {
+				return jsonOk({ session_id: 'sess-2', mode: 'app' });
+			}
+			throw new Error(`unexpected fetch: ${method} ${String(url)}`);
+		});
+	}
+
+	it('stops the old session, then starts a fresh app session', async () => {
+		const fetchMock = restartFetch(async () => jsonOk(undefined));
+
+		const { result, client } = renderHookWithClient(() => useRestartApp(PID, NID), {
+			toaster: false,
+		});
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			await result.current.mutateAsync('sess-1');
+		});
+
+		const methods = fetchMock.mock.calls.map(([url, init]) => `${init?.method} ${String(url)}`);
+		expect(methods).toEqual([`DELETE ${sessionsPath}/sess-1`, `POST ${sessionsPath}`]);
+		const [, startInit] = fetchMock.mock.calls[1];
+		expect(String(startInit?.body)).toBe('{"mode":"app"}');
+		expect(invalidatedKeys(spy)).toEqual([sessionKeys.listByProject(PID)]);
+	});
+
+	it('still starts when the old session is already gone (404)', async () => {
+		const fetchMock = restartFetch(async () => jsonError('NOT_FOUND', 'Session not found', 404));
+
+		const { result } = renderHookWithClient(() => useRestartApp(PID, NID), { toaster: false });
+		let started: { session_id?: string } | undefined;
+		await act(async () => {
+			started = await result.current.mutateAsync('sess-1');
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(started).toMatchObject({ session_id: 'sess-2' });
+	});
+
+	it('aborts without starting when the stop fails for any other reason', async () => {
+		const fetchMock = restartFetch(async () => jsonError('INTERNAL_ERROR', 'teardown failed', 500));
+
+		const { result, client } = renderHookWithClient(() => useRestartApp(PID, NID), {
+			toaster: false,
+		});
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			await expect(result.current.mutateAsync('sess-1')).rejects.toThrow('teardown failed');
+		});
+
+		// A restart that half-ran (stopped, never started) is worse than one that failed.
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(spy).not.toHaveBeenCalled();
+	});
+});
+
+describe('list + detail invalidation', () => {
+	it('useUpdateNotebook drops both the list and the notebook it patched', async () => {
+		stubFetch(async () => jsonOk({ notebook_id: NID }));
+
+		const { result, client } = renderHookWithClient(() => useUpdateNotebook(PID), {
+			toaster: false,
+		});
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			await result.current.mutateAsync({ notebookId: NID, title: 'Renamed' });
+		});
+
+		expect(invalidatedKeys(spy)).toEqual([notebookKeys.list(PID), notebookKeys.detail(PID, NID)]);
+	});
+
+	it('useUpdateProject drops both the list and the project it patched', async () => {
+		const fetchMock = stubFetch(async () => jsonOk({ project_id: PID }));
+
+		const { result, client } = renderHookWithClient(() => useUpdateProject(), { toaster: false });
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			await result.current.mutateAsync({ projectId: PID, name: 'Renamed' });
+		});
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toBe(`/api/v1/projects/${PID}`);
+		expect(init?.method).toBe('PATCH');
+		// `projectId` addresses the resource; it must not be sent as a patch field.
+		expect(String(init?.body)).toBe('{"name":"Renamed"}');
+		expect(invalidatedKeys(spy)).toEqual([projectKeys.list(), projectKeys.detail(PID)]);
+	});
+});
+
+describe('useDownloadWorkspace', () => {
+	it('throws with the status when the zip route fails', async () => {
+		stubFetch(async () => new Response('nope', { status: 503 }));
+
+		const { result } = renderHookWithClient(() => useDownloadWorkspace(PID), { toaster: false });
+
+		await act(async () => {
+			await expect(
+				result.current.mutateAsync({ notebookId: NID, title: 'My Notebook' }),
+			).rejects.toThrow('Failed to download workspace (503)');
+		});
+	});
+});
+
+describe('deployment-scoped queries', () => {
+	it.each([
+		['useVersionQuery', useVersionQuery],
+		['useCapabilitiesQuery', useCapabilitiesQuery],
+		['useUserQuery', useUserQuery],
+	] as const)('%s does not retry a failure', async (_name, useHook) => {
+		const fetchMock = stubFetch(async () => jsonError('INTERNAL_ERROR', 'boom', 500));
+
+		const { result } = renderHookWithClient(() => useHook(), { toaster: false });
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -1,11 +1,18 @@
+import { useQuery, useSuspenseQuery, useMutation, keepPreviousData } from '@tanstack/react-query';
+import { apiFetch } from './client';
+import { useApiMutation } from './mutation';
 import {
-	useQuery,
-	useSuspenseQuery,
-	useMutation,
-	useQueryClient,
-	keepPreviousData,
-} from '@tanstack/react-query';
-import { apiFetch, ApiRequestError } from './client';
+	del,
+	fetchItems,
+	isApiErrorCode,
+	isNotFoundError,
+	notebookPath,
+	patchJson,
+	post,
+	postJson,
+	projectPath,
+	putJson,
+} from './request';
 import { sanitizeFilename, triggerDownload } from '../lib/download';
 import { userKeys, projectKeys, notebookKeys, sessionKeys, systemKeys } from './queryKeys';
 import type {
@@ -34,19 +41,19 @@ import type {
 /** How often the notebook table re-polls runtime status, in ms. */
 const SESSIONS_POLL_INTERVAL_MS = 5_000;
 
-/** A page of a list endpoint: items plus an opaque cursor for the next page. */
-interface Paginated<T> {
-	items: T[];
-	next_cursor: string | null;
-}
+/**
+ * Deployment-scoped facts (identity, version, capabilities): fixed for the life
+ * of a page load, so they are held fresh forever and a failure is not retried —
+ * the dependent UI just renders nothing rather than spamming the endpoint.
+ */
+const IMMUTABLE_QUERY = { staleTime: Number.POSITIVE_INFINITY, retry: false } as const;
 
 // Auth
 export function useUserQuery() {
 	return useQuery({
 		queryKey: userKeys.me(),
 		queryFn: () => apiFetch<User>('/api/v1/me'),
-		staleTime: Number.POSITIVE_INFINITY,
-		retry: false,
+		...IMMUTABLE_QUERY,
 	});
 }
 
@@ -63,54 +70,37 @@ export function useApiTokensQuery(enabled = true) {
 
 /** Mint a token. The response's `token` is shown once and never retrievable again. */
 export function useCreateApiToken() {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: (body: { name: string; expires_in_days?: number }) =>
-			apiFetch<ApiTokenCreated>('/api/v1/me/tokens', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
-			}),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: userKeys.tokens() });
-		},
-	});
+	return useApiMutation(
+		(body: { name: string; expires_in_days?: number }) =>
+			postJson<ApiTokenCreated>('/api/v1/me/tokens', body),
+		() => [userKeys.tokens()],
+	);
 }
 
 export function useRevokeApiToken() {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: (tokenId: string) =>
-			apiFetch<void>(`/api/v1/me/tokens/${tokenId}`, { method: 'DELETE' }),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: userKeys.tokens() });
-		},
-	});
+	return useApiMutation(
+		(tokenId: string) => del(`/api/v1/me/tokens/${tokenId}`),
+		() => [userKeys.tokens()],
+	);
 }
 
 // System
 
-/**
- * Fetch deployment metadata for the footer info popover. Effectively immutable
- * for the life of a page load, so it's held fresh forever; `retry: false` keeps a
- * failure from spamming — the footer just shows nothing.
- */
+/** Deployment metadata for the footer info popover. */
 export function useVersionQuery() {
 	return useQuery({
 		queryKey: systemKeys.version(),
 		queryFn: () => apiFetch<ServerVersion>('/api/v1/version'),
-		staleTime: Number.POSITIVE_INFINITY,
-		retry: false,
+		...IMMUTABLE_QUERY,
 	});
 }
 
-/** Deployment capability flags (e.g. whether WIF is configured). Fixed per page load. */
+/** Deployment capability flags (e.g. whether WIF is configured). */
 export function useCapabilitiesQuery() {
 	return useQuery({
 		queryKey: systemKeys.capabilities(),
 		queryFn: () => apiFetch<Capabilities>('/api/v1/capabilities'),
-		staleTime: Number.POSITIVE_INFINITY,
-		retry: false,
+		...IMMUTABLE_QUERY,
 	});
 }
 
@@ -155,7 +145,7 @@ export function useUserSearchQuery(query: string) {
 export function useProjectsQuery() {
 	return useSuspenseQuery({
 		queryKey: projectKeys.list(),
-		queryFn: async () => (await apiFetch<Paginated<ProjectSummary>>('/api/v1/projects')).items,
+		queryFn: () => fetchItems<ProjectSummary>('/api/v1/projects'),
 	});
 }
 
@@ -163,122 +153,90 @@ export function useProjectQuery(projectId: string) {
 	return useSuspenseQuery({
 		queryKey: projectKeys.detail(projectId),
 		// Full project meta (incl. `federation`), not the snapshot summary the list returns.
-		queryFn: () => apiFetch<ProjectDetail>(`/api/v1/projects/${projectId}`),
+		queryFn: () => apiFetch<ProjectDetail>(projectPath(projectId)),
 	});
 }
 
 export function useCreateProject() {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: (body: { name: string; description: string }) =>
-			apiFetch<ProjectSummary>('/api/v1/projects', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
-			}),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: projectKeys.list() });
-		},
-	});
+	return useApiMutation(
+		(body: { name: string; description: string }) =>
+			postJson<ProjectSummary>('/api/v1/projects', body),
+		() => [projectKeys.list()],
+	);
 }
 
 export function useUpdateProject() {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: ({
+	return useApiMutation(
+		// Partial update: callers send only the fields they change.
+		({
 			projectId,
 			...body
 		}: {
-			// Partial update: callers send only the fields they change.
 			projectId: string;
 			name?: string;
 			description?: string;
 			tags?: string[];
 			federation?: ProjectFederation;
-		}) =>
-			apiFetch<ProjectDetail>(`/api/v1/projects/${projectId}`, {
-				method: 'PATCH',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
-			}),
-		onSuccess: (_data, { projectId }) => {
-			void queryClient.invalidateQueries({ queryKey: projectKeys.list() });
-			void queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectId) });
-		},
-	});
+		}) => patchJson<ProjectDetail>(projectPath(projectId), body),
+		({ projectId }) => [projectKeys.list(), projectKeys.detail(projectId)],
+	);
 }
 
 export function useDeleteProject() {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: (projectId: string) =>
-			apiFetch<void>(`/api/v1/projects/${projectId}`, { method: 'DELETE' }),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: projectKeys.list() });
-		},
-	});
+	return useApiMutation(
+		(projectId: string) => del(projectPath(projectId)),
+		() => [projectKeys.list()],
+	);
 }
 
 // Project members
 export function useProjectMembersQuery(projectId: string) {
 	return useQuery({
 		queryKey: projectKeys.members(projectId),
-		queryFn: () => apiFetch<ProjectMember[]>(`/api/v1/projects/${projectId}/members`),
+		queryFn: () => apiFetch<ProjectMember[]>(`${projectPath(projectId)}/members`),
 	});
 }
 
-/** Invalidate a project's member list and detail (both carry membership). */
-function useInvalidateMembers(projectId: string) {
-	const queryClient = useQueryClient();
-	return () => {
-		void queryClient.invalidateQueries({ queryKey: projectKeys.members(projectId) });
-		void queryClient.invalidateQueries({ queryKey: projectKeys.detail(projectId) });
-	};
-}
+/** A project's member list and its detail both carry membership — drop both. */
+const memberKeys = (projectId: string) => [
+	projectKeys.members(projectId),
+	projectKeys.detail(projectId),
+];
 
 export function useAddMember(projectId: string) {
-	const invalidate = useInvalidateMembers(projectId);
-	return useMutation({
+	return useApiMutation(
 		// Exactly one of user_id / email, enforced server-side (422).
-		mutationFn: (body: { user_id?: string; email?: string; role: ProjectRole }) =>
-			apiFetch<ProjectDetail>(`/api/v1/projects/${projectId}/members`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
-			}),
-		onSuccess: invalidate,
-	});
+		(body: { user_id?: string; email?: string; role: ProjectRole }) =>
+			postJson<ProjectDetail>(`${projectPath(projectId)}/members`, body),
+		() => memberKeys(projectId),
+	);
 }
 
 // `uid` is the member's user id or invite email; emails need URL-encoding.
+const memberPath = (projectId: string, uid: string) =>
+	`${projectPath(projectId)}/members/${encodeURIComponent(uid)}`;
+
 export function useUpdateMemberRole(projectId: string) {
-	const invalidate = useInvalidateMembers(projectId);
-	return useMutation({
-		mutationFn: ({ uid, role }: { uid: string; role: ProjectRole }) =>
-			apiFetch<ProjectDetail>(`/api/v1/projects/${projectId}/members/${encodeURIComponent(uid)}`, {
-				method: 'PUT',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ role }),
-			}),
-		onSuccess: invalidate,
-	});
+	return useApiMutation(
+		({ uid, role }: { uid: string; role: ProjectRole }) =>
+			putJson<ProjectDetail>(memberPath(projectId, uid), { role }),
+		() => memberKeys(projectId),
+	);
 }
 
 export function useRemoveMember(projectId: string) {
-	const invalidate = useInvalidateMembers(projectId);
-	return useMutation({
-		mutationFn: (uid: string) =>
-			apiFetch<void>(`/api/v1/projects/${projectId}/members/${encodeURIComponent(uid)}`, {
-				method: 'DELETE',
-			}),
-		onSuccess: invalidate,
-	});
+	return useApiMutation(
+		(uid: string) => del(memberPath(projectId, uid)),
+		() => memberKeys(projectId),
+	);
 }
 
 /** A 404 from the secrets routes means the deployment has the feature disabled. */
 export function isSecretsDisabledError(err: unknown): boolean {
-	return err instanceof ApiRequestError && err.code === 'NOT_FOUND';
+	return isApiErrorCode(err, 'NOT_FOUND');
 }
+
+const secretsPath = (projectId: string) => `${projectPath(projectId)}/secrets`;
 
 /**
  * List a project's secret entries (metadata only — never a value). Resolves to
@@ -292,18 +250,13 @@ export function useProjectSecretsQuery(projectId: string, enabled = true) {
 		retry: (count, err) => !isSecretsDisabledError(err) && count < 2,
 		queryFn: async () => {
 			try {
-				return await apiFetch<SecretEntry[]>(`/api/v1/projects/${projectId}/secrets`);
+				return await apiFetch<SecretEntry[]>(secretsPath(projectId));
 			} catch (err) {
 				if (isSecretsDisabledError(err)) return null;
 				throw err;
 			}
 		},
 	});
-}
-
-function useInvalidateSecrets(projectId: string) {
-	const queryClient = useQueryClient();
-	return () => queryClient.invalidateQueries({ queryKey: projectKeys.secrets(projectId) });
 }
 
 interface ReferenceInput {
@@ -326,49 +279,40 @@ function referenceBody({ backend, locator, expand, prefix }: ReferenceInput) {
 }
 
 export function usePutSecret(projectId: string) {
-	const invalidate = useInvalidateSecrets(projectId);
-	return useMutation({
-		mutationFn: (input: ReferenceInput) =>
-			apiFetch<SecretEntry>(
-				`/api/v1/projects/${projectId}/secrets/${encodeURIComponent(input.name)}`,
-				{
-					method: 'PUT',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify(referenceBody(input)),
-				},
+	return useApiMutation(
+		(input: ReferenceInput) =>
+			putJson<SecretEntry>(
+				`${secretsPath(projectId)}/${encodeURIComponent(input.name)}`,
+				referenceBody(input),
 			),
-		onSuccess: invalidate,
-	});
+		() => [projectKeys.secrets(projectId)],
+	);
 }
 
 export function useValidateSecret(projectId: string) {
 	return useMutation({
 		mutationFn: (input: ReferenceInput) =>
-			apiFetch<{ ok: boolean; reason?: string }>(`/api/v1/projects/${projectId}/secrets/validate`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(referenceBody(input)),
-			}),
+			postJson<{ ok: boolean; reason?: string }>(
+				`${secretsPath(projectId)}/validate`,
+				referenceBody(input),
+			),
 	});
 }
 
 export function useDeleteSecret(projectId: string) {
-	const invalidate = useInvalidateSecrets(projectId);
-	return useMutation({
-		mutationFn: (name: string) =>
-			apiFetch<void>(`/api/v1/projects/${projectId}/secrets/${encodeURIComponent(name)}`, {
-				method: 'DELETE',
-			}),
-		onSuccess: invalidate,
-	});
+	return useApiMutation(
+		(name: string) => del(`${secretsPath(projectId)}/${encodeURIComponent(name)}`),
+		() => [projectKeys.secrets(projectId)],
+	);
 }
 
 // Notebooks
+const notebooksPath = (projectId: string) => `${projectPath(projectId)}/notebooks`;
+
 export function useNotebooksQuery(projectId: string) {
 	return useSuspenseQuery({
 		queryKey: notebookKeys.list(projectId),
-		queryFn: async () =>
-			(await apiFetch<Paginated<NotebookEntry>>(`/api/v1/projects/${projectId}/notebooks`)).items,
+		queryFn: () => fetchItems<NotebookEntry>(notebooksPath(projectId)),
 	});
 }
 
@@ -389,26 +333,18 @@ export function useNotebookQuery(
 ) {
 	return useQuery({
 		queryKey: notebookKeys.detail(projectId, notebookId),
-		queryFn: () =>
-			apiFetch<NotebookDetail>(`/api/v1/projects/${projectId}/notebooks/${notebookId}`),
+		queryFn: () => apiFetch<NotebookDetail>(notebookPath(projectId, notebookId)),
 		staleTime: options.staleTime ?? 5 * 60 * 1000,
 		refetchInterval: options.refetchIntervalMs,
 	});
 }
 
 export function useCreateNotebook(projectId: string) {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: (body: { title: string; description: string; code: string; base_image?: string }) =>
-			apiFetch<NotebookMeta>(`/api/v1/projects/${projectId}/notebooks`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
-			}),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: notebookKeys.list(projectId) });
-		},
-	});
+	return useApiMutation(
+		(body: { title: string; description: string; code: string; base_image?: string }) =>
+			postJson<NotebookMeta>(notebooksPath(projectId), body),
+		() => [notebookKeys.list(projectId)],
+	);
 }
 
 /**
@@ -417,88 +353,52 @@ export function useCreateNotebook(projectId: string) {
  * notebooks are copied as detached local notebooks.
  */
 export function useDuplicateNotebook(projectId: string) {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: ({ notebookId, title }: { notebookId: string; title?: string }) =>
-			apiFetch<NotebookMeta>(`/api/v1/projects/${projectId}/notebooks/${notebookId}/duplicate`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(title ? { title } : {}),
-			}),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: notebookKeys.list(projectId) });
-		},
-	});
+	return useApiMutation(
+		({ notebookId, title }: { notebookId: string; title?: string }) =>
+			postJson<NotebookMeta>(
+				`${notebookPath(projectId, notebookId)}/duplicate`,
+				title ? { title } : {},
+			),
+		() => [notebookKeys.list(projectId)],
+	);
 }
 
 /** Create a git-synced notebook; the response carries its write-once sync token. */
 export function useCreateSyncedNotebook(projectId: string) {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: (body: {
+	return useApiMutation(
+		(body: {
 			title: string;
 			description: string;
 			repo: string;
 			branch: string;
 			root_path?: string;
 			entry_notebook: string;
-		}) =>
-			apiFetch<GitNotebookCreateResult>(`/api/v1/projects/${projectId}/notebooks/git`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
-			}),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: notebookKeys.list(projectId) });
-		},
-	});
+		}) => postJson<GitNotebookCreateResult>(`${notebooksPath(projectId)}/git`, body),
+		() => [notebookKeys.list(projectId)],
+	);
 }
 
 /** Rotate a synced notebook's sync token, invalidating the old one. */
 export function useRotateSyncToken(projectId: string) {
 	return useMutation({
 		mutationFn: (notebookId: string) =>
-			apiFetch<SyncToken>(
-				`/api/v1/projects/${projectId}/notebooks/${notebookId}/sync-token/rotate`,
-				{ method: 'POST' },
-			),
+			post<SyncToken>(`${notebookPath(projectId, notebookId)}/sync-token/rotate`),
 	});
 }
 
 export function useUpdateNotebook(projectId: string) {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: ({
-			notebookId,
-			...body
-		}: {
-			notebookId: string;
-			title?: string;
-			base_image?: string | null;
-		}) =>
-			apiFetch<NotebookMeta>(`/api/v1/projects/${projectId}/notebooks/${notebookId}`, {
-				method: 'PATCH',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(body),
-			}),
-		onSuccess: (_data, { notebookId }) => {
-			void queryClient.invalidateQueries({ queryKey: notebookKeys.list(projectId) });
-			void queryClient.invalidateQueries({ queryKey: notebookKeys.detail(projectId, notebookId) });
-		},
-	});
+	return useApiMutation(
+		({ notebookId, ...body }: { notebookId: string; title?: string; base_image?: string | null }) =>
+			patchJson<NotebookMeta>(notebookPath(projectId, notebookId), body),
+		({ notebookId }) => [notebookKeys.list(projectId), notebookKeys.detail(projectId, notebookId)],
+	);
 }
 
 export function useDeleteNotebook(projectId: string) {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: (notebookId: string) =>
-			apiFetch<void>(`/api/v1/projects/${projectId}/notebooks/${notebookId}`, {
-				method: 'DELETE',
-			}),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: notebookKeys.list(projectId) });
-		},
-	});
+	return useApiMutation(
+		(notebookId: string) => del(notebookPath(projectId, notebookId)),
+		() => [notebookKeys.list(projectId)],
+	);
 }
 
 /** Fetch the notebook's current `.py` source and save it as `<title>.py`. */
@@ -506,7 +406,7 @@ export function useDownloadNotebookFile(projectId: string) {
 	return useMutation({
 		mutationFn: async ({ notebookId, title }: { notebookId: string; title: string }) => {
 			const { code } = await apiFetch<{ code: string }>(
-				`/api/v1/projects/${projectId}/notebooks/${notebookId}/content`,
+				`${notebookPath(projectId, notebookId)}/content`,
 			);
 			triggerDownload(`${sanitizeFilename(title)}.py`, new Blob([code], { type: 'text/x-python' }));
 		},
@@ -521,9 +421,7 @@ export function useDownloadNotebookFile(projectId: string) {
 export function useDownloadWorkspace(projectId: string) {
 	return useMutation({
 		mutationFn: async ({ notebookId, title }: { notebookId: string; title: string }) => {
-			const res = await fetch(
-				`/api/v1/projects/${projectId}/notebooks/${notebookId}/workspace.zip`,
-			);
+			const res = await fetch(`${notebookPath(projectId, notebookId)}/workspace.zip`);
 			if (!res.ok) {
 				throw new Error(`Failed to download workspace (${res.status})`);
 			}
@@ -533,6 +431,8 @@ export function useDownloadWorkspace(projectId: string) {
 }
 
 // Notebook versions
+const versionsPath = (projectId: string, notebookId: string) =>
+	`${notebookPath(projectId, notebookId)}/versions`;
 
 /**
  * A notebook's saved versions, newest first (the API's order). Single page
@@ -541,12 +441,7 @@ export function useDownloadWorkspace(projectId: string) {
 export function useNotebookVersionsQuery(projectId: string, notebookId: string) {
 	return useQuery({
 		queryKey: notebookKeys.versions(projectId, notebookId),
-		queryFn: async () =>
-			(
-				await apiFetch<Paginated<NotebookVersion>>(
-					`/api/v1/projects/${projectId}/notebooks/${notebookId}/versions`,
-				)
-			).items,
+		queryFn: () => fetchItems<NotebookVersion>(versionsPath(projectId, notebookId)),
 	});
 }
 
@@ -559,9 +454,7 @@ export function useNotebookVersionQuery(
 	return useQuery({
 		queryKey: notebookKeys.version(projectId, notebookId, versionId ?? ''),
 		queryFn: () =>
-			apiFetch<NotebookVersionDetail>(
-				`/api/v1/projects/${projectId}/notebooks/${notebookId}/versions/${versionId}`,
-			),
+			apiFetch<NotebookVersionDetail>(`${versionsPath(projectId, notebookId)}/${versionId}`),
 		enabled: !!versionId,
 		staleTime: Number.POSITIVE_INFINITY,
 	});
@@ -584,7 +477,7 @@ export function useNotebookHtmlQuery(projectId: string, notebookId: string) {
 	return useQuery({
 		queryKey: notebookKeys.html(projectId, notebookId),
 		queryFn: async (): Promise<NotebookHtmlSnapshot | null> => {
-			const res = await fetch(`/api/v1/projects/${projectId}/notebooks/${notebookId}/html`);
+			const res = await fetch(`${notebookPath(projectId, notebookId)}/html`);
 			if (res.status === 404) {
 				// Only "exists but never ran" is the empty state; a deleted/hidden
 				// notebook (code NOT_FOUND) must surface as an error, not "no outputs".
@@ -610,21 +503,15 @@ export function useNotebookHtmlQuery(projectId: string, notebookId: string) {
  * list as well as the notebook itself.
  */
 export function useRestoreVersion(projectId: string, notebookId: string) {
-	const queryClient = useQueryClient();
-	return useMutation({
-		mutationFn: (versionId: string) =>
-			apiFetch<NotebookMeta>(
-				`/api/v1/projects/${projectId}/notebooks/${notebookId}/versions/${versionId}/restore`,
-				{ method: 'POST' },
-			),
-		onSuccess: () => {
-			void queryClient.invalidateQueries({
-				queryKey: notebookKeys.versions(projectId, notebookId),
-			});
-			void queryClient.invalidateQueries({ queryKey: notebookKeys.detail(projectId, notebookId) });
-			void queryClient.invalidateQueries({ queryKey: notebookKeys.list(projectId) });
-		},
-	});
+	return useApiMutation(
+		(versionId: string) =>
+			post<NotebookMeta>(`${versionsPath(projectId, notebookId)}/${versionId}/restore`),
+		() => [
+			notebookKeys.versions(projectId, notebookId),
+			notebookKeys.detail(projectId, notebookId),
+			notebookKeys.list(projectId),
+		],
+	);
 }
 
 // Sessions
@@ -638,8 +525,7 @@ export function useRestoreVersion(projectId: string, notebookId: string) {
 export function useProjectSessionsQuery(projectId: string, enabled = true) {
 	return useQuery({
 		queryKey: sessionKeys.listByProject(projectId),
-		queryFn: async () =>
-			(await apiFetch<Paginated<Session>>(`/api/v1/projects/${projectId}/sessions`)).items,
+		queryFn: () => fetchItems<Session>(`${projectPath(projectId)}/sessions`),
 		refetchInterval: SESSIONS_POLL_INTERVAL_MS,
 		enabled,
 	});
@@ -647,7 +533,15 @@ export function useProjectSessionsQuery(projectId: string, enabled = true) {
 
 /** Base URL of a notebook's session collection (also exported for the session hook). */
 export const notebookSessionsPath = (projectId: string, notebookId: string) =>
-	`/api/v1/projects/${projectId}/notebooks/${notebookId}/sessions`;
+	`${notebookPath(projectId, notebookId)}/sessions`;
+
+/**
+ * Provisioning a cold sandbox can take a while (the kernel may build its uv venv
+ * on first boot), and teardown saves the notebook and destroys the sandbox
+ * synchronously with no server-side budget bounding it — so both override the
+ * client's default 20s timeout. Must exceed the provisioner's waitForPort budget.
+ */
+const SESSION_LIFECYCLE_TIMEOUT_MS = 150_000; // 2.5 minutes
 
 /**
  * The create-session request. Sent with no body for `edit` (byte-identical to
@@ -655,29 +549,16 @@ export const notebookSessionsPath = (projectId: string, notebookId: string) =>
  * the server attaches ANY editor to the notebook's running app.
  */
 function startSessionRequest(projectId: string, notebookId: string, mode: 'edit' | 'app') {
-	// Provisioning a cold sandbox can take a while (the kernel may build its uv
-	// venv on first boot), so override the client's default 20s timeout. Must
-	// exceed the provisioner's waitForPort budget.
-	return apiFetch<Session>(notebookSessionsPath(projectId, notebookId), {
-		method: 'POST',
-		timeout: 150_000, // 2.5 minutes
-		...(mode === 'app'
-			? {
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ mode }),
-				}
-			: {}),
-	});
+	const path = notebookSessionsPath(projectId, notebookId);
+	const init = { timeout: SESSION_LIFECYCLE_TIMEOUT_MS };
+	return mode === 'app' ? postJson<Session>(path, { mode }, init) : post<Session>(path, init);
 }
 
+// An abort surfaces as a failed stop, which halts a restart half-done (app
+// stopped, never restarted) while the server tears down anyway.
 function stopSessionRequest(projectId: string, notebookId: string, sessionId: string) {
-	// Teardown saves the notebook and destroys the sandbox synchronously, and —
-	// unlike start — has no server-side budget bounding it. An abort surfaces as a
-	// failed stop, which halts a restart half-done (app stopped, never restarted)
-	// while the server tears down anyway, so allow the same budget as create.
-	return apiFetch<void>(`${notebookSessionsPath(projectId, notebookId)}/${sessionId}`, {
-		method: 'DELETE',
-		timeout: 150_000, // 2.5 minutes
+	return del<void>(`${notebookSessionsPath(projectId, notebookId)}/${sessionId}`, {
+		timeout: SESSION_LIFECYCLE_TIMEOUT_MS,
 	});
 }
 
@@ -691,40 +572,31 @@ export function useStartSession(
 	});
 }
 
-/** Refresh the status indicators right away rather than waiting for the poll. */
-function useInvalidateSessions(projectId: string) {
-	const queryClient = useQueryClient();
-	return () => {
-		void queryClient.invalidateQueries({ queryKey: sessionKeys.listByProject(projectId) });
-	};
-}
-
 /**
  * Restart the shared app: stop the given session, then start a fresh one (which
  * picks up the notebook's current head — the staleness banner's action). The
  * stop is awaited so the fresh create can't reuse the dying sandbox.
  */
 export function useRestartApp(projectId: string, notebookId: string) {
-	const invalidate = useInvalidateSessions(projectId);
-	return useMutation({
-		mutationFn: async (sessionId: string) => {
+	return useApiMutation(
+		async (sessionId: string) => {
 			try {
 				await stopSessionRequest(projectId, notebookId, sessionId);
 			} catch (err) {
 				// Already gone (stopped/reaped underneath us): the restart intent
 				// still holds, so proceed to the fresh start.
-				if (!(err instanceof ApiRequestError && err.code === 'NOT_FOUND')) throw err;
+				if (!isNotFoundError(err)) throw err;
 			}
 			return startSessionRequest(projectId, notebookId, 'app');
 		},
-		onSuccess: invalidate,
-	});
+		// Refresh the status indicators right away rather than waiting for the poll.
+		() => [sessionKeys.listByProject(projectId)],
+	);
 }
 
 export function useStopSession(projectId: string, notebookId: string) {
-	const invalidate = useInvalidateSessions(projectId);
-	return useMutation({
-		mutationFn: (sessionId: string) => stopSessionRequest(projectId, notebookId, sessionId),
-		onSuccess: invalidate,
-	});
+	return useApiMutation(
+		(sessionId: string) => stopSessionRequest(projectId, notebookId, sessionId),
+		() => [sessionKeys.listByProject(projectId)],
+	);
 }

--- a/packages/web/src/api/mutation.test.tsx
+++ b/packages/web/src/api/mutation.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { renderHookWithClient } from '@/test/render';
+import { useApiMutation, useInvalidate } from './mutation';
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+/** The query keys passed to `invalidateQueries`, in call order. */
+function invalidatedKeys(spy: { mock: { calls: unknown[][] } }): unknown[] {
+	return spy.mock.calls.map((call) => (call[0] as { queryKey: unknown }).queryKey);
+}
+
+describe('useInvalidate', () => {
+	it('invalidates every key it is given', async () => {
+		const { result, client } = renderHookWithClient(() => useInvalidate(), { toaster: false });
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			result.current(['a'], ['b', { id: 1 }]);
+		});
+
+		expect(invalidatedKeys(spy)).toEqual([['a'], ['b', { id: 1 }]]);
+	});
+
+	it('is a no-op with zero keys', async () => {
+		const { result, client } = renderHookWithClient(() => useInvalidate(), { toaster: false });
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			result.current();
+		});
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('keeps a stable identity across renders', () => {
+		const { result, rerender } = renderHookWithClient(() => useInvalidate(), { toaster: false });
+		const first = result.current;
+
+		rerender();
+
+		expect(result.current).toBe(first);
+	});
+});
+
+describe('useApiMutation', () => {
+	it('resolves the mutationFn data through to the caller', async () => {
+		const { result } = renderHookWithClient(
+			() => useApiMutation(async (n: number) => ({ doubled: n * 2 })),
+			{ toaster: false },
+		);
+
+		let data: { doubled: number } | undefined;
+		await act(async () => {
+			data = await result.current.mutateAsync(21);
+		});
+
+		expect(data).toEqual({ doubled: 42 });
+		await waitFor(() => expect(result.current.data).toEqual({ doubled: 42 }));
+	});
+
+	it('invalidates the declared keys on success', async () => {
+		const { result, client } = renderHookWithClient(
+			() =>
+				useApiMutation(
+					async () => 'ok',
+					() => [['things'], ['other']],
+				),
+			{ toaster: false },
+		);
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			await result.current.mutateAsync();
+		});
+
+		expect(invalidatedKeys(spy)).toEqual([['things'], ['other']]);
+	});
+
+	it('invalidates nothing when the mutationFn rejects', async () => {
+		const { result, client } = renderHookWithClient(
+			() =>
+				useApiMutation(
+					async () => {
+						throw new Error('boom');
+					},
+					() => [['things']],
+				),
+			{ toaster: false },
+		);
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			await expect(result.current.mutateAsync()).rejects.toThrow('boom');
+		});
+
+		expect(spy).not.toHaveBeenCalled();
+		await waitFor(() => expect(result.current.isError).toBe(true));
+	});
+
+	it('invalidates nothing when no keys callback is given', async () => {
+		const { result, client } = renderHookWithClient(() => useApiMutation(async () => 'ok'), {
+			toaster: false,
+		});
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			await result.current.mutateAsync();
+		});
+
+		expect(spy).not.toHaveBeenCalled();
+	});
+
+	it('passes both the variables and the returned data to the keys callback', async () => {
+		const invalidates = vi.fn(
+			(variables: { id: string }, data: { serverId: string }) =>
+				[
+					['by-variable', variables.id],
+					['by-data', data.serverId],
+				] as const,
+		);
+		const { result, client } = renderHookWithClient(
+			() =>
+				useApiMutation(
+					async (variables: { id: string }) => ({ serverId: `srv-${variables.id}` }),
+					invalidates,
+				),
+			{ toaster: false },
+		);
+		const spy = vi.spyOn(client, 'invalidateQueries');
+
+		await act(async () => {
+			await result.current.mutateAsync({ id: 'a1' });
+		});
+
+		expect(invalidates).toHaveBeenCalledWith({ id: 'a1' }, { serverId: 'srv-a1' });
+		expect(invalidatedKeys(spy)).toEqual([
+			['by-variable', 'a1'],
+			['by-data', 'srv-a1'],
+		]);
+	});
+});

--- a/packages/web/src/api/mutation.ts
+++ b/packages/web/src/api/mutation.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { QueryKey } from '@tanstack/react-query';
+
+/** Keys are taken per call, so they may depend on a mutation's variables. */
+export function useInvalidate(): (...keys: readonly QueryKey[]) => void {
+	const queryClient = useQueryClient();
+	return useCallback(
+		(...keys: readonly QueryKey[]) => {
+			for (const queryKey of keys) {
+				void queryClient.invalidateQueries({ queryKey });
+			}
+		},
+		[queryClient],
+	);
+}
+
+/** `useMutation` that drops the keys `invalidates` names, on success only. */
+export function useApiMutation<TData, TVariables = void>(
+	mutationFn: (variables: TVariables) => Promise<TData>,
+	invalidates?: (variables: TVariables, data: TData) => readonly QueryKey[],
+) {
+	const invalidate = useInvalidate();
+	return useMutation({
+		mutationFn,
+		onSuccess: (data, variables) => {
+			if (invalidates) invalidate(...invalidates(variables, data));
+		},
+	});
+}

--- a/packages/web/src/api/request.test.ts
+++ b/packages/web/src/api/request.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { jsonOk } from '@/test/render';
+import { ApiRequestError } from './client';
+import {
+	del,
+	fetchItems,
+	isApiErrorCode,
+	isNotFoundError,
+	notebookPath,
+	patchJson,
+	post,
+	postJson,
+	projectPath,
+	putJson,
+} from './request';
+
+const PID = 'proj-1';
+const NID = 'nb-1';
+
+function stubFetch(data: unknown = { ok: true }) {
+	const fetchMock = vi.fn(async (..._args: Parameters<typeof fetch>) => jsonOk(data));
+	vi.stubGlobal('fetch', fetchMock);
+	return fetchMock;
+}
+
+/** The last fetch call the request under test made, as (url, init). */
+function lastCall(fetchMock: ReturnType<typeof stubFetch>) {
+	const call = fetchMock.mock.calls.at(-1);
+	if (!call) throw new Error('fetch was never called');
+	const [url, init] = call;
+	return { url: String(url), init };
+}
+
+function headerOf(init: RequestInit | undefined, name: string): string | null {
+	return new Headers(init?.headers).get(name);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('path builders', () => {
+	it('composes the project and notebook roots', () => {
+		expect(projectPath(PID)).toBe('/api/v1/projects/proj-1');
+		expect(notebookPath(PID, NID)).toBe('/api/v1/projects/proj-1/notebooks/nb-1');
+	});
+
+	it('nests the notebook path under its project path', () => {
+		expect(notebookPath(PID, NID).startsWith(`${projectPath(PID)}/`)).toBe(true);
+	});
+});
+
+describe('JSON senders', () => {
+	it.each([
+		['postJson', postJson, 'POST'],
+		['putJson', putJson, 'PUT'],
+		['patchJson', patchJson, 'PATCH'],
+	] as const)('%s sends %s with a JSON body', async (_name, send, method) => {
+		const fetchMock = stubFetch();
+
+		await send('/api/v1/thing', { a: 1, b: 'two' });
+
+		const { url, init } = lastCall(fetchMock);
+		expect(url).toBe('/api/v1/thing');
+		expect(init?.method).toBe(method);
+		expect(headerOf(init, 'content-type')).toBe('application/json');
+		expect(String(init?.body)).toBe(JSON.stringify({ a: 1, b: 'two' }));
+	});
+
+	it('postJson with no body sends an empty JSON object', async () => {
+		const fetchMock = stubFetch();
+
+		await postJson('/api/v1/thing');
+
+		expect(String(lastCall(fetchMock).init?.body)).toBe('{}');
+	});
+
+	it('forwards an init without clobbering the Content-Type header', async () => {
+		const fetchMock = stubFetch();
+
+		await postJson('/api/v1/thing', { a: 1 }, { timeout: 99_000 });
+
+		const { init } = lastCall(fetchMock);
+		expect(headerOf(init, 'content-type')).toBe('application/json');
+		// The timeout is applied as an abort signal by the underlying client.
+		expect(init?.signal).toBeInstanceOf(AbortSignal);
+		expect(init?.signal?.aborted).toBe(false);
+	});
+
+	it('lets an init add headers alongside the JSON content type', async () => {
+		const fetchMock = stubFetch();
+
+		await postJson('/api/v1/thing', { a: 1 }, { headers: { 'X-Trace': 'abc' } });
+
+		const { init } = lastCall(fetchMock);
+		expect(headerOf(init, 'content-type')).toBe('application/json');
+		expect(headerOf(init, 'x-trace')).toBe('abc');
+	});
+
+	it('unwraps the response envelope to the typed data', async () => {
+		stubFetch({ id: 'x' });
+
+		await expect(postJson<{ id: string }>('/api/v1/thing')).resolves.toEqual({ id: 'x' });
+	});
+});
+
+describe('bodyless verbs', () => {
+	it('post sends POST with no body at all', async () => {
+		const fetchMock = stubFetch();
+
+		await post('/api/v1/thing');
+
+		const { init } = lastCall(fetchMock);
+		expect(init?.method).toBe('POST');
+		expect(init?.body ?? undefined).toBeUndefined();
+	});
+
+	it('post forwards an init and still sends no body', async () => {
+		const fetchMock = stubFetch();
+
+		await post('/api/v1/thing', { timeout: 99_000 });
+
+		const { init } = lastCall(fetchMock);
+		expect(init?.method).toBe('POST');
+		expect(init?.body ?? undefined).toBeUndefined();
+		expect(init?.signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it('del sends DELETE with no body', async () => {
+		const fetchMock = stubFetch(null);
+
+		await del('/api/v1/thing/1');
+
+		const { url, init } = lastCall(fetchMock);
+		expect(url).toBe('/api/v1/thing/1');
+		expect(init?.method).toBe('DELETE');
+		expect(init?.body ?? undefined).toBeUndefined();
+	});
+});
+
+describe('fetchItems', () => {
+	it('unwraps the paginated envelope to just the items', async () => {
+		stubFetch({ items: [{ id: 'a' }, { id: 'b' }], next_cursor: 'cur-1' });
+
+		await expect(fetchItems<{ id: string }>('/api/v1/things')).resolves.toEqual([
+			{ id: 'a' },
+			{ id: 'b' },
+		]);
+	});
+
+	it('returns an empty list for an empty page', async () => {
+		stubFetch({ items: [], next_cursor: null });
+
+		await expect(fetchItems('/api/v1/things')).resolves.toEqual([]);
+	});
+});
+
+describe('error predicates', () => {
+	it('matches an ApiRequestError by code', () => {
+		expect(isApiErrorCode(new ApiRequestError('NOT_FOUND', 'gone'), 'NOT_FOUND')).toBe(true);
+	});
+
+	it('rejects a different code', () => {
+		expect(isApiErrorCode(new ApiRequestError('FORBIDDEN', 'nope'), 'NOT_FOUND')).toBe(false);
+	});
+
+	it('rejects a plain Error and a non-error value', () => {
+		expect(isApiErrorCode(new Error('NOT_FOUND'), 'NOT_FOUND')).toBe(false);
+		expect(isApiErrorCode({ code: 'NOT_FOUND' }, 'NOT_FOUND')).toBe(false);
+		expect(isApiErrorCode(undefined, 'NOT_FOUND')).toBe(false);
+		expect(isApiErrorCode('NOT_FOUND', 'NOT_FOUND')).toBe(false);
+	});
+
+	it('isNotFoundError is isApiErrorCode pinned to NOT_FOUND', () => {
+		expect(isNotFoundError(new ApiRequestError('NOT_FOUND', 'gone'))).toBe(true);
+		expect(isNotFoundError(new ApiRequestError('INTERNAL_ERROR', 'boom'))).toBe(false);
+		expect(isNotFoundError(new Error('gone'))).toBe(false);
+		expect(isNotFoundError(null)).toBe(false);
+	});
+});
+
+describe('header merging', () => {
+	it('keeps headers given as a Headers instance', async () => {
+		const fetchMock = stubFetch();
+
+		await postJson('/api/v1/thing', { a: 1 }, { headers: new Headers({ 'X-Trace': 'abc' }) });
+
+		const { init } = lastCall(fetchMock);
+		expect(headerOf(init, 'content-type')).toBe('application/json');
+		expect(headerOf(init, 'x-trace')).toBe('abc');
+	});
+
+	it('keeps headers given as an entry array', async () => {
+		const fetchMock = stubFetch();
+
+		await postJson('/api/v1/thing', { a: 1 }, { headers: [['X-Trace', 'abc']] });
+
+		const { init } = lastCall(fetchMock);
+		expect(headerOf(init, 'content-type')).toBe('application/json');
+		expect(headerOf(init, 'x-trace')).toBe('abc');
+	});
+
+	it('wins over a caller-supplied content type — the body is always JSON', async () => {
+		const fetchMock = stubFetch();
+
+		await postJson('/api/v1/thing', { a: 1 }, { headers: { 'content-type': 'text/plain' } });
+
+		expect(headerOf(lastCall(fetchMock).init, 'content-type')).toBe('application/json');
+	});
+});

--- a/packages/web/src/api/request.ts
+++ b/packages/web/src/api/request.ts
@@ -1,0 +1,44 @@
+import { apiFetch, ApiRequestError } from './client';
+
+export const projectPath = (projectId: string) => `/api/v1/projects/${projectId}`;
+export const notebookPath = (projectId: string, notebookId: string) =>
+	`${projectPath(projectId)}/notebooks/${notebookId}`;
+
+/** A page of a list endpoint: items plus an opaque cursor for the next page. */
+export interface Paginated<T> {
+	items: T[];
+	next_cursor: string | null;
+}
+
+export async function fetchItems<T>(path: string): Promise<T[]> {
+	return (await apiFetch<Paginated<T>>(path)).items;
+}
+
+type RequestOptions = RequestInit & { timeout?: number };
+
+function sendJson<T>(method: string, path: string, body?: unknown, init?: RequestOptions) {
+	// Merged through `Headers`, not object spread: `HeadersInit` is also allowed to
+	// be a `Headers` or an entry array, and spreading either drops the caller's
+	// headers (or invents numeric ones).
+	const headers = new Headers(init?.headers);
+	headers.set('Content-Type', 'application/json');
+	return apiFetch<T>(path, { ...init, method, headers, body: JSON.stringify(body ?? {}) });
+}
+
+export const postJson = <T>(path: string, body?: unknown, init?: RequestOptions) =>
+	sendJson<T>('POST', path, body, init);
+export const putJson = <T>(path: string, body?: unknown) => sendJson<T>('PUT', path, body);
+export const patchJson = <T>(path: string, body?: unknown) => sendJson<T>('PATCH', path, body);
+
+/** POST with no body at all — distinct from `postJson(path)`, which sends `{}`. */
+export const post = <T>(path: string, init?: RequestOptions) =>
+	apiFetch<T>(path, { ...init, method: 'POST' });
+
+export const del = <T = void>(path: string, init?: RequestOptions) =>
+	apiFetch<T>(path, { ...init, method: 'DELETE' });
+
+export function isApiErrorCode(err: unknown, code: string): boolean {
+	return err instanceof ApiRequestError && err.code === code;
+}
+
+export const isNotFoundError = (err: unknown) => isApiErrorCode(err, 'NOT_FOUND');

--- a/packages/web/src/components/Account/ApiTokensDialog.tsx
+++ b/packages/web/src/components/Account/ApiTokensDialog.tsx
@@ -1,43 +1,24 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { AlertTriangle, Check, Copy, Plus, Trash2 } from 'lucide-react';
-import { Button, ConfirmDialog, DialogModal, IconButton, TextField } from '@/components/ui';
+import { Plus, Trash2 } from 'lucide-react';
+import {
+	Button,
+	ConfirmDialog,
+	CopyField,
+	DialogModal,
+	IconButton,
+	TextField,
+	WriteOnceWarning,
+} from '@/components/ui';
 import { useApiTokensQuery, useCreateApiToken, useRevokeApiToken } from '@/api/hooks';
+import { useDialogTarget } from '@/hooks/useDialogTarget';
+import { toastError } from '@/lib/errors';
 import { formatDuration, formatRelative } from '@/lib/time';
 import type { ApiToken, ApiTokenCreated } from '@/types';
 
 export interface ApiTokensDialogProps {
 	isOpen: boolean;
 	onClose: () => void;
-}
-
-function CopyTokenField({ value }: { value: string }) {
-	const [copied, setCopied] = useState(false);
-
-	const copy = async () => {
-		try {
-			await navigator.clipboard.writeText(value);
-			setCopied(true);
-			setTimeout(() => setCopied(false), 1500);
-		} catch {
-			toast.error('Could not copy to clipboard');
-		}
-	};
-
-	return (
-		<div className="flex items-center gap-2">
-			<input
-				readOnly
-				aria-label="API token"
-				value={value}
-				onFocus={(e) => e.target.select()}
-				className="h-9 w-full rounded-md border border-input bg-muted/40 px-3 font-mono text-xs text-foreground outline-none"
-			/>
-			<IconButton label={copied ? 'Copied' : 'Copy token'} onPress={() => void copy()}>
-				{copied ? <Check className="size-4 text-primary" /> : <Copy className="size-4" />}
-			</IconButton>
-		</div>
-	);
 }
 
 /**
@@ -65,7 +46,7 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 	const [name, setName] = useState('');
 	const [expiresInDays, setExpiresInDays] = useState('');
 	const [created, setCreated] = useState<ApiTokenCreated | null>(null);
-	const [revokeTarget, setRevokeTarget] = useState<ApiToken | null>(null);
+	const confirmRevoke = useDialogTarget<ApiToken>();
 
 	const handleCreate = async () => {
 		const trimmed = name.trim();
@@ -87,18 +68,19 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 			setName('');
 			setExpiresInDays('');
 		} catch (err) {
-			toast.error((err as Error).message);
+			toastError(err);
 		}
 	};
 
 	const handleRevoke = () => {
-		if (!revokeTarget) return;
-		revokeToken.mutate(revokeTarget.id, {
+		const target = confirmRevoke.target;
+		if (!target) return;
+		revokeToken.mutate(target.id, {
 			onSuccess: () => {
 				toast.success('Token revoked');
-				setRevokeTarget(null);
+				confirmRevoke.close();
 			},
-			onError: (err) => toast.error(err.message),
+			onError: toastError,
 		});
 	};
 
@@ -119,11 +101,8 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 				{created && (
 					<div className="flex flex-col gap-2 rounded-md border p-3">
 						<span className="text-xs font-semibold">{created.name}</span>
-						<CopyTokenField value={created.token} />
-						<div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
-							<AlertTriangle className="mt-px size-4 shrink-0" />
-							<span>Copy this token now — it is shown once and cannot be retrieved later.</span>
-						</div>
+						<CopyField label="API token" value={created.token} copyLabel="Copy token" hideLabel />
+						<WriteOnceWarning />
 					</div>
 				)}
 
@@ -152,7 +131,7 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 										label={`Revoke ${token.name}`}
 										tooltip="Revoke token"
 										tone="danger"
-										onPress={() => setRevokeTarget(token)}
+										onPress={() => confirmRevoke.open(token)}
 									>
 										<Trash2 className="size-4" />
 									</IconButton>
@@ -191,10 +170,10 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 				</form>
 
 				<ConfirmDialog
-					isOpen={!!revokeTarget}
-					onClose={() => setRevokeTarget(null)}
+					isOpen={confirmRevoke.isOpen}
+					onClose={confirmRevoke.close}
 					title="Revoke token"
-					description={`Revoke "${revokeTarget?.name}"? Anything still using it will stop authenticating within about a minute.`}
+					description={`Revoke "${confirmRevoke.target?.name}"? Anything still using it will stop authenticating within about a minute.`}
 					confirmLabel="Revoke"
 					pendingLabel="Revoking..."
 					isPending={revokeToken.isPending}

--- a/packages/web/src/components/Header/Header.test.tsx
+++ b/packages/web/src/components/Header/Header.test.tsx
@@ -50,6 +50,9 @@ async function openUserMenu(user: ReturnType<typeof userEvent.setup>) {
 afterEach(() => {
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
+	// Neither of the above reverts a property descriptor, so the stub would stay
+	// installed over the real Clipboard API for the rest of the run.
+	Reflect.deleteProperty(navigator, 'clipboard');
 	localStorage.clear();
 	document.documentElement.classList.remove('dark');
 });

--- a/packages/web/src/components/Header/Header.test.tsx
+++ b/packages/web/src/components/Header/Header.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider } from '@/context/AuthContext';
+import { ThemeProvider } from '@/context/ThemeContext';
+import { installMatchMedia, jsonOk, renderWithClient } from '@/test/render';
+import { Header } from './Header';
+
+const USER = { id: 'usr-123', email: 'ada@example.com' };
+
+/**
+ * `userEvent.setup()` installs its own `navigator.clipboard`, so the app's must
+ * be stubbed afterwards or the copy silently succeeds against user-event's stub.
+ */
+function setup(writeText: () => Promise<void> = () => Promise.resolve()) {
+	installMatchMedia(false);
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input);
+			if (url === '/api/v1/me') return jsonOk(USER);
+			if (url === '/api/v1/me/tokens') return jsonOk([]);
+			throw new Error(`unexpected fetch: ${init?.method ?? 'GET'} ${url}`);
+		}),
+	);
+	const user = userEvent.setup();
+	const clipboard = vi.fn(writeText);
+	Object.defineProperty(navigator, 'clipboard', {
+		value: { writeText: clipboard },
+		configurable: true,
+	});
+	renderWithClient(
+		<ThemeProvider>
+			<AuthProvider>
+				<Header />
+			</AuthProvider>
+		</ThemeProvider>,
+		{ route: '/' },
+	);
+	return { user, clipboard };
+}
+
+async function openUserMenu(user: ReturnType<typeof userEvent.setup>) {
+	await waitFor(() =>
+		expect(screen.getByRole('button', { name: 'User menu' })).toBeInTheDocument(),
+	);
+	await user.click(screen.getByRole('button', { name: 'User menu' }));
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+	localStorage.clear();
+	document.documentElement.classList.remove('dark');
+});
+
+describe('Header', () => {
+	it('shows the signed-in user and their id in the menu', async () => {
+		const { user } = setup();
+		await openUserMenu(user);
+
+		expect(screen.getByText(USER.email)).toBeInTheDocument();
+		expect(screen.getByText(USER.id)).toBeInTheDocument();
+	});
+
+	it('copies the user id — invites are addressed by id, not email', async () => {
+		const { user, clipboard } = setup();
+		await openUserMenu(user);
+
+		await user.click(screen.getByRole('menuitem', { name: /Copy user id/ }));
+
+		expect(clipboard).toHaveBeenCalledWith(USER.id);
+	});
+
+	it('opens the API tokens dialog from the menu', async () => {
+		const { user } = setup();
+		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+		await openUserMenu(user);
+
+		await user.click(screen.getByRole('menuitem', { name: /API tokens/ }));
+
+		await waitFor(() =>
+			expect(screen.getByRole('heading', { name: 'API tokens' })).toBeInTheDocument(),
+		);
+	});
+
+	it('toggles the theme', async () => {
+		const { user } = setup();
+		expect(document.documentElement).not.toHaveClass('dark');
+
+		await user.click(screen.getByRole('button', { name: 'Toggle theme' }));
+		expect(document.documentElement).toHaveClass('dark');
+
+		await user.click(screen.getByRole('button', { name: 'Toggle theme' }));
+		expect(document.documentElement).not.toHaveClass('dark');
+	});
+
+	it('hides the user menu until the identity resolves', () => {
+		setup();
+		expect(screen.queryByRole('button', { name: 'User menu' })).not.toBeInTheDocument();
+	});
+});

--- a/packages/web/src/components/Header/Header.tsx
+++ b/packages/web/src/components/Header/Header.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { MenuTrigger, Button, Popover, Menu, MenuItem, Separator } from 'react-aria-components';
 import { ChevronDown, Copy, KeyRound, Moon, Sun } from 'lucide-react';
@@ -6,12 +5,15 @@ import { toast } from 'sonner';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/context/ThemeContext';
 import { Brand } from '@/components/ui';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { useDisclosure } from '@/hooks/useDisclosure';
 import { ApiTokensDialog } from '@/components/Account/ApiTokensDialog';
 
 export function Header() {
 	const { user, signOut } = useAuth();
 	const { theme, toggleTheme } = useTheme();
-	const [tokensOpen, setTokensOpen] = useState(false);
+	const tokensDialog = useDisclosure();
+	const { copy } = useCopyToClipboard();
 
 	return (
 		<header className="sticky top-0 z-40 flex h-14 shrink-0 items-center justify-between border-b bg-background/85 px-4 backdrop-blur-md max-md:px-3">
@@ -52,9 +54,8 @@ export function Header() {
 								onAction={(key) => {
 									if (key === 'signout') signOut();
 									else if (key === 'copy-id') {
-										void navigator.clipboard.writeText(user.id);
-										toast.success('User id copied');
-									} else if (key === 'api-tokens') setTokensOpen(true);
+										void copy(user.id).then((ok) => ok && toast.success('User id copied'));
+									} else if (key === 'api-tokens') tokensDialog.open();
 								}}
 							>
 								<MenuItem
@@ -95,7 +96,7 @@ export function Header() {
 				)}
 			</div>
 
-			<ApiTokensDialog isOpen={tokensOpen} onClose={() => setTokensOpen(false)} />
+			<ApiTokensDialog isOpen={tokensDialog.isOpen} onClose={tokensDialog.close} />
 		</header>
 	);
 }

--- a/packages/web/src/components/Notebook/SyncKeysDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncKeysDialog.tsx
@@ -1,7 +1,4 @@
-import { useState } from 'react';
-import { toast } from 'sonner';
-import { AlertTriangle, Check, Copy } from 'lucide-react';
-import { Button, DialogModal, IconButton } from '@/components/ui';
+import { Button, CopyField, DialogModal, WriteOnceWarning } from '@/components/ui';
 import { DOCS_SYNCING_URL } from '@/lib/links';
 
 export interface SyncKeysDialogProps {
@@ -11,41 +8,6 @@ export interface SyncKeysDialogProps {
 	syncUrl: string;
 	/** The write-once token, present only right after creation or rotation. */
 	token?: string;
-}
-
-function CopyField({ label, value }: { label: string; value: string }) {
-	const [copied, setCopied] = useState(false);
-
-	const copy = async () => {
-		try {
-			await navigator.clipboard.writeText(value);
-			setCopied(true);
-			setTimeout(() => setCopied(false), 1500);
-		} catch {
-			toast.error('Could not copy to clipboard');
-		}
-	};
-
-	return (
-		<div className="flex flex-col gap-1.5">
-			<span className="text-xs font-medium text-muted-foreground">{label}</span>
-			<div className="flex items-center gap-2">
-				<input
-					readOnly
-					aria-label={label}
-					value={value}
-					onFocus={(e) => e.target.select()}
-					className="h-9 w-full rounded-md border border-input bg-muted/40 px-3 font-mono text-xs text-foreground outline-none"
-				/>
-				<IconButton
-					label={copied ? 'Copied' : `Copy ${label.toLowerCase()}`}
-					onPress={() => void copy()}
-				>
-					{copied ? <Check className="size-4 text-primary" /> : <Copy className="size-4" />}
-				</IconButton>
-			</div>
-		</div>
-	);
 }
 
 /**
@@ -77,10 +39,7 @@ export function SyncKeysDialog({ isOpen, onClose, title, syncUrl, token }: SyncK
 				{token ? (
 					<>
 						<CopyField label="Sync token" value={token} />
-						<div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
-							<AlertTriangle className="mt-px size-4 shrink-0" />
-							<span>Copy this token now — it is shown once and cannot be retrieved later.</span>
-						</div>
+						<WriteOnceWarning />
 					</>
 				) : (
 					<p className="rounded-md border border-input bg-muted/40 px-3 py-2 text-xs text-muted-foreground">

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
@@ -5,6 +5,7 @@ import {
 	Button,
 	ConfirmDialog,
 	DialogModal,
+	displayName,
 	EmptyState,
 	Skeleton,
 	UserLabel,
@@ -16,6 +17,8 @@ import {
 	useUsersQuery,
 } from '@/api/hooks';
 import type { UserDirectory } from '@/api/hooks';
+import { useDialogTarget } from '@/hooks/useDialogTarget';
+import { toastError } from '@/lib/errors';
 import { formatRelative } from '@/lib/time';
 import { cn } from '@/lib/utils';
 import type { NotebookEntry, NotebookVersion } from '@/types';
@@ -143,7 +146,7 @@ export function VersionHistoryDialog({
 	// against the fetched list so selection self-heals when it refetches.
 	const [baseId, setBaseId] = useState<string | null>(null);
 	const [compareId, setCompareId] = useState<string | null>(null);
-	const [restoreTarget, setRestoreTarget] = useState<NotebookVersion | null>(null);
+	const confirmRestore = useDialogTarget<NotebookVersion>();
 
 	const versionsQuery = useNotebookVersionsQuery(projectId, notebook.id);
 	const versions = versionsQuery.data ?? [];
@@ -166,24 +169,23 @@ export function VersionHistoryDialog({
 	const restorable = canRestore && notebook.source_type !== 'git';
 
 	const handleRestore = () => {
-		if (!restoreTarget) return;
-		restoreVersion.mutate(restoreTarget.version_id, {
+		const target = confirmRestore.target;
+		if (!target) return;
+		restoreVersion.mutate(target.version_id, {
 			onSuccess: () => {
 				toast.success('Version restored');
-				setRestoreTarget(null);
+				confirmRestore.close();
 				// Back to defaults: after the list refetches, the diff shows
 				// what changed — pre-restore current → restored current.
 				setBaseId(null);
 				setCompareId(null);
 			},
-			onError: (err) => toast.error(err.message),
+			onError: toastError,
 		});
 	};
 
-	const restoreTargetAuthor = restoreTarget
-		? users?.[restoreTarget.author]?.name ||
-			users?.[restoreTarget.author]?.email ||
-			restoreTarget.author
+	const restoreTargetAuthor = confirmRestore.target
+		? displayName(users?.[confirmRestore.target.author], confirmRestore.target.author)
 		: '';
 
 	const diffPane = () => {
@@ -259,7 +261,7 @@ export function VersionHistoryDialog({
 											setBaseId(v.version_id);
 											setCompareId(null);
 										}}
-										onRestore={() => setRestoreTarget(v)}
+										onRestore={() => confirmRestore.open(v)}
 									/>
 								))}
 							</ul>
@@ -287,12 +289,12 @@ export function VersionHistoryDialog({
 			</DialogModal>
 
 			<ConfirmDialog
-				isOpen={!!restoreTarget}
-				onClose={() => setRestoreTarget(null)}
+				isOpen={confirmRestore.isOpen}
+				onClose={confirmRestore.close}
 				title="Restore Version"
 				description={
-					restoreTarget
-						? `Restore the version saved ${formatRelative(restoreTarget.saved_at)} by ${restoreTargetAuthor}? Your current notebook is preserved as a version in history — nothing is lost.`
+					confirmRestore.target
+						? `Restore the version saved ${formatRelative(confirmRestore.target.saved_at)} by ${restoreTargetAuthor}? Your current notebook is preserved as a version in history — nothing is lost.`
 						: ''
 				}
 				confirmLabel="Restore"

--- a/packages/web/src/components/Notebook/baseImage.test.tsx
+++ b/packages/web/src/components/Notebook/baseImage.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+import { systemKeys } from '@/api/queryKeys';
+import { jsonError, jsonOk, renderHookWithClient } from '@/test/render';
+import { DEFAULT_BASE_IMAGE, baseImageOptions, useSandboxImages } from './baseImage';
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('baseImageOptions', () => {
+	it('offers only Default, undescribed, when no images are configured', () => {
+		expect(baseImageOptions([])).toEqual([
+			{ value: DEFAULT_BASE_IMAGE, label: 'Default', description: undefined },
+		]);
+	});
+
+	it('describes Default with the first image and lists every image in order', () => {
+		expect(baseImageOptions(['a', 'b'])).toEqual([
+			{ value: DEFAULT_BASE_IMAGE, label: 'Default', description: 'a' },
+			{ value: 'a', label: 'a' },
+			{ value: 'b', label: 'b' },
+		]);
+	});
+});
+
+describe('useSandboxImages', () => {
+	it('returns an empty list until the capabilities query resolves', async () => {
+		let resolveCapabilities: (response: Response) => void = () => {};
+		const inFlight = new Promise<Response>((resolve) => {
+			resolveCapabilities = resolve;
+		});
+		const fetchMock = vi.fn((..._args: Parameters<typeof fetch>) => inFlight);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const { result } = renderHookWithClient(() => useSandboxImages(), { toaster: false });
+
+		expect(result.current).toEqual([]);
+		expect(String(fetchMock.mock.calls[0][0])).toBe('/api/v1/capabilities');
+
+		resolveCapabilities(jsonOk({ sandbox_images: ['img-a', 'img-b'] }));
+
+		await waitFor(() => expect(result.current).toEqual(['img-a', 'img-b']));
+	});
+
+	it('returns an empty list when the capabilities query fails', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonError('INTERNAL', 'capabilities unavailable', 500)),
+		);
+
+		const { result, client } = renderHookWithClient(() => useSandboxImages(), { toaster: false });
+
+		await waitFor(() =>
+			expect(client.getQueryState(systemKeys.capabilities())?.status).toBe('error'),
+		);
+		expect(result.current).toEqual([]);
+	});
+});

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { AlertTriangle, AppWindow, ArrowLeft, Eye, Pencil, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -21,6 +21,7 @@ import {
 } from '@/api/hooks';
 import { useNotebookSession } from '@/hooks/useNotebookSession';
 import type { SessionEnded } from '@/hooks/useNotebookSession';
+import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { RenameNotebookDialog } from '@/components/Notebook/RenameNotebookDialog';
 import { StaticNotebookView } from '@/components/NotebookPage/StaticNotebookView';
@@ -56,7 +57,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 	const notebookTitle = (location.state as { title?: string } | null)?.title ?? nid ?? 'Notebook';
 	const renameModal = useDisclosure();
 	// Stop/Restart disconnect everyone using the shared app, so both confirm first.
-	const [confirmAppAction, setConfirmAppAction] = useState<'stop' | 'restart' | null>(null);
+	const confirmAppAction = useDialogTarget<'stop' | 'restart'>();
 
 	// The viewer branch (server-enforced regardless): editors get a session as
 	// always; a viewer gets an edit kernel only when the deployment's evaluated
@@ -108,7 +109,8 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 	// time someone types.
 	// Stops once the app has ended — the banner it feeds is gone with the iframe.
 	const { data: projectSessions } = useProjectSessionsQuery(pid!, isApp && !ended);
-	const editActive = isApp && !!sessionsByNotebook(projectSessions).get(nid!)?.edit;
+	const sessionByNotebook = useMemo(() => sessionsByNotebook(projectSessions), [projectSessions]);
+	const editActive = isApp && !!sessionByNotebook.get(nid!)?.edit;
 	const appStale =
 		isApp && !!session && !editActive && isAppStale(session, notebook?.source.current_version_id);
 	// A viewer deep-linking to /app gets a plain 403 panel; retrying can only
@@ -186,7 +188,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 						<Button
 							variant="unstyled"
 							className="flex h-[26px] items-center gap-1 rounded-md border border-input px-2 text-xs text-muted-foreground transition-colors hover:border-primary hover:text-primary max-md:min-h-11"
-							onPress={() => setConfirmAppAction('restart')}
+							onPress={() => confirmAppAction.open('restart')}
 						>
 							<RefreshCw className="size-3" />
 							Restart
@@ -196,7 +198,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 						<Button
 							variant="unstyled"
 							className="flex h-[26px] items-center rounded-md border border-input px-2 text-xs text-muted-foreground transition-colors hover:border-destructive hover:bg-destructive/10 hover:text-destructive max-md:min-h-11"
-							onPress={isApp ? () => setConfirmAppAction('stop') : handleStop}
+							onPress={isApp ? () => confirmAppAction.open('stop') : handleStop}
 						>
 							Stop
 						</Button>
@@ -243,7 +245,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 								<Button
 									variant="unstyled"
 									className="ml-1 shrink-0 rounded text-xs font-medium text-primary underline-offset-2 hover:underline"
-									onPress={() => setConfirmAppAction('restart')}
+									onPress={() => confirmAppAction.open('restart')}
 								>
 									Restart to update
 								</Button>
@@ -317,18 +319,18 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 
 			{isApp && (
 				<ConfirmDialog
-					isOpen={confirmAppAction !== null}
-					onClose={() => setConfirmAppAction(null)}
-					title={confirmAppAction === 'restart' ? 'Restart App' : 'Stop App'}
+					isOpen={confirmAppAction.isOpen}
+					onClose={confirmAppAction.close}
+					title={confirmAppAction.target === 'restart' ? 'Restart App' : 'Stop App'}
 					description={
-						confirmAppAction === 'restart'
+						confirmAppAction.target === 'restart'
 							? `Restart the app for "${title}"? It will come back serving the latest saved version — anyone using it now will be disconnected and must reopen it.${appConnectionHint(session ?? undefined)}`
 							: `Stop the app for "${title}"? Anyone using it will be disconnected.${appConnectionHint(session ?? undefined)}`
 					}
-					confirmLabel={confirmAppAction === 'restart' ? 'Restart' : 'Stop App'}
+					confirmLabel={confirmAppAction.target === 'restart' ? 'Restart' : 'Stop App'}
 					onConfirm={() => {
-						const action = confirmAppAction;
-						setConfirmAppAction(null);
+						const action = confirmAppAction.target;
+						confirmAppAction.close();
 						if (action === 'restart') restart();
 						else handleStop();
 					}}

--- a/packages/web/src/components/Project/AppSessionIndicator.tsx
+++ b/packages/web/src/components/Project/AppSessionIndicator.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
 import { AppWindow, Power, RefreshCw } from 'lucide-react';
 import type { Session } from '@/types';
 import { useNotebookQuery, useUsersQuery } from '@/api/hooks';
 import { Button, Popover, UserLabel } from '@/components/ui';
-import { useInterval } from '@/hooks/useInterval';
+import { useNow } from '@/hooks/useNow';
 import { cn } from '@/lib/utils';
 import { formatDuration, formatRelative } from '@/lib/time';
 
@@ -16,13 +15,6 @@ const APP_STATUS: Partial<
 	starting: { className: 'text-amber-500', label: 'App starting', pulse: true },
 	terminating: { className: 'text-orange-500', label: 'App stopping', pulse: true },
 };
-
-/** Tick `now` once a second so an open popover's elapsed duration stays live. */
-function useNow(): number {
-	const [now, setNow] = useState(() => Date.now());
-	useInterval(() => setNow(Date.now()), 1000);
-	return now;
-}
 
 /**
  * Whether the app session is serving an older version than the notebook's

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { FileTrigger } from 'react-aria-components';
 import { toast } from 'sonner';
@@ -78,8 +78,10 @@ import { SyncedNotebookDialog } from '@/components/Notebook/SyncedNotebookDialog
 import type { SyncedNotebookCreated } from '@/components/Notebook/SyncedNotebookDialog';
 import { SyncKeysDialog } from '@/components/Notebook/SyncKeysDialog';
 import { VersionHistoryDialog } from '@/components/Notebook/VersionHistoryDialog';
+import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { useDisclosure } from '@/hooks/useDisclosure';
-import { useSearchHotkey } from '@/hooks/useSearchHotkey';
+import { useSearchField } from '@/hooks/useSearchField';
+import { toastError } from '@/lib/errors';
 import { filterBySearch } from '@/lib/search';
 import { formatRelative } from '@/lib/time';
 import { syncUrl } from '@/lib/links';
@@ -111,36 +113,28 @@ const NEW_NOTEBOOK_CODE = (name: string) =>
 export function Project() {
 	const { pid } = useParams<{ pid: string }>();
 	const navigate = useNavigate();
-	const [searchQuery, setSearchQuery] = useState('');
-	const searchRef = useRef<HTMLInputElement>(null);
-	useSearchHotkey(searchRef);
+	const search = useSearchField();
 
-	// Data-bearing dialogs keep the target in state; boolean dialogs use useDisclosure.
+	// Dialogs acting on a row use useDialogTarget; plain ones use useDisclosure.
 	const uploadModal = useDisclosure();
 	// When set, a `.py` file's contents seed the new notebook instead of the template.
 	const [uploadedCode, setUploadedCode] = useState<string | null>(null);
 	const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
-	const [deleteModal, setDeleteModal] = useState<NotebookEntry | null>(null);
-	const [renameModal, setRenameModal] = useState<NotebookEntry | null>(null);
-	const [baseImageModal, setBaseImageModal] = useState<NotebookEntry | null>(null);
-	const [historyModal, setHistoryModal] = useState<NotebookEntry | null>(null);
+	const deleteModal = useDialogTarget<NotebookEntry>();
+	const renameModal = useDialogTarget<NotebookEntry>();
+	const baseImageModal = useDialogTarget<NotebookEntry>();
+	const historyModal = useDialogTarget<NotebookEntry>();
 	const syncedCreateModal = useDisclosure();
-	const [syncKeys, setSyncKeys] = useState<{
-		notebookId: string;
-		title: string;
-		token?: string;
-	} | null>(null);
-	const [rotateModal, setRotateModal] = useState<NotebookEntry | null>(null);
-	const [stopModal, setStopModal] = useState<{ notebook: NotebookEntry; session: Session } | null>(
-		null,
-	);
+	const syncKeys = useDialogTarget<{ notebookId: string; title: string; token?: string }>();
+	const rotateModal = useDialogTarget<NotebookEntry>();
+	const stopModal = useDialogTarget<{ notebook: NotebookEntry; session: Session }>();
 	// The shared app's stop/restart confirm — separate from the edit-kernel stop
 	// so the copy can warn about disconnecting other people.
-	const [appModal, setAppModal] = useState<{
+	const appModal = useDialogTarget<{
 		action: 'stop' | 'restart';
 		notebook: NotebookEntry;
 		session: Session;
-	} | null>(null);
+	}>();
 	// Project-level edit/delete (this page's project, not the notebooks).
 	const editProjectModal = useDisclosure();
 	const deleteProjectModal = useDisclosure();
@@ -163,9 +157,9 @@ export function Project() {
 	const offersImageChoice = sandboxImages.length > 1;
 	const rotateSyncToken = useRotateSyncToken(pid!);
 	// Re-bound each render to the notebook in the stop dialog; only fired on confirm.
-	const stopSession = useStopSession(pid!, stopModal?.notebook.id ?? '');
-	const stopAppSession = useStopSession(pid!, appModal?.notebook.id ?? '');
-	const restartAppSession = useRestartApp(pid!, appModal?.notebook.id ?? '');
+	const stopSession = useStopSession(pid!, stopModal.target?.notebook.id ?? '');
+	const stopAppSession = useStopSession(pid!, appModal.target?.notebook.id ?? '');
+	const restartAppSession = useRestartApp(pid!, appModal.target?.notebook.id ?? '');
 	// Per-session actions render from the server-evaluated `session.can` grants.
 	// Start has no session to carry grants, so it derives from the evaluated
 	// admission row in capabilities. The server enforces all of it regardless.
@@ -186,7 +180,7 @@ export function Project() {
 				toast.success(`Updated project "${name}"`);
 				editProjectModal.close();
 			} catch (err) {
-				toast.error((err as Error).message);
+				toastError(err);
 			}
 		},
 	});
@@ -208,7 +202,7 @@ export function Project() {
 				toast.success(`Deleted "${project.name}"`);
 				void navigate('/');
 			} catch (err) {
-				toast.error((err as Error).message);
+				toastError(err);
 			}
 		},
 	});
@@ -229,7 +223,7 @@ export function Project() {
 				toast.success(`Created "${name}"`);
 				closeCreateModal();
 			} catch (err) {
-				toast.error((err as Error).message);
+				toastError(err);
 			}
 		},
 	});
@@ -248,9 +242,7 @@ export function Project() {
 					);
 					secretsModal.close();
 				},
-				onError: (err) => {
-					toast.error(err.message);
-				},
+				onError: toastError,
 			},
 		);
 	};
@@ -260,16 +252,10 @@ export function Project() {
 
 	// Resolve every author (and session starter) shown on the page in one batch,
 	// so opaque user ids render as names.
-	const userIds = useMemo(
-		() => [
-			...new Set([
-				...(notebooks ?? []).map((nb) => nb.author),
-				...(sessions ?? []).map((s) => s.user_id),
-			]),
-		],
-		[notebooks, sessions],
-	);
-	const { data: users, isLoading: usersLoading } = useUsersQuery(userIds);
+	const { data: users, isLoading: usersLoading } = useUsersQuery([
+		...(notebooks ?? []).map((nb) => nb.author),
+		...(sessions ?? []).map((s) => s.user_id),
+	]);
 
 	const closeCreateModal = () => {
 		setUploadedCode(null);
@@ -298,16 +284,15 @@ export function Project() {
 	};
 
 	const handleDelete = () => {
-		if (!deleteModal) return;
+		const nb = deleteModal.target;
+		if (!nb) return;
 
-		deleteNotebook.mutate(deleteModal.id, {
+		deleteNotebook.mutate(nb.id, {
 			onSuccess: () => {
-				toast.success(`Deleted "${deleteModal.title}"`);
-				setDeleteModal(null);
+				toast.success(`Deleted "${nb.title}"`);
+				deleteModal.close();
 			},
-			onError: (err) => {
-				toast.error(err.message);
-			},
+			onError: toastError,
 		});
 	};
 
@@ -320,10 +305,7 @@ export function Project() {
 	};
 
 	const handleDownloadFile = (nb: NotebookEntry) => {
-		downloadNotebookFile.mutate(
-			{ notebookId: nb.id, title: nb.title },
-			{ onError: (err) => toast.error(err.message) },
-		);
+		downloadNotebookFile.mutate({ notebookId: nb.id, title: nb.title }, { onError: toastError });
 	};
 
 	const handleDownloadWorkspace = (nb: NotebookEntry) => {
@@ -335,22 +317,21 @@ export function Project() {
 	};
 
 	const handleStop = () => {
-		if (!stopModal) return;
+		const stop = stopModal.target;
+		if (!stop) return;
 
-		stopSession.mutate(stopModal.session.session_id, {
+		stopSession.mutate(stop.session.session_id, {
 			onSuccess: () => {
-				toast.success(`Stopped "${stopModal.notebook.title}"`);
-				setStopModal(null);
+				toast.success(`Stopped "${stop.notebook.title}"`);
+				stopModal.close();
 			},
-			onError: (err) => {
-				toast.error(err.message);
-			},
+			onError: toastError,
 		});
 	};
 
 	const handleAppAction = () => {
-		if (!appModal) return;
-		const { action, notebook, session } = appModal;
+		if (!appModal.target) return;
+		const { action, notebook, session } = appModal.target;
 		const mutation = action === 'stop' ? stopAppSession : restartAppSession;
 		mutation.mutate(session.session_id, {
 			onSuccess: () => {
@@ -359,29 +340,27 @@ export function Project() {
 						? `Stopped the app for "${notebook.title}"`
 						: `Restarted the app for "${notebook.title}"`,
 				);
-				setAppModal(null);
+				appModal.close();
 			},
-			onError: (err) => {
-				toast.error(err.message);
-			},
+			onError: toastError,
 		});
 	};
 
 	const handleSyncedCreated = (result: SyncedNotebookCreated) => {
 		syncedCreateModal.close();
-		setSyncKeys({ notebookId: result.notebookId, title: result.title, token: result.token });
+		syncKeys.open({ notebookId: result.notebookId, title: result.title, token: result.token });
 	};
 
 	const handleRotateToken = () => {
-		if (!rotateModal) return;
-		const { id, title } = rotateModal;
+		if (!rotateModal.target) return;
+		const { id, title } = rotateModal.target;
 		rotateSyncToken.mutate(id, {
 			onSuccess: (data) => {
 				toast.success(`Rotated sync token for "${title}"`);
-				setRotateModal(null);
-				setSyncKeys({ notebookId: id, title, token: data.sync_token });
+				rotateModal.close();
+				syncKeys.open({ notebookId: id, title, token: data.sync_token });
 			},
-			onError: (err) => toast.error(err.message),
+			onError: toastError,
 		});
 	};
 
@@ -439,7 +418,7 @@ export function Project() {
 		{ id: 'delete', label: 'Delete', icon: <Trash2 className="size-4" />, danger: true },
 	];
 
-	const filteredNotebooks = filterBySearch(notebooks, searchQuery, (nb) => nb.title);
+	const filteredNotebooks = filterBySearch(notebooks, search.query, (nb) => nb.title);
 
 	return (
 		<PageContainer>
@@ -517,17 +496,17 @@ export function Project() {
 				<SearchField
 					aria-label="Search notebooks"
 					placeholder="Search notebooks..."
-					value={searchQuery}
-					onChange={setSearchQuery}
-					inputRef={searchRef}
+					value={search.query}
+					onChange={search.setQuery}
+					inputRef={search.inputRef}
 				/>
 			</div>
 
 			{filteredNotebooks.length === 0 ? (
-				searchQuery ? (
+				search.query ? (
 					<EmptyState
 						icon={<SearchX />}
-						message={`No notebooks matching "${searchQuery}"`}
+						message={`No notebooks matching "${search.query}"`}
 						description="Try a different search term."
 					/>
 				) : (
@@ -565,7 +544,7 @@ export function Project() {
 												label="Shut down kernel"
 												tooltip="Shut down kernel"
 												tone="danger"
-												onPress={() => setStopModal({ notebook: nb, session: live.edit! })}
+												onPress={() => stopModal.open({ notebook: nb, session: live.edit! })}
 											>
 												<Power className="size-4" />
 											</IconButton>
@@ -576,7 +555,7 @@ export function Project() {
 											triggerClassName="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-100"
 											options={notebookActions(nb)}
 											onAction={(key) => {
-												if (key === 'rename') setRenameModal(nb);
+												if (key === 'rename') renameModal.open(nb);
 												else if (key === 'duplicate') handleDuplicate(nb);
 												else if (key === 'run-app' || key === 'open-app')
 													void navigate(`/projects/${pid}/notebooks/${nb.id}/app`, {
@@ -584,15 +563,15 @@ export function Project() {
 													});
 												else if (key === 'stop-app') {
 													const app = sessionByNotebook.get(nb.id)?.app;
-													if (app) setAppModal({ action: 'stop', notebook: nb, session: app });
-												} else if (key === 'change-image') setBaseImageModal(nb);
-												else if (key === 'history') setHistoryModal(nb);
+													if (app) appModal.open({ action: 'stop', notebook: nb, session: app });
+												} else if (key === 'change-image') baseImageModal.open(nb);
+												else if (key === 'history') historyModal.open(nb);
 												else if (key === 'sync-keys')
-													setSyncKeys({ notebookId: nb.id, title: nb.title });
-												else if (key === 'rotate-token') setRotateModal(nb);
+													syncKeys.open({ notebookId: nb.id, title: nb.title });
+												else if (key === 'rotate-token') rotateModal.open(nb);
 												else if (key === 'download-file') handleDownloadFile(nb);
 												else if (key === 'download-workspace') handleDownloadWorkspace(nb);
-												else if (key === 'delete') setDeleteModal(nb);
+												else if (key === 'delete') deleteModal.open(nb);
 											}}
 										/>
 									</>
@@ -624,10 +603,10 @@ export function Project() {
 											canOpen={!!live.app.can?.attach}
 											editActive={!!live.edit}
 											onStop={() =>
-												setAppModal({ action: 'stop', notebook: nb, session: live.app! })
+												appModal.open({ action: 'stop', notebook: nb, session: live.app! })
 											}
 											onRestart={() =>
-												setAppModal({ action: 'restart', notebook: nb, session: live.app! })
+												appModal.open({ action: 'restart', notebook: nb, session: live.app! })
 											}
 										/>
 									)}
@@ -700,31 +679,31 @@ export function Project() {
 				</div>
 			</FormDialog>
 
-			{renameModal && (
+			{renameModal.target && (
 				<RenameNotebookDialog
-					isOpen={!!renameModal}
-					onClose={() => setRenameModal(null)}
+					isOpen={renameModal.isOpen}
+					onClose={renameModal.close}
 					projectId={pid!}
-					notebook={renameModal}
+					notebook={renameModal.target}
 				/>
 			)}
 
-			{baseImageModal && (
+			{baseImageModal.target && (
 				<ChangeBaseImageDialog
-					isOpen={!!baseImageModal}
-					onClose={() => setBaseImageModal(null)}
+					isOpen={baseImageModal.isOpen}
+					onClose={baseImageModal.close}
 					projectId={pid!}
-					notebook={baseImageModal}
+					notebook={baseImageModal.target}
 				/>
 			)}
 
 			{/* Mounted only while open so history is fetched on demand and selection resets. */}
-			{historyModal && (
+			{historyModal.target && (
 				<VersionHistoryDialog
 					isOpen
-					onClose={() => setHistoryModal(null)}
+					onClose={historyModal.close}
 					projectId={pid!}
-					notebook={historyModal}
+					notebook={historyModal.target}
 					canRestore={project.your_role !== 'viewer'}
 				/>
 			)}
@@ -736,21 +715,21 @@ export function Project() {
 				onCreated={handleSyncedCreated}
 			/>
 
-			{syncKeys && (
+			{syncKeys.target && (
 				<SyncKeysDialog
-					isOpen={!!syncKeys}
-					onClose={() => setSyncKeys(null)}
-					title={syncKeys.title}
-					syncUrl={syncUrl(pid!, syncKeys.notebookId)}
-					token={syncKeys.token}
+					isOpen={syncKeys.isOpen}
+					onClose={syncKeys.close}
+					title={syncKeys.target.title}
+					syncUrl={syncUrl(pid!, syncKeys.target.notebookId)}
+					token={syncKeys.target.token}
 				/>
 			)}
 
 			<ConfirmDialog
-				isOpen={!!rotateModal}
-				onClose={() => setRotateModal(null)}
+				isOpen={rotateModal.isOpen}
+				onClose={rotateModal.close}
 				title="Rotate Sync Token"
-				description={`Rotate the sync token for "${rotateModal?.title}"? The current token stops working immediately and any pusher using it must be updated.`}
+				description={`Rotate the sync token for "${rotateModal.target?.title}"? The current token stops working immediately and any pusher using it must be updated.`}
 				confirmLabel="Rotate"
 				pendingLabel="Rotating..."
 				isPending={rotateSyncToken.isPending}
@@ -758,10 +737,10 @@ export function Project() {
 			/>
 
 			<ConfirmDialog
-				isOpen={!!deleteModal}
-				onClose={() => setDeleteModal(null)}
+				isOpen={deleteModal.isOpen}
+				onClose={deleteModal.close}
 				title="Delete Notebook"
-				description={`Are you sure you want to delete "${deleteModal?.title}"? This action cannot be undone.`}
+				description={`Are you sure you want to delete "${deleteModal.target?.title}"? This action cannot be undone.`}
 				confirmLabel="Delete"
 				pendingLabel="Deleting..."
 				isPending={deleteNotebook.isPending}
@@ -769,10 +748,10 @@ export function Project() {
 			/>
 
 			<ConfirmDialog
-				isOpen={!!stopModal}
-				onClose={() => setStopModal(null)}
+				isOpen={stopModal.isOpen}
+				onClose={stopModal.close}
 				title="Shut Down Kernel"
-				description={`Shut down the running kernel for "${stopModal?.notebook.title}"? Saved work is preserved; the sandbox is stopped and can be started again later.`}
+				description={`Shut down the running kernel for "${stopModal.target?.notebook.title}"? Saved work is preserved; the sandbox is stopped and can be started again later.`}
 				confirmLabel="Shut Down"
 				pendingLabel="Stopping..."
 				isPending={stopSession.isPending}
@@ -780,16 +759,16 @@ export function Project() {
 			/>
 
 			<ConfirmDialog
-				isOpen={!!appModal}
-				onClose={() => setAppModal(null)}
-				title={appModal?.action === 'restart' ? 'Restart App' : 'Stop App'}
+				isOpen={appModal.isOpen}
+				onClose={appModal.close}
+				title={appModal.target?.action === 'restart' ? 'Restart App' : 'Stop App'}
 				description={
-					appModal?.action === 'restart'
-						? `Restart the app for "${appModal.notebook.title}"? It will come back serving the latest saved version — anyone using it now will be disconnected and must reopen it.${appConnectionHint(appModal.session)}`
-						: `Stop the app for "${appModal?.notebook.title}"? Anyone using it will be disconnected.${appConnectionHint(appModal?.session)}`
+					appModal.target?.action === 'restart'
+						? `Restart the app for "${appModal.target.notebook.title}"? It will come back serving the latest saved version — anyone using it now will be disconnected and must reopen it.${appConnectionHint(appModal.target.session)}`
+						: `Stop the app for "${appModal.target?.notebook.title}"? Anyone using it will be disconnected.${appConnectionHint(appModal.target?.session)}`
 				}
-				confirmLabel={appModal?.action === 'restart' ? 'Restart' : 'Stop App'}
-				pendingLabel={appModal?.action === 'restart' ? 'Restarting...' : 'Stopping...'}
+				confirmLabel={appModal.target?.action === 'restart' ? 'Restart' : 'Stop App'}
+				pendingLabel={appModal.target?.action === 'restart' ? 'Restarting...' : 'Stopping...'}
 				isPending={stopAppSession.isPending || restartAppSession.isPending}
 				onConfirm={handleAppAction}
 			/>

--- a/packages/web/src/components/Project/ProjectMembersDialog.tsx
+++ b/packages/web/src/components/Project/ProjectMembersDialog.tsx
@@ -6,6 +6,7 @@ import {
 	ComboBox,
 	ConfirmDialog,
 	DialogModal,
+	displayName,
 	IconButton,
 	Tooltip,
 	UserLabel,
@@ -21,6 +22,8 @@ import {
 } from '@/api/hooks';
 import type { UserDirectory } from '@/api/hooks';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useDialogTarget } from '@/hooks/useDialogTarget';
+import { toastError } from '@/lib/errors';
 import { defaultAccessSummary, ROLES, roleDescriptions } from '@/lib/roles';
 import type { ProjectDetail, ProjectMember, ProjectRole, ResolvedUser } from '@/types';
 
@@ -243,7 +246,7 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 	const addMember = useAddMember(project.id);
 	const updateRole = useUpdateMemberRole(project.id);
 	const removeMember = useRemoveMember(project.id);
-	const [removeTarget, setRemoveTarget] = useState<ProjectMember | null>(null);
+	const confirmRemove = useDialogTarget<ProjectMember>();
 
 	const handleAdd = async (choice: MemberChoice, role: ProjectRole) => {
 		try {
@@ -251,7 +254,7 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 			toast.success('email' in choice ? 'Invite added' : 'Member added');
 			return true;
 		} catch (err) {
-			toast.error((err as Error).message);
+			toastError(err);
 			return false;
 		}
 	};
@@ -261,26 +264,28 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 			{ uid: memberKey(member), role },
 			{
 				onSuccess: () => toast.success('Role updated'),
-				onError: (err) => toast.error(err.message),
+				onError: toastError,
 			},
 		);
 	};
 
 	const handleRemove = () => {
-		if (!removeTarget) return;
-		removeMember.mutate(memberKey(removeTarget), {
+		const target = confirmRemove.target;
+		if (!target) return;
+		removeMember.mutate(memberKey(target), {
 			onSuccess: () => {
 				toast.success('Member removed');
-				setRemoveTarget(null);
+				confirmRemove.close();
 			},
-			onError: (err) => toast.error(err.message),
+			onError: toastError,
 		});
 	};
 
-	const removeTargetName = removeTarget
-		? (removeTarget.user_id &&
-				(users?.[removeTarget.user_id]?.name || users?.[removeTarget.user_id]?.email)) ||
-			memberKey(removeTarget)
+	const removeTargetName = confirmRemove.target
+		? displayName(
+				confirmRemove.target.user_id ? users?.[confirmRemove.target.user_id] : undefined,
+				memberKey(confirmRemove.target),
+			)
 		: '';
 
 	return (
@@ -334,7 +339,7 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 													label={`Remove ${key}`}
 													tooltip="Remove member"
 													tone="danger"
-													onPress={() => setRemoveTarget(member)}
+													onPress={() => confirmRemove.open(member)}
 												>
 													<Trash2 className="size-4" />
 												</IconButton>
@@ -363,8 +368,8 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 			</DialogModal>
 
 			<ConfirmDialog
-				isOpen={!!removeTarget}
-				onClose={() => setRemoveTarget(null)}
+				isOpen={confirmRemove.isOpen}
+				onClose={confirmRemove.close}
 				title="Remove Member"
 				description={`Remove "${removeTargetName}" from "${project.name}"? They lose access to all notebooks in this project.`}
 				confirmLabel="Remove"

--- a/packages/web/src/components/Project/ProjectSecretsDialog.tsx
+++ b/packages/web/src/components/Project/ProjectSecretsDialog.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { toast } from 'sonner';
 import { useSelector } from '@tanstack/react-store';
 import { ExternalLink, KeyRound, Plus, Trash2 } from 'lucide-react';
@@ -10,6 +9,8 @@ import {
 	usePutSecret,
 	useValidateSecret,
 } from '@/api/hooks';
+import { useDialogTarget } from '@/hooks/useDialogTarget';
+import { toastError } from '@/lib/errors';
 import { DOCS_FEDERATION_URL } from '@/lib/links';
 import type { ProjectDetail, SecretEntry } from '@/types';
 
@@ -157,7 +158,7 @@ function StoredKeysSection({ project, isOpen }: { project: ProjectDetail; isOpen
 	const putSecret = usePutSecret(project.id);
 	const deleteSecret = useDeleteSecret(project.id);
 	const isAdmin = project.your_role === 'admin';
-	const [removeTarget, setRemoveTarget] = useState<SecretEntry | null>(null);
+	const confirmDelete = useDialogTarget<SecretEntry>();
 
 	const validateSecret = useValidateSecret(project.id);
 
@@ -174,7 +175,7 @@ function StoredKeysSection({ project, isOpen }: { project: ProjectDetail; isOpen
 				toast.success('Secret saved');
 				form.reset();
 			} catch (err) {
-				toast.error((err as Error).message);
+				toastError(err);
 			}
 		},
 	});
@@ -187,18 +188,19 @@ function StoredKeysSection({ project, isOpen }: { project: ProjectDetail; isOpen
 			if (res.ok) toast.success('Reference resolves');
 			else toast.error(res.reason ?? 'Reference did not resolve');
 		} catch (err) {
-			toast.error((err as Error).message);
+			toastError(err);
 		}
 	};
 
 	const handleRemove = () => {
-		if (!removeTarget) return;
-		deleteSecret.mutate(removeTarget.name, {
+		const target = confirmDelete.target;
+		if (!target) return;
+		deleteSecret.mutate(target.name, {
 			onSuccess: () => {
 				toast.success('Secret deleted');
-				setRemoveTarget(null);
+				confirmDelete.close();
 			},
-			onError: (err) => toast.error(err.message),
+			onError: toastError,
 		});
 	};
 
@@ -246,7 +248,7 @@ function StoredKeysSection({ project, isOpen }: { project: ProjectDetail; isOpen
 									label={`Delete ${entry.name}`}
 									tooltip="Delete secret"
 									tone="danger"
-									onPress={() => setRemoveTarget(entry)}
+									onPress={() => confirmDelete.open(entry)}
 								>
 									<Trash2 className="size-4" />
 								</IconButton>
@@ -318,10 +320,10 @@ function StoredKeysSection({ project, isOpen }: { project: ProjectDetail; isOpen
 			)}
 
 			<ConfirmDialog
-				isOpen={!!removeTarget}
-				onClose={() => setRemoveTarget(null)}
+				isOpen={confirmDelete.isOpen}
+				onClose={confirmDelete.close}
 				title="Delete secret"
-				description={`Delete "${removeTarget?.name}"? Sessions in this project will no longer receive it.`}
+				description={`Delete "${confirmDelete.target?.name}"? Sessions in this project will no longer receive it.`}
 				confirmLabel="Delete"
 				pendingLabel="Deleting..."
 				isPending={deleteSecret.isPending}

--- a/packages/web/src/components/ProjectList/ProjectList.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.tsx
@@ -1,4 +1,3 @@
-import { useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { ChevronRight, Folder, FolderPlus, Plus, SearchX } from 'lucide-react';
@@ -21,7 +20,8 @@ import {
 } from '@/components/form';
 import { useProjectsQuery, useCreateProject } from '@/api/hooks';
 import { useDisclosure } from '@/hooks/useDisclosure';
-import { useSearchHotkey } from '@/hooks/useSearchHotkey';
+import { useSearchField } from '@/hooks/useSearchField';
+import { toastError } from '@/lib/errors';
 import { filterBySearch } from '@/lib/search';
 
 const projectSchema = z.object({
@@ -32,10 +32,8 @@ const projectSchema = z.object({
 const EMPTY_PROJECT = { name: '', description: '' };
 
 export function ProjectList() {
-	const [searchQuery, setSearchQuery] = useState('');
+	const search = useSearchField();
 	const createModal = useDisclosure();
-	const searchRef = useRef<HTMLInputElement>(null);
-	useSearchHotkey(searchRef);
 
 	const { data: projects } = useProjectsQuery();
 	const createProject = useCreateProject();
@@ -51,7 +49,7 @@ export function ProjectList() {
 				toast.success(`Created project "${name}"`);
 				createModal.close();
 			} catch (err) {
-				toast.error((err as Error).message);
+				toastError(err);
 			}
 		},
 	});
@@ -59,7 +57,7 @@ export function ProjectList() {
 
 	const filteredProjects = filterBySearch(
 		projects,
-		searchQuery,
+		search.query,
 		(p) => `${p.name} ${p.description}`,
 	);
 
@@ -86,17 +84,17 @@ export function ProjectList() {
 				<SearchField
 					aria-label="Search projects"
 					placeholder="Search projects..."
-					value={searchQuery}
-					onChange={setSearchQuery}
-					inputRef={searchRef}
+					value={search.query}
+					onChange={search.setQuery}
+					inputRef={search.inputRef}
 				/>
 			</div>
 
 			{filteredProjects.length === 0 ? (
-				searchQuery ? (
+				search.query ? (
 					<EmptyState
 						icon={<SearchX />}
-						message={`No projects matching "${searchQuery}"`}
+						message={`No projects matching "${search.query}"`}
 						description="Try a different search term."
 					/>
 				) : (

--- a/packages/web/src/components/form/useSeedOnOpen.test.tsx
+++ b/packages/web/src/components/form/useSeedOnOpen.test.tsx
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSelector } from '@tanstack/react-store';
+import { z } from 'zod';
+import { renderWithClient } from '@/test/render';
+import { useAppForm } from './useAppForm';
+import { schemaValidators } from './validators';
+import { useSeedOnOpen } from './useSeedOnOpen';
+
+const nameSchema = z.object({ name: z.string().trim().min(1, 'Required') });
+
+type Values = { name: string };
+
+/**
+ * Stands in for a dialog body: stays mounted while `isOpen` flips, exactly like a
+ * real dialog held open for its exit animation. `defaultValues` is derived from
+ * the same source as the seed, as every caller of the hook does — the form's own
+ * `update()` refuses to overwrite a touched form, which is why the explicit reset
+ * is needed at all.
+ */
+function SeededForm({ isOpen, values }: { isOpen: boolean; values: Values }) {
+	const form = useAppForm({
+		defaultValues: values,
+		validators: schemaValidators(nameSchema),
+		onSubmit: () => {},
+	});
+	useSeedOnOpen(form, isOpen, values);
+	const canSubmit = useSelector(form.store, (s) => s.canSubmit);
+	return (
+		<div>
+			<form.AppField name="name">{(f) => <f.TextField label="Name" />}</form.AppField>
+			<span data-testid="can-submit">{String(canSubmit)}</span>
+		</div>
+	);
+}
+
+function renderSeeded(isOpen: boolean, values: Values) {
+	const { rerender } = renderWithClient(<SeededForm isOpen={isOpen} values={values} />, {
+		toaster: false,
+	});
+	return {
+		input: () => screen.getByLabelText('Name'),
+		canSubmit: () => screen.getByTestId('can-submit'),
+		setProps: (next: { isOpen: boolean; values: Values }) =>
+			rerender(<SeededForm isOpen={next.isOpen} values={next.values} />),
+	};
+}
+
+describe('useSeedOnOpen', () => {
+	it('leaves the form alone while the dialog is closed', async () => {
+		const user = userEvent.setup();
+		const { input, setProps } = renderSeeded(false, { name: 'Alpha' });
+
+		await user.clear(input());
+		await user.type(input(), 'Draft');
+
+		// A different subject arrives while closed: still no reset.
+		setProps({ isOpen: false, values: { name: 'Beta' } });
+		expect(input()).toHaveValue('Draft');
+	});
+
+	it('seeds the form on the closed → open transition', async () => {
+		const user = userEvent.setup();
+		const { input, setProps } = renderSeeded(false, { name: 'Alpha' });
+
+		await user.clear(input());
+		await user.type(input(), 'Draft');
+
+		setProps({ isOpen: true, values: { name: 'Beta' } });
+
+		await waitFor(() => expect(input()).toHaveValue('Beta'));
+	});
+
+	it('re-seeds on reopen, discarding edits from a cancelled session', async () => {
+		const user = userEvent.setup();
+		const values: Values = { name: 'Alpha' };
+		const { input, setProps } = renderSeeded(false, values);
+
+		setProps({ isOpen: true, values });
+		await waitFor(() => expect(input()).toHaveValue('Alpha'));
+
+		await user.clear(input());
+		await user.type(input(), 'Abandoned edit');
+		expect(input()).toHaveValue('Abandoned edit');
+
+		// Close — the component stays mounted for the exit animation — then reopen.
+		setProps({ isOpen: false, values });
+		expect(input()).toHaveValue('Abandoned edit');
+
+		setProps({ isOpen: true, values });
+		await waitFor(() => expect(input()).toHaveValue('Alpha'));
+	});
+
+	it('does not clobber in-progress edits when values change while the dialog stays open', async () => {
+		const user = userEvent.setup();
+		const { input, setProps } = renderSeeded(true, { name: 'Alpha' });
+
+		await waitFor(() => expect(input()).toHaveValue('Alpha'));
+		await user.type(input(), ' edited');
+		expect(input()).toHaveValue('Alpha edited');
+
+		// A fresh object — and even a fresh value — must not re-seed: the effect
+		// deliberately depends on `isOpen` only.
+		setProps({ isOpen: true, values: { name: 'Alpha' } });
+		expect(input()).toHaveValue('Alpha edited');
+
+		setProps({ isOpen: true, values: { name: 'Refetched' } });
+		expect(input()).toHaveValue('Alpha edited');
+	});
+
+	it('re-runs validation after the reset so canSubmit reflects the seeded values', async () => {
+		const user = userEvent.setup();
+		const values: Values = { name: '' };
+		const { canSubmit, input, setProps } = renderSeeded(false, values);
+
+		expect(canSubmit()).toHaveTextContent('false');
+
+		await user.type(input(), 'Typed');
+		await waitFor(() => expect(canSubmit()).toHaveTextContent('true'));
+
+		// Reopening restores the invalid seed; reset() alone would clear the error
+		// state and leave canSubmit stuck on true.
+		setProps({ isOpen: true, values });
+
+		await waitFor(() => expect(input()).toHaveValue(''));
+		await waitFor(() => expect(canSubmit()).toHaveTextContent('false'));
+		// The reset also clears touched state, so the message stays hidden.
+		expect(screen.queryByText('Required')).not.toBeInTheDocument();
+	});
+
+	it('marks a valid seed as submittable without the user touching a field', async () => {
+		const user = userEvent.setup();
+		const values: Values = { name: 'Alpha' };
+		const { canSubmit, setProps, input } = renderSeeded(false, values);
+
+		await user.clear(input());
+		await waitFor(() => expect(canSubmit()).toHaveTextContent('false'));
+
+		setProps({ isOpen: true, values });
+
+		await waitFor(() => expect(canSubmit()).toHaveTextContent('true'));
+		expect(input()).toHaveValue('Alpha');
+	});
+});

--- a/packages/web/src/components/form/useSeedOnOpen.ts
+++ b/packages/web/src/components/form/useSeedOnOpen.ts
@@ -4,6 +4,12 @@ import type { AnyFormApi } from '@tanstack/react-form';
 /**
  * Reset (and re-seed) a form each time its dialog opens. Dialogs stay mounted for
  * their exit animation, so without this a cancelled edit leaks into the next open.
+ *
+ * `values` must be what the form was given as `defaultValues` for that render.
+ * `useForm` re-runs `formApi.update(opts)` in a layout effect on every render,
+ * and that writes `opts.defaultValues` back over an *untouched* form — so a seed
+ * drawn from anywhere else is silently reverted on the next commit. Re-seeding a
+ * touched form, the reopen case this hook exists for, is unaffected.
  */
 export function useSeedOnOpen(form: AnyFormApi, isOpen: boolean, values: Record<string, unknown>) {
 	useEffect(() => {

--- a/packages/web/src/components/ui/CopyField.test.tsx
+++ b/packages/web/src/components/ui/CopyField.test.tsx
@@ -17,6 +17,9 @@ function setupWithClipboard(writeText: () => Promise<void>) {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	// restoreAllMocks does not revert a property descriptor, so the stub would
+	// stay installed over the real Clipboard API for the rest of the run.
+	Reflect.deleteProperty(navigator, 'clipboard');
 });
 
 describe('CopyField', () => {

--- a/packages/web/src/components/ui/CopyField.test.tsx
+++ b/packages/web/src/components/ui/CopyField.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CopyField } from './CopyField';
+
+/**
+ * `userEvent.setup()` installs its own `navigator.clipboard`, so the component's
+ * clipboard must be stubbed after it — otherwise the copy silently succeeds
+ * against user-event's stub and the refusal case can't be exercised.
+ */
+function setupWithClipboard(writeText: () => Promise<void>) {
+	const user = userEvent.setup();
+	const spy = vi.fn(writeText);
+	Object.defineProperty(navigator, 'clipboard', { value: { writeText: spy }, configurable: true });
+	return { user, writeText: spy };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('CopyField', () => {
+	it('captions the value and names the input for assistive tech', () => {
+		render(<CopyField label="Sync URL" value="https://hub.example/sync" />);
+		expect(screen.getByText('Sync URL')).toBeInTheDocument();
+		expect(screen.getByLabelText('Sync URL')).toHaveValue('https://hub.example/sync');
+	});
+
+	it('drops the caption but keeps the accessible name when hideLabel is set', () => {
+		render(<CopyField label="API token" value="mhub_pat_abc" hideLabel />);
+		expect(screen.queryByText('API token')).not.toBeInTheDocument();
+		expect(screen.getByLabelText('API token')).toHaveValue('mhub_pat_abc');
+	});
+
+	it('derives the button label from the field label, unless overridden', () => {
+		const { unmount } = render(<CopyField label="Sync token" value="t" />);
+		expect(screen.getByRole('button', { name: 'Copy sync token' })).toBeInTheDocument();
+		unmount();
+
+		render(<CopyField label="API token" value="t" hideLabel copyLabel="Copy token" />);
+		expect(screen.getByRole('button', { name: 'Copy token' })).toBeInTheDocument();
+	});
+
+	it('copies the value and acknowledges it on the button', async () => {
+		const { user, writeText } = setupWithClipboard(() => Promise.resolve());
+		render(<CopyField label="Sync URL" value="https://hub.example/sync" />);
+
+		await user.click(screen.getByRole('button', { name: 'Copy sync url' }));
+
+		expect(writeText).toHaveBeenCalledWith('https://hub.example/sync');
+		await waitFor(() => expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument());
+	});
+
+	it('leaves the button unacknowledged when the clipboard write is refused', async () => {
+		const { user } = setupWithClipboard(() => Promise.reject(new Error('denied')));
+		render(<CopyField label="Sync URL" value="https://hub.example/sync" />);
+
+		await user.click(screen.getByRole('button', { name: 'Copy sync url' }));
+
+		await waitFor(() =>
+			expect(screen.getByRole('button', { name: 'Copy sync url' })).toBeInTheDocument(),
+		);
+		expect(screen.queryByRole('button', { name: 'Copied' })).not.toBeInTheDocument();
+	});
+
+	it('is read-only — the value cannot be edited in place', async () => {
+		const user = userEvent.setup();
+		render(<CopyField label="Sync URL" value="https://hub.example/sync" />);
+		const input = screen.getByLabelText('Sync URL');
+
+		await user.type(input, 'tampered');
+
+		expect(input).toHaveValue('https://hub.example/sync');
+	});
+});

--- a/packages/web/src/components/ui/CopyField.tsx
+++ b/packages/web/src/components/ui/CopyField.tsx
@@ -1,0 +1,48 @@
+import { Check, Copy } from 'lucide-react';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { IconButton } from './IconButton';
+
+export interface CopyFieldProps {
+	/** Names the input for assistive tech, and captions it unless `hideLabel`. */
+	label: string;
+	value: string;
+	/** The copy button's label; defaults to `Copy <label>`. */
+	copyLabel?: string;
+	hideLabel?: boolean;
+}
+
+/**
+ * A read-only value with a copy button — sync URLs, sync tokens, API tokens.
+ * Selecting on focus keeps a manual copy to one keystroke, for when the
+ * clipboard API is unavailable (insecure context, denied permission).
+ */
+export function CopyField({ label, value, copyLabel, hideLabel }: CopyFieldProps) {
+	const { copied, copy } = useCopyToClipboard();
+
+	const row = (
+		<div className="flex items-center gap-2">
+			<input
+				readOnly
+				aria-label={label}
+				value={value}
+				onFocus={(e) => e.target.select()}
+				className="h-9 w-full rounded-md border border-input bg-muted/40 px-3 font-mono text-xs text-foreground outline-none"
+			/>
+			<IconButton
+				label={copied ? 'Copied' : (copyLabel ?? `Copy ${label.toLowerCase()}`)}
+				onPress={() => void copy(value)}
+			>
+				{copied ? <Check className="size-4 text-primary" /> : <Copy className="size-4" />}
+			</IconButton>
+		</div>
+	);
+
+	if (hideLabel) return row;
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<span className="text-xs font-medium text-muted-foreground">{label}</span>
+			{row}
+		</div>
+	);
+}

--- a/packages/web/src/components/ui/SessionStatusDot.tsx
+++ b/packages/web/src/components/ui/SessionStatusDot.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
 import type { Session } from '@/types';
 import { useUsersQuery } from '@/api/hooks';
-import { useInterval } from '@/hooks/useInterval';
+import { useNow } from '@/hooks/useNow';
 import { formatDuration, formatRelative } from '@/lib/time';
 import { StatusDot } from './StatusDot';
 import { Popover } from './Popover';
@@ -25,13 +24,6 @@ const STATUS_DOT: Partial<
 	terminating: { className: 'bg-orange-500', label: 'Stopping', pulse: true },
 	failed: { className: 'bg-red-500', label: 'Failed' },
 };
-
-/** Tick `now` once a second so an open popover's elapsed duration stays live. */
-function useNow(): number {
-	const [now, setNow] = useState(() => Date.now());
-	useInterval(() => setNow(Date.now()), 1000);
-	return now;
-}
 
 /**
  * Popover body for a live session: who started it, when, and (while running) how

--- a/packages/web/src/components/ui/UserLabel.tsx
+++ b/packages/web/src/components/ui/UserLabel.tsx
@@ -12,8 +12,11 @@ export interface UserLabelProps {
 	className?: string;
 }
 
-/** Display name for a user, with the email as a hover title for disambiguation. */
-function displayName(user: ResolvedUser | undefined, fallbackId: string): string {
+/**
+ * How a user is named in prose. Exported so confirmation copy ("Remove <name>?")
+ * names them the same way as the row it was opened from.
+ */
+export function displayName(user: ResolvedUser | undefined, fallbackId: string): string {
 	return user?.name || user?.email || fallbackId;
 }
 

--- a/packages/web/src/components/ui/WriteOnceWarning.tsx
+++ b/packages/web/src/components/ui/WriteOnceWarning.tsx
@@ -1,0 +1,11 @@
+import { AlertTriangle } from 'lucide-react';
+
+/** The server keeps only a hash — this is the one render carrying the plaintext. */
+export function WriteOnceWarning() {
+	return (
+		<div className="flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+			<AlertTriangle className="mt-px size-4 shrink-0" />
+			<span>Copy this token now — it is shown once and cannot be retrieved later.</span>
+		</div>
+	);
+}

--- a/packages/web/src/components/ui/index.ts
+++ b/packages/web/src/components/ui/index.ts
@@ -53,7 +53,12 @@ export type { TooltipProps } from './Tooltip';
 
 export { SessionStatusDot } from './SessionStatusDot';
 
-export { UserLabel } from './UserLabel';
+export { UserLabel, displayName } from './UserLabel';
 export type { UserLabelProps } from './UserLabel';
+
+export { CopyField } from './CopyField';
+export type { CopyFieldProps } from './CopyField';
+
+export { WriteOnceWarning } from './WriteOnceWarning';
 
 export { ErrorBoundary } from './ErrorBoundary';

--- a/packages/web/src/context/AuthContext.test.tsx
+++ b/packages/web/src/context/AuthContext.test.tsx
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient } from '@tanstack/react-query';
+import { userKeys } from '@/api/queryKeys';
+import type { User } from '@/types';
+import { jsonError, jsonOk, renderWithClient } from '@/test/render';
+import { AuthProvider, useAuth } from './AuthContext';
+
+const ME: User = { id: 'usr-1', email: 'ada@example.com' };
+
+type AuthValue = ReturnType<typeof useAuth>;
+
+/** Every context value this probe has rendered with, oldest first. */
+const seen: AuthValue[] = [];
+
+function Probe({ label = 'a' }: { label?: string }) {
+	const auth = useAuth();
+	seen.push(auth);
+	return (
+		<div>
+			<span data-testid="label">{label}</span>
+			<span data-testid="user">{auth.user?.email ?? 'anonymous'}</span>
+			<span data-testid="pending">{String(auth.isPending)}</span>
+			<span data-testid="error">{auth.error?.message ?? 'no-error'}</span>
+			<button type="button" onClick={auth.signIn}>
+				Sign in
+			</button>
+			<button type="button" onClick={auth.signOut}>
+				Sign out
+			</button>
+			<button type="button" onClick={auth.refetchUser}>
+				Refetch
+			</button>
+		</div>
+	);
+}
+
+function stubLocation(): void {
+	vi.stubGlobal('location', { ...window.location, href: '' });
+}
+
+beforeEach(() => {
+	seen.length = 0;
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('useAuth', () => {
+	it('throws when rendered outside an AuthProvider', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(() => renderWithClient(<Probe />, { toaster: false })).toThrow(
+			'useAuth must be used within an AuthProvider',
+		);
+	});
+});
+
+describe('AuthProvider', () => {
+	it('reports no user while /api/v1/me is in flight, then the resolved user', async () => {
+		let resolveMe: (response: Response) => void = () => {};
+		const inFlight = new Promise<Response>((resolve) => {
+			resolveMe = resolve;
+		});
+		const fetchMock = vi.fn((..._args: Parameters<typeof fetch>) => inFlight);
+		vi.stubGlobal('fetch', fetchMock);
+
+		renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		expect(screen.getByTestId('pending')).toHaveTextContent('true');
+		expect(screen.getByTestId('user')).toHaveTextContent('anonymous');
+		expect(String(fetchMock.mock.calls[0][0])).toBe('/api/v1/me');
+
+		await act(async () => {
+			resolveMe(jsonOk(ME));
+		});
+
+		await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('ada@example.com'));
+		expect(screen.getByTestId('pending')).toHaveTextContent('false');
+		expect(screen.getByTestId('error')).toHaveTextContent('no-error');
+	});
+
+	it('exposes the error without a user and does not retry the failed request', async () => {
+		// A client that WOULD retry, so the single call proves the query's own
+		// `retry: false` (not the test client's default) is what stops it.
+		const client = new QueryClient({
+			defaultOptions: { queries: { retry: 3, retryDelay: 0 } },
+		});
+		const fetchMock = vi.fn(async () => jsonError('UNAUTHORIZED', 'not signed in', 401));
+		vi.stubGlobal('fetch', fetchMock);
+
+		renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ client, toaster: false },
+		);
+
+		await waitFor(() => expect(screen.getByTestId('error')).toHaveTextContent('not signed in'));
+		expect(screen.getByTestId('user')).toHaveTextContent('anonymous');
+		expect(screen.getByTestId('pending')).toHaveTextContent('false');
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('signIn navigates to the server OIDC entry point', async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonOk(ME)),
+		);
+		stubLocation();
+
+		renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Sign in' }));
+		expect(window.location.href).toBe('/api/auth/login');
+	});
+
+	it('signOut navigates to the IdP logout url when the user has one', async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonOk({ ...ME, logout_url: 'https://idp.example/logout' })),
+		);
+		stubLocation();
+
+		renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('ada@example.com'));
+		await user.click(screen.getByRole('button', { name: 'Sign out' }));
+		expect(window.location.href).toBe('https://idp.example/logout');
+	});
+
+	it('signOut clears the cached user when there is no logout url', async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonOk(ME)),
+		);
+		stubLocation();
+
+		const { client } = renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('ada@example.com'));
+		await user.click(screen.getByRole('button', { name: 'Sign out' }));
+
+		expect(window.location.href).toBe('');
+		expect(client.getQueryData(userKeys.me())).toBeNull();
+		await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('anonymous'));
+	});
+
+	it('refetchUser invalidates the me query and refetches it', async () => {
+		const user = userEvent.setup();
+		const fetchMock = vi
+			.fn<() => Promise<Response>>()
+			.mockImplementationOnce(async () => jsonOk(ME))
+			.mockImplementation(async () => jsonOk({ ...ME, email: 'grace@example.com' }));
+		vi.stubGlobal('fetch', fetchMock);
+
+		renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('ada@example.com'));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await user.click(screen.getByRole('button', { name: 'Refetch' }));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+		await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('grace@example.com'));
+	});
+
+	it('keeps the context value referentially stable across an unrelated re-render', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonOk(ME)),
+		);
+
+		const { rerender } = renderWithClient(
+			<AuthProvider>
+				<Probe label="a" />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		await waitFor(() => expect(screen.getByTestId('user')).toHaveTextContent('ada@example.com'));
+		const before = seen.at(-1);
+		const rendersBefore = seen.length;
+
+		rerender(
+			<AuthProvider>
+				<Probe label="b" />
+			</AuthProvider>,
+		);
+
+		expect(screen.getByTestId('label')).toHaveTextContent('b');
+		expect(seen.length).toBeGreaterThan(rendersBefore);
+		expect(seen.at(-1)).toBe(before);
+	});
+});

--- a/packages/web/src/context/ThemeContext.test.tsx
+++ b/packages/web/src/context/ThemeContext.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { installMatchMedia, renderWithClient } from '@/test/render';
+import { ThemeProvider, useTheme } from './ThemeContext';
+import type { Theme } from './ThemeContext';
+
+const STORAGE_KEY = 'marimohub-theme';
+
+function Probe() {
+	const { theme, toggleTheme, setTheme } = useTheme();
+	return (
+		<div>
+			<span data-testid="theme">{theme}</span>
+			<button type="button" onClick={toggleTheme}>
+				Toggle
+			</button>
+			<button type="button" onClick={() => setTheme('dark')}>
+				Go dark
+			</button>
+			<button type="button" onClick={() => setTheme('light')}>
+				Go light
+			</button>
+		</div>
+	);
+}
+
+function renderTheme() {
+	return renderWithClient(
+		<ThemeProvider>
+			<Probe />
+		</ThemeProvider>,
+		{ toaster: false },
+	);
+}
+
+const isDarkClassOn = () => document.documentElement.classList.contains('dark');
+
+beforeEach(() => {
+	localStorage.clear();
+	installMatchMedia(false);
+});
+
+afterEach(() => {
+	localStorage.clear();
+	document.documentElement.classList.remove('dark');
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('useTheme', () => {
+	it('throws when rendered outside a ThemeProvider', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		expect(() => renderWithClient(<Probe />, { toaster: false })).toThrow(
+			'useTheme must be used within a ThemeProvider',
+		);
+	});
+});
+
+describe('ThemeProvider', () => {
+	it.each<Theme>(['light', 'dark'])('starts from the stored %s theme', (stored) => {
+		localStorage.setItem(STORAGE_KEY, stored);
+		// The stored value wins over a conflicting system preference.
+		installMatchMedia(stored === 'light');
+
+		renderTheme();
+
+		expect(screen.getByTestId('theme')).toHaveTextContent(stored);
+		expect(isDarkClassOn()).toBe(stored === 'dark');
+	});
+
+	it('falls back to the system preference when storage is empty', () => {
+		installMatchMedia(true);
+
+		renderTheme();
+
+		expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+	});
+
+	it('falls back to light when storage is empty and the system prefers light', () => {
+		installMatchMedia(false);
+
+		renderTheme();
+
+		expect(screen.getByTestId('theme')).toHaveTextContent('light');
+	});
+
+	it('ignores a garbage stored value and uses the system preference', () => {
+		localStorage.setItem(STORAGE_KEY, 'chartreuse');
+		installMatchMedia(true);
+
+		renderTheme();
+
+		expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+	});
+
+	it('adds the dark class for dark and removes it for light', async () => {
+		const user = userEvent.setup();
+		localStorage.setItem(STORAGE_KEY, 'dark');
+
+		renderTheme();
+		expect(isDarkClassOn()).toBe(true);
+
+		await user.click(screen.getByRole('button', { name: 'Go light' }));
+		expect(isDarkClassOn()).toBe(false);
+	});
+
+	it('persists the theme to localStorage on mount and on every change', async () => {
+		const user = userEvent.setup();
+
+		renderTheme();
+		expect(localStorage.getItem(STORAGE_KEY)).toBe('light');
+
+		await user.click(screen.getByRole('button', { name: 'Go dark' }));
+		expect(localStorage.getItem(STORAGE_KEY)).toBe('dark');
+	});
+
+	it('toggleTheme flips between light and dark', async () => {
+		const user = userEvent.setup();
+
+		renderTheme();
+		expect(screen.getByTestId('theme')).toHaveTextContent('light');
+
+		await user.click(screen.getByRole('button', { name: 'Toggle' }));
+		expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+
+		await user.click(screen.getByRole('button', { name: 'Toggle' }));
+		expect(screen.getByTestId('theme')).toHaveTextContent('light');
+	});
+
+	it('setTheme sets the theme directly', async () => {
+		const user = userEvent.setup();
+
+		renderTheme();
+
+		await user.click(screen.getByRole('button', { name: 'Go dark' }));
+		expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+		expect(isDarkClassOn()).toBe(true);
+
+		await user.click(screen.getByRole('button', { name: 'Go dark' }));
+		expect(screen.getByTestId('theme')).toHaveTextContent('dark');
+	});
+});

--- a/packages/web/src/hooks/useCopyToClipboard.test.ts
+++ b/packages/web/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { toast } from 'sonner';
+import { useCopyToClipboard } from './useCopyToClipboard';
+
+vi.mock('sonner', () => ({
+	toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const writeText = vi.fn<(value: string) => Promise<void>>();
+
+function installClipboard() {
+	Object.defineProperty(navigator, 'clipboard', {
+		value: { writeText },
+		configurable: true,
+		writable: true,
+	});
+}
+
+describe('useCopyToClipboard', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		writeText.mockReset().mockResolvedValue(undefined);
+		vi.mocked(toast.error).mockClear();
+		installClipboard();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		Reflect.deleteProperty(navigator, 'clipboard');
+	});
+
+	async function copy(copyFn: (value: string) => Promise<boolean>, value: string) {
+		let landed: boolean | undefined;
+		await act(async () => {
+			landed = await copyFn(value);
+		});
+		return landed;
+	}
+
+	it('writes the value to the clipboard and resolves true', async () => {
+		const { result } = renderHook(() => useCopyToClipboard());
+		expect(result.current.copied).toBe(false);
+
+		const landed = await copy(result.current.copy, 'mhub_pat_abc');
+
+		expect(landed).toBe(true);
+		expect(writeText).toHaveBeenCalledWith('mhub_pat_abc');
+		expect(result.current.copied).toBe(true);
+	});
+
+	it('resets copied after the delay', async () => {
+		const { result } = renderHook(() => useCopyToClipboard(1500));
+		await copy(result.current.copy, 'value');
+
+		act(() => {
+			vi.advanceTimersByTime(1499);
+		});
+		expect(result.current.copied).toBe(true);
+
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+		expect(result.current.copied).toBe(false);
+	});
+
+	it('honors a custom reset delay', async () => {
+		const { result } = renderHook(() => useCopyToClipboard(100));
+		await copy(result.current.copy, 'value');
+
+		act(() => {
+			vi.advanceTimersByTime(100);
+		});
+		expect(result.current.copied).toBe(false);
+	});
+
+	it('restarts the window when copying again before the timer expires', async () => {
+		const { result } = renderHook(() => useCopyToClipboard(1500));
+		await copy(result.current.copy, 'first');
+
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+		await copy(result.current.copy, 'second');
+
+		// Past the first copy's deadline, but the second copy restarted the clock.
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(result.current.copied).toBe(true);
+
+		act(() => {
+			vi.advanceTimersByTime(500);
+		});
+		expect(result.current.copied).toBe(false);
+	});
+
+	it('resolves false, stays uncopied, and toasts when the write is rejected', async () => {
+		writeText.mockRejectedValue(new Error('not allowed'));
+		const { result } = renderHook(() => useCopyToClipboard());
+
+		const landed = await copy(result.current.copy, 'value');
+
+		expect(landed).toBe(false);
+		expect(result.current.copied).toBe(false);
+		expect(toast.error).toHaveBeenCalledWith('Could not copy to clipboard');
+	});
+
+	it('clears the acknowledgement when a copy fails inside a previous copy’s window', async () => {
+		const { result } = renderHook(() => useCopyToClipboard(1500));
+		await copy(result.current.copy, 'first');
+		expect(result.current.copied).toBe(true);
+
+		writeText.mockRejectedValue(new Error('not allowed'));
+		await copy(result.current.copy, 'second');
+
+		// The ✓ must not linger from the successful copy over a failed one.
+		expect(result.current.copied).toBe(false);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('does not fire the reset timer after unmount', async () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const { result, unmount } = renderHook(() => useCopyToClipboard(1500));
+		await copy(result.current.copy, 'value');
+
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
+
+		act(() => {
+			vi.advanceTimersByTime(5000);
+		});
+		expect(consoleError).not.toHaveBeenCalled();
+		consoleError.mockRestore();
+	});
+});

--- a/packages/web/src/hooks/useCopyToClipboard.ts
+++ b/packages/web/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+export interface Clipboard {
+	/** True for `resetAfterMs` following a successful copy — drives the ✓ swap. */
+	copied: boolean;
+	/** Resolves to whether the write landed, for callers wanting their own toast. */
+	copy: (value: string) => Promise<boolean>;
+}
+
+/**
+ * The reset timer is cleared on unmount, so copying from a dialog and closing it
+ * within the window does not set state on a gone component. A rejected
+ * `writeText` (no permission, insecure context) toasts rather than going
+ * unhandled.
+ */
+export function useCopyToClipboard(resetAfterMs = 1500): Clipboard {
+	const [copied, setCopied] = useState(false);
+	const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+	useEffect(() => () => clearTimeout(timer.current), []);
+
+	const copy = useCallback(
+		async (value: string) => {
+			try {
+				await navigator.clipboard.writeText(value);
+				setCopied(true);
+				clearTimeout(timer.current);
+				timer.current = setTimeout(() => setCopied(false), resetAfterMs);
+				return true;
+			} catch {
+				// Clear the flag rather than leaving it: a failed copy that follows a
+				// successful one inside the reset window would otherwise keep showing ✓.
+				clearTimeout(timer.current);
+				setCopied(false);
+				toast.error('Could not copy to clipboard');
+				return false;
+			}
+		},
+		[resetAfterMs],
+	);
+
+	return { copied, copy };
+}

--- a/packages/web/src/hooks/useDialogTarget.test.ts
+++ b/packages/web/src/hooks/useDialogTarget.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useDialogTarget } from './useDialogTarget';
+
+interface Row {
+	id: string;
+}
+
+describe('useDialogTarget', () => {
+	it('starts closed with no target', () => {
+		const { result } = renderHook(() => useDialogTarget<Row>());
+		expect(result.current.target).toBeNull();
+		expect(result.current.isOpen).toBe(false);
+	});
+
+	it('honors an initial target', () => {
+		const row = { id: 'nb-1' };
+		const { result } = renderHook(() => useDialogTarget<Row>(row));
+		expect(result.current.target).toBe(row);
+		expect(result.current.isOpen).toBe(true);
+	});
+
+	it('open sets the target and close clears both', () => {
+		const row = { id: 'nb-1' };
+		const { result } = renderHook(() => useDialogTarget<Row>());
+
+		act(() => result.current.open(row));
+		expect(result.current.target).toBe(row);
+		expect(result.current.isOpen).toBe(true);
+
+		act(() => result.current.close());
+		expect(result.current.target).toBeNull();
+		expect(result.current.isOpen).toBe(false);
+	});
+
+	it('replaces the target when opened again', () => {
+		const first = { id: 'nb-1' };
+		const second = { id: 'nb-2' };
+		const { result } = renderHook(() => useDialogTarget<Row>());
+
+		act(() => result.current.open(first));
+		act(() => result.current.open(second));
+		expect(result.current.target).toBe(second);
+		expect(result.current.isOpen).toBe(true);
+	});
+
+	it('is open for falsy-but-valid targets', () => {
+		const numeric = renderHook(() => useDialogTarget<number>());
+		act(() => numeric.result.current.open(0));
+		expect(numeric.result.current.target).toBe(0);
+		expect(numeric.result.current.isOpen).toBe(true);
+
+		const text = renderHook(() => useDialogTarget<string>());
+		act(() => text.result.current.open(''));
+		expect(text.result.current.target).toBe('');
+		expect(text.result.current.isOpen).toBe(true);
+	});
+
+	it('keeps stable callback identities across renders', () => {
+		const { result, rerender } = renderHook(() => useDialogTarget<Row>());
+		const first = result.current;
+
+		act(() => result.current.open({ id: 'nb-1' }));
+		rerender();
+
+		expect(result.current.open).toBe(first.open);
+		expect(result.current.close).toBe(first.close);
+	});
+});

--- a/packages/web/src/hooks/useDialogTarget.ts
+++ b/packages/web/src/hooks/useDialogTarget.ts
@@ -1,0 +1,21 @@
+import { useCallback, useMemo, useState } from 'react';
+
+export interface DialogTarget<T> {
+	/** The row/record the dialog is acting on, or `null` while closed. */
+	target: T | null;
+	isOpen: boolean;
+	open: (target: T) => void;
+	close: () => void;
+}
+
+/**
+ * {@link useDisclosure} for a dialog that acts on a *subject* — the notebook
+ * being deleted, the member being removed. Openness is derived from the target
+ * rather than tracked alongside it, so the two can never disagree.
+ */
+export function useDialogTarget<T>(initialTarget: T | null = null): DialogTarget<T> {
+	const [target, setTarget] = useState<T | null>(initialTarget);
+	const open = useCallback((next: T) => setTarget(next), []);
+	const close = useCallback(() => setTarget(null), []);
+	return useMemo(() => ({ target, isOpen: target !== null, open, close }), [target, open, close]);
+}

--- a/packages/web/src/hooks/useGeneration.test.ts
+++ b/packages/web/src/hooks/useGeneration.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useGeneration } from './useGeneration';
+
+describe('useGeneration', () => {
+	it('starts at generation 0', () => {
+		const { result } = renderHook(() => useGeneration());
+		expect(result.current.current()).toBe(0);
+		expect(result.current.isCurrent(0)).toBe(true);
+	});
+
+	it('bump increments and returns the new generation', () => {
+		const { result } = renderHook(() => useGeneration());
+		expect(result.current.bump()).toBe(1);
+		expect(result.current.bump()).toBe(2);
+		expect(result.current.current()).toBe(2);
+	});
+
+	it('isCurrent is true only for the latest generation', () => {
+		const { result } = renderHook(() => useGeneration());
+		result.current.bump();
+		result.current.bump();
+
+		expect(result.current.isCurrent(2)).toBe(true);
+		expect(result.current.isCurrent(1)).toBe(false);
+		expect(result.current.isCurrent(0)).toBe(false);
+		expect(result.current.isCurrent(3)).toBe(false);
+	});
+
+	it('marks work captured before a bump as stale', () => {
+		const { result } = renderHook(() => useGeneration());
+
+		// A poll in flight when the user restarts must not write its late response.
+		const inFlight = result.current.current();
+		expect(result.current.isCurrent(inFlight)).toBe(true);
+
+		const restarted = result.current.bump();
+
+		expect(result.current.isCurrent(inFlight)).toBe(false);
+		expect(result.current.isCurrent(restarted)).toBe(true);
+	});
+
+	it('keeps a stable handle across renders', () => {
+		const { result, rerender } = renderHook(() => useGeneration());
+		const first = result.current;
+
+		result.current.bump();
+		rerender();
+
+		expect(result.current).toBe(first);
+		expect(result.current.current()).toBe(1);
+	});
+});

--- a/packages/web/src/hooks/useGeneration.ts
+++ b/packages/web/src/hooks/useGeneration.ts
@@ -1,0 +1,31 @@
+import { useCallback, useMemo, useRef } from 'react';
+
+export interface Generation {
+	/** Invalidate everything in flight and return the new current generation. */
+	bump: () => number;
+	/** The generation to capture before starting async work. */
+	current: () => number;
+	/** False once a newer generation has started — drop the result. */
+	isCurrent: (generation: number) => boolean;
+}
+
+/**
+ * A monotonic counter for cancelling stale async work. `apiFetch` has no abort
+ * hook and clearing a timer does not recall a request already in flight, so a
+ * poll issued before a restart still lands after it. Capture `current()` before
+ * the request and check `isCurrent()` before writing state; `bump()` on every
+ * user-initiated transition orphans whatever was outstanding.
+ *
+ * A counter rather than comparing ids, so it also holds for work started while
+ * the tracked id was still the old one.
+ */
+export function useGeneration(): Generation {
+	const ref = useRef(0);
+	const bump = useCallback(() => {
+		ref.current += 1;
+		return ref.current;
+	}, []);
+	const current = useCallback(() => ref.current, []);
+	const isCurrent = useCallback((generation: number) => ref.current === generation, []);
+	return useMemo(() => ({ bump, current, isCurrent }), [bump, current, isCurrent]);
+}

--- a/packages/web/src/hooks/useMediaQuery.test.ts
+++ b/packages/web/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { installMatchMedia } from '@/test/render';
+import { useIsMobile, useMediaQuery } from './useMediaQuery';
+
+interface MediaStub {
+	/** Flip a query and notify its subscribers, as the browser would. */
+	fire: (query: string, matches: boolean) => void;
+	listenerCount: (query: string) => number;
+	queries: () => string[];
+}
+
+/**
+ * `installMatchMedia` from the test helpers has no-op listeners, so it can't
+ * model a query that changes after mount. This one keeps a listener set per
+ * query — shared across the `MediaQueryList` objects the hook creates on each
+ * effect run — so `fire` reaches whatever is currently subscribed.
+ */
+function installLiveMatchMedia(matchesFor: (query: string) => boolean): MediaStub {
+	const lists = new Map<string, { matches: boolean; listeners: Set<() => void> }>();
+	const listFor = (query: string) => {
+		let entry = lists.get(query);
+		if (!entry) {
+			entry = { matches: matchesFor(query), listeners: new Set() };
+			lists.set(query, entry);
+		}
+		return entry;
+	};
+
+	vi.stubGlobal('matchMedia', (query: string) => {
+		const entry = listFor(query);
+		return {
+			get matches() {
+				return entry.matches;
+			},
+			media: query,
+			onchange: null,
+			addEventListener: (_type: string, listener: () => void) => entry.listeners.add(listener),
+			removeEventListener: (_type: string, listener: () => void) =>
+				entry.listeners.delete(listener),
+			addListener: () => {},
+			removeListener: () => {},
+			dispatchEvent: () => false,
+		};
+	});
+
+	return {
+		fire(query, matches) {
+			const entry = listFor(query);
+			entry.matches = matches;
+			act(() => {
+				for (const listener of entry.listeners) listener();
+			});
+		},
+		listenerCount: (query) => listFor(query).listeners.size,
+		queries: () => [...lists.keys()],
+	};
+}
+
+describe('useMediaQuery', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('reports the initial match state', () => {
+		installMatchMedia(true);
+		const matching = renderHook(() => useMediaQuery('(min-width: 900px)'));
+		expect(matching.result.current).toBe(true);
+
+		installMatchMedia(false);
+		const notMatching = renderHook(() => useMediaQuery('(min-width: 900px)'));
+		expect(notMatching.result.current).toBe(false);
+	});
+
+	it('re-renders when the media list fires a change', () => {
+		const media = installLiveMatchMedia(() => false);
+		const { result } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+		expect(result.current).toBe(false);
+
+		media.fire('(max-width: 767px)', true);
+		expect(result.current).toBe(true);
+
+		media.fire('(max-width: 767px)', false);
+		expect(result.current).toBe(false);
+	});
+
+	it('removes its listener on unmount', () => {
+		const media = installLiveMatchMedia(() => false);
+		const { unmount } = renderHook(() => useMediaQuery('(max-width: 767px)'));
+		expect(media.listenerCount('(max-width: 767px)')).toBe(1);
+
+		unmount();
+		expect(media.listenerCount('(max-width: 767px)')).toBe(0);
+
+		media.fire('(max-width: 767px)', true); // no subscriber left to update
+	});
+
+	it('re-subscribes when the query changes', () => {
+		const media = installLiveMatchMedia((query) => query === '(min-width: 900px)');
+		const { result, rerender } = renderHook(({ query }) => useMediaQuery(query), {
+			initialProps: { query: '(max-width: 767px)' },
+		});
+		expect(result.current).toBe(false);
+
+		rerender({ query: '(min-width: 900px)' });
+		expect(result.current).toBe(true);
+		expect(media.listenerCount('(max-width: 767px)')).toBe(0);
+		expect(media.listenerCount('(min-width: 900px)')).toBe(1);
+
+		// Changes on the abandoned query no longer matter.
+		media.fire('(max-width: 767px)', true);
+		expect(result.current).toBe(true);
+
+		media.fire('(min-width: 900px)', false);
+		expect(result.current).toBe(false);
+	});
+});
+
+describe('useIsMobile', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('queries the 767px breakpoint exactly', () => {
+		const media = installLiveMatchMedia(() => false);
+		renderHook(() => useIsMobile());
+		expect(media.queries()).toEqual(['(max-width: 767px)']);
+	});
+
+	it('tracks the phone-width breakpoint', () => {
+		const media = installLiveMatchMedia((query) => query === '(max-width: 767px)');
+		const { result } = renderHook(() => useIsMobile());
+		expect(result.current).toBe(true);
+
+		media.fire('(max-width: 767px)', false);
+		expect(result.current).toBe(false);
+	});
+});

--- a/packages/web/src/hooks/useNotebookSession.ts
+++ b/packages/web/src/hooks/useNotebookSession.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch, ApiRequestError } from '@/api/client';
 import { notebookSessionsPath, useStartSession, useStopSession } from '@/api/hooks';
+import { fetchItems, isNotFoundError, projectPath } from '@/api/request';
+import { useGeneration } from '@/hooks/useGeneration';
 import { useInterval } from '@/hooks/useInterval';
 import type { Session } from '@/types';
 
@@ -23,6 +25,10 @@ export interface SessionError {
 	message: string;
 	/** The API error code (e.g. `FORBIDDEN`), when the failure was an API error. */
 	code?: string;
+}
+
+function toSessionError(err: Error): SessionError {
+	return { message: err.message, code: err instanceof ApiRequestError ? err.code : undefined };
 }
 
 /** Why a watched session stopped being renderable — see `ended` below. */
@@ -88,16 +94,16 @@ export function useNotebookSession(
 	const [restarting, setRestarting] = useState(false);
 	const sessionRef = useRef<Session | null>(null);
 	const startedRef = useRef(false);
-	// Bumped by every start/stop/restart. Async work started under an older
-	// generation must not write state: `useInterval` clears only the timer and an
-	// in-flight `apiFetch` has no abort hook, so a poll issued before a restart
-	// still lands afterwards — re-arming the dying session, or failing the fresh
-	// one. A counter rather than a session-id comparison so it also holds for
-	// handlers entered while `sessionRef` still points at the old session.
-	const genRef = useRef(0);
-	const nextGeneration = useCallback(() => {
-		genRef.current += 1;
-		return genRef.current;
+	// Bumped by every start/stop/restart: a poll issued before one still lands
+	// afterwards, re-arming the dying session or failing the fresh one.
+	const generation = useGeneration();
+
+	// The state and the ref must move together: the ref is what handlers entered
+	// under an older render read, so a `setSession` without it re-arms a session
+	// the user has already left behind.
+	const commitSession = useCallback((next: Session | null) => {
+		sessionRef.current = next;
+		setSession(next);
 	}, []);
 
 	// The server withholds `sandbox_url` from a caller who may no longer reach the
@@ -105,54 +111,47 @@ export function useNotebookSession(
 	// shape satisfies neither `isRunning` nor `isProvisioning` — keeping it would
 	// leave the page rendering nothing at all.
 	const concludeAccessLost = useCallback(() => {
-		setSession(null);
-		sessionRef.current = null;
+		commitSession(null);
 		if (mode === 'app') setEnded('access_lost');
 		else setError({ message: 'You no longer have access to this session.', code: 'FORBIDDEN' });
-	}, [mode]);
+	}, [mode, commitSession]);
 
 	const start = useCallback(() => {
-		const gen = nextGeneration();
+		const gen = generation.bump();
 		setError(null);
 		setEnded(null);
 		startSession.mutate(undefined, {
 			onSuccess: (data) => {
-				if (genRef.current !== gen) return;
+				if (!generation.isCurrent(gen)) return;
 				if (data.status === 'running' && !data.sandbox_url) {
 					concludeAccessLost();
 					return;
 				}
-				setSession(data);
-				sessionRef.current = data;
+				commitSession(data);
 			},
 			onError: (err) => {
-				if (genRef.current !== gen) return;
-				setError({
-					message: err.message,
-					code: err instanceof ApiRequestError ? err.code : undefined,
-				});
+				if (!generation.isCurrent(gen)) return;
+				setError(toSessionError(err));
 			},
 		});
-	}, [startSession, concludeAccessLost, nextGeneration]);
+	}, [startSession, concludeAccessLost, commitSession, generation]);
 
 	const stop = useCallback(() => {
 		const s = sessionRef.current;
 		if (s) {
-			nextGeneration();
+			generation.bump();
 			stopSession.mutate(s.session_id);
-			sessionRef.current = null;
-			setSession(null);
+			commitSession(null);
 		}
-	}, [stopSession, nextGeneration]);
+	}, [stopSession, commitSession, generation]);
 
 	const restart = useCallback(() => {
 		const s = sessionRef.current;
-		const gen = nextGeneration();
+		const gen = generation.bump();
 		setError(null);
 		setEnded(null);
 		if (s) {
-			sessionRef.current = null;
-			setSession(null);
+			commitSession(null);
 			setRestarting(true);
 			// Await the stop before starting: the create must not attach to the
 			// still-terminating sandbox it is meant to replace. A failed stop must
@@ -161,29 +160,26 @@ export function useNotebookSession(
 			// that did nothing.
 			stopSession.mutate(s.session_id, {
 				onSuccess: () => {
-					if (genRef.current !== gen) return;
+					if (!generation.isCurrent(gen)) return;
 					setRestarting(false);
 					start();
 				},
 				onError: (err) => {
-					if (genRef.current !== gen) return;
+					if (!generation.isCurrent(gen)) return;
 					setRestarting(false);
 					// Already gone (stopped/reaped underneath us): the restart intent
 					// still holds, so start fresh.
-					if (err instanceof ApiRequestError && err.code === 'NOT_FOUND') {
+					if (isNotFoundError(err)) {
 						start();
 						return;
 					}
-					setError({
-						message: err.message,
-						code: err instanceof ApiRequestError ? err.code : undefined,
-					});
+					setError(toSessionError(err));
 				},
 			});
 		} else {
 			start();
 		}
-	}, [stopSession, start, nextGeneration]);
+	}, [stopSession, start, commitSession, generation]);
 
 	// Start once, on the first enabled render (guarded so strict-mode's
 	// double-invoke doesn't provision two sandboxes).
@@ -197,6 +193,33 @@ export function useNotebookSession(
 	const startFailedMessage =
 		mode === 'app' ? 'The app failed to start.' : 'The kernel failed to start.';
 
+	const failStart = useCallback(
+		(code?: string) => {
+			setError({ message: startFailedMessage, ...(code ? { code } : {}) });
+			commitSession(null);
+		},
+		[startFailedMessage, commitSession],
+	);
+
+	/**
+	 * Re-read the watched session under a staleness guard. A 404 means the record
+	 * is gone — a terminal answer, so it gets its own branch; every other failure
+	 * is transient and the next tick retries.
+	 */
+	const pollSession = useCallback(
+		(sessionId: string, onNext: (next: Session) => void, onGone: () => void) => {
+			const gen = generation.current();
+			apiFetch<Session>(`${sessionsPath}/${sessionId}`)
+				.then((next) => {
+					if (generation.isCurrent(gen)) onNext(next);
+				})
+				.catch((err: unknown) => {
+					if (generation.isCurrent(gen) && isNotFoundError(err)) onGone();
+				});
+		},
+		[sessionsPath, generation],
+	);
+
 	// A start that reuses an in-flight `starting` session (a concurrent refresh was
 	// already provisioning) returns before the kernel is up. Poll until it is
 	// `running` (connect) or terminal (surface an error). Normal starts return
@@ -204,33 +227,20 @@ export function useNotebookSession(
 	useInterval(
 		() => {
 			if (session?.status !== 'starting') return;
-			const sid = session.session_id;
-			const gen = genRef.current;
-			apiFetch<Session>(`${sessionsPath}/${sid}`)
-				.then((next) => {
-					if (genRef.current !== gen) return;
+			pollSession(
+				session.session_id,
+				(next) => {
 					if (next.status === 'running' && !next.sandbox_url) {
 						concludeAccessLost();
 					} else if (next.status === 'running') {
-						setSession(next);
-						sessionRef.current = next;
+						commitSession(next);
 					} else if (next.status !== 'starting' && next.status !== 'terminating') {
-						setError({ message: startFailedMessage });
-						setSession(null);
-						sessionRef.current = null;
+						failStart();
 					}
-				})
-				.catch((err: unknown) => {
-					if (genRef.current !== gen) return;
-					// The record vanished mid-start (reaped, or the notebook deleted):
-					// a terminal answer, unlike the transient errors below.
-					if (err instanceof ApiRequestError && err.code === 'NOT_FOUND') {
-						setError({ message: startFailedMessage, code: 'NOT_FOUND' });
-						setSession(null);
-						sessionRef.current = null;
-					}
-					// Anything else is transient; the next tick retries.
-				});
+				},
+				// The record vanished mid-start (reaped, or the notebook deleted).
+				() => failStart('NOT_FOUND'),
+			);
 		},
 		session?.status === 'starting' ? START_POLL_INTERVAL_MS : null,
 	);
@@ -243,17 +253,16 @@ export function useNotebookSession(
 		(fallback: Session['status'] | 'gone') => {
 			// Re-taken here: this runs a second async hop, and the caller's guard
 			// says nothing about a start/stop/restart landing during THIS request.
-			const gen = genRef.current;
+			const gen = generation.current();
 			const conclude = (next: Session | undefined) => {
-				if (genRef.current !== gen) return;
-				setSession(next ?? null);
-				sessionRef.current = next ?? null;
+				if (!generation.isCurrent(gen)) return;
+				commitSession(next ?? null);
 				if (!next) setEnded(fallback);
 			};
-			apiFetch<{ items: Session[] }>(`/api/v1/projects/${projectId}/sessions`)
-				.then((page) =>
+			fetchItems<Session>(`${projectPath(projectId)}/sessions`)
+				.then((items) =>
 					conclude(
-						page.items.find(
+						items.find(
 							(s) =>
 								s.notebook_id === notebookId &&
 								s.mode === 'app' &&
@@ -265,7 +274,7 @@ export function useNotebookSession(
 				)
 				.catch(() => conclude(undefined));
 		},
-		[projectId, notebookId],
+		[projectId, notebookId, commitSession, generation],
 	);
 
 	// App pages: watch the running session so a stop by another editor, a
@@ -276,29 +285,22 @@ export function useNotebookSession(
 		() => {
 			const sid = session?.session_id;
 			if (!sid) return;
-			const gen = genRef.current;
-			apiFetch<Session>(`${sessionsPath}/${sid}`)
-				.then((next) => {
-					if (genRef.current !== gen) return;
+			pollSession(
+				sid,
+				(next) => {
 					if (next.status === 'running' && !next.sandbox_url) {
 						// The app runs on — this caller just lost their seat, so adopting a
 						// "replacement" would only find the same unreachable session.
 						concludeAccessLost();
 					} else if (next.status === 'running') {
 						// Keep connection-count/staleness fields fresh for the banner.
-						setSession(next);
-						sessionRef.current = next;
+						commitSession(next);
 					} else if (next.status !== 'starting') {
 						adoptReplacementOr(next.status);
 					}
-				})
-				.catch((err: unknown) => {
-					if (genRef.current !== gen) return;
-					if (err instanceof ApiRequestError && err.code === 'NOT_FOUND') {
-						adoptReplacementOr('gone');
-					}
-					// Anything else is transient; the next tick retries.
-				});
+				},
+				() => adoptReplacementOr('gone'),
+			);
 		},
 		mode === 'app' && session?.status === 'running' ? RUN_WATCH_INTERVAL_MS : null,
 	);

--- a/packages/web/src/hooks/useNow.test.ts
+++ b/packages/web/src/hooks/useNow.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useNow } from './useNow';
+
+const START = 1_700_000_000_000;
+
+describe('useNow', () => {
+	let clock = START;
+
+	// The stubbed `Date.now` and the fake timers are advanced together so the
+	// timestamp the hook reads matches the tick that woke it.
+	function advance(ms: number) {
+		clock += ms;
+		act(() => {
+			vi.advanceTimersByTime(ms);
+		});
+	}
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		clock = START;
+		vi.spyOn(Date, 'now').mockImplementation(() => clock);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it('returns the current timestamp', () => {
+		const { result } = renderHook(() => useNow());
+		expect(result.current).toBe(START);
+	});
+
+	it('advances on every tick', () => {
+		const { result } = renderHook(() => useNow(1000));
+
+		advance(1000);
+		expect(result.current).toBe(START + 1000);
+
+		advance(1000);
+		expect(result.current).toBe(START + 2000);
+
+		advance(3000);
+		expect(result.current).toBe(START + 5000);
+	});
+
+	it('honors a custom interval', () => {
+		const { result } = renderHook(() => useNow(5000));
+
+		advance(4000);
+		expect(result.current).toBe(START);
+
+		advance(1000);
+		expect(result.current).toBe(START + 5000);
+	});
+
+	it('freezes at the value it last read when the interval is null', () => {
+		const { result } = renderHook(() => useNow(null));
+		expect(result.current).toBe(START);
+
+		advance(60_000);
+		expect(result.current).toBe(START);
+	});
+
+	it('stops reading the clock after unmount', () => {
+		const { result, unmount } = renderHook(() => useNow(1000));
+		advance(1000);
+		const last = result.current;
+
+		unmount();
+		advance(10_000);
+		expect(result.current).toBe(last);
+	});
+});

--- a/packages/web/src/hooks/useNow.ts
+++ b/packages/web/src/hooks/useNow.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+import { useInterval } from '@/hooks/useInterval';
+
+/**
+ * A `Date.now()` that ticks, so a rendered elapsed/relative time stays live.
+ * Pass `null` to freeze it — e.g. while the popover showing it is closed.
+ */
+export function useNow(intervalMs: number | null = 1000): number {
+	const [now, setNow] = useState(() => Date.now());
+	useInterval(() => setNow(Date.now()), intervalMs);
+	return now;
+}

--- a/packages/web/src/hooks/useSearchField.test.tsx
+++ b/packages/web/src/hooks/useSearchField.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import { useSearchField } from './useSearchField';
+
+function Harness({ initialQuery }: { initialQuery?: string }) {
+	const { query, setQuery, inputRef } = useSearchField(initialQuery);
+	return (
+		<div>
+			<input
+				ref={inputRef}
+				aria-label="search"
+				value={query}
+				onChange={(event) => setQuery(event.target.value)}
+			/>
+			<input aria-label="other" />
+		</div>
+	);
+}
+
+function pressSlash() {
+	document.dispatchEvent(new KeyboardEvent('keydown', { key: '/', bubbles: true }));
+}
+
+describe('useSearchField', () => {
+	it('starts empty and honors an initial query', () => {
+		const empty = renderHook(() => useSearchField());
+		expect(empty.result.current.query).toBe('');
+
+		const seeded = renderHook(() => useSearchField('notebooks'));
+		expect(seeded.result.current.query).toBe('notebooks');
+	});
+
+	it('setQuery updates the query', () => {
+		const { result } = renderHook(() => useSearchField());
+
+		act(() => result.current.setQuery('deploy'));
+		expect(result.current.query).toBe('deploy');
+
+		act(() => result.current.setQuery(''));
+		expect(result.current.query).toBe('');
+	});
+
+	it('focuses the wired input when "/" is pressed', () => {
+		render(<Harness />);
+		const search = screen.getByLabelText('search');
+		expect(search).not.toHaveFocus();
+
+		pressSlash();
+		expect(search).toHaveFocus();
+	});
+
+	it('does not steal focus while the user is typing in another field', () => {
+		render(<Harness />);
+		const other = screen.getByLabelText('other');
+		other.focus();
+
+		pressSlash();
+		expect(other).toHaveFocus();
+		expect(screen.getByLabelText('search')).not.toHaveFocus();
+	});
+
+	it('renders the query into the wired input', () => {
+		render(<Harness initialQuery="charts" />);
+		expect(screen.getByLabelText('search')).toHaveValue('charts');
+	});
+});

--- a/packages/web/src/hooks/useSearchField.ts
+++ b/packages/web/src/hooks/useSearchField.ts
@@ -1,0 +1,17 @@
+import { useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import { useSearchHotkey } from '@/hooks/useSearchHotkey';
+
+export interface SearchField {
+	query: string;
+	setQuery: (query: string) => void;
+	/** Wire to `<SearchField inputRef>` so the `/` hotkey can focus it. */
+	inputRef: RefObject<HTMLInputElement | null>;
+}
+
+export function useSearchField(initialQuery = ''): SearchField {
+	const [query, setQuery] = useState(initialQuery);
+	const inputRef = useRef<HTMLInputElement>(null);
+	useSearchHotkey(inputRef);
+	return { query, setQuery, inputRef };
+}

--- a/packages/web/src/lib/errors.test.ts
+++ b/packages/web/src/lib/errors.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { toast } from 'sonner';
+import { ApiRequestError } from '@/api/client';
+import { errorMessage, toastError } from './errors';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('errorMessage', () => {
+	it('reads the message off an Error', () => {
+		expect(errorMessage(new Error('boom'))).toBe('boom');
+	});
+
+	it('carries the server message through an ApiRequestError', () => {
+		expect(errorMessage(new ApiRequestError('FORBIDDEN', 'Not your project'))).toBe(
+			'Not your project',
+		);
+	});
+
+	it('passes a non-empty string through', () => {
+		expect(errorMessage('plain failure')).toBe('plain failure');
+	});
+
+	it('falls back for anything without a message', () => {
+		expect(errorMessage(undefined)).toBe('Something went wrong');
+		expect(errorMessage(null)).toBe('Something went wrong');
+		expect(errorMessage('')).toBe('Something went wrong');
+		expect(errorMessage({ code: 500 })).toBe('Something went wrong');
+	});
+});
+
+describe('toastError', () => {
+	it('surfaces the message as an error toast', () => {
+		const error = vi.spyOn(toast, 'error').mockImplementation(() => '');
+		toastError(new Error('could not save'));
+		expect(error).toHaveBeenCalledWith('could not save');
+	});
+});

--- a/packages/web/src/lib/errors.ts
+++ b/packages/web/src/lib/errors.ts
@@ -1,0 +1,15 @@
+import { toast } from 'sonner';
+
+/**
+ * A displayable message for anything thrown. Rejections from the api hooks are
+ * always `Error`s (`ApiRequestError` carries the server's message), but `catch`
+ * binds `unknown`, so this narrows without the `(err as Error)` cast.
+ */
+export function errorMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	return typeof err === 'string' && err ? err : 'Something went wrong';
+}
+
+export function toastError(err: unknown): void {
+	toast.error(errorMessage(err));
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -44,5 +44,13 @@ export default defineConfig({
 		environment: 'jsdom',
 		setupFiles: ['./src/test/setup.ts'],
 		include: ['src/**/*.test.{ts,tsx}'],
+		// The root config excludes this package from its coverage run (the `@/`
+		// aliases only resolve under this config), so the settings live here.
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'html'],
+			include: ['src/**/*.{ts,tsx}'],
+			exclude: ['src/**/*.test.{ts,tsx}', 'src/test/**', 'src/main.tsx', 'src/**/*.d.ts'],
+		},
 	},
 });


### PR DESCRIPTION
Pure refactor of the frontend hook layer plus test coverage for it. No
behavior change except the three bugs noted below.

api/hooks.ts drops 730 -> 566 lines by extracting two primitives:

- api/request.ts: path builders, postJson/putJson/patchJson/post/del,
  fetchItems, isNotFoundError. Replaces ~15 copies of the
  { method, headers, body: JSON.stringify(...) } block and the
  hand-spelled URL templates.
- api/mutation.ts: useInvalidate + useApiMutation. Replaces the three
  bespoke useInvalidateMembers/Secrets/Sessions hooks and ~12 inline
  useQueryClient + onSuccess blocks.

useNotebookSession now composes instead of inlining: the generation
counter moved to useGeneration, the setSession + sessionRef pair became
commitSession, the two near-identical polls share pollSession, and the
thrice-repeated error shaping became toSessionError.

Six shared hooks, each adopted at every duplicate site:

  useGeneration       stale-async guard, was inline in the session hook
  useNow              two byte-identical private copies
  useCopyToClipboard  two copies + an unhandled rejection in Header
  useDialogTarget     13 useState<T|null> + isOpen={!!x} triples
  useSearchField      4 useState + useRef + useSearchHotkey triples
  lib/errors          11 toast.error((err as Error).message) casts

Plus ui/CopyField, ui/WriteOnceWarning, and an exported displayName for
three reimplementations of `name || email || id`.

Bugs found while writing the tests:

- sendJson dropped caller headers given as a Headers instance and
  produced a junk `0` header for an entry array (object spread only
  works on the plain-object form of HeadersInit). Also tripped
  no-misused-spread. Now merged through new Headers().
- The clipboard reset timer was never cleared, so both original copy
  buttons called setCopied on an unmounted component if the dialog
  closed within 1.5s.
- A failed copy following a successful one inside the reset window left
  the checkmark showing.

Coverage: src/api 88.6% -> 96.9% statements and 68.6% -> 97.3% branches;
src/context and the new hooks at 100%. 131 new tests across 13 files
(228 -> 359), covering the six new hooks, the previously untested
useMediaQuery / AuthContext / ThemeContext / useSeedOnOpen / baseImage /
Header, and the whole src/api surface, which had no direct tests at all.
packages/web/vite.config.ts gains a coverage block that excludes test
files, so these numbers are against a stricter baseline than before.

Documented but not changed: useSeedOnOpen's form.reset(values) is
silently reverted when values differ from that render's defaultValues,
because useForm re-runs formApi.update(opts) in a layout effect. Every
current caller passes matching values, so nothing is broken today.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the web API hook layer to use shared request/mutation primitives, reduced duplication across components, and added comprehensive tests. No behavior change beyond three small bug fixes.

- **Refactors**
  - Added `api/request.ts` with path builders (`projectPath`, `notebookPath`), JSON helpers (`postJson`, `putJson`, `patchJson`, `post`, `del`), `fetchItems`, and error helpers (`isNotFoundError`, `isApiErrorCode`).
  - Added `api/mutation.ts` with `useInvalidate` and `useApiMutation`, replacing bespoke invalidation and inline `onSuccess` blocks.
  - Reworked `useNotebookSession` to compose shared utilities (generation guard, polling, error shaping).
  - Introduced shared hooks/utilities and adopted them across the app: `useGeneration`, `useNow`, `useCopyToClipboard`, `useDialogTarget`, `useSearchField`, and `lib/errors` (`errorMessage`, `toastError`).
  - Added `ui/CopyField`, `ui/WriteOnceWarning`, and exported `displayName` from `UserLabel`; updated dialogs and header to use them.
  - Tests: +131 tests; `src/api` statements 88.6%→96.9% and branches 68.6%→97.3%; contexts/new hooks at 100%; added coverage config in `packages/web/vite.config.ts`; ensured clipboard stubs are deleted after each test to prevent leaks.

- **Bug Fixes**
  - JSON request helper now merges `HeadersInit` via `new Headers()`, preserving caller headers and avoiding bogus numeric entries.
  - Clipboard copy timer is cleared on unmount to prevent setState on unmounted components.
  - Copy state resets correctly after a failed copy following a success within the reset window.

<sup>Written for commit 1c26fa098e126b06f7b68641fec365dbbdbe88b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

