### PR TITLE
feat(web): per-route document titles

### DIFF
--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -168,6 +168,7 @@ describe('NotebookPage viewer modes', () => {
 				container.querySelector('iframe[src="https://sandbox.example/kernel"]'),
 			).not.toBeNull(),
 		);
+		expect(document.title).toBe('Forecast · marimohub');
 		expect(sessionPosts(impl)).toHaveLength(1);
 		expect(screen.queryByText(/won't be saved/)).toBeNull();
 	});

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -135,6 +135,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 
 	return (
 		<div className="flex h-dvh flex-col">
+			<title>{`${title} · marimohub`}</title>
 			<header className="flex h-10 min-h-10 items-center gap-2 border-b bg-background px-3 max-md:h-11 max-md:min-h-11">
 				<IconLink
 					to={`/projects/${pid}`}

--- a/packages/web/src/components/Project/Project.test.tsx
+++ b/packages/web/src/components/Project/Project.test.tsx
@@ -134,6 +134,7 @@ describe('Project — Delete Project (type-to-confirm)', () => {
 		const calls = makeFetch();
 		await renderProject();
 
+		expect(document.title).toBe('Sales · marimohub');
 		await user.click(screen.getByRole('button', { name: 'Delete project' }));
 		const dialog = screen.getByRole('dialog');
 		const confirm = within(dialog).getByRole('button', { name: 'Delete' });

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -422,6 +422,7 @@ export function Project() {
 
 	return (
 		<PageContainer>
+			<title>{`${project.name} · marimohub`}</title>
 			<PageHeader
 				actions={
 					<div className="flex items-center gap-1.5">

--- a/packages/web/src/components/ProjectList/ProjectList.test.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.test.tsx
@@ -59,6 +59,7 @@ describe('ProjectList', () => {
 		renderList([project('Sales'), project('Marketing')]);
 		await waitForLoaded();
 
+		expect(document.title).toBe('Projects · marimohub');
 		expect(screen.getByText('Sales')).toBeInTheDocument();
 		expect(screen.getByText('Marketing')).toBeInTheDocument();
 	});

--- a/packages/web/src/components/ProjectList/ProjectList.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.tsx
@@ -63,6 +63,7 @@ export function ProjectList() {
 
 	return (
 		<PageContainer>
+			<title>Projects · marimohub</title>
 			<PageHeader
 				actions={
 					<Button variant="primary" onPress={createModal.open}>

--- a/packages/web/src/components/SignIn/SignIn.tsx
+++ b/packages/web/src/components/SignIn/SignIn.tsx
@@ -33,6 +33,7 @@ export function SignIn() {
 
 	return (
 		<div className="flex min-h-dvh flex-col items-center justify-center gap-8 p-8">
+			<title>Sign in · marimohub</title>
 			<Brand size="lg" />
 
 			<div className="flex w-full max-w-sm flex-col items-center gap-6 rounded-xl border bg-card p-8 text-center shadow-md">


### PR DESCRIPTION
Sets the browser tab title per route using React 19's hoistable `<title>`, so tabs and history entries are distinguishable instead of all reading the static `index.html` title.

| Route | Title |
| --- | --- |
| `/projects` | `Projects · marimohub` |
| `/projects/{pid}` | `{project name} · marimohub` |
| `/projects/{pid}/notebooks/{nid}` (edit + app) | `{notebook title} · marimohub` |
| sign-in | `Sign in · marimohub` |

Each page's existing test asserts `document.title`. `pnpm check` clean, 359 web tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a unique document title per route using React 19’s hoistable <title> so tabs and history entries are clear instead of all using the static index.html title. Covers project list, project, notebook (edit/app), and sign-in.

- **New Features**
  - /projects → Projects · marimohub
  - /projects/{pid} → {project name} · marimohub
  - /projects/{pid}/notebooks/{nid} → {notebook title} · marimohub
  - /sign-in → Sign in · marimohub

<sup>Written for commit e3ef480041e4e7fdb0b6f33913d00c9f0182ece9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marimo-team/marimohub/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

