### PR TITLE
refactor(runtime): flatten sandbox workdirs to /workspace

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ Read regardless of the selected compute backend.
 | `MARIMOHUB_COMPUTE_IMAGE` | Container image with marimo + uv + python, or a comma-separated list of such images: the first is the default and the rest are selectable per notebook as base images. Required by the `modal` backend; recommended for `coreweave`. | — | — | `ghcr.io/orgname/marimo-sandbox:latest` |
 | `MARIMOHUB_COMPUTE_IDLE_TIMEOUT` | Idle duration before a kernel auto-stops (modal). | — | — | `20m` |
 | `MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME` | Public hostname used to expose kernel ports. | — | `'' (empty)` | `hub.example.com` |
-| `MARIMOHUB_COMPUTE_WORKDIR` | Working directory inside the sandbox; notebook files land in `<workdir>/notebooks`. | — | `/workspace` | — |
+| `MARIMOHUB_COMPUTE_WORKDIR` | Working directory inside the sandbox where notebook files land and marimo runs. | — | `/workspace` | — |
 | `MARIMOHUB_COMPUTE_ASSET_URL` | Base URL for marimo frontend assets (e.g. a CDN). Omit to use the bundled assets. | — | — | `https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist` |
 
 ### CoreWeave Sandbox

--- a/docs/deploying/cks.md
+++ b/docs/deploying/cks.md
@@ -333,7 +333,7 @@ config:
   # Compute — CoreWeave Sandboxes (steps 4–5)
   MARIMOHUB_COMPUTE_BACKEND: coreweave
   MARIMOHUB_COMPUTE_IMAGE: ghcr.io/marimo-team/marimo:latest-sql
-  MARIMOHUB_COMPUTE_WORKDIR: /home/appuser
+  MARIMOHUB_COMPUTE_WORKDIR: /home/appuser/workspace
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: sandbox.<ORG-ID>-marimohub.coreweave.app
   # No {port}: Traefik routes the hostname to the kernel port.
   MARIMOHUB_COMPUTE_COREWEAVE_HOSTNAME_TEMPLATE: https://{sandboxId}.{host}
@@ -360,8 +360,8 @@ Two values worth calling out:
   the hub UI.
 - `MARIMOHUB_COMPUTE_IMAGE` is the kernel image. `ghcr.io/marimo-team/marimo:latest-sql`
   works out of the box (it runs as a non-root user whose writable home is
-  `/home/appuser` — hence `MARIMOHUB_COMPUTE_WORKDIR`). To build your own, see
-  [Sandbox image](../sandbox-image.md).
+  `/home/appuser`, so this config uses `/home/appuser/workspace`). To build your
+  own, see [Sandbox image](../sandbox-image.md).
 
 Install:
 

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -51,7 +51,7 @@ which takes a comma-separated list of template ids.
 ## The contract
 
 marimohub copies the notebook into the image and launches the kernel itself,
-reusing the image's pre-installed environment. With cwd `/workspace/notebooks`:
+reusing the image's pre-installed environment. With cwd `/workspace`:
 
 ```sh
 uv sync --inexact --no-compile-bytecode   # add the notebook's deps to the base env (skipped when it declares none)
@@ -68,7 +68,7 @@ So your image must provide:
 3. **A POSIX shell (`sh`) + coreutils** — `base64`, `mkdir`, `rm`, `cat`, `true`.
    marimohub transfers notebook files and probes reachability with these.
 4. **`git`** — only if notebooks use git checkouts, but cheap to include.
-5. **A writable working directory** (`/workspace/notebooks`) **and a writable
+5. **A writable working directory** (`/workspace`) **and a writable
    `UV_PROJECT_ENVIRONMENT`**, so `uv sync --inexact` can add a notebook's extra
    deps. If your image's non-root user can't write `/workspace`, set
    `MARIMOHUB_COMPUTE_WORKDIR` to a directory it can.
@@ -114,13 +114,13 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv UV_LINK_MODE=copy
 # Skip marimo's PyPI version ping, and continuously snapshot the notebook to
 # __marimo__/notebook.html so the host captures it on teardown.
 ENV MARIMO_SKIP_UPDATE_CHECK=1 _MARIMO_APP_OVERLOAD_AUTO_DOWNLOAD=[html]
-RUN useradd -m appuser && mkdir -p /workspace/notebooks && chown -R appuser:appuser /workspace
+RUN useradd -m appuser && mkdir -p /workspace && chown -R appuser:appuser /workspace
 COPY warm/pyproject.toml /tmp/base/pyproject.toml
 RUN cd /tmp/base && uv add --compile-bytecode "marimo[recommended]==${MARIMO_VERSION}" \
  && uv cache clean && rm -rf /tmp/base && chown -R appuser:appuser /opt/venv
 ENV VIRTUAL_ENV=/opt/venv PATH=/opt/venv/bin:$PATH
 USER appuser
-WORKDIR /workspace/notebooks
+WORKDIR /workspace
 ```
 
 Build with a version-stamped tag, push, and point `MARIMOHUB_COMPUTE_IMAGE` at it:

--- a/examples/e2b-template/README.md
+++ b/examples/e2b-template/README.md
@@ -46,7 +46,7 @@ env the launch needs — above all `UV_PROJECT_ENVIRONMENT=/opt/venv`, so
 ## How it works
 
 marimo + the base libraries are pre-installed into `/opt/venv`
-(`UV_PROJECT_ENVIRONMENT`), so the provisioner's launch in `/workspace/notebooks`
+(`UV_PROJECT_ENVIRONMENT`), so the provisioner's launch in `/workspace`
 starts instantly for a notebook that only uses them:
 
 ```sh

--- a/examples/e2b-template/template.mjs
+++ b/examples/e2b-template/template.mjs
@@ -38,12 +38,11 @@ export const template = Template()
 	.runCmd(
 		`cd /tmp/base && uv venv --python 3.13 /opt/venv && uv add --compile-bytecode "marimo[recommended,ai,sql]==${MARIMO_VERSION}" && rm -rf /tmp/base`,
 	)
-	// Kernels run in /workspace/notebooks; world-writable so the exec user can write
-	// the notebook + snapshots.
-	.runCmd('mkdir -p /workspace/notebooks && chmod -R 0777 /workspace')
+	// The exec user must be able to write the notebook and snapshots in /workspace.
+	.runCmd('mkdir -p /workspace && chmod -R 0777 /workspace')
 	// Runtime env for the kernel's login shell (see files/marimo.sh). THE KEY GOTCHA:
 	// E2B runs commands in a login shell that re-sources /etc/profile, so the build
 	// env above never reaches the launch — `UV_PROJECT_ENVIRONMENT` etc. must live in
 	// /etc/profile.d for `uv run --no-sync marimo` to resolve /opt/venv.
 	.copy('files/marimo.sh', '/etc/profile.d/marimo.sh')
-	.setWorkdir('/workspace/notebooks');
+	.setWorkdir('/workspace');

--- a/examples/sandbox-image/Dockerfile
+++ b/examples/sandbox-image/Dockerfile
@@ -34,9 +34,9 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV MARIMO_SKIP_UPDATE_CHECK=1 \
     _MARIMO_APP_OVERLOAD_AUTO_DOWNLOAD=[html]
 
-# Non-root user + a writable /workspace (kernels run in /workspace/notebooks).
+# Non-root user + a writable /workspace.
 RUN useradd -m appuser \
- && mkdir -p /workspace/notebooks \
+ && mkdir -p /workspace \
  && chown -R appuser:appuser /workspace
 
 # Pre-install marimo (pinned) + the popular libraries in warm/pyproject.toml into
@@ -61,7 +61,7 @@ ENV VIRTUAL_ENV=/opt/venv \
     PATH=/opt/venv/bin:$PATH
 
 USER appuser
-WORKDIR /workspace/notebooks
+WORKDIR /workspace
 
 # Not used in production (the provisioner supplies the launch command); lets a bare
 # `docker run` start a kernel for a sanity check, straight from the pre-installed

--- a/examples/sandbox-image/README.md
+++ b/examples/sandbox-image/README.md
@@ -34,7 +34,7 @@ deliberate, manual step, never automatic.
 
 ## How it works
 
-The provisioner runs, in `/workspace/notebooks`:
+The provisioner runs in `/workspace`:
 
 ```sh
 uv sync --inexact --no-compile-bytecode   # add the notebook's deps, keep the pre-installed base

--- a/examples/sandbox-image/acceptance-test.sh
+++ b/examples/sandbox-image/acceptance-test.sh
@@ -63,13 +63,13 @@ wait_http_200() { # $1 = host port
 	return 1
 }
 
-# Lay out /workspace/notebooks the way the provisioner does: a marimo notebook
+# Lay out /workspace the way the provisioner does: a marimo notebook
 # (deps NOT inline — marimohub stores them in pyproject.toml) plus a pyproject
 # that declares them.
 provision_notebook() { # $1 = container id
 	# `-i` keeps stdin open so the heredoc reaches `cat` inside the container;
 	# without it docker exec discards stdin and writes an empty file.
-	docker exec -i "$1" sh -lc 'cd /workspace/notebooks && cat > notebook.py' <<'PY'
+	docker exec -i "$1" sh -lc 'cd /workspace && cat > notebook.py' <<'PY'
 import marimo
 
 app = marimo.App()
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     app.run()
 PY
 	# Only the user's libraries — marimo is pre-installed in the image's env.
-	docker exec -i "$1" sh -lc 'cd /workspace/notebooks && cat > pyproject.toml' <<'TOML'
+	docker exec -i "$1" sh -lc 'cd /workspace && cat > pyproject.toml' <<'TOML'
 [project]
 name = "nb"
 version = "0.1.0"
@@ -100,7 +100,7 @@ TOML
 # detached, logging to /tmp/m.log.
 launch_kernel() { # $1 = container id
 	docker exec -d "$1" sh -lc '
-		cd /workspace/notebooks
+		cd /workspace
 		[ -s pyproject.toml ] && uv sync --inexact || true
 		uv run --no-sync marimo edit notebook.py \
 			--convert --headless --no-token --host 0.0.0.0 --port 2718 >/tmp/m.log 2>&1
@@ -120,25 +120,25 @@ docker run --rm "$IMAGE" sh -lc '
 	command -v uv >/dev/null   || { echo "uv missing"; exit 1; }
 	command -v git >/dev/null  || { echo "git missing"; exit 1; }
 	command -v base64 >/dev/null || { echo "base64 missing"; exit 1; }
-	test -w /workspace/notebooks || { echo "/workspace/notebooks not writable"; exit 1; }
+	test -w /workspace || { echo "/workspace not writable"; exit 1; }
 	[ "$(id -u)" != "0" ] || { echo "running as root"; exit 1; }
 ' || fail "image contract not satisfied (uv/git/coreutils/writable non-root workdir)"
-ok "uv + git + coreutils present; /workspace/notebooks writable; non-root"
+ok "uv + git + coreutils present; /workspace writable; non-root"
 
 # --- 2. pre-installed env: marimo + base libs ready with no install ----------
 echo "==> 2. Pre-installed env (fast startup)"
 # marimo + base libs must already be importable from the env (not just cached), so
 # the base case starts with no build.
-docker run --rm "$IMAGE" sh -lc 'cd /workspace/notebooks && uv run --no-sync python -c "import marimo, polars, narwhals"' \
+docker run --rm "$IMAGE" sh -lc 'cd /workspace && uv run --no-sync python -c "import marimo, polars, narwhals"' \
 	|| fail "image does not pre-install marimo + base libraries into the project env"
 ok "marimo + base libs pre-installed (importable, no build → fast base-case startup)"
 cid="$(run_detached "$IMAGE" sleep infinity)"
 provision_notebook "$cid"
 # The launch setup step (`uv sync --inexact`) must add the notebook's deps without
 # removing the pre-installed base, and download little — the base is already there.
-docker exec "$cid" sh -lc 'cd /workspace/notebooks && uv sync --inexact >/tmp/sync.log 2>&1' \
+docker exec "$cid" sh -lc 'cd /workspace && uv sync --inexact >/tmp/sync.log 2>&1' \
 	|| { docker exec "$cid" sh -lc 'tail -10 /tmp/sync.log'; fail "uv sync --inexact failed"; }
-docker exec "$cid" sh -lc 'cd /workspace/notebooks && uv run --no-sync python -c "import marimo, polars"' \
+docker exec "$cid" sh -lc 'cd /workspace && uv run --no-sync python -c "import marimo, polars"' \
 	|| fail "marimo or base lib missing after uv sync --inexact (base was removed?)"
 dl="$(docker exec "$cid" sh -lc 'grep -ic "Downloading" /tmp/sync.log || true')"
 [ "${dl:-99}" -le 5 ] || fail "uv sync --inexact downloaded $dl wheels (expected ≤5; base is pre-installed)"
@@ -149,7 +149,7 @@ docker rm -f "$cid" >/dev/null 2>&1
 echo "==> 2b. Pinned marimo (no auto-upgrade)"
 mv="$(docker run --rm "$IMAGE" sh -lc 'printf %s "$MARIMO_VERSION"')"
 [ -n "$mv" ] || fail "image does not set MARIMO_VERSION — marimo is not pinned"
-got="$(docker run --rm "$IMAGE" sh -lc 'cd /workspace/notebooks && uv run --no-sync python -c "import marimo; print(marimo.__version__)" 2>/dev/null | tail -1')"
+got="$(docker run --rm "$IMAGE" sh -lc 'cd /workspace && uv run --no-sync python -c "import marimo; print(marimo.__version__)" 2>/dev/null | tail -1')"
 [ "$got" = "$mv" ] || fail "pre-installed marimo is ${got:-none}, expected pinned $mv"
 ok "marimo pinned to $mv (pre-installed; launch never upgrades it)"
 
@@ -165,7 +165,7 @@ docker rm -f "$cid" >/dev/null 2>&1
 # --- 4. --convert rescues a non-marimo python file (no pyproject) ------------
 echo "==> 4. --convert opens a non-marimo file"
 cid="$(run_detached -p 127.0.0.1:2719:2718 "$IMAGE" sleep infinity)"
-docker exec "$cid" sh -lc 'cd /workspace/notebooks && printf "import marimo\n" > notebook.py'
+docker exec "$cid" sh -lc 'cd /workspace && printf "import marimo\n" > notebook.py'
 launch_kernel "$cid"
 wait_http_200 2719 || { docker exec "$cid" sh -lc 'tail -20 /tmp/m.log' || true; fail "--convert did not open the non-marimo file"; }
 ok "--convert serves a plain Python file with no pyproject (HTTP 200)"

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -21,7 +21,7 @@ ENV LANG=en_US.UTF-8 \
     _MARIMO_APP_OVERLOAD_AUTO_DOWNLOAD=[html]
 
 RUN useradd -m appuser \
- && mkdir -p /workspace/notebooks \
+ && mkdir -p /workspace \
  && chown -R appuser:appuser /workspace
 
 # Retaining uv's cache makes overlapping per-notebook dependency installs cache hits.
@@ -57,6 +57,6 @@ ENV VIRTUAL_ENV=/opt/venv \
     PATH=/opt/venv/bin:$PATH
 
 USER appuser
-WORKDIR /workspace/notebooks
+WORKDIR /workspace
 
 CMD ["uv", "run", "--no-sync", "marimo", "edit", "notebook.py", "--convert", "--headless", "--no-token", "--host", "0.0.0.0", "--port", "2718"]

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -62,10 +62,10 @@ export interface SandboxConfig {
 	/** Public hostname used when exposing kernel ports (was `c.env.SANDBOX_HOSTNAME`). */
 	hostname: string;
 	/**
-	 * Working directory inside the sandbox (notebook files land in
-	 * `<workdir>/notebooks`). Must be writable by the sandbox image's user —
-	 * e.g. the marimo OSS image runs as a non-root user with no `/workspace`.
-	 * Config: MARIMOHUB_COMPUTE_WORKDIR. Defaults to `/workspace`.
+	 * Working directory inside the sandbox where notebook files land and marimo
+	 * runs. Must be writable by the sandbox image's user — e.g. the marimo OSS
+	 * image runs as a non-root user with no `/workspace`. Config:
+	 * MARIMOHUB_COMPUTE_WORKDIR. Defaults to `/workspace`.
 	 */
 	workdir: string;
 	/**

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -298,7 +298,7 @@ describe('Session routes', () => {
 	});
 
 	it('DELETE /sessions/{sid} cuts a version from the sandbox edits and captures snapshots', async () => {
-		const MOUNT = '/workspace/notebooks';
+		const MOUNT = '/workspace';
 		// A compute whose sandbox reports the session's edited files + marimo artifacts.
 		const editing = createTestApi({
 			bucket,
@@ -661,8 +661,8 @@ describe('Session routes', () => {
 			// The sandbox holds edits that a persisting teardown WOULD commit.
 			const compute = makeFakeCompute({
 				files: {
-					'/workspace/notebooks/notebook.py': 'print(2)  # viewer edit',
-					'/workspace/notebooks/__marimo__/notebook.html': '<html>x</html>',
+					'/workspace/notebook.py': 'print(2)  # viewer edit',
+					'/workspace/__marimo__/notebook.html': '<html>x</html>',
 				},
 			});
 			const viewer = viewerModeApi(VIEWER, 'ephemeral-sandbox', compute);

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -134,7 +134,7 @@ describe('KubernetesCompute', () => {
 			// A fresh instance (as the API does for teardown) targets the same Pod.
 			await compute
 				.create(SANDBOX_ID)
-				.writeFiles([{ path: '/workspace/notebooks/notebook.py', content: 'x=1' }]);
+				.writeFiles([{ path: '/workspace/notebook.py', content: 'x=1' }]);
 			expect(world.execCalls.every((c) => c.name === NAME)).toBe(true);
 		});
 
@@ -183,11 +183,11 @@ describe('KubernetesCompute', () => {
 			const world = makeWorld();
 			await makeCompute(world)
 				.create(SANDBOX_ID)
-				.writeFiles([{ path: '/workspace/notebooks/notebook.py', content: 'x=1' }]);
+				.writeFiles([{ path: '/workspace/notebook.py', content: 'x=1' }]);
 			const call = world.execCalls.at(-1)!;
 			expect(call.stdin).toBe('x=1');
-			expect(shCmd(call)).toContain("mkdir -p '/workspace/notebooks'");
-			expect(shCmd(call)).toContain("cat > '/workspace/notebooks/notebook.py'");
+			expect(shCmd(call)).toContain("mkdir -p '/workspace'");
+			expect(shCmd(call)).toContain("cat > '/workspace/notebook.py'");
 		});
 
 		it('readFile returns file contents from the in-pod cat', async () => {
@@ -197,9 +197,7 @@ describe('KubernetesCompute', () => {
 						? { stdout: 'print(1)', stderr: '', exitCode: 0 }
 						: undefined,
 			});
-			const res = await makeCompute(world)
-				.create(SANDBOX_ID)
-				.readFile('/workspace/notebooks/notebook.py');
+			const res = await makeCompute(world).create(SANDBOX_ID).readFile('/workspace/notebook.py');
 			expectFileResult(res, { success: true, content: 'print(1)', encoding: 'utf-8' });
 		});
 
@@ -208,9 +206,7 @@ describe('KubernetesCompute', () => {
 				execImpl: (cmd) =>
 					cmd[2].startsWith('cat -- ') ? { stdout: '', stderr: 'missing', exitCode: 1 } : undefined,
 			});
-			const res = await makeCompute(world)
-				.create(SANDBOX_ID)
-				.readFile('/workspace/notebooks/missing.py');
+			const res = await makeCompute(world).create(SANDBOX_ID).readFile('/workspace/missing.py');
 
 			expect(res).toEqual({ success: false, content: '' });
 		});
@@ -239,7 +235,7 @@ describe('KubernetesCompute', () => {
 			await expect(
 				makeCompute(world)
 					.create(SANDBOX_ID)
-					.writeFiles([{ path: '/workspace/notebooks/notebook.py', content: 'x=1' }]),
+					.writeFiles([{ path: '/workspace/notebook.py', content: 'x=1' }]),
 			).rejects.toThrow(/permission denied/);
 		});
 	});

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -78,14 +78,14 @@ describe('rewriteWorkspace (pure)', () => {
 describe('LocalCompute file ops', () => {
 	it('round-trips files under the workspace and maps /workspace paths', async () => {
 		const sb = newSandbox();
-		const mkdir = await sb.exec('mkdir -p /workspace/notebooks');
+		const mkdir = await sb.exec('mkdir -p /workspace');
 		expect(mkdir.success).toBe(true);
 
-		await sb.writeFiles([{ path: '/workspace/notebooks/notebook.py', content: 'print(1)' }]);
-		const read = await sb.readFile('/workspace/notebooks/notebook.py');
+		await sb.writeFiles([{ path: '/workspace/notebook.py', content: 'print(1)' }]);
+		const read = await sb.readFile('/workspace/notebook.py');
 		expectFileResult(read, { success: true, content: 'print(1)' });
 
-		const list = await sb.listFiles('/workspace/notebooks');
+		const list = await sb.listFiles('/workspace');
 		expect(list.success).toBe(true);
 		expect(list.files.map((f) => f.name)).toContain('notebook.py');
 	});

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -216,7 +216,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						id: 'MARIMOHUB_COMPUTE_WORKDIR',
 						name: 'Sandbox working directory',
 						description:
-							'Working directory inside the sandbox; notebook files land in `<workdir>/notebooks`.',
+							'Working directory inside the sandbox where notebook files land and marimo runs.',
 						default: '/workspace',
 					},
 					{

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -16,7 +16,7 @@ import type { NotebookService } from '../content/NotebookService';
 import { SandboxProvisioner } from './SandboxProvisioner';
 import type { BucketConfig, WorkspaceLoadStrategies } from './SandboxProvisioner';
 
-const MOUNT_PATH = '/workspace/notebooks';
+const MOUNT_PATH = '/workspace';
 
 const bucketConfig: BucketConfig = {
 	name: 'test-bucket',
@@ -83,9 +83,11 @@ describe('SandboxProvisioner', () => {
 			expect(calls.exec).toContain('true');
 			// Bucket was mounted (no fallback file copy).
 			expect(calls.mountBucket).toHaveLength(1);
+			expect(calls.mountBucket[0].mountPath).toBe(MOUNT_PATH);
 			expect(calls.writeFile).toHaveLength(0);
 
 			expect(calls.startProcess).toHaveLength(1);
+			expect(calls.startProcess[0].options?.cwd).toBe(MOUNT_PATH);
 			expect(calls.startProcess[0].cmd).toContain('marimo edit');
 			expect(calls.startProcess[0].cmd).toContain('2718');
 			expect(calls.waitForPort).toEqual([2718]);

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -56,9 +56,8 @@ export interface ProvisionOptions {
 	/** Storage bucket handle for fallback file copy. */
 	bucketHandle?: Bucket;
 	/**
-	 * Working directory inside the sandbox (cwd for marimo; notebook files land in
-	 * `<workdir>/notebooks`). Must be writable by the sandbox image's user.
-	 * Defaults to `/workspace`.
+	 * Working directory inside the sandbox where notebook files land and marimo
+	 * runs. Must be writable by the sandbox image's user. Defaults to `/workspace`.
 	 */
 	workdir?: string;
 	/**
@@ -271,7 +270,7 @@ export class SandboxProvisioner {
 	): Promise<ProvisionResult> {
 		const nb = paths.project(options.projectId).notebook(options.notebookId);
 		const workdir = options.workdir ?? DEFAULT_WORKDIR;
-		const mountPath = `${workdir}/notebooks`;
+		const mountPath = workdir;
 		const sw = new Stopwatch();
 
 		const ensureReachable = () => this.ensureReachable(sandbox, sw);
@@ -482,7 +481,7 @@ export class SandboxProvisioner {
 		const { source } = await notebooks.getNotebook(projectId, notebookId);
 		if (!workspaceSourcePolicy(source).persistSessionEdits) return false;
 
-		const mountPath = `${workdir}/notebooks`;
+		const mountPath = workdir;
 		// The commit chain and the workspace mirror are independent best-effort
 		// steps over disjoint bucket keys, so they run concurrently.
 		const { commit, workspace } = await allSettled({

--- a/packages/core/src/services/runtime/sandboxFiles.test.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.test.ts
@@ -12,7 +12,7 @@ import {
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
 
 // `makeFsSandbox`'s default root — every test mounts the notebook here.
-const MOUNT = '/workspace/notebooks';
+const MOUNT = '/workspace';
 
 function nbCtx() {
 	const projectId = createProjectId();

--- a/packages/core/src/testing/fakes.ts
+++ b/packages/core/src/testing/fakes.ts
@@ -131,7 +131,7 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 	return { instance, calls };
 }
 
-const DEFAULT_FS_ROOT = '/workspace/notebooks';
+const DEFAULT_FS_ROOT = '/workspace';
 
 function fsBase64Encode(bytes: Uint8Array): string {
 	let bin = '';


### PR DESCRIPTION
Notebook files, bucket mounts/copies, marimo cwd, and teardown capture
now use the configured workdir directly, dropping the /workspace/notebooks
subpath. Custom workdirs are flattened too (CKS example uses
/home/appuser/workspace).
