### PR TITLE
feat(auth): default OIDC login to account picker

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -32,6 +32,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -75,6 +76,7 @@ exports[`config -> code generators > azure + kubernetes + oidc > compose 1`] = `
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: none
@@ -108,6 +110,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: source
@@ -203,6 +206,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -242,6 +246,7 @@ exports[`config -> code generators > default-prod (s3 + modal + oidc) > compose 
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: none
@@ -268,6 +273,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: source
@@ -355,6 +361,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -389,6 +396,7 @@ exports[`config -> code generators > fs + docker + oidc (single-box) > compose 1
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: none
@@ -414,6 +422,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: source
@@ -493,6 +502,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -527,6 +537,7 @@ exports[`config -> code generators > fs + podman + oidc > compose 1`] = `
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: none
@@ -552,6 +563,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: source
@@ -642,6 +654,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -686,6 +699,7 @@ exports[`config -> code generators > gcs + kubernetes + oidc, persist workspace 
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: none
@@ -719,6 +733,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: workspace
@@ -940,6 +955,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -989,6 +1005,7 @@ exports[`config -> code generators > s3 + coreweave + oidc, custom image > compo
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: none
@@ -1026,6 +1043,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: source
@@ -1258,6 +1276,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -1299,6 +1318,7 @@ exports[`config -> code generators > s3 + e2b + oidc > compose 1`] = `
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: none
@@ -1328,6 +1348,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: source
@@ -1417,6 +1438,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -1465,6 +1487,7 @@ exports[`config -> code generators > s3 + modal + oidc, managed ai > compose 1`]
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: openai-compatible
@@ -1500,6 +1523,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: openai-compatible
   MARIMOHUB_AI_UPSTREAM_BASE_URL: _replace_me_ # e.g. https://api.openai.com/v1
@@ -1609,6 +1633,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=acme.com
 
@@ -1648,6 +1673,7 @@ exports[`config -> code generators > s3 + modal + oidc, value overrides > compos
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: acme.com
       MARIMOHUB_AI_BACKEND: none
@@ -1674,6 +1700,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: acme.com
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: source
@@ -1903,6 +1930,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
 MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
 
@@ -1945,6 +1973,7 @@ exports[`config -> code generators > s3 + wandb + oidc > compose 1`] = `
       MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
       MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
       MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
       MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
       MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
       MARIMOHUB_AI_BACKEND: none
@@ -1975,6 +2004,7 @@ config:
   MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
   MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
   MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
   MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
   MARIMOHUB_AI_BACKEND: none
   MARIMOHUB_PERSIST_WORKSPACE: source

--- a/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
@@ -13,6 +13,7 @@ MARIMOHUB_AUTH_OIDC_REDIRECT_URI=https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_SESSION_SECRET=…            # signs the session cookie (HS256, ≥32 bytes)
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com  # REQUIRED allowlist (verified email); \`*\` allows all
 # MARIMOHUB_AUTH_OIDC_AUDIENCE=…           # optional: expected ID-token audience (the client id is enforced anyway)
+# MARIMOHUB_AUTH_OIDC_PROMPT=consent       # optional: override the default (select_account) OAuth prompt
 </code></pre>
 <p>The <strong>redirect URI</strong> is always <code>https://&lt;your-host&gt;/api/auth/callback</code>. Register
 it with your provider exactly as you set it here, or login fails with a
@@ -34,6 +35,10 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=…apps.googleusercontent.com
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=…
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com   # a single domain is also sent to Google as the \`hd\` hint
 </code></pre>
+<p>marimohub defaults the OAuth <code>prompt</code> to <code>select_account</code>, so a returning user
+always gets the Google account chooser instead of being silently logged in with
+their last account. Override it via <code>MARIMOHUB_AUTH_OIDC_PROMPT</code> (e.g. <code>consent</code>
+to also re-show the consent screen).</p>
 <p>See <a href="https://developers.google.com/identity/openid-connect/openid-connect">Google's OpenID Connect docs</a>.</p>
 <h3>Microsoft Entra ID</h3>
 <ol>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,6 +276,7 @@ App-native OpenID Connect (the production backend).
 | `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET` 🔒 | OAuth2 client secret. | Yes | — | — |
 | `MARIMOHUB_AUTH_OIDC_REDIRECT_URI` | Absolute callback URL. | Yes | — | `https://hub.example.com/api/auth/callback` |
 | `MARIMOHUB_AUTH_OIDC_AUDIENCE` | Expected ID-token audience (optional; oauth4webapi enforces the client id automatically). | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_PROMPT` | OAuth `prompt` parameter. Defaults to `select_account`, so a returning user always gets the account chooser instead of being silently logged in with their last account. Override with `consent` to re-show the consent screen, or space-separated combinations. | — | `select_account` | `consent` |
 | `MARIMOHUB_AUTH_SESSION_SECRET` 🔒 | Secret that signs the session cookie (HS256; ≥32 bytes). | Yes | — | — |
 | `MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS` | Comma-separated email-domain allowlist (requires a verified email). Required so a deployment cannot silently admit every account the IdP authenticates; set `*` to explicitly allow all domains. A single domain is also sent to Google as the `hd` hint. | Yes | — | `example.com,example.org` |
 

--- a/docs/setup/auth/oidc.md
+++ b/docs/setup/auth/oidc.md
@@ -14,6 +14,7 @@ MARIMOHUB_AUTH_OIDC_REDIRECT_URI=https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_SESSION_SECRET=…            # signs the session cookie (HS256, ≥32 bytes)
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com  # REQUIRED allowlist (verified email); `*` allows all
 # MARIMOHUB_AUTH_OIDC_AUDIENCE=…           # optional: expected ID-token audience (the client id is enforced anyway)
+# MARIMOHUB_AUTH_OIDC_PROMPT=consent       # optional: override the default (select_account) OAuth prompt
 ```
 
 The **redirect URI** is always `https://<your-host>/api/auth/callback`. Register
@@ -39,6 +40,11 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=…apps.googleusercontent.com
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=…
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com   # a single domain is also sent to Google as the `hd` hint
 ```
+
+marimohub defaults the OAuth `prompt` to `select_account`, so a returning user
+always gets the Google account chooser instead of being silently logged in with
+their last account. Override it via `MARIMOHUB_AUTH_OIDC_PROMPT` (e.g. `consent`
+to also re-show the consent screen).
 
 See [Google's OpenID Connect docs](https://developers.google.com/identity/openid-connect/openid-connect).
 

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -237,9 +237,28 @@ describe('OIDC routes', () => {
 		expect(location.searchParams.get('code_challenge')).toBe('challenge-1');
 		expect(location.searchParams.get('code_challenge_method')).toBe('S256');
 		expect(location.searchParams.get('hd')).toBe('example.com');
+		expect(location.searchParams.get('prompt')).toBe('select_account');
 		expect(setCookie).toContain(`${TXN_COOKIE}=`);
 		expect(setCookie).toContain('HttpOnly');
 		expect(setCookie).toContain('Secure');
+	});
+
+	it('defaults prompt to select_account, forcing the account chooser', async () => {
+		const { routes } = makeOidc({});
+
+		const res = await routes.request('/api/auth/login');
+		const location = new URL(res.headers.get('location') ?? '');
+
+		expect(location.searchParams.get('prompt')).toBe('select_account');
+	});
+
+	it('lets the configured prompt override the default', async () => {
+		const { routes } = makeOidc({ prompt: 'consent' });
+
+		const res = await routes.request('/api/auth/login');
+		const location = new URL(res.headers.get('location') ?? '');
+
+		expect(location.searchParams.get('prompt')).toBe('consent');
 	});
 
 	it('does not include an hd hint when multiple domains are allowed', async () => {

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -38,6 +38,8 @@ export interface OidcConfig {
 	audience?: string;
 	/** OAuth scopes (default `openid email profile`). */
 	scopes?: string;
+	/** OAuth `prompt` parameter (default `select_account`). */
+	prompt?: string;
 	/** Secret used to sign the session + transaction cookies (HS256). */
 	sessionSecret: string;
 	/** Where to send the user after a successful login (default `/`). */
@@ -202,6 +204,7 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		if (allowedDomains.length === 1) {
 			url.searchParams.set('hd', allowedDomains[0]);
 		}
+		url.searchParams.set('prompt', config.prompt ?? 'select_account');
 		return c.redirect(url.toString());
 	});
 

--- a/packages/config/src/auth.ts
+++ b/packages/config/src/auth.ts
@@ -70,6 +70,7 @@ export function makeAuth(env: Env): { authenticator: Authenticator; authRoutes?:
 				audience: env.MARIMOHUB_AUTH_OIDC_AUDIENCE,
 				sessionSecret: oidc('MARIMOHUB_AUTH_SESSION_SECRET'),
 				allowedEmailDomains: parseEmailDomains(env.MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS),
+				prompt: env.MARIMOHUB_AUTH_OIDC_PROMPT?.trim() || undefined,
 			});
 			return { authenticator, authRoutes: routes };
 		}

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -714,6 +714,14 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 							'Expected ID-token audience (optional; oauth4webapi enforces the client id automatically).',
 					},
 					{
+						id: 'MARIMOHUB_AUTH_OIDC_PROMPT',
+						name: 'OIDC prompt',
+						description:
+							'OAuth `prompt` parameter. Defaults to `select_account`, so a returning user always gets the account chooser instead of being silently logged in with their last account. Override with `consent` to re-show the consent screen, or space-separated combinations.',
+						default: 'select_account',
+						example: 'consent',
+					},
+					{
 						id: 'MARIMOHUB_AUTH_SESSION_SECRET',
 						name: 'Session secret',
 						description: 'Secret that signs the session cookie (HS256; ≥32 bytes).',


### PR DESCRIPTION
This PR adds the `MARIMOHUB_AUTH_OIDC_PROMPT` configuration (default set to `select_account`)

> OAuth `prompt` parameter. Defaults to `select_account`, so a returning user always gets the account chooser instead of being silently logged in with their last account. Override with `consent` to re-show the consent screen, or space-separated combinations.'
