### PR TITLE
feat(web): match embedded marimo app theme to marimohub

### DIFF
--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { NotebookPage } from './NotebookPage';
+import { ThemeProvider } from '@/context/ThemeContext';
 import type { Session } from '@/types';
 
 const PID = 'proj-x';
@@ -121,7 +122,9 @@ function renderPage(variant: 'edit' | 'app' = 'edit') {
 	const wrapper = ({ children }: { children: ReactNode }) => (
 		<MemoryRouter initialEntries={[path]}>
 			<QueryClientProvider client={client}>
-				<Suspense fallback={<div>loading</div>}>{children}</Suspense>
+				<ThemeProvider>
+					<Suspense fallback={<div>loading</div>}>{children}</Suspense>
+				</ThemeProvider>
 			</QueryClientProvider>
 		</MemoryRouter>
 	);
@@ -140,6 +143,9 @@ const sessionPosts = (impl: ReturnType<typeof makeFetch>) =>
 	);
 
 beforeEach(() => {
+	// The theme baked into the kernel iframe URL reads from localStorage; clear it
+	// so each test resolves the default (light) unless it opts into dark.
+	localStorage.clear();
 	// jsdom has no matchMedia; Tooltip's mobile check needs it.
 	vi.stubGlobal('matchMedia', (query: string) => ({
 		matches: false,
@@ -165,12 +171,24 @@ describe('NotebookPage viewer modes', () => {
 
 		await waitFor(() =>
 			expect(
-				container.querySelector('iframe[src="https://sandbox.example/kernel"]'),
+				container.querySelector('iframe[src="https://sandbox.example/kernel?theme=light"]'),
 			).not.toBeNull(),
 		);
 		expect(document.title).toBe('Forecast · marimohub');
 		expect(sessionPosts(impl)).toHaveLength(1);
 		expect(screen.queryByText(/won't be saved/)).toBeNull();
+	});
+
+	it('dark theme: forces the embedded app onto ?theme=dark', async () => {
+		localStorage.setItem('marimohub-theme', 'dark');
+		makeFetch({ role: 'editor' });
+		const { container } = renderPage();
+
+		await waitFor(() =>
+			expect(
+				container.querySelector('iframe[src="https://sandbox.example/kernel?theme=dark"]'),
+			).not.toBeNull(),
+		);
 	});
 
 	it('viewer + static: renders the snapshot sandboxed, never starts a session', async () => {
@@ -215,7 +233,9 @@ describe('NotebookPage viewer modes', () => {
 		const { container } = renderPage();
 
 		await waitFor(() => expect(screen.getByText(/won't be saved/)).toBeInTheDocument());
-		expect(container.querySelector('iframe[src="https://sandbox.example/kernel"]')).not.toBeNull();
+		expect(
+			container.querySelector('iframe[src="https://sandbox.example/kernel?theme=light"]'),
+		).not.toBeNull();
 		expect(sessionPosts(impl)).toHaveLength(1);
 	});
 });
@@ -230,7 +250,7 @@ describe('NotebookPage app variant', () => {
 
 		await waitFor(() =>
 			expect(
-				container.querySelector('iframe[src="https://sandbox.example/kernel"]'),
+				container.querySelector('iframe[src="https://sandbox.example/kernel?theme=light"]'),
 			).not.toBeNull(),
 		);
 		const [, init] = sessionPosts(impl)[0];
@@ -286,7 +306,7 @@ describe('NotebookPage app variant', () => {
 
 		await waitFor(() =>
 			expect(
-				container.querySelector('iframe[src="https://sandbox.example/kernel"]'),
+				container.querySelector('iframe[src="https://sandbox.example/kernel?theme=light"]'),
 			).not.toBeNull(),
 		);
 		expect(sessionPosts(impl)).toHaveLength(1);

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -27,6 +27,8 @@ import { RenameNotebookDialog } from '@/components/Notebook/RenameNotebookDialog
 import { StaticNotebookView } from '@/components/NotebookPage/StaticNotebookView';
 import { isAppStale } from '@/components/Project/AppSessionIndicator';
 import { appConnectionHint, sessionsByNotebook } from '@/lib/sessions';
+import { useTheme } from '@/context/ThemeContext';
+import type { Theme } from '@/context/ThemeContext';
 
 /** Copy for the app page's terminal panel, keyed by how the session ended. */
 function endedPanel(ended: SessionEnded): { title: string; message: string; canRestart: boolean } {
@@ -46,6 +48,21 @@ function endedPanel(ended: SessionEnded): { title: string; message: string; canR
 	}
 	if (ended === 'failed') return stopped('The app crashed.');
 	return stopped('The app is no longer running.');
+}
+
+/**
+ * Point the embedded marimo app at the marimohub theme via its `?theme=` query
+ * param (marimo-team/marimo#10196). The origin base lets a relative proxy URL
+ * resolve; `theme` is already `'light' | 'dark'`.
+ */
+function withThemeParam(url: string, theme: Theme): string {
+	try {
+		const parsed = new URL(url, window.location.origin);
+		parsed.searchParams.set('theme', theme);
+		return parsed.toString();
+	} catch {
+		return url;
+	}
 }
 
 export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' }) {
@@ -86,6 +103,16 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 			enabled: isApp || !isViewer || viewerHasEditKernel,
 			mode: isApp ? 'app' : 'edit',
 		});
+
+	// Freeze the theme when the URL is first established, not on every toggle:
+	// marimo reads `?theme=` only on load, so re-deriving it live would reload
+	// (and reset) the running app. Restart mints a fresh URL and re-reads it.
+	const { theme } = useTheme();
+	const iframeSrc = useMemo(
+		() => (sandboxUrl ? withThemeParam(sandboxUrl, theme) : undefined),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[sandboxUrl],
+	);
 
 	// Metadata for the "created by" line — loaded lazily so it never blocks the
 	// kernel from starting. The author id is resolved to a name via the directory.
@@ -256,7 +283,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 					<div className="flex-1 overflow-hidden">
 						<iframe
 							className="size-full border-0"
-							src={sandboxUrl}
+							src={iframeSrc}
 							sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
 							allow="clipboard-read; clipboard-write"
 							title={title}


### PR DESCRIPTION
Force the embedded marimo app onto the marimohub light/dark theme via marimo's `?theme=` query param ([marimo-team/marimo#10196](https://github.com/marimo-team/marimo/pull/10196)), so the notebook matches the chrome around it.

## Changes
- `NotebookPage.tsx`: append `?theme=light`/`?theme=dark` (from `useTheme()`, already resolved) to the kernel iframe URL via the `URL` API.
- The URL is memoized on `sandboxUrl` only — the theme is frozen at load, since marimo reads `?theme=` only on load and re-deriving it live would reload (and reset) the running app on a toggle. **Restart** re-reads the current theme.