### PR TITLE
feat(runtime): inject marimo.toml defaults into kernel sessions

### DIFF
--- a/packages/api/src/routes/ai.ts
+++ b/packages/api/src/routes/ai.ts
@@ -3,7 +3,7 @@
  *
  * Notebook kernels run untrusted user code, so they never hold the real upstream
  * provider key — only a short-lived, session-scoped token marimohub mints at
- * provision time (see `aiConfigToSessionEnv`). This route verifies that token,
+ * provision time (see `marimoAiContributor`). This route verifies that token,
  * then forwards the request to the configured upstream with the real key,
  * streaming the response straight back. It authenticates by the token alone, so
  * it lives OUTSIDE the `/api/v1/*` cookie-auth + CSRF guards.

--- a/packages/api/src/routes/sessions.appMode.test.ts
+++ b/packages/api/src/routes/sessions.appMode.test.ts
@@ -212,6 +212,45 @@ describe('Session routes (app mode)', () => {
 		expect(runFake.calls.setEnvVars.flatMap(Object.keys)).not.toContain('XDG_CONFIG_HOME');
 	});
 
+	it.each(['', 'relative/path', '/'])(
+		'falls back to default-only editor config when managed AI uses invalid XDG path %j',
+		async (xdgPath) => {
+			const fake = makeFakeSandbox();
+			const api = createTestApi({
+				bucket,
+				userId: ACTOR,
+				compute: fakeComputeFrom(fake.instance),
+				deps: {
+					ai: {
+						upstreamBaseUrl: 'https://ai.example',
+						upstreamApiKey: 'k',
+						model: 'gpt-test',
+						signingSecret: 's'.repeat(32),
+						xdgPath,
+					},
+				},
+			});
+
+			const session = await expectOk<any>(await api.request('POST', sessionsPath()));
+
+			expect(session.status).toBe('running');
+			const configFiles = fake.calls.writeFiles
+				.flat()
+				.filter((file) => file.path.endsWith('/marimo/marimo.toml'));
+			expect(configFiles).toEqual([
+				expect.objectContaining({
+					path: '/tmp/marimohub-config/marimo/marimo.toml',
+				}),
+			]);
+			expect(configFiles[0].content).toContain('default_width = "medium"');
+			expect(configFiles[0].content).toContain('default_sql_output = "native"');
+			expect(configFiles[0].content).not.toContain('[ai]');
+			expect(fake.calls.setEnvVars).toContainEqual({
+				XDG_CONFIG_HOME: '/tmp/marimohub-config',
+			});
+		},
+	);
+
 	describe('viewer admission per MARIMOHUB_VIEWER_MODE', () => {
 		const viewerApi = (viewerMode?: 'static' | 'applications' | 'ephemeral-sandbox') =>
 			createTestApi({

--- a/packages/api/src/routes/sessions.appMode.test.ts
+++ b/packages/api/src/routes/sessions.appMode.test.ts
@@ -174,7 +174,7 @@ describe('Session routes (app mode)', () => {
 		expect(fake.calls.startProcess[0].cmd).not.toContain('--convert');
 	});
 
-	it('does not inject managed-AI config into an app session', async () => {
+	it('merges managed AI into edit config but injects no config into an app session', async () => {
 		const ai = {
 			upstreamBaseUrl: 'https://ai.example',
 			upstreamApiKey: 'k',
@@ -190,7 +190,13 @@ describe('Session routes (app mode)', () => {
 			deps: { ai },
 		});
 		await expectOk<any>(await editApi.request('POST', sessionsPath()));
-		expect(editFake.calls.writeFiles.flat().some((f) => f.path.startsWith('/xdg'))).toBe(true);
+		const editConfig = editFake.calls.writeFiles
+			.flat()
+			.find((file) => file.path === '/xdg/marimo/marimo.toml');
+		expect(editConfig?.content).toContain('default_width = "medium"');
+		expect(editConfig?.content).toContain('default_sql_output = "native"');
+		expect(editConfig?.content).toContain('[ai]');
+		expect(editConfig?.content).toContain('[ai.custom_providers.marimohub]');
 
 		const runFake = makeFakeSandbox();
 		const runApi = createTestApi({
@@ -200,9 +206,10 @@ describe('Session routes (app mode)', () => {
 			deps: { ai },
 		});
 		await expectOk<any>(await runApi.request('POST', sessionsPath(), { mode: 'app' }));
-		// The copy-only workspace load also uses writeFiles; only the AI config
-		// (under the XDG path) must be absent.
-		expect(runFake.calls.writeFiles.flat().some((f) => f.path.startsWith('/xdg'))).toBe(false);
+		expect(
+			runFake.calls.writeFiles.flat().some((file) => file.path.endsWith('/marimo/marimo.toml')),
+		).toBe(false);
+		expect(runFake.calls.setEnvVars.flatMap(Object.keys)).not.toContain('XDG_CONFIG_HOME');
 	});
 
 	describe('viewer admission per MARIMOHUB_VIEWER_MODE', () => {

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -105,6 +105,27 @@ describe('Session routes', () => {
 		expect(data.error).toBeUndefined();
 	});
 
+	it('injects notebook defaults into an edit session without managed AI', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: fakeComputeFrom(instance),
+		}).request;
+
+		await expectOk<any>(await request('POST', sessionsPath()));
+
+		const config = calls.writeFiles
+			.flat()
+			.find((file) => file.path === '/tmp/marimohub-config/marimo/marimo.toml');
+		expect(config?.content).toContain('default_width = "medium"');
+		expect(config?.content).toContain('default_sql_output = "native"');
+		expect(config?.content).not.toContain('[ai]');
+		expect(calls.setEnvVars).toContainEqual({
+			XDG_CONFIG_HOME: '/tmp/marimohub-config',
+		});
+	});
+
 	describe('base image resolution', () => {
 		function imageApi(compute: ReturnType<typeof makeFakeCompute>) {
 			return createTestApi({
@@ -760,7 +781,7 @@ describe('Session routes', () => {
 			}).request;
 
 			await expectOk<any>(await req('POST', sessionsPath()));
-			expect(calls.setEnvVars).toHaveLength(0);
+			expect(calls.setEnvVars.flatMap(Object.keys)).not.toContain('AWS_ACCESS_KEY_ID');
 		});
 
 		it('still provisions when the credential exchange fails (non-fatal)', async () => {
@@ -777,7 +798,7 @@ describe('Session routes', () => {
 
 			const data = await expectOk<any>(await req('POST', sessionsPath()));
 			expect(data.status).toBe('running');
-			expect(calls.setEnvVars).toHaveLength(0);
+			expect(calls.setEnvVars.flatMap(Object.keys)).not.toContain('AWS_ACCESS_KEY_ID');
 		});
 
 		it("never injects creds into a viewer's ephemeral session, even when opted in", async () => {
@@ -795,7 +816,7 @@ describe('Session routes', () => {
 
 			const data = await expectOk<any>(await req('POST', sessionsPath()));
 			expect(data.ephemeral).toBe(true);
-			expect(calls.setEnvVars).toHaveLength(0);
+			expect(calls.setEnvVars.flatMap(Object.keys)).not.toContain('AWS_ACCESS_KEY_ID');
 		});
 
 		it('does not inject creds when WIF is unconfigured at the deployment', async () => {
@@ -808,7 +829,7 @@ describe('Session routes', () => {
 			}).request;
 
 			await expectOk<any>(await req('POST', sessionsPath()));
-			expect(calls.setEnvVars).toHaveLength(0);
+			expect(calls.setEnvVars.flatMap(Object.keys)).not.toContain('AWS_ACCESS_KEY_ID');
 		});
 	});
 
@@ -956,7 +977,7 @@ describe('Session routes', () => {
 
 			const data = await expectOk<any>(await req('POST', sessionsPath()));
 			expect(data.ephemeral).toBe(true);
-			expect(calls.setEnvVars).toHaveLength(0);
+			expect(calls.setEnvVars.flatMap(Object.keys)).not.toContain('MY_SECRET');
 		});
 	});
 });

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1,6 +1,7 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import type {
 	AuthUser,
+	MarimoConfigContributor,
 	Project,
 	ProjectId,
 	SessionEnv,
@@ -10,13 +11,16 @@ import type {
 	UserId,
 } from '@marimo-hub/core';
 import {
-	aiConfigToSessionEnv,
 	BadRequestError,
 	ConflictError,
 	createSandboxId,
+	DEFAULT_INJECTED_CONFIG_DIR,
 	DomainError,
 	effectiveRole,
 	exchangeFederatedStorageEnv,
+	marimoAiContributor,
+	marimoConfigToSessionEnv,
+	marimoNotebookDefaults,
 	mintAiSessionToken,
 	NotFoundError,
 	paths,
@@ -57,16 +61,9 @@ import {
 } from '../shared';
 import { pageSchema, paginate, PaginationQuery } from '../pagination';
 
-/**
- * Compose two sessionEnv producers (e.g. WIF + managed AI): concat `files`,
- * spread-merge `vars`. Either side may be undefined.
- */
-function mergeSessionEnv(
-	base: SessionEnv | undefined,
-	add: { files: { path: string; content: string }[]; vars: Record<string, string> },
-): SessionEnv {
+function mergeSessionEnv(base: SessionEnv | undefined, add: SessionEnv): SessionEnv {
 	return {
-		files: [...(base?.files ?? []), ...add.files],
+		files: [...(base?.files ?? []), ...(add.files ?? [])],
 		vars: { ...base?.vars, ...add.vars },
 	};
 }
@@ -601,42 +598,43 @@ app.openapi(createSession, async (c) => {
 						}
 					};
 
-					// Managed AI: best-effort session-scoped token + marimo AI config pointed
-					// at our proxy. A mint failure yields no AI config, never a failed kernel.
-					// Skipped for apps: the injected config drives the *editor's* AI
-					// assistant, and `marimo run` has no editor surface.
-					const resolveAiEnv = async () => {
-						if (!deps.ai || !MODE_POLICY[mode].injectEditorAi) return;
-						try {
-							const token = await mintAiSessionToken(
-								deps.ai.signingSecret,
-								{
-									projectId: pid,
-									notebookId: nid,
-									sessionId: session!.session_id,
-									userId: user.id,
-								},
-								{ ttlSeconds: deps.ai.tokenTtlSeconds },
-							);
-							return aiConfigToSessionEnv(
-								{
-									baseUrl: `${appBaseUrl}/api/ai/v1`,
-									apiKey: token,
-									model: deps.ai.model,
-									enabled: true,
-									maxTokens: deps.ai.maxTokens,
-									rules: deps.ai.rules,
-								},
-								deps.ai.xdgPath,
-							);
-						} catch (err) {
-							observer.tag('ai_inject_failed', true);
-							observer.tag(
-								'ai_inject_error',
-								err instanceof Error ? `${err.name}: ${err.message}` : String(err),
-							);
-							return;
+					const resolveMarimoConfigEnv = async () => {
+						if (!MODE_POLICY[mode].injectEditorConfig) return;
+						const contributors: MarimoConfigContributor[] = [marimoNotebookDefaults];
+						if (deps.ai) {
+							try {
+								const token = await mintAiSessionToken(
+									deps.ai.signingSecret,
+									{
+										projectId: pid,
+										notebookId: nid,
+										sessionId: session!.session_id,
+										userId: user.id,
+									},
+									{ ttlSeconds: deps.ai.tokenTtlSeconds },
+								);
+								contributors.push(
+									marimoAiContributor({
+										baseUrl: `${appBaseUrl}/api/ai/v1`,
+										apiKey: token,
+										model: deps.ai.model,
+										enabled: true,
+										maxTokens: deps.ai.maxTokens,
+										rules: deps.ai.rules,
+									}),
+								);
+							} catch (err) {
+								observer.tag('ai_inject_failed', true);
+								observer.tag(
+									'ai_inject_error',
+									err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+								);
+							}
 						}
+						return marimoConfigToSessionEnv(
+							deps.ai?.xdgPath ?? DEFAULT_INJECTED_CONFIG_DIR,
+							contributors,
+						);
 					};
 
 					// Project secrets: unlike WIF/AI, this FAILS CLOSED — a key the author
@@ -664,16 +662,16 @@ app.openapi(createSession, async (c) => {
 					};
 
 					// The three sources are independent, so resolve them together. Secrets are
-					// the base; the system/WIF/AI vars win a name collision, so a user secret
-					// can never shadow them.
+					// the base; the system/WIF/config vars win a name collision, so a user
+					// secret can never shadow them.
 					const resolveSessionEnv = async (): Promise<SessionEnv | undefined> => {
-						const [wifVars, aiEnv, secretVars] = await Promise.all([
+						const [wifVars, marimoEnv, secretVars] = await Promise.all([
 							resolveWifVars(),
-							resolveAiEnv(),
+							resolveMarimoConfigEnv(),
 							resolveSecretVars(),
 						]);
 						let env: SessionEnv | undefined = wifVars ? { vars: wifVars } : undefined;
-						if (aiEnv) env = mergeSessionEnv(env, aiEnv);
+						if (marimoEnv) env = mergeSessionEnv(env, marimoEnv);
 						if (secretVars) {
 							env = { files: env?.files ?? [], vars: { ...secretVars, ...env?.vars } };
 						}

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1,7 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import type {
 	AuthUser,
-	MarimoConfigContributor,
 	Project,
 	ProjectId,
 	SessionEnv,
@@ -600,41 +599,43 @@ app.openapi(createSession, async (c) => {
 
 					const resolveMarimoConfigEnv = async () => {
 						if (!MODE_POLICY[mode].injectEditorConfig) return;
-						const contributors: MarimoConfigContributor[] = [marimoNotebookDefaults];
-						if (deps.ai) {
-							try {
-								const token = await mintAiSessionToken(
-									deps.ai.signingSecret,
-									{
-										projectId: pid,
-										notebookId: nid,
-										sessionId: session!.session_id,
-										userId: user.id,
-									},
-									{ ttlSeconds: deps.ai.tokenTtlSeconds },
-								);
-								contributors.push(
-									marimoAiContributor({
-										baseUrl: `${appBaseUrl}/api/ai/v1`,
-										apiKey: token,
-										model: deps.ai.model,
-										enabled: true,
-										maxTokens: deps.ai.maxTokens,
-										rules: deps.ai.rules,
-									}),
-								);
-							} catch (err) {
-								observer.tag('ai_inject_failed', true);
-								observer.tag(
-									'ai_inject_error',
-									err instanceof Error ? `${err.name}: ${err.message}` : String(err),
-								);
-							}
+						if (!deps.ai) {
+							return marimoConfigToSessionEnv(DEFAULT_INJECTED_CONFIG_DIR, [
+								marimoNotebookDefaults,
+							]);
 						}
-						return marimoConfigToSessionEnv(
-							deps.ai?.xdgPath ?? DEFAULT_INJECTED_CONFIG_DIR,
-							contributors,
-						);
+						try {
+							const token = await mintAiSessionToken(
+								deps.ai.signingSecret,
+								{
+									projectId: pid,
+									notebookId: nid,
+									sessionId: session!.session_id,
+									userId: user.id,
+								},
+								{ ttlSeconds: deps.ai.tokenTtlSeconds },
+							);
+							return marimoConfigToSessionEnv(deps.ai.xdgPath, [
+								marimoNotebookDefaults,
+								marimoAiContributor({
+									baseUrl: `${appBaseUrl}/api/ai/v1`,
+									apiKey: token,
+									model: deps.ai.model,
+									enabled: true,
+									maxTokens: deps.ai.maxTokens,
+									rules: deps.ai.rules,
+								}),
+							]);
+						} catch (err) {
+							observer.tag('ai_inject_failed', true);
+							observer.tag(
+								'ai_inject_error',
+								err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+							);
+							return marimoConfigToSessionEnv(DEFAULT_INJECTED_CONFIG_DIR, [
+								marimoNotebookDefaults,
+							]);
+						}
 					};
 
 					// Project secrets: unlike WIF/AI, this FAILS CLOSED — a key the author

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"better-all": "catalog:",
+		"smol-toml": "catalog:",
 		"ulidx": "catalog:",
 		"zod": "catalog:"
 	},

--- a/packages/core/src/services/ai/aiSessionConfig.test.ts
+++ b/packages/core/src/services/ai/aiSessionConfig.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
+import { parse } from 'smol-toml';
 import { Seconds } from '../../duration';
 import { toBase64Url, utf8ToBase64Url } from '../../internal/base64url';
 import { hmacSha256 } from '../../internal/hmac';
+import { assembleMarimoToml } from '../marimoConfig';
 import {
-	aiConfigToSessionEnv,
 	buildMarimoAiToml,
+	marimoAiContributor,
 	MARIMOHUB_AI_PROVIDER,
 	mintAiSessionToken,
 	verifyAiSessionToken,
@@ -50,8 +52,9 @@ describe('buildMarimoAiToml', () => {
 			model: 'm',
 			rules: 'be "concise"',
 		});
-		expect(toml).toContain('api_key = "a\\"b\\\\c"');
-		expect(toml).toContain('rules = "be \\"concise\\""');
+		const config = parse(toml);
+		expect(config.ai).toMatchObject({ rules: 'be "concise"' });
+		expect(config.ai).toHaveProperty(`custom_providers.${MARIMOHUB_AI_PROVIDER}.api_key`, 'a"b\\c');
 	});
 
 	it('omits optional fields when absent', () => {
@@ -67,28 +70,23 @@ describe('buildMarimoAiToml', () => {
 	});
 
 	it('escapes newline, carriage-return, and tab in rules (no TOML string break-out)', () => {
+		const rules = 'line1\nline2\rline3\tcol';
 		const toml = buildMarimoAiToml({
 			baseUrl: 'u',
 			apiKey: 'k',
 			model: 'm',
-			rules: 'line1\nline2\rline3\tcol',
+			rules,
 		});
-		expect(toml).toContain('rules = "line1\\nline2\\rline3\\tcol"');
-		// The raw control chars must NOT appear inside the emitted rules string.
-		expect(toml).not.toContain('line1\nline2');
+		expect(parse(toml).ai).toMatchObject({ rules });
 	});
 });
 
-describe('aiConfigToSessionEnv', () => {
-	it('writes marimo.toml under XDG_CONFIG_HOME outside the mount path', () => {
-		const env = aiConfigToSessionEnv(
-			{ baseUrl: 'u', apiKey: 'k', model: 'm' },
-			'/opt/marimohub-config/',
-		);
-		expect(env.vars.XDG_CONFIG_HOME).toBe('/opt/marimohub-config');
-		expect(env.files).toHaveLength(1);
-		expect(env.files[0].path).toBe('/opt/marimohub-config/marimo/marimo.toml');
-		expect(env.files[0].content).toContain('[ai.models]');
+describe('marimoAiContributor', () => {
+	it('produces the same [ai] sections as buildMarimoAiToml when assembled alone', () => {
+		const config = { baseUrl: 'https://app.example/api/ai/v1', apiKey: 'mh_token', model: 'm' };
+		const assembled = assembleMarimoToml([marimoAiContributor(config)]);
+		expect(assembled).toBe(buildMarimoAiToml(config));
+		expect(assembled).toContain(`[ai.custom_providers.${MARIMOHUB_AI_PROVIDER}]`);
 	});
 });
 

--- a/packages/core/src/services/ai/aiSessionConfig.ts
+++ b/packages/core/src/services/ai/aiSessionConfig.ts
@@ -12,6 +12,8 @@
 import { Millis, Seconds } from '../../duration';
 import { fromBase64Url, toBase64Url, utf8ToBase64Url } from '../../internal/base64url';
 import { hmacSha256, timingSafeEqual } from '../../internal/hmac';
+import { serializeMarimoToml } from '../marimoConfig';
+import type { MarimoConfigContributor, TomlTable } from '../marimoConfig';
 
 /** The marimo custom-provider name our config registers (routes `<name>/<model>`). */
 export const MARIMOHUB_AI_PROVIDER = 'marimohub';
@@ -31,11 +33,6 @@ export interface AiSessionConfig {
 	rules?: string;
 }
 
-export interface SessionEnvFragment {
-	files: { path: string; content: string }[];
-	vars: Record<string, string>;
-}
-
 /** Claims carried by an AI session token; `sessionId` is the JWT `sub`. */
 export interface AiTokenClaims {
 	projectId: string;
@@ -44,58 +41,37 @@ export interface AiTokenClaims {
 	userId: string;
 }
 
-/** Escape a value into a TOML basic string (double-quoted). */
-function tomlString(value: string): string {
-	const escaped = value
-		.replaceAll('\\', '\\\\')
-		.replaceAll('"', '\\"')
-		.replaceAll('\n', '\\n')
-		.replaceAll('\r', '\\r')
-		.replaceAll('\t', '\\t');
-	return `"${escaped}"`;
-}
-
 /**
- * Render the marimo `[ai]` config that points a named custom provider at the
- * proxy. A named provider (NOT `[ai.open_ai]`) avoids polluting the editor's
- * default OpenAI model list with entries that don't route to the proxy. It also
- * pins marimo to pydantic-ai's `OpenAIChatModel` (`POST /v1/chat/completions`);
- * the built-in `[ai.open_ai]` provider would use `OpenAIResponsesModel`
- * (`POST /v1/responses`) instead — the proxy handles both, but the custom provider
- * is the tested path.
+ * The marimo `[ai]` config as a mergeable fragment: a named custom provider
+ * pointed at the proxy. A named provider (NOT `[ai.open_ai]`) avoids polluting
+ * the editor's default OpenAI model list with entries that don't route to the
+ * proxy. It also pins marimo to pydantic-ai's `OpenAIChatModel`
+ * (`POST /v1/chat/completions`); the built-in `[ai.open_ai]` provider would use
+ * `OpenAIResponsesModel` (`POST /v1/responses`) instead — the proxy handles both,
+ * but the custom provider is the tested path.
  */
-export function buildMarimoAiToml(config: AiSessionConfig): string {
+function aiConfigTable(config: AiSessionConfig): TomlTable {
 	const modelRef = `${MARIMOHUB_AI_PROVIDER}/${config.model}`;
-	const lines = ['[ai]', `enabled = ${config.enabled === false ? 'false' : 'true'}`];
-	if (config.maxTokens !== undefined) lines.push(`max_tokens = ${config.maxTokens}`);
-	if (config.rules) lines.push(`rules = ${tomlString(config.rules)}`);
-	lines.push(
-		'',
-		'[ai.models]',
-		`chat_model = ${tomlString(modelRef)}`,
-		`edit_model = ${tomlString(modelRef)}`,
-		`autocomplete_model = ${tomlString(modelRef)}`,
-		'',
-		`[ai.custom_providers.${MARIMOHUB_AI_PROVIDER}]`,
-		`base_url = ${tomlString(config.baseUrl)}`,
-		`api_key = ${tomlString(config.apiKey)}`,
-		'',
-	);
-	return lines.join('\n');
+	const ai: TomlTable = { enabled: config.enabled !== false };
+	if (config.maxTokens !== undefined) ai.max_tokens = config.maxTokens;
+	if (config.rules) ai.rules = config.rules;
+	ai.models = {
+		chat_model: modelRef,
+		edit_model: modelRef,
+		autocomplete_model: modelRef,
+	};
+	ai.custom_providers = {
+		[MARIMOHUB_AI_PROVIDER]: { base_url: config.baseUrl, api_key: config.apiKey },
+	};
+	return { ai };
 }
 
-/**
- * Shape the marimo config as a sandbox env fragment: a `marimo.toml` under an
- * XDG config dir plus `XDG_CONFIG_HOME` pointing at it. The dir lives OUTSIDE the
- * notebook's mount path, so the token/url are never read back into the committed
- * `pyproject.toml` or captured into the workspace.
- */
-export function aiConfigToSessionEnv(config: AiSessionConfig, xdgPath: string): SessionEnvFragment {
-	const dir = xdgPath.replace(/\/+$/, '');
-	return {
-		files: [{ path: `${dir}/marimo/marimo.toml`, content: buildMarimoAiToml(config) }],
-		vars: { XDG_CONFIG_HOME: dir },
-	};
+export function buildMarimoAiToml(config: AiSessionConfig): string {
+	return serializeMarimoToml(aiConfigTable(config));
+}
+
+export function marimoAiContributor(config: AiSessionConfig): MarimoConfigContributor {
+	return () => aiConfigTable(config);
 }
 
 /** Mint a short-lived HS256 JWT scoped to one session, signed with `secret`. */

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -101,13 +101,20 @@ export type { WifClaims, JwksKey } from './identity/WorkloadIdentityIssuer';
 export { s3CredsToEnv } from './identity/s3CredsEnv';
 export { exchangeFederatedStorageEnv, projectSubject } from './identity/federation';
 export {
-	aiConfigToSessionEnv,
 	buildMarimoAiToml,
+	marimoAiContributor,
 	mintAiSessionToken,
 	verifyAiSessionToken,
 	MARIMOHUB_AI_PROVIDER,
 } from './ai/aiSessionConfig';
-export type { AiSessionConfig, AiTokenClaims, SessionEnvFragment } from './ai/aiSessionConfig';
+export type { AiSessionConfig, AiTokenClaims } from './ai/aiSessionConfig';
+export {
+	assembleMarimoToml,
+	DEFAULT_INJECTED_CONFIG_DIR,
+	marimoConfigToSessionEnv,
+	marimoNotebookDefaults,
+} from './marimoConfig';
+export type { MarimoConfigContributor } from './marimoConfig';
 export {
 	captureFilesystemSnapshot,
 	createOrRestoreSandbox,

--- a/packages/core/src/services/marimoConfig.test.ts
+++ b/packages/core/src/services/marimoConfig.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import { parse } from 'smol-toml';
+import {
+	assembleMarimoToml,
+	marimoConfigToSessionEnv,
+	marimoNotebookDefaults,
+	serializeMarimoToml,
+} from './marimoConfig';
+import type { MarimoConfigContributor } from './marimoConfig';
+
+describe('serializeMarimoToml', () => {
+	it('round-trips nested tables and arrays', () => {
+		const config = {
+			ai: {
+				enabled: true,
+				max_tokens: 512,
+				model_order: ['chat', 'edit'],
+				models: { chat_model: 'x/y' },
+				custom_providers: { x: { base_url: 'u' } },
+			},
+		};
+		expect(parse(serializeMarimoToml(config))).toEqual(config);
+	});
+
+	it('quotes keys and escapes every control character', () => {
+		const config = {
+			'section.with.dots': {
+				'quoted"key': Array.from({ length: 32 }, (_, code) => String.fromCharCode(code)).join(''),
+			},
+		};
+		expect(parse(serializeMarimoToml(config))).toEqual(config);
+	});
+
+	it('is empty for an empty config', () => {
+		expect(serializeMarimoToml({})).toBe('');
+	});
+});
+
+describe('assembleMarimoToml', () => {
+	it('starts empty — no contributors yields no config', () => {
+		expect(assembleMarimoToml([])).toBe('');
+	});
+
+	it('treats an empty-table contributor as a no-op', () => {
+		const nothing: MarimoConfigContributor = () => ({});
+		expect(assembleMarimoToml([nothing, marimoNotebookDefaults])).toBe(
+			assembleMarimoToml([marimoNotebookDefaults]),
+		);
+	});
+
+	it('deep-merges overlapping sections from multiple contributors', () => {
+		const a: MarimoConfigContributor = () => ({ display: { default_width: 'medium' } });
+		const b: MarimoConfigContributor = () => ({ display: { theme: 'dark' } });
+		expect(parse(assembleMarimoToml([a, b]))).toEqual({
+			display: { default_width: 'medium', theme: 'dark' },
+		});
+	});
+
+	it('later contributors win a scalar collision', () => {
+		const a: MarimoConfigContributor = () => ({ display: { default_width: 'medium' } });
+		const b: MarimoConfigContributor = () => ({ display: { default_width: 'full' } });
+		expect(parse(assembleMarimoToml([a, b]))).toEqual({
+			display: { default_width: 'full' },
+		});
+	});
+
+	it('later contributors win table-scalar collisions in either direction', () => {
+		const table: MarimoConfigContributor = () => ({ feature: { enabled: true } });
+		const scalar: MarimoConfigContributor = () => ({ feature: 'disabled' });
+
+		expect(parse(assembleMarimoToml([table, scalar]))).toEqual({ feature: 'disabled' });
+		expect(parse(assembleMarimoToml([scalar, table]))).toEqual({
+			feature: { enabled: true },
+		});
+	});
+
+	it('does not mutate fragments while merging them', () => {
+		const fragment = { display: { default_width: 'medium' } };
+		const first: MarimoConfigContributor = () => fragment;
+		const second: MarimoConfigContributor = () => ({ display: { theme: 'dark' } });
+
+		assembleMarimoToml([first, second]);
+
+		expect(fragment).toEqual({ display: { default_width: 'medium' } });
+	});
+});
+
+describe('marimoNotebookDefaults', () => {
+	it('sets medium width and native SQL output', () => {
+		expect(parse(assembleMarimoToml([marimoNotebookDefaults]))).toEqual({
+			display: { default_width: 'medium' },
+			runtime: { default_sql_output: 'native' },
+		});
+	});
+});
+
+describe('marimoConfigToSessionEnv', () => {
+	it('writes marimo.toml under XDG_CONFIG_HOME (trailing slash trimmed)', () => {
+		const env = marimoConfigToSessionEnv('/opt/marimohub-config///', [marimoNotebookDefaults]);
+		expect(env.vars.XDG_CONFIG_HOME).toBe('/opt/marimohub-config');
+		expect(env.files).toHaveLength(1);
+		expect(env.files[0].path).toBe('/opt/marimohub-config/marimo/marimo.toml');
+		expect(parse(env.files[0].content)).toEqual({
+			display: { default_width: 'medium' },
+			runtime: { default_sql_output: 'native' },
+		});
+	});
+
+	it.each(['', '/', 'relative/path'])('rejects invalid XDG config path %j', (path) => {
+		expect(() => marimoConfigToSessionEnv(path, [])).toThrow(
+			'XDG config path must be an absolute, non-root path',
+		);
+	});
+});

--- a/packages/core/src/services/marimoConfig.ts
+++ b/packages/core/src/services/marimoConfig.ts
@@ -1,0 +1,59 @@
+import { stringify } from 'smol-toml';
+import type { TomlTable, TomlValue } from 'smol-toml';
+import type { SessionEnv } from './runtime/SandboxProvisioner';
+
+export type MarimoConfigContributor = () => TomlTable;
+
+export const DEFAULT_INJECTED_CONFIG_DIR = '/tmp/marimohub-config';
+
+function isTomlTable(value: TomlValue | undefined): value is TomlTable {
+	return (
+		typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date)
+	);
+}
+
+function emptyTable(): TomlTable {
+	return Object.create(null) as TomlTable;
+}
+
+export function serializeMarimoToml(table: TomlTable): string {
+	return Object.keys(table).length === 0 ? '' : stringify(table);
+}
+
+function mergeInto(target: TomlTable, source: TomlTable): void {
+	for (const [key, value] of Object.entries(source)) {
+		const existing = Object.hasOwn(target, key) ? target[key] : undefined;
+		if (isTomlTable(value)) {
+			const merged = isTomlTable(existing) ? existing : emptyTable();
+			target[key] = merged;
+			mergeInto(merged, value);
+		} else {
+			target[key] = value;
+		}
+	}
+}
+
+export function assembleMarimoToml(contributors: readonly MarimoConfigContributor[]): string {
+	const merged = emptyTable();
+	for (const contribute of contributors) mergeInto(merged, contribute());
+	return serializeMarimoToml(merged);
+}
+
+export const marimoNotebookDefaults: MarimoConfigContributor = () => ({
+	display: { default_width: 'medium' },
+	runtime: { default_sql_output: 'native' },
+});
+
+export function marimoConfigToSessionEnv(
+	xdgPath: string,
+	contributors: readonly MarimoConfigContributor[],
+): SessionEnv {
+	const dir = xdgPath.replace(/\/+$/, '');
+	if (!dir.startsWith('/')) {
+		throw new TypeError('XDG config path must be an absolute, non-root path');
+	}
+	return {
+		files: [{ path: `${dir}/marimo/marimo.toml`, content: assembleMarimoToml(contributors) }],
+		vars: { XDG_CONFIG_HOME: dir },
+	};
+}

--- a/packages/core/src/services/runtime/sessionState.ts
+++ b/packages/core/src/services/runtime/sessionState.ts
@@ -80,8 +80,8 @@ export interface SessionModePolicy {
 	 * sandbox must not write through to the workspace mirror.
 	 */
 	workspaceLoad: 'source-policy' | 'copy-only';
-	/** Inject the marimo editor's AI config (meaningless without an editor surface). */
-	injectEditorAi: boolean;
+	/** App sessions skip this because `marimo run` has no editor surface. */
+	injectEditorConfig: boolean;
 	/** Anchored by the per-notebook claim object (`claimApp`/`releaseApp`). */
 	singleton: boolean;
 	/**
@@ -105,7 +105,7 @@ export const MODE_POLICY: Record<SessionMode, SessionModePolicy> = {
 		capScope: 'user',
 		persistsEdits: true,
 		workspaceLoad: 'source-policy',
-		injectEditorAi: true,
+		injectEditorConfig: true,
 		singleton: false,
 		viewerSession: 'ephemeral',
 	},
@@ -120,7 +120,7 @@ export const MODE_POLICY: Record<SessionMode, SessionModePolicy> = {
 		capScope: 'project',
 		persistsEdits: false,
 		workspaceLoad: 'copy-only',
-		injectEditorAi: false,
+		injectEditorConfig: false,
 		singleton: true,
 		viewerSession: 'shared',
 	},

--- a/packages/web/src/components/Project/Project.test.tsx
+++ b/packages/web/src/components/Project/Project.test.tsx
@@ -215,6 +215,26 @@ describe('Project — Create Notebook', () => {
 			expect(post?.body).toMatchObject({ title: 'Churn', description: 'Churn' });
 			const code = (post?.body as { code?: string } | undefined)?.code;
 			expect(code).toContain('import marimo');
+			expect(code).toContain('marimo.App(width="medium", sql_output="native")');
+			expect(code).toContain('mo.md("# Churn")');
+		});
+	});
+
+	it('quotes the notebook name safely in the generated Python', async () => {
+		const user = userEvent.setup();
+		const calls = makeFetch();
+		await renderProject();
+
+		await user.click(screen.getByRole('button', { name: 'New Notebook' }));
+		const dialog = screen.getByRole('dialog');
+		await user.type(within(dialog).getByLabelText('Notebook Name'), 'Quote"""Break');
+		await user.click(within(dialog).getByRole('button', { name: 'Create' }));
+
+		await waitFor(() => {
+			const post = calls.find((call) => call.method === 'POST');
+			const code = (post?.body as { code?: string } | undefined)?.code;
+			expect(code).toContain('mo.md("# Quote\\\"\\\"\\\"Break")');
+			expect(code).not.toContain('r"""');
 		});
 	});
 

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -106,8 +106,10 @@ const projectSchema = z.object({
 });
 const notebookNameSchema = z.object({ name: requiredText('Notebook name'), baseImage: z.string() });
 
-const NEW_NOTEBOOK_CODE = (name: string) =>
-	`import marimo\n\napp = marimo.App()\n\n\n@app.cell\ndef _():\n    import marimo as mo\n    return (mo,)\n\n\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md(r"""# ${name}""")\n    return\n\n\nif __name__ == "__main__":\n    app.run()\n`;
+const NEW_NOTEBOOK_CODE = (name: string) => {
+	const heading = JSON.stringify(`# ${name}`);
+	return `import marimo\n\napp = marimo.App(width="medium", sql_output="native")\n\n\n@app.cell\ndef _():\n    import marimo as mo\n    return (mo,)\n\n\n@app.cell(hide_code=True)\ndef _(mo):\n    mo.md(${heading})\n    return\n\n\nif __name__ == "__main__":\n    app.run()\n`;
+};
 
 export function Project() {
 	const { pid } = useParams<{ pid: string }>();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ catalogs:
     openapi-fetch:
       specifier: ^0.17.0
       version: 0.17.0
+    smol-toml:
+      specifier: ^1.7.0
+      version: 1.7.0
     sonner:
       specifier: ^2.0.7
       version: 2.0.7
@@ -749,6 +752,9 @@ importers:
       better-all:
         specifier: 'catalog:'
         version: 0.0.7
+      smol-toml:
+        specifier: 'catalog:'
+        version: 1.7.0
       ulidx:
         specifier: 'catalog:'
         version: 2.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ catalog:
   ofetch: ^1.5.1
   openapi-fetch: ^0.17.0
   sonner: ^2.0.7
+  smol-toml: ^1.7.0
   tailwind-merge: ^3.6.0
   tailwindcss: ^4.3.0
   tailwindcss-react-aria-components: ^2.1.1


### PR DESCRIPTION
## What

Injects a `marimo.toml` into editor kernel sessions assembled from mergeable **config contributors**:

- **Notebook defaults** — `display.default_width = "medium"`, `runtime.default_sql_output = "native"` — now applied to every editor session, even when managed AI is unconfigured.
- **Managed AI** — the existing session-scoped provider config, refactored from `aiConfigToSessionEnv` into a `marimoAiContributor` fragment that merges into the same TOML.

App sessions (`marimo run`) still skip config injection — the policy field is renamed `injectEditorAi` → `injectEditorConfig` to reflect the broader scope.

## Details

- New `packages/core/src/services/marimoConfig.ts` deep-merges contributor tables and serializes via `smol-toml` (added to core deps).
- New-notebook scaffold seeds the same defaults inline: `marimo.App(width="medium", sql_output="native")`.

## Test plan

- `pnpm test` / `pnpm check`