### PR TITLE
feat(runtime): add marimohub metadata to fresh project init

### DIFF
--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -59,4 +59,11 @@ describe('buildMarimoLaunch', () => {
 		const { start } = buildMarimoLaunch({ ...BASE, mode: 'app', notebookFile: 'apps/my app.py' });
 		expect(start).toContain("'apps/my app.py'");
 	});
+
+	it('initializes a fresh project with marimohub metadata', () => {
+		const [setup] = buildMarimoLaunch(BASE).setup;
+		expect(setup).toContain('uv init');
+		expect(setup).toContain('--name notebook');
+		expect(setup).toContain('--description "Built in marimohub"');
+	});
 });

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -88,7 +88,7 @@ export const MARIMO_LAUNCH_STRATEGIES = {
 			// --no-build keeps it to wheels so a source build can't run arbitrary code /
 			// stall the launch. The image must NOT set UV_COMPILE_BYTECODE (it would
 			// conflict with --no-compile-bytecode). `|| true` never blocks launch.
-			`if python3 -c "import tomllib,sys;sys.exit(0 if tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies') else 1)" 2>/dev/null; then uv sync --inexact --no-compile-bytecode --no-build || true; elif ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then { rm -f pyproject.toml && uv init --vcs none --name notebooks; } || true; fi`,
+			`if python3 -c "import tomllib,sys;sys.exit(0 if tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies') else 1)" 2>/dev/null; then uv sync --inexact --no-compile-bytecode --no-build || true; elif ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then { rm -f pyproject.toml && uv init --vcs none --name notebook --description "Built in marimohub"; } || true; fi`,
 		],
 		start: `uv run --no-sync ${marimoCommand(p)}`,
 	}),


### PR DESCRIPTION
Sets `--name notebook` and `--description "Built in marimohub"` when `uv init` bootstraps a fresh project (no `[project]` in pyproject.toml). Adds a test covering the init command.