### PR TITLE
refactor: internalize marimo XDG config path

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -1452,7 +1452,6 @@ MARIMOHUB_AI_ALLOWED_MODELS=gpt-4o-mini,gpt-4o
 MARIMOHUB_AI_MAX_TOKENS=4096
 MARIMOHUB_AI_RULES=Prefer polars over pandas.
 MARIMOHUB_AI_TOKEN_TTL_SECONDS=3600
-MARIMOHUB_AI_XDG_PATH=/tmp/marimohub-config
 
 # --- Options ---
 MARIMOHUB_PERSIST_WORKSPACE=source"
@@ -1499,7 +1498,6 @@ exports[`config -> code generators > s3 + modal + oidc, managed ai > compose 1`]
       MARIMOHUB_AI_MAX_TOKENS: 4096
       MARIMOHUB_AI_RULES: "Prefer polars over pandas."
       MARIMOHUB_AI_TOKEN_TTL_SECONDS: 3600
-      MARIMOHUB_AI_XDG_PATH: /tmp/marimohub-config
       MARIMOHUB_PERSIST_WORKSPACE: source"
 `;
 
@@ -1533,7 +1531,6 @@ config:
   MARIMOHUB_AI_MAX_TOKENS: 4096
   MARIMOHUB_AI_RULES: "Prefer polars over pandas."
   MARIMOHUB_AI_TOKEN_TTL_SECONDS: 3600
-  MARIMOHUB_AI_XDG_PATH: /tmp/marimohub-config
   MARIMOHUB_PERSIST_WORKSPACE: source
 
 # Secret values -> Secret (prefer secrets.existingSecret in production).

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -32,7 +32,6 @@ The full set of variables:
 | `MARIMOHUB_AI_MAX_TOKENS`        | no       | `[ai] max_tokens` written into the notebook config.                                                                  |
 | `MARIMOHUB_AI_RULES`             | no       | `[ai] rules` — custom assistant instructions.                                                                        |
 | `MARIMOHUB_AI_TOKEN_TTL_SECONDS` | no       | Session-token lifetime in seconds (default 3600).                                                                    |
-| `MARIMOHUB_AI_XDG_PATH`          | no       | Where the injected `marimo.toml` lives (default `/tmp/marimohub-config`; must be writable by the sandbox user).      |
 
 Managed AI also requires `MARIMOHUB_AUTH_SESSION_SECRET` — the per-session tokens
 are signed with it (the same secret that signs login cookies).
@@ -52,10 +51,10 @@ provider's base and `MARIMOHUB_AI_MODEL` to one of its model ids:
 
 ## How it works
 
-1. **Inject.** At session start, marimohub writes a `marimo.toml` into the sandbox
-   (in an XDG config dir, outside the notebook's files) that registers a custom AI
-   provider pointed at marimohub's own proxy, using a short-lived, session-scoped
-   token as the `api_key`.
+1. **Inject.** At session start, marimohub sets `XDG_CONFIG_HOME` and writes a
+   `marimo.toml` into that sandbox-local config directory, outside the notebook's
+   files. The config registers a custom AI provider pointed at marimohub's own
+   proxy using a short-lived, session-scoped token as the `api_key`.
 2. **Proxy.** marimohub hosts an OpenAI-compatible endpoint at `/api/ai/v1`. It
    verifies the session token, then forwards the request to your upstream with the
    **real** key (held server-side), streaming the response back.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -381,7 +381,6 @@ Fronts any OpenAI-compatible upstream (OpenAI, OpenRouter, LiteLLM, or Anthropic
 | `MARIMOHUB_AI_MAX_TOKENS` | Optional `[ai] max_tokens` written into the injected notebook config. | — | — | `4096` |
 | `MARIMOHUB_AI_RULES` | Optional `[ai] rules` (custom assistant instructions). | — | — | `Prefer polars over pandas.` |
 | `MARIMOHUB_AI_TOKEN_TTL_SECONDS` | Per-session token lifetime in seconds. | — | `3600` | — |
-| `MARIMOHUB_AI_XDG_PATH` | Where the injected `marimo.toml` lives in the sandbox (an XDG config dir, kept outside the notebook’s mount path so the token is never committed). Must be writable by the non-root sandbox user. | — | `/tmp/marimohub-config` | — |
 
 ## Project secrets
 

--- a/examples/cloudflare-worker/src/index.ts
+++ b/examples/cloudflare-worker/src/index.ts
@@ -87,7 +87,6 @@ export function buildDeps(request: Request, env: Env): ApiDeps {
 					upstreamApiKey: env.AI_UPSTREAM_API_KEY,
 					model: env.AI_MODEL,
 					signingSecret: env.AI_SESSION_SECRET,
-					xdgPath: '/tmp/marimohub-config',
 					upstreamProject: env.AI_UPSTREAM_PROJECT,
 				}
 			: undefined;

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -135,8 +135,6 @@ export interface AiProxyConfig {
 	model: string;
 	/** Secret used to sign/verify the per-session token (the auth session secret). */
 	signingSecret: string;
-	/** Where the injected `marimo.toml` lives (XDG config dir, outside the mount path). */
-	xdgPath: string;
 	/** Optional allowlist of upstream model ids; off-list requests fall back to `model`. */
 	allowedModels?: string[];
 	maxTokens?: number;

--- a/packages/api/src/routes/ai.test.ts
+++ b/packages/api/src/routes/ai.test.ts
@@ -11,7 +11,6 @@ const AI: ApiDeps['ai'] = {
 	upstreamApiKey: 'real-key',
 	model: 'gpt-4o-mini',
 	signingSecret: SECRET,
-	xdgPath: '/opt/marimohub-config',
 };
 
 function app(overrides: Partial<ApiDeps> = {}) {

--- a/packages/api/src/routes/sessions.appMode.test.ts
+++ b/packages/api/src/routes/sessions.appMode.test.ts
@@ -180,7 +180,6 @@ describe('Session routes (app mode)', () => {
 			upstreamApiKey: 'k',
 			model: 'gpt-test',
 			signingSecret: 's'.repeat(32),
-			xdgPath: '/xdg',
 		};
 		const editFake = makeFakeSandbox();
 		const editApi = createTestApi({
@@ -192,7 +191,7 @@ describe('Session routes (app mode)', () => {
 		await expectOk<any>(await editApi.request('POST', sessionsPath()));
 		const editConfig = editFake.calls.writeFiles
 			.flat()
-			.find((file) => file.path === '/xdg/marimo/marimo.toml');
+			.find((file) => file.path === '/tmp/marimohub-config/marimo/marimo.toml');
 		expect(editConfig?.content).toContain('default_width = "medium"');
 		expect(editConfig?.content).toContain('default_sql_output = "native"');
 		expect(editConfig?.content).toContain('[ai]');
@@ -211,45 +210,6 @@ describe('Session routes (app mode)', () => {
 		).toBe(false);
 		expect(runFake.calls.setEnvVars.flatMap(Object.keys)).not.toContain('XDG_CONFIG_HOME');
 	});
-
-	it.each(['', 'relative/path', '/'])(
-		'falls back to default-only editor config when managed AI uses invalid XDG path %j',
-		async (xdgPath) => {
-			const fake = makeFakeSandbox();
-			const api = createTestApi({
-				bucket,
-				userId: ACTOR,
-				compute: fakeComputeFrom(fake.instance),
-				deps: {
-					ai: {
-						upstreamBaseUrl: 'https://ai.example',
-						upstreamApiKey: 'k',
-						model: 'gpt-test',
-						signingSecret: 's'.repeat(32),
-						xdgPath,
-					},
-				},
-			});
-
-			const session = await expectOk<any>(await api.request('POST', sessionsPath()));
-
-			expect(session.status).toBe('running');
-			const configFiles = fake.calls.writeFiles
-				.flat()
-				.filter((file) => file.path.endsWith('/marimo/marimo.toml'));
-			expect(configFiles).toEqual([
-				expect.objectContaining({
-					path: '/tmp/marimohub-config/marimo/marimo.toml',
-				}),
-			]);
-			expect(configFiles[0].content).toContain('default_width = "medium"');
-			expect(configFiles[0].content).toContain('default_sql_output = "native"');
-			expect(configFiles[0].content).not.toContain('[ai]');
-			expect(fake.calls.setEnvVars).toContainEqual({
-				XDG_CONFIG_HOME: '/tmp/marimohub-config',
-			});
-		},
-	);
 
 	describe('viewer admission per MARIMOHUB_VIEWER_MODE', () => {
 		const viewerApi = (viewerMode?: 'static' | 'applications' | 'ephemeral-sandbox') =>

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -3,6 +3,7 @@ import type {
 	AuthUser,
 	Project,
 	ProjectId,
+	MarimoConfigContributor,
 	SessionEnv,
 	Session,
 	SessionId,
@@ -13,7 +14,6 @@ import {
 	BadRequestError,
 	ConflictError,
 	createSandboxId,
-	DEFAULT_INJECTED_CONFIG_DIR,
 	DomainError,
 	effectiveRole,
 	exchangeFederatedStorageEnv,
@@ -599,43 +599,38 @@ app.openapi(createSession, async (c) => {
 
 					const resolveMarimoConfigEnv = async () => {
 						if (!MODE_POLICY[mode].injectEditorConfig) return;
-						if (!deps.ai) {
-							return marimoConfigToSessionEnv(DEFAULT_INJECTED_CONFIG_DIR, [
-								marimoNotebookDefaults,
-							]);
+						const contributors: MarimoConfigContributor[] = [marimoNotebookDefaults];
+						if (deps.ai) {
+							try {
+								const token = await mintAiSessionToken(
+									deps.ai.signingSecret,
+									{
+										projectId: pid,
+										notebookId: nid,
+										sessionId: session!.session_id,
+										userId: user.id,
+									},
+									{ ttlSeconds: deps.ai.tokenTtlSeconds },
+								);
+								contributors.push(
+									marimoAiContributor({
+										baseUrl: `${appBaseUrl}/api/ai/v1`,
+										apiKey: token,
+										model: deps.ai.model,
+										enabled: true,
+										maxTokens: deps.ai.maxTokens,
+										rules: deps.ai.rules,
+									}),
+								);
+							} catch (err) {
+								observer.tag('ai_inject_failed', true);
+								observer.tag(
+									'ai_inject_error',
+									err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+								);
+							}
 						}
-						try {
-							const token = await mintAiSessionToken(
-								deps.ai.signingSecret,
-								{
-									projectId: pid,
-									notebookId: nid,
-									sessionId: session!.session_id,
-									userId: user.id,
-								},
-								{ ttlSeconds: deps.ai.tokenTtlSeconds },
-							);
-							return marimoConfigToSessionEnv(deps.ai.xdgPath, [
-								marimoNotebookDefaults,
-								marimoAiContributor({
-									baseUrl: `${appBaseUrl}/api/ai/v1`,
-									apiKey: token,
-									model: deps.ai.model,
-									enabled: true,
-									maxTokens: deps.ai.maxTokens,
-									rules: deps.ai.rules,
-								}),
-							]);
-						} catch (err) {
-							observer.tag('ai_inject_failed', true);
-							observer.tag(
-								'ai_inject_error',
-								err instanceof Error ? `${err.name}: ${err.message}` : String(err),
-							);
-							return marimoConfigToSessionEnv(DEFAULT_INJECTED_CONFIG_DIR, [
-								marimoNotebookDefaults,
-							]);
-						}
+						return marimoConfigToSessionEnv(contributors);
 					};
 
 					// Project secrets: unlike WIF/AI, this FAILS CLOSED — a key the author

--- a/packages/config/src/ai.ts
+++ b/packages/config/src/ai.ts
@@ -11,9 +11,6 @@ import { parseIntEnv, parseList, requiredVar } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
 
-// `/tmp` so the non-root sandbox user can always write the injected config, and
-// it stays outside the mount path (never committed/captured).
-const DEFAULT_XDG_PATH = '/tmp/marimohub-config';
 const DOCS = 'docs/ai.md';
 
 export function makeAi(env: Env): Pick<ApiDeps, 'ai'> {
@@ -68,7 +65,6 @@ export function makeAi(env: Env): Pick<ApiDeps, 'ai'> {
 				docs: DOCS,
 			}),
 			signingSecret,
-			xdgPath: env.MARIMOHUB_AI_XDG_PATH ?? DEFAULT_XDG_PATH,
 			allowedModels: parseList(env.MARIMOHUB_AI_ALLOWED_MODELS),
 			maxTokens: parseIntEnv(env, 'MARIMOHUB_AI_MAX_TOKENS'),
 			rules: env.MARIMOHUB_AI_RULES,

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -1087,13 +1087,6 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						description: 'Per-session token lifetime in seconds.',
 						default: '3600',
 					},
-					{
-						id: 'MARIMOHUB_AI_XDG_PATH',
-						name: 'Injected config dir',
-						description:
-							'Where the injected `marimo.toml` lives in the sandbox (an XDG config dir, kept outside the notebook’s mount path so the token is never committed). Must be writable by the non-root sandbox user.',
-						default: '/tmp/marimohub-config',
-					},
 				],
 			},
 		],

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -110,7 +110,6 @@ export {
 export type { AiSessionConfig, AiTokenClaims } from './ai/aiSessionConfig';
 export {
 	assembleMarimoToml,
-	DEFAULT_INJECTED_CONFIG_DIR,
 	marimoConfigToSessionEnv,
 	marimoNotebookDefaults,
 } from './marimoConfig';

--- a/packages/core/src/services/marimoConfig.test.ts
+++ b/packages/core/src/services/marimoConfig.test.ts
@@ -95,20 +95,14 @@ describe('marimoNotebookDefaults', () => {
 });
 
 describe('marimoConfigToSessionEnv', () => {
-	it('writes marimo.toml under XDG_CONFIG_HOME (trailing slash trimmed)', () => {
-		const env = marimoConfigToSessionEnv('/opt/marimohub-config///', [marimoNotebookDefaults]);
-		expect(env.vars.XDG_CONFIG_HOME).toBe('/opt/marimohub-config');
+	it('writes marimo.toml under the injected XDG_CONFIG_HOME', () => {
+		const env = marimoConfigToSessionEnv([marimoNotebookDefaults]);
+		expect(env.vars.XDG_CONFIG_HOME).toBe('/tmp/marimohub-config');
 		expect(env.files).toHaveLength(1);
-		expect(env.files[0].path).toBe('/opt/marimohub-config/marimo/marimo.toml');
+		expect(env.files[0].path).toBe('/tmp/marimohub-config/marimo/marimo.toml');
 		expect(parse(env.files[0].content)).toEqual({
 			display: { default_width: 'medium' },
 			runtime: { default_sql_output: 'native' },
 		});
-	});
-
-	it.each(['', '/', 'relative/path'])('rejects invalid XDG config path %j', (path) => {
-		expect(() => marimoConfigToSessionEnv(path, [])).toThrow(
-			'XDG config path must be an absolute, non-root path',
-		);
 	});
 });

--- a/packages/core/src/services/marimoConfig.ts
+++ b/packages/core/src/services/marimoConfig.ts
@@ -4,7 +4,7 @@ import type { SessionEnv } from './runtime/SandboxProvisioner';
 
 export type MarimoConfigContributor = () => TomlTable;
 
-export const DEFAULT_INJECTED_CONFIG_DIR = '/tmp/marimohub-config';
+const XDG_CONFIG_HOME = '/tmp/marimohub-config';
 
 function isTomlTable(value: TomlValue | undefined): value is TomlTable {
 	return (
@@ -45,15 +45,15 @@ export const marimoNotebookDefaults: MarimoConfigContributor = () => ({
 });
 
 export function marimoConfigToSessionEnv(
-	xdgPath: string,
 	contributors: readonly MarimoConfigContributor[],
 ): SessionEnv {
-	const dir = xdgPath.replace(/\/+$/, '');
-	if (!dir.startsWith('/')) {
-		throw new TypeError('XDG config path must be an absolute, non-root path');
-	}
 	return {
-		files: [{ path: `${dir}/marimo/marimo.toml`, content: assembleMarimoToml(contributors) }],
-		vars: { XDG_CONFIG_HOME: dir },
+		files: [
+			{
+				path: `${XDG_CONFIG_HOME}/marimo/marimo.toml`,
+				content: assembleMarimoToml(contributors),
+			},
+		],
+		vars: { XDG_CONFIG_HOME },
 	};
 }


### PR DESCRIPTION
## Summary

Removes the configurable `MARIMOHUB_AI_XDG_PATH` env var and hardcodes the injected `marimo.toml` location (`/tmp/marimohub-config`) inside `marimoConfig`. The path was never meaningfully user-tunable — it must be writable by the non-root sandbox user and stay outside the notebook mount — so making it an env var only added surface area to config, spec, docs, and the AI proxy context.

## Changes

- `marimoConfigToSessionEnv` no longer takes an `xdgPath` argument; it uses the internal `XDG_CONFIG_HOME` constant.
- Drop `MARIMOHUB_AI_XDG_PATH` from the config spec, `ai` builder, and `AiProxyConfig` context.
- Update docs and tests accordingly.

## Test plan

- `pnpm check`
- `pnpm test`