### PR TITLE
feat(runtime): always disable marimo sharing options in sessions

### DIFF
--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -131,6 +131,10 @@ describe('Session routes', () => {
 			.find((file) => file.path === '/tmp/marimohub-config/marimo/marimo.toml');
 		expect(config?.content).toContain('default_width = "medium"');
 		expect(config?.content).toContain('default_sql_output = "native"');
+		expect(config?.content).toContain('[sharing]');
+		expect(config?.content).toContain('html = false');
+		expect(config?.content).toContain('wasm = false');
+		expect(config?.content).toContain('molab = false');
 		expect(config?.content).not.toContain('[ai]');
 		expect(calls.setEnvVars).toContainEqual({
 			XDG_CONFIG_HOME: '/tmp/marimohub-config',

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -20,6 +20,7 @@ import {
 	marimoAiContributor,
 	marimoConfigToSessionEnv,
 	marimoNotebookDefaults,
+	marimoSharingDisabled,
 	mintAiSessionToken,
 	NotFoundError,
 	paths,
@@ -656,7 +657,10 @@ app.openapi(createSession, async (c) => {
 
 					const resolveMarimoConfigEnv = async () => {
 						if (!MODE_POLICY[mode].injectEditorConfig) return;
-						const contributors: MarimoConfigContributor[] = [marimoNotebookDefaults];
+						const contributors: MarimoConfigContributor[] = [
+							marimoNotebookDefaults,
+							marimoSharingDisabled,
+						];
 						if (deps.ai) {
 							try {
 								const token = await mintAiSessionToken(

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -112,6 +112,7 @@ export {
 	assembleMarimoToml,
 	marimoConfigToSessionEnv,
 	marimoNotebookDefaults,
+	marimoSharingDisabled,
 } from './marimoConfig';
 export type { MarimoConfigContributor } from './marimoConfig';
 export {

--- a/packages/core/src/services/marimoConfig.test.ts
+++ b/packages/core/src/services/marimoConfig.test.ts
@@ -4,6 +4,7 @@ import {
 	assembleMarimoToml,
 	marimoConfigToSessionEnv,
 	marimoNotebookDefaults,
+	marimoSharingDisabled,
 	serializeMarimoToml,
 } from './marimoConfig';
 import type { MarimoConfigContributor } from './marimoConfig';
@@ -90,6 +91,14 @@ describe('marimoNotebookDefaults', () => {
 		expect(parse(assembleMarimoToml([marimoNotebookDefaults]))).toEqual({
 			display: { default_width: 'medium' },
 			runtime: { default_sql_output: 'native' },
+		});
+	});
+});
+
+describe('marimoSharingDisabled', () => {
+	it('turns off every sharing surface', () => {
+		expect(parse(assembleMarimoToml([marimoSharingDisabled]))).toEqual({
+			sharing: { html: false, wasm: false, molab: false },
 		});
 	});
 });

--- a/packages/core/src/services/marimoConfig.ts
+++ b/packages/core/src/services/marimoConfig.ts
@@ -44,6 +44,11 @@ export const marimoNotebookDefaults: MarimoConfigContributor = () => ({
 	runtime: { default_sql_output: 'native' },
 });
 
+// marimo's built-in sharing (HTML/WASM export, molab) publishes outside the deployment.
+export const marimoSharingDisabled: MarimoConfigContributor = () => ({
+	sharing: { html: false, wasm: false, molab: false },
+});
+
 export function marimoConfigToSessionEnv(
 	contributors: readonly MarimoConfigContributor[],
 ): SessionEnv {


### PR DESCRIPTION
## Summary

Adds a new `MarimoConfigContributor` (`marimoSharingDisabled`) that injects

```toml
[sharing]
html = false
wasm = false
molab = false
```

into every session's generated `marimo.toml`, hiding marimo's built-in sharing options (HTML/WASM export, molab) from the UI. These surfaces publish outside the deployment, so the contributor is always enabled and not configurable — no env var, no backend selector.

## Changes
- `packages/core/src/services/marimoConfig.ts`: new `marimoSharingDisabled` contributor (exported from `@marimo-hub/core`)
- `packages/api/src/routes/sessions.ts`: added unconditionally alongside `marimoNotebookDefaults` for every session with editor config injection

## Testing
- Unit test for the contributor output in `marimoConfig.test.ts`
- Extended the existing `sessions.test.ts` marimo.toml assertion to cover the `[sharing]` keys
- `pnpm check` passes; core (12) and api sessions (90) tests pass