### PR TITLE
feat(auth): preserve deep links through sign-in via sanitized redirect_url

### DIFF
--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -461,6 +461,27 @@ describe('OIDC routes', () => {
 		expect(res.headers.get('location')).toBe('/p/proj-1?tab=files&auth_error=auth_failed');
 	});
 
+	it.each([
+		['/p/proj-1#cell-3', '/p/proj-1?auth_error=auth_failed#cell-3'],
+		['/p/proj-1?tab=files#cell-3', '/p/proj-1?tab=files&auth_error=auth_failed#cell-3'],
+	])('inserts auth_error into the query, before the fragment (%s)', async (deepLink, expected) => {
+		oauthMock.validateAuthResponse.mockImplementation(() => {
+			throw new Error('provider rejected the callback');
+		});
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(
+			routes,
+			`/api/auth/login?redirect_url=${encodeURIComponent(deepLink)}`,
+		);
+
+		const res = await routes.request('/api/auth/callback?error=access_denied&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe(expected);
+	});
+
 	it('rejects a restricted-domain callback when the email is unverified', async () => {
 		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
 			sub: 'user-1',

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { SignJWT } from 'jose';
-import { createOidcAuth, normalizeEmailDomains, emailDomainAllowed } from './index';
+import {
+	createOidcAuth,
+	normalizeEmailDomains,
+	emailDomainAllowed,
+	sanitizeReturnTo,
+} from './index';
 
 const oauthMock = vi.hoisted(() => ({
 	ClientSecretPost: vi.fn(),
@@ -113,8 +118,9 @@ function cookiePair(res: Response, name: string): string {
 
 async function beginOidcTransaction(
 	routes: ReturnType<typeof createOidcAuth>['routes'],
+	loginPath = '/api/auth/login',
 ): Promise<string> {
-	const login = await routes.request('/api/auth/login');
+	const login = await routes.request(loginPath);
 	expect(login.status).toBe(302);
 	return cookiePair(login, TXN_COOKIE);
 }
@@ -159,6 +165,74 @@ describe('normalizeEmailDomains', () => {
 
 	it('returns an empty array for undefined', () => {
 		expect(normalizeEmailDomains(undefined)).toEqual([]);
+	});
+});
+
+describe('sanitizeReturnTo', () => {
+	it('accepts a same-origin absolute path', () => {
+		expect(sanitizeReturnTo('/p/proj-1/notebooks/nb-1')).toBe('/p/proj-1/notebooks/nb-1');
+	});
+
+	it('keeps the query string and hash', () => {
+		expect(sanitizeReturnTo('/p/proj-1?tab=files#cell-3')).toBe('/p/proj-1?tab=files#cell-3');
+	});
+
+	it('accepts the root path', () => {
+		expect(sanitizeReturnTo('/')).toBe('/');
+	});
+
+	it('rejects empty, null, and undefined', () => {
+		expect(sanitizeReturnTo('')).toBeNull();
+		expect(sanitizeReturnTo(null)).toBeNull();
+		expect(sanitizeReturnTo(undefined)).toBeNull();
+	});
+
+	it('rejects absolute URLs and bare hostnames', () => {
+		expect(sanitizeReturnTo('https://evil.com/phish')).toBeNull();
+		expect(sanitizeReturnTo('http://evil.com')).toBeNull();
+		expect(sanitizeReturnTo('evil.com/phish')).toBeNull();
+	});
+
+	it('rejects dangerous schemes', () => {
+		expect(sanitizeReturnTo('javascript:alert(1)')).toBeNull();
+		expect(sanitizeReturnTo('data:text/html,x')).toBeNull();
+	});
+
+	it('rejects scheme-relative //host redirects', () => {
+		expect(sanitizeReturnTo('//evil.com')).toBeNull();
+		expect(sanitizeReturnTo('//evil.com/phish')).toBeNull();
+	});
+
+	it('rejects backslash variants browsers normalize to //', () => {
+		expect(sanitizeReturnTo('/\\evil.com')).toBeNull();
+		expect(sanitizeReturnTo('\\\\evil.com')).toBeNull();
+		expect(sanitizeReturnTo('/p\\x')).toBeNull();
+	});
+
+	it('rejects paths whose dot-segment normalization escapes the origin', () => {
+		expect(sanitizeReturnTo('/..//evil.com')).toBeNull();
+		expect(sanitizeReturnTo('/a/..//evil.com')).toBeNull();
+	});
+
+	it('normalizes benign dot segments', () => {
+		expect(sanitizeReturnTo('/a/../b')).toBe('/b');
+	});
+
+	it('rejects control characters', () => {
+		expect(sanitizeReturnTo('/p\u0000x')).toBeNull();
+		expect(sanitizeReturnTo('/p\nx')).toBeNull();
+		expect(sanitizeReturnTo('/p\u007fx')).toBeNull();
+	});
+
+	it('rejects API paths (would loop back into the auth routes)', () => {
+		expect(sanitizeReturnTo('/api/auth/login')).toBeNull();
+		expect(sanitizeReturnTo('/api')).toBeNull();
+		// ...but only the /api segment itself, not a lookalike prefix.
+		expect(sanitizeReturnTo('/apifoo')).toBe('/apifoo');
+	});
+
+	it('rejects over-length values instead of truncating', () => {
+		expect(sanitizeReturnTo(`/${'a'.repeat(600)}`)).toBeNull();
 	});
 });
 
@@ -303,6 +377,88 @@ describe('OIDC routes', () => {
 			name: 'Ada Lovelace',
 		});
 		expect(res.headers.get('set-cookie') ?? '').toContain(`${TXN_COOKIE}=`);
+	});
+
+	it('returns to the redirect_url deep link after a successful callback', async () => {
+		const { routes } = makeOidc({ postLoginRedirect: '/app' });
+		const deepLink = '/p/proj-1/notebooks/nb-1?tab=files#cell-3';
+		const txn = await beginOidcTransaction(
+			routes,
+			`/api/auth/login?redirect_url=${encodeURIComponent(deepLink)}`,
+		);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe(deepLink);
+		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
+	});
+
+	it.each(['https://evil.com/phish', '//evil.com', '/\\evil.com', '/..//evil.com'])(
+		'ignores a hostile redirect_url (%s) and falls back to the post-login redirect',
+		async (hostile) => {
+			const { routes } = makeOidc();
+			const txn = await beginOidcTransaction(
+				routes,
+				`/api/auth/login?redirect_url=${encodeURIComponent(hostile)}`,
+			);
+
+			const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+				headers: { cookie: txn },
+			});
+
+			expect(res.status).toBe(302);
+			expect(res.headers.get('location')).toBe('/');
+		},
+	);
+
+	it('does not leak redirect_url to the identity provider', async () => {
+		const { routes } = makeOidc();
+
+		const res = await routes.request('/api/auth/login?redirect_url=%2Fp%2Fproj-1');
+		const location = new URL(res.headers.get('location') ?? '');
+
+		expect(location.origin + location.pathname).toBe('https://issuer.example.com/authorize');
+		expect(location.searchParams.has('redirect_url')).toBe(false);
+		expect(location.searchParams.get('state')).toBe('state-1');
+	});
+
+	it('carries auth_error back to the deep link when the callback rejects the user', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.org',
+			email_verified: true,
+		});
+		const { routes } = makeOidc({ allowedEmailDomains: ['example.com'] });
+		const txn = await beginOidcTransaction(routes, '/api/auth/login?redirect_url=%2Fp%2Fproj-1');
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/p/proj-1?auth_error=domain_not_allowed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('appends auth_error with & when the deep link already has a query', async () => {
+		oauthMock.validateAuthResponse.mockImplementation(() => {
+			throw new Error('provider rejected the callback');
+		});
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(
+			routes,
+			`/api/auth/login?redirect_url=${encodeURIComponent('/p/proj-1?tab=files')}`,
+		);
+
+		const res = await routes.request('/api/auth/callback?error=access_denied&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/p/proj-1?tab=files&auth_error=auth_failed');
 	});
 
 	it('rejects a restricted-domain callback when the email is unverified', async () => {
@@ -518,12 +674,18 @@ describe('OIDC authenticate (cookie session)', () => {
 
 describe('OIDC callback integrity (security)', () => {
 	/** Mint a transaction cookie the way `/api/auth/login` does, with a chosen secret. */
-	async function signTxn(opts: { secret: string; verifier?: string; state?: string }) {
+	async function signTxn(opts: {
+		secret: string;
+		verifier?: string;
+		state?: string;
+		returnTo?: string;
+	}) {
 		const secret = new TextEncoder().encode(opts.secret);
 		return new SignJWT({
 			verifier: opts.verifier ?? 'verifier-1',
 			state: opts.state ?? 'state-1',
 			nonce: 'nonce-1',
+			returnTo: opts.returnTo ?? null,
 		})
 			.setProtectedHeader({ alg: 'HS256' })
 			.setIssuedAt()
@@ -545,6 +707,21 @@ describe('OIDC callback integrity (security)', () => {
 		expect(res.status).toBe(302);
 		expect(res.headers.get('location')).toBe('/?auth_error=session_expired');
 		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	// Defense in depth: the login route already sanitizes before signing, but a
+	// hostile returnTo inside a validly-signed txn cookie (e.g. minted before a
+	// sanitizer fix) must still be re-sanitized at redirect time.
+	it('re-sanitizes returnTo from the transaction cookie before redirecting', async () => {
+		const { routes } = makeOidc();
+		const txn = await signTxn({ secret: SESSION_SECRET, returnTo: 'https://evil.com/phish' });
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: `${TXN_COOKIE}=${txn}` },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/');
 	});
 
 	it('fails auth_failed when the ID token has a sub but no email', async () => {

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -200,8 +200,13 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 	function callbackError(c: Context, code: string, returnTo?: string | null): Response {
 		deleteCookie(c, TXN_COOKIE, { path: '/' });
 		const target = returnTo ?? postLoginRedirect;
-		const sep = target.includes('?') ? '&' : '?';
-		return c.redirect(`${target}${sep}auth_error=${code}`);
+		// `auth_error` must land in the query string, before any `#fragment` — the
+		// sign-in screen reads it via useSearchParams(), which never sees the hash.
+		const hashIndex = target.indexOf('#');
+		const base = hashIndex === -1 ? target : target.slice(0, hashIndex);
+		const hash = hashIndex === -1 ? '' : target.slice(hashIndex);
+		const sep = base.includes('?') ? '&' : '?';
+		return c.redirect(`${base}${sep}auth_error=${code}${hash}`);
 	}
 
 	const routes = new Hono();

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -62,6 +62,47 @@ export interface OidcConfig {
 const SESSION_COOKIE = 'mh_session';
 const TXN_COOKIE = 'mh_oidc_txn';
 
+/** Generous bound for an in-app deep link; anything longer is dropped, not truncated. */
+const MAX_RETURN_TO_LENGTH = 512;
+
+/**
+ * Validate a client-supplied post-login destination (`?redirect_url=` on the
+ * login route) down to a same-origin absolute path, or null if it is anything
+ * else. This is the open-redirect guard: the value is attacker-controllable (a
+ * phisher can send a victim a crafted /api/auth/login link), so it must never
+ * be able to leave this origin. Rejected here:
+ *
+ * - absolute URLs and scheme-relative `//evil.com` (and `/\evil.com` — browsers
+ *   normalize `\` to `/` in URLs, so a backslash anywhere is rejected outright)
+ * - schemes like `javascript:`/`data:` (no leading `/`)
+ * - control characters (header/URL smuggling)
+ * - paths that URL-normalize back OUT to another origin (`/..//evil.com`
+ *   dot-segment-normalizes to `//evil.com`)
+ * - `/api/…` paths (would loop straight back into the auth routes, and there is
+ *   no UI there)
+ *
+ * Exported for direct unit testing.
+ */
+export function sanitizeReturnTo(value: string | null | undefined): string | null {
+	if (!value || value.length > MAX_RETURN_TO_LENGTH) return null;
+	if (!value.startsWith('/') || value.startsWith('//')) return null;
+	// eslint-disable-next-line no-control-regex
+	if (/[\\\u0000-\u001f\u007f]/.test(value)) return null;
+	let url: URL;
+	try {
+		url = new URL(value, 'http://marimohub.invalid');
+	} catch {
+		return null;
+	}
+	if (url.origin !== 'http://marimohub.invalid') return null;
+	const path = url.pathname + url.search + url.hash;
+	// Dot-segment normalization can surface a scheme-relative `//` prefix that the
+	// prefix check above did not see (e.g. `/..//evil.com`).
+	if (!path.startsWith('/') || path.startsWith('//')) return null;
+	if (path === '/api' || path.startsWith('/api/')) return null;
+	return path;
+}
+
 /**
  * Normalize an email-domain allowlist: lowercase, trimmed, leading-`@` stripped,
  * blanks dropped. Exported for direct unit testing of the (otherwise network-gated)
@@ -152,12 +193,15 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 	 * with a dead-end URL. Instead we clear the in-flight transaction cookie and
 	 * bounce to the post-login target with an `auth_error` code that the sign-in
 	 * screen turns into a friendly, actionable message (e.g. "domain not allowed").
-	 * No session cookie is set, so the user stays unauthenticated.
+	 * No session cookie is set, so the user stays unauthenticated. When the
+	 * transaction carried a `returnTo` deep link, the error bounces there instead
+	 * of `/` so a retry from the sign-in screen keeps the destination.
 	 */
-	function callbackError(c: Context, code: string): Response {
+	function callbackError(c: Context, code: string, returnTo?: string | null): Response {
 		deleteCookie(c, TXN_COOKIE, { path: '/' });
-		const sep = postLoginRedirect.includes('?') ? '&' : '?';
-		return c.redirect(`${postLoginRedirect}${sep}auth_error=${code}`);
+		const target = returnTo ?? postLoginRedirect;
+		const sep = target.includes('?') ? '&' : '?';
+		return c.redirect(`${target}${sep}auth_error=${code}`);
 	}
 
 	const routes = new Hono();
@@ -168,9 +212,13 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		const codeChallenge = await oauth.calculatePKCECodeChallenge(codeVerifier);
 		const state = oauth.generateRandomState();
 		const nonce = oauth.generateRandomNonce();
+		// The post-login deep link rides in the SIGNED transaction cookie — never
+		// through the IdP round-trip — so it cannot be tampered with mid-flow.
+		// Anything that fails the open-redirect sanitizer is silently dropped.
+		const returnTo = sanitizeReturnTo(c.req.query('redirect_url'));
 
 		// Stash the PKCE/transaction values in a short-lived signed cookie.
-		const txn = await new SignJWT({ verifier: codeVerifier, state, nonce })
+		const txn = await new SignJWT({ verifier: codeVerifier, state, nonce, returnTo })
 			.setProtectedHeader({ alg: 'HS256' })
 			.setIssuedAt()
 			.setExpirationTime('10m')
@@ -217,12 +265,16 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		let verifier: string;
 		let expectedState: string | undefined;
 		let expectedNonce: string | undefined;
+		let returnTo: string | null = null;
 		try {
 			const { payload } = await jwtVerify(txnCookie, secret);
 			if (typeof payload.verifier !== 'string') throw new Error('missing verifier');
 			verifier = payload.verifier;
 			expectedState = typeof payload.state === 'string' ? payload.state : undefined;
 			expectedNonce = typeof payload.nonce === 'string' ? payload.nonce : undefined;
+			// Re-sanitize on the way out (defense in depth): the cookie is signed, but
+			// the redirect below must hold even if the sanitizer or signing changes.
+			returnTo = sanitizeReturnTo(typeof payload.returnTo === 'string' ? payload.returnTo : null);
 		} catch {
 			return callbackError(c, 'session_expired');
 		}
@@ -248,11 +300,11 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 			});
 			claims = oauth.getValidatedIdTokenClaims(result);
 		} catch {
-			return callbackError(c, 'auth_failed');
+			return callbackError(c, 'auth_failed', returnTo);
 		}
 
 		if (!claims?.sub || typeof claims.email !== 'string') {
-			return callbackError(c, 'auth_failed');
+			return callbackError(c, 'auth_failed', returnTo);
 		}
 
 		// The email is an authorization credential (project email-invites match on
@@ -262,17 +314,17 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		// here — rejecting absence would break IdPs that never send it — but the
 		// domain-allowlist branch below stays strict and demands `true`.
 		if (claims.email_verified === false) {
-			return callbackError(c, 'email_not_verified');
+			return callbackError(c, 'email_not_verified', returnTo);
 		}
 
 		if (restrictDomains) {
 			// Require a provider-verified address before trusting its domain — an
 			// unverified email could carry an attacker-chosen `@marimo.io` value.
 			if (claims.email_verified !== true) {
-				return callbackError(c, 'email_not_verified');
+				return callbackError(c, 'email_not_verified', returnTo);
 			}
 			if (!emailDomainAllowed(claims.email, allowedDomains)) {
-				return callbackError(c, 'domain_not_allowed');
+				return callbackError(c, 'domain_not_allowed', returnTo);
 			}
 		}
 
@@ -288,7 +340,7 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 			maxAge: sessionTtl,
 		});
 		deleteCookie(c, TXN_COOKIE, { path: '/' });
-		return c.redirect(postLoginRedirect);
+		return c.redirect(returnTo ?? postLoginRedirect);
 	});
 
 	routes.get('/api/auth/logout', async (c) => {

--- a/packages/web/src/context/AuthContext.test.tsx
+++ b/packages/web/src/context/AuthContext.test.tsx
@@ -36,8 +36,15 @@ function Probe({ label = 'a' }: { label?: string }) {
 	);
 }
 
-function stubLocation(): void {
-	vi.stubGlobal('location', { ...window.location, href: '' });
+function stubLocation(overrides: Partial<Location> = {}): void {
+	vi.stubGlobal('location', {
+		...window.location,
+		pathname: '/',
+		search: '',
+		hash: '',
+		href: '',
+		...overrides,
+	});
 }
 
 beforeEach(() => {
@@ -111,13 +118,81 @@ describe('AuthProvider', () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it('signIn navigates to the server OIDC entry point', async () => {
+	it('signIn navigates to the server OIDC entry point without redirect_url from the root', async () => {
 		const user = userEvent.setup();
 		vi.stubGlobal(
 			'fetch',
 			vi.fn(async () => jsonOk(ME)),
 		);
 		stubLocation();
+
+		renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Sign in' }));
+		expect(window.location.href).toBe('/api/auth/login');
+	});
+
+	it('signIn carries the current deep link as redirect_url', async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonOk(ME)),
+		);
+		stubLocation({
+			pathname: '/p/proj-1/notebooks/nb-1',
+			search: '?tab=files',
+			hash: '#cell-3',
+		});
+
+		renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Sign in' }));
+		expect(window.location.href).toBe(
+			`/api/auth/login?redirect_url=${encodeURIComponent('/p/proj-1/notebooks/nb-1?tab=files#cell-3')}`,
+		);
+	});
+
+	it('signIn strips a stale auth_error from the redirect_url', async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonOk(ME)),
+		);
+		stubLocation({
+			pathname: '/p/proj-1',
+			search: '?tab=files&auth_error=domain_not_allowed',
+		});
+
+		renderWithClient(
+			<AuthProvider>
+				<Probe />
+			</AuthProvider>,
+			{ toaster: false },
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Sign in' }));
+		expect(window.location.href).toBe(
+			`/api/auth/login?redirect_url=${encodeURIComponent('/p/proj-1?tab=files')}`,
+		);
+	});
+
+	it('signIn treats a root URL carrying only auth_error as having no destination', async () => {
+		const user = userEvent.setup();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => jsonOk(ME)),
+		);
+		stubLocation({ search: '?auth_error=auth_failed' });
 
 		renderWithClient(
 			<AuthProvider>

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -19,10 +19,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 	const queryClient = useQueryClient();
 	const { data: user, isPending, error } = useUserQuery();
 
-	// Full-page navigation to the server's OIDC entry point, which redirects to
-	// the IdP and (after the callback sets the session cookie) back to `/`.
+	// Full-page navigation to the server's OIDC entry point. The current SPA
+	// location rides along as `redirect_url` so the deep link survives the IdP
+	// round-trip; the server sanitizes it to a same-origin path (open-redirect
+	// guard), falling back to `/`.
 	const signIn = useCallback(() => {
-		window.location.href = '/api/auth/login';
+		const params = new URLSearchParams(window.location.search);
+		// Drop a stale error from a previous failed attempt so it doesn't resurface
+		// after a successful sign-in.
+		params.delete('auth_error');
+		const search = params.toString();
+		const returnTo = window.location.pathname + (search ? `?${search}` : '') + window.location.hash;
+		window.location.href =
+			returnTo === '/'
+				? '/api/auth/login'
+				: `/api/auth/login?redirect_url=${encodeURIComponent(returnTo)}`;
 	}, []);
 
 	const signOut = useCallback(() => {


### PR DESCRIPTION
## Summary

Signing in from a deep link (e.g. a shared notebook URL) previously always landed back on `/` — the OIDC callback had no notion of where the user started. This adds `redirect_url` support end-to-end, treating the value as untrusted the whole way:

- **`packages/web`**: `signIn()` sends the current SPA location (path + query + hash) as `?redirect_url=` on `/api/auth/login`, stripping any stale `auth_error` param first. Plain `/` sends no param.
- **`packages/auth-oidc`**: the login route sanitizes the value and carries it inside the **signed** transaction cookie (never through the IdP round-trip, so it can't be tampered with mid-flow). The callback re-sanitizes on the way out (defense in depth) and uses it for both the success redirect and `auth_error` bounces, so a retry from the sign-in screen keeps the destination.

## Open-redirect protections

`sanitizeReturnTo` (exported, unit-tested) only lets same-origin absolute paths through. Rejected: absolute URLs and schemes (`javascript:`, `data:`), protocol-relative `//evil.com`, backslash variants like `/\evil.com` (browsers normalize `\` to `/`), paths whose dot-segment normalization escapes the origin (`/..//evil.com` → `//evil.com`), control characters, `/api/…` targets (login loops), and over-length values. Anything rejected silently falls back to the configured post-login redirect.

## Testing

- `packages/auth-oidc`: 66 tests pass — sanitizer unit tests plus route tests covering the deep-link round-trip, hostile `redirect_url` fallback, no leakage of `redirect_url` to the IdP, `auth_error` carried to the deep link, and read-side re-sanitization of a validly-signed hostile cookie.
- `packages/web`: 393 tests pass, including new `signIn` deep-link / `auth_error`-stripping cases.
- `pnpm check` clean. (`pnpm typecheck` fails on this branch in `packages/core` marimo-config files — pre-existing and unrelated.)