### PR TITLE
feat(sandbox): add data/DB libraries to marimo-sandbox image

### DIFF
--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /tmp \
  && uv init --bare --no-readme base \
  && cd base \
  && uv add --compile-bytecode \
-      "marimo[recommended,ai]==${MARIMO_VERSION}" \
+      "marimo[recommended]==${MARIMO_VERSION}" \
       polars \
       narwhals \
       numpy \

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /tmp \
  && uv init --bare --no-readme base \
  && cd base \
  && uv add --compile-bytecode \
-      "marimo[recommended]==${MARIMO_VERSION}" \
+      "marimo[recommended,ai]==${MARIMO_VERSION}" \
       polars \
       narwhals \
       numpy \
@@ -41,6 +41,14 @@ RUN cd /tmp \
       plotly \
       anywidget \
       moutils \
+      connectorx \
+      pyiceberg \
+      sqlalchemy \
+      fsspec \
+      s3fs \
+      gcsfs \
+      python-dotenv \
+      pydantic \
       scikit-learn \
       scipy \
       requests \


### PR DESCRIPTION
Add commonly used, lightweight libraries to the marimo-sandbox base image.

- **connectorx**, **pyiceberg** — fast DB reads + Iceberg tables
- **sqlalchemy** — general DB engine for marimo SQL cells (Postgres/MySQL/etc.)
- **fsspec** + **s3fs** + **gcsfs** — remote file access (`s3://`, `gs://`), companions to pyiceberg/pyarrow
- **python-dotenv** — `.env` loading for secrets/credentials workflows
- **pydantic** — data modeling/validation