### PR TITLE
feat(runtime): redirect marimo XDG cache/state dirs via fallback session env

### DIFF
--- a/examples/cloudflare-worker/src/tieredCompute.ts
+++ b/examples/cloudflare-worker/src/tieredCompute.ts
@@ -35,6 +35,7 @@ import type {
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
+	SetEnvVarsOptions,
 	StartProcessOptions,
 } from '@marimo-hub/core/ports';
 import type { SandboxId } from '@marimo-hub/core';
@@ -109,8 +110,8 @@ class TieredSandboxInstance implements SandboxInstance {
 		return (await this.resolve()).gitCheckout(repo, options);
 	}
 
-	async setEnvVars(vars: Record<string, string>): Promise<void> {
-		return (await this.resolve()).setEnvVars(vars);
+	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {
+		return (await this.resolve()).setEnvVars(vars, options);
 	}
 
 	async mountBucket(options: MountBucketOptions): Promise<void> {

--- a/packages/api/src/routes/sessions.appMode.test.ts
+++ b/packages/api/src/routes/sessions.appMode.test.ts
@@ -209,6 +209,7 @@ describe('Session routes (app mode)', () => {
 			runFake.calls.writeFiles.flat().some((file) => file.path.endsWith('/marimo/marimo.toml')),
 		).toBe(false);
 		expect(runFake.calls.setEnvVars.flatMap(Object.keys)).not.toContain('XDG_CONFIG_HOME');
+		expect(runFake.calls.setEnvDefaults).toHaveLength(0);
 	});
 
 	describe('viewer admission per MARIMOHUB_VIEWER_MODE', () => {

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -139,6 +139,11 @@ describe('Session routes', () => {
 		expect(calls.setEnvVars).toContainEqual({
 			XDG_CONFIG_HOME: '/tmp/marimohub-config',
 		});
+		// Cache/state redirects are fallbacks — an image defining its own wins.
+		expect(calls.setEnvDefaults).toContainEqual({
+			XDG_CACHE_HOME: '/tmp/marimohub-cache',
+			XDG_STATE_HOME: '/tmp/marimohub-state',
+		});
 	});
 
 	describe('base image resolution', () => {

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -66,6 +66,7 @@ function mergeSessionEnv(base: SessionEnv | undefined, add: SessionEnv): Session
 	return {
 		files: [...(base?.files ?? []), ...(add.files ?? [])],
 		vars: { ...base?.vars, ...add.vars },
+		defaults: { ...base?.defaults, ...add.defaults },
 	};
 }
 

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -343,10 +343,9 @@ describe('CloudflareSandboxProvider', () => {
 	});
 
 	describe('simple delegations', () => {
-		it('writeFile / gitCheckout / setEnvVars / unmountBucket / destroy forward to the sandbox', async () => {
+		it('writeFile / setEnvVars / unmountBucket / destroy forward; gitCheckout clones via exec', async () => {
 			for (const fn of [
 				fakeSandbox.writeFile,
-				fakeSandbox.gitCheckout,
 				fakeSandbox.setEnvVars,
 				fakeSandbox.unmountBucket,
 				fakeSandbox.destroy,
@@ -357,8 +356,9 @@ describe('CloudflareSandboxProvider', () => {
 
 			await instance.writeFiles([{ path: '/f', content: 'data' }]);
 			expect(fakeSandbox.writeFile).toHaveBeenCalledWith('/f', 'data');
+			fakeSandbox.exec.mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
 			await instance.gitCheckout('https://x/y', { branch: 'main' });
-			expect(fakeSandbox.gitCheckout).toHaveBeenCalledWith('https://x/y', { branch: 'main' });
+			expect(fakeSandbox.exec).toHaveBeenCalledWith("git clone --branch 'main' 'https://x/y' '.'");
 			await instance.setEnvVars({ A: '1' });
 			expect(fakeSandbox.setEnvVars).toHaveBeenCalledWith({ A: '1' });
 			await instance.unmountBucket('/m');
@@ -391,6 +391,12 @@ describe('CloudflareSandboxProvider', () => {
 			expect(fakeSandbox.startProcess).toHaveBeenCalledWith(
 				'[ -n "${CACHE:-}" ] || export CACHE=\'/tmp/c\'; serve',
 				expect.anything(),
+			);
+
+			fakeSandbox.exec.mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
+			await instance.gitCheckout('https://x/y');
+			expect(fakeSandbox.exec).toHaveBeenCalledWith(
+				"[ -n \"${CACHE:-}\" ] || export CACHE='/tmp/c'; git clone 'https://x/y' '.'",
 			);
 		});
 	});

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -366,6 +366,33 @@ describe('CloudflareSandboxProvider', () => {
 			await instance.destroy();
 			expect(fakeSandbox.destroy).toHaveBeenCalled();
 		});
+
+		it('setEnvVars with onlyIfUnset skips the SDK and prefixes commands instead', async () => {
+			fakeSandbox.setEnvVars.mockClear();
+			fakeSandbox.exec.mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
+			const instance = makeProvider().create(SANDBOX_ID);
+
+			await instance.setEnvVars({ CACHE: '/tmp/c' }, { onlyIfUnset: true });
+			expect(fakeSandbox.setEnvVars).not.toHaveBeenCalled();
+
+			await instance.exec('run');
+			expect(fakeSandbox.exec).toHaveBeenCalledWith(
+				'[ -n "${CACHE:-}" ] || export CACHE=\'/tmp/c\'; run',
+			);
+
+			fakeSandbox.startProcess.mockResolvedValueOnce({
+				id: 'p1',
+				command: 'serve',
+				kill: async () => {},
+				waitForPort: async () => {},
+				getLogs: async () => ({ stdout: '', stderr: '' }),
+			});
+			await instance.startProcess('serve');
+			expect(fakeSandbox.startProcess).toHaveBeenCalledWith(
+				'[ -n "${CACHE:-}" ] || export CACHE=\'/tmp/c\'; serve',
+				expect.anything(),
+			);
+		});
 	});
 
 	describe('provider surface', () => {

--- a/packages/compute-cloudflare/src/index.ts
+++ b/packages/compute-cloudflare/src/index.ts
@@ -2,6 +2,7 @@ import { getSandbox, proxyToSandbox } from '@cloudflare/sandbox';
 import type { Sandbox } from '@cloudflare/sandbox';
 import {
 	base64Encode,
+	buildGitCloneCommand,
 	mapWithConcurrency,
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
@@ -111,7 +112,10 @@ class CloudflareSandboxInstance implements SandboxInstance {
 	}
 
 	async gitCheckout(repo: string, options?: GitCheckoutOptions): Promise<void> {
-		await this.sandbox.gitCheckout(repo, options);
+		// Via exec rather than the SDK's gitCheckout so the env-defaults prefix
+		// applies to the clone, like every other adapter.
+		const res = await this.exec(buildGitCloneCommand(repo, options));
+		if (!res.success) throw new Error(`git checkout failed: ${res.stderr}`);
 	}
 
 	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {

--- a/packages/compute-cloudflare/src/index.ts
+++ b/packages/compute-cloudflare/src/index.ts
@@ -1,6 +1,11 @@
 import { getSandbox, proxyToSandbox } from '@cloudflare/sandbox';
 import type { Sandbox } from '@cloudflare/sandbox';
-import { base64Encode, mapWithConcurrency, WRITE_CONCURRENCY } from '@marimo-hub/compute-commons';
+import {
+	base64Encode,
+	mapWithConcurrency,
+	withEnvPrefix,
+	WRITE_CONCURRENCY,
+} from '@marimo-hub/compute-commons';
 import type { SandboxId } from '@marimo-hub/core';
 import type {
 	ExecResult,
@@ -16,6 +21,7 @@ import type {
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
+	SetEnvVarsOptions,
 	StartProcessOptions,
 } from '@marimo-hub/core/ports';
 
@@ -54,6 +60,7 @@ async function waitForTunnelReady(url: string): Promise<void> {
 class CloudflareSandboxInstance implements SandboxInstance {
 	private sandbox: SandboxType;
 	private useTunnel: boolean;
+	private envDefaults: Record<string, string> = {};
 
 	constructor(sandbox: SandboxType, useTunnel = false) {
 		this.sandbox = sandbox;
@@ -61,12 +68,12 @@ class CloudflareSandboxInstance implements SandboxInstance {
 	}
 
 	async exec(cmd: string): Promise<ExecResult> {
-		const res = await this.sandbox.exec(cmd);
+		const res = await this.sandbox.exec(this.withDefaults(cmd));
 		return { success: res.success, stdout: res.stdout, stderr: res.stderr };
 	}
 
 	async execStream(cmd: string, options?: ExecStreamOptions): Promise<ReadableStream> {
-		return this.sandbox.execStream(cmd, {
+		return this.sandbox.execStream(this.withDefaults(cmd), {
 			timeout: options?.timeout,
 		});
 	}
@@ -107,8 +114,18 @@ class CloudflareSandboxInstance implements SandboxInstance {
 		await this.sandbox.gitCheckout(repo, options);
 	}
 
-	async setEnvVars(vars: Record<string, string>): Promise<void> {
+	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {
+		if (options?.onlyIfUnset) {
+			// The SDK's session-level setEnvVars always overwrites, so defaults are
+			// applied as a guarded shell prefix on each command instead.
+			this.envDefaults = { ...this.envDefaults, ...vars };
+			return;
+		}
 		await this.sandbox.setEnvVars(vars);
+	}
+
+	private withDefaults(cmd: string): string {
+		return withEnvPrefix(cmd, {}, this.envDefaults);
 	}
 
 	async mountBucket(options: MountBucketOptions): Promise<void> {
@@ -133,7 +150,7 @@ class CloudflareSandboxInstance implements SandboxInstance {
 	}
 
 	async startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess> {
-		const proc = await this.sandbox.startProcess(cmd, {
+		const proc = await this.sandbox.startProcess(this.withDefaults(cmd), {
 			processId: options?.processId,
 			cwd: options?.cwd,
 			env: options?.env,

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -62,6 +62,22 @@ describe('withEnvPrefix', () => {
 	it('shell-quotes env values (injection-safe)', () => {
 		expect(withEnvPrefix('run', { TOKEN: "a'b" })).toBe("export TOKEN='a'\\''b'; run");
 	});
+
+	it('emits defaults as guarded exports the existing environment wins over', () => {
+		expect(withEnvPrefix('run', {}, { A: '1' })).toBe('[ -n "${A:-}" ] || export A=\'1\'; run');
+	});
+
+	it('puts forced exports before default guards, so a forced value wins the key', () => {
+		expect(withEnvPrefix('run', { A: '1' }, { A: '2', B: '3' })).toBe(
+			"export A='1'; [ -n \"${A:-}\" ] || export A='2'; [ -n \"${B:-}\" ] || export B='3'; run",
+		);
+	});
+
+	it('shell-quotes default values (injection-safe)', () => {
+		expect(withEnvPrefix('run', {}, { TOKEN: "a'b" })).toBe(
+			"[ -n \"${TOKEN:-}\" ] || export TOKEN='a'\\''b'; run",
+		);
+	});
 });
 
 describe('removeUndefined', () => {

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -30,13 +30,24 @@ export function shellQuote(value: string): string {
  * Build the `export K='v'; …` shell prefix that carries accumulated env vars into
  * a command, for backends whose `exec` has no per-command env (CoreWeave,
  * Docker, Podman, Kubernetes pod-exec). Values are {@link shellQuote}d. Returns
- * `cmd` unchanged when `env` is empty.
+ * `cmd` unchanged when `env` and `defaults` are empty.
+ *
+ * `defaults` are fallbacks (`setEnvVars` with `onlyIfUnset`): each is exported
+ * behind a `[ -n "${K:-}" ]` guard, so a value the sandbox already defines —
+ * image ENV, profile script, or a forced export from `env` — wins. The guards
+ * come after the forced exports, which is what lets a key present in both
+ * resolve to the forced value.
  */
-export function withEnvPrefix(cmd: string, env: Record<string, string>): string {
-	const keys = Object.keys(env);
-	if (keys.length === 0) return cmd;
-	const prefix = keys.map((k) => `export ${k}=${shellQuote(env[k])}; `).join('');
-	return prefix + cmd;
+export function withEnvPrefix(
+	cmd: string,
+	env: Record<string, string>,
+	defaults: Record<string, string> = {},
+): string {
+	const forced = Object.keys(env).map((k) => `export ${k}=${shellQuote(env[k])}; `);
+	const guarded = Object.keys(defaults).map(
+		(k) => `[ -n "\${${k}:-}" ] || export ${k}=${shellQuote(defaults[k])}; `,
+	);
+	return forced.join('') + guarded.join('') + cmd;
 }
 
 /**

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -163,6 +163,20 @@ describe('DockerCompute', () => {
 		);
 	});
 
+	it('applies onlyIfUnset vars as guarded defaults after the forced exports', async () => {
+		const { runner, calls } = fakeRunner(defaultHandler);
+		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
+
+		await sb.setEnvVars({ MODE: 'prod' });
+		await sb.setEnvVars({ CACHE: '/tmp/c' }, { onlyIfUnset: true });
+		await sb.exec('echo defaults');
+
+		const exec = calls.find((c) => c.args.at(-1)?.includes('echo defaults'));
+		expect(exec?.args.at(-1)).toBe(
+			"export MODE='prod'; [ -n \"${CACHE:-}\" ] || export CACHE='/tmp/c'; echo defaults",
+		);
+	});
+
 	it('exposePort: resolves the OS-assigned host port into an http URL', async () => {
 		const { runner } = fakeRunner(defaultHandler);
 		const sb = new DockerCompute({ host: 'example.test' }, runner).create(SANDBOX_ID);

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -33,6 +33,7 @@ import type {
 	SandboxProcess,
 	SandboxProvider,
 	StartProcessOptions,
+	SetEnvVarsOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
 
@@ -107,6 +108,7 @@ let procSeq = 0;
 class ContainerSandboxInstance implements SandboxInstance {
 	private readonly name: string;
 	private env: Record<string, string> = {};
+	private envDefaults: Record<string, string> = {};
 	/** Cached host port for the published kernel port, once known. */
 	private hostPort?: number;
 
@@ -154,7 +156,7 @@ class ContainerSandboxInstance implements SandboxInstance {
 
 	/** Prefix accumulated env vars onto a shell command. */
 	private withEnv(cmd: string): string {
-		return withEnvPrefix(cmd, this.env);
+		return withEnvPrefix(cmd, this.env, this.envDefaults);
 	}
 
 	private async dexec(cmd: string, flags: string[] = []): Promise<ContainerRunResult> {
@@ -217,8 +219,12 @@ class ContainerSandboxInstance implements SandboxInstance {
 		if (!res.success) throw new Error(`git checkout failed: ${res.stderr}`);
 	}
 
-	async setEnvVars(vars: Record<string, string>): Promise<void> {
-		this.env = { ...this.env, ...vars };
+	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {
+		if (options?.onlyIfUnset) {
+			this.envDefaults = { ...this.envDefaults, ...vars };
+		} else {
+			this.env = { ...this.env, ...vars };
+		}
 	}
 
 	async mountBucket(_options: MountBucketOptions): Promise<void> {

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -459,6 +459,16 @@ describe('CoreWeaveCompute', () => {
 			expect(cmd).toContain("export A='1'; ");
 			expect(cmd).toContain("export B='2'; ");
 		});
+
+		it('applies onlyIfUnset vars as guarded defaults after the forced exports', async () => {
+			const world = makeWorld();
+			const inst = makeCompute(world).create(SANDBOX_ID);
+			await inst.setEnvVars({ A: '1' });
+			await inst.setEnvVars({ CACHE: '/tmp/c' }, { onlyIfUnset: true });
+			await inst.exec('run');
+			const cmd = [...world.registry.values()][0].fake.runCalls.at(-1)![2];
+			expect(cmd).toBe("export A='1'; [ -n \"${CACHE:-}\" ] || export CACHE='/tmp/c'; run");
+		});
 	});
 
 	describe('listFiles()', () => {

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -73,6 +73,7 @@ import type {
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
+	SetEnvVarsOptions,
 	StartProcessOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
@@ -232,6 +233,7 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	private readonly kernelPort: number;
 	private sandbox?: CoreWeaveSandbox;
 	private env: Record<string, string> = {};
+	private envDefaults: Record<string, string> = {};
 	private lastEnsureTimings?: Timings;
 
 	constructor(
@@ -364,7 +366,7 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 
 	/** Prefix accumulated env vars onto a shell command (the SDK has no per-command env). */
 	private withEnv(cmd: string): string {
-		return withEnvPrefix(cmd, this.env);
+		return withEnvPrefix(cmd, this.env, this.envDefaults);
 	}
 
 	async exec(cmd: string): Promise<ExecResult> {
@@ -427,10 +429,14 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		if (!res.success) throw new Error(`git checkout failed: ${res.stderr}`);
 	}
 
-	async setEnvVars(vars: Record<string, string>): Promise<void> {
+	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {
 		// Stored and applied as a shell prefix by withEnv(); the SDK sets env only at
 		// create time, and the provisioner never calls this on the hot path.
-		this.env = { ...this.env, ...vars };
+		if (options?.onlyIfUnset) {
+			this.envDefaults = { ...this.envDefaults, ...vars };
+		} else {
+			this.env = { ...this.env, ...vars };
+		}
 	}
 
 	async mountBucket(_options: MountBucketOptions): Promise<void> {

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -385,6 +385,26 @@ describe('E2bCompute', () => {
 		});
 	});
 
+	it('applies onlyIfUnset vars as a guarded prefix, not run envs', async () => {
+		const fake = new FakeE2b({});
+		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+
+		await sb.setEnvVars({ TOKEN: 'abc' });
+		await sb.setEnvVars({ CACHE: '/tmp/c' }, { onlyIfUnset: true });
+		await sb.exec('echo env');
+
+		const run = fake.runOptions.find((r) => r.cmd.endsWith('echo env'));
+		expect(run?.cmd).toBe('[ -n "${CACHE:-}" ] || export CACHE=\'/tmp/c\'; echo env');
+		expect(run?.options?.envs).toEqual({ TOKEN: 'abc' });
+
+		const proc = await sb.startProcess('run kernel', { cwd: '/workspace' });
+		await proc.kill();
+		expect(fake.backgroundCalls[0]).toMatchObject({
+			cmd: '[ -n "${CACHE:-}" ] || export CACHE=\'/tmp/c\'; run kernel > /tmp/marimohub-kernel.log 2>&1',
+			options: { cwd: '/workspace', envs: { TOKEN: 'abc' } },
+		});
+	});
+
 	describe('gitCheckout', () => {
 		it('runs a shell-quoted git clone (injection-safe via compute-commons)', async () => {
 			const fake = new FakeE2b();

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -22,6 +22,7 @@ import {
 	buildGitCloneCommand,
 	parseFindFilesOutput,
 	pollUntilReady,
+	withEnvPrefix,
 } from '@marimo-hub/compute-commons';
 import { SandboxId, Seconds } from '@marimo-hub/core';
 import type {
@@ -40,6 +41,7 @@ import type {
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
+	SetEnvVarsOptions,
 	StartProcessOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
@@ -134,6 +136,7 @@ export interface E2bConfig {
 class E2bSandboxInstance implements SandboxInstance {
 	private handle?: E2bSandboxHandle;
 	private env: Record<string, string> = {};
+	private envDefaults: Record<string, string> = {};
 
 	constructor(
 		private readonly id: SandboxId,
@@ -163,7 +166,9 @@ class E2bSandboxInstance implements SandboxInstance {
 
 	async exec(cmd: string): Promise<ExecResult> {
 		const sb = await this.ensure();
-		const res = await sb.commands.run(cmd, { envs: this.env });
+		// Forced vars ride the SDK's per-command `envs`; defaults can't (that channel
+		// always overwrites), so they go in as a guarded shell prefix instead.
+		const res = await sb.commands.run(this.withDefaults(cmd), { envs: this.env });
 		return { success: res.exitCode === 0, stdout: res.stdout, stderr: res.stderr };
 	}
 
@@ -208,8 +213,16 @@ class E2bSandboxInstance implements SandboxInstance {
 		if (!res.success) throw new Error(`git checkout failed: ${res.stderr}`);
 	}
 
-	async setEnvVars(vars: Record<string, string>): Promise<void> {
-		this.env = { ...this.env, ...vars };
+	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {
+		if (options?.onlyIfUnset) {
+			this.envDefaults = { ...this.envDefaults, ...vars };
+		} else {
+			this.env = { ...this.env, ...vars };
+		}
+	}
+
+	private withDefaults(cmd: string): string {
+		return withEnvPrefix(cmd, {}, this.envDefaults);
 	}
 
 	async mountBucket(_options: MountBucketOptions): Promise<void> {
@@ -225,7 +238,7 @@ class E2bSandboxInstance implements SandboxInstance {
 	async startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess> {
 		const sb = await this.ensure();
 		const logPath = '/tmp/marimohub-kernel.log';
-		const handle = await sb.commands.runBackground(`${cmd} > ${logPath} 2>&1`, {
+		const handle = await sb.commands.runBackground(this.withDefaults(`${cmd} > ${logPath} 2>&1`), {
 			envs: this.env,
 			cwd: options?.cwd,
 		});

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -504,6 +504,20 @@ describe('KubernetesCompute', () => {
 			);
 		});
 
+		it('applies onlyIfUnset vars as guarded defaults after the forced exports', async () => {
+			const world = makeWorld();
+			const inst = makeCompute(world).create(SANDBOX_ID);
+
+			await inst.setEnvVars({ MODE: 'prod' });
+			await inst.setEnvVars({ CACHE: '/tmp/c' }, { onlyIfUnset: true });
+			await inst.exec('echo defaults');
+
+			const exec = world.execCalls.find((c) => shCmd(c).includes('echo defaults'));
+			expect(shCmd(exec!)).toBe(
+				"export MODE='prod'; [ -n \"${CACHE:-}\" ] || export CACHE='/tmp/c'; echo defaults",
+			);
+		});
+
 		it('proxy() is a no-op (kernel reached via its Ingress host)', async () => {
 			const world = makeWorld();
 			expect(await makeCompute(world).proxy(new Request('http://x/'))).toBeNull();

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -72,6 +72,7 @@ import type {
 	SandboxProcess,
 	SandboxProvider,
 	StartProcessOptions,
+	SetEnvVarsOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
 
@@ -118,6 +119,7 @@ class KubernetesSandboxInstance implements SandboxInstance {
 	private readonly kernelPort: number;
 	private ready = false;
 	private env: Record<string, string> = {};
+	private envDefaults: Record<string, string> = {};
 
 	constructor(
 		private readonly id: SandboxId,
@@ -199,7 +201,7 @@ class KubernetesSandboxInstance implements SandboxInstance {
 
 	/** Prefix accumulated env vars onto a shell command (exec carries no env). */
 	private withEnv(cmd: string): string {
-		return withEnvPrefix(cmd, this.env);
+		return withEnvPrefix(cmd, this.env, this.envDefaults);
 	}
 
 	async exec(cmd: string): Promise<ExecResult> {
@@ -267,10 +269,14 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		if (!res.success) throw new Error(`git checkout failed: ${res.stderr}`);
 	}
 
-	async setEnvVars(vars: Record<string, string>): Promise<void> {
+	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {
 		// Stored and applied as a shell prefix by withEnv(); the Pod env is fixed at
 		// create time and the provisioner never calls this on the hot path.
-		this.env = { ...this.env, ...vars };
+		if (options?.onlyIfUnset) {
+			this.envDefaults = { ...this.envDefaults, ...vars };
+		} else {
+			this.env = { ...this.env, ...vars };
+		}
 	}
 
 	async mountBucket(_options: MountBucketOptions): Promise<void> {

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -152,6 +152,45 @@ describe('LocalCompute env propagation', () => {
 		}
 		expect(content).toBe('hello-env');
 	});
+
+	it('onlyIfUnset vars apply when the environment does not define them', async () => {
+		const sb = newSandbox();
+		await sb.setEnvVars({ MH_TEST_DEFAULT: 'fallback' }, { onlyIfUnset: true });
+
+		const cmd = `node -e "require('fs').writeFileSync('/workspace/env-default.txt', process.env.MH_TEST_DEFAULT || 'MISSING')"`;
+		await sb.startProcess(cmd, { cwd: '/workspace' });
+
+		let content = '';
+		for (let i = 0; i < 50; i++) {
+			const read = await sb.readFile('/workspace/env-default.txt');
+			if (read.success && read.content) {
+				content = read.content;
+				break;
+			}
+			await new Promise((r) => setTimeout(r, 50));
+		}
+		expect(content).toBe('fallback');
+	});
+
+	it('onlyIfUnset vars defer to a value the process environment already has', async () => {
+		const sb = newSandbox();
+		await sb.setEnvVars({ MH_TEST_DEFAULT: 'from-env' });
+		await sb.setEnvVars({ MH_TEST_DEFAULT: 'fallback' }, { onlyIfUnset: true });
+
+		const cmd = `node -e "require('fs').writeFileSync('/workspace/env-forced.txt', process.env.MH_TEST_DEFAULT || 'MISSING')"`;
+		await sb.startProcess(cmd, { cwd: '/workspace' });
+
+		let content = '';
+		for (let i = 0; i < 50; i++) {
+			const read = await sb.readFile('/workspace/env-forced.txt');
+			if (read.success && read.content) {
+				content = read.content;
+				break;
+			}
+			await new Promise((r) => setTimeout(r, 50));
+		}
+		expect(content).toBe('from-env');
+	});
 });
 
 describe('LocalCompute process lifecycle', () => {

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -28,6 +28,7 @@ import {
 	buildGitCloneCommand,
 	mapWithConcurrency,
 	pollUntilReady,
+	withEnvPrefix,
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
 import type { SandboxId } from '@marimo-hub/core';
@@ -47,6 +48,7 @@ import type {
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
+	SetEnvVarsOptions,
 	StartProcessOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
@@ -161,6 +163,7 @@ class LocalSandboxInstance implements SandboxInstance {
 	/** Logical port (as named in core, e.g. 2718) → real allocated host port. */
 	private readonly portMap = new Map<number, number>();
 	private env: Record<string, string> = {};
+	private envDefaults: Record<string, string> = {};
 	/** ISO timestamp the instance was constructed — surfaced via listActive(). */
 	readonly createdAt = new Date().toISOString();
 
@@ -297,8 +300,12 @@ class LocalSandboxInstance implements SandboxInstance {
 		if (!res.success) throw new Error(`git checkout failed: ${res.stderr}`);
 	}
 
-	async setEnvVars(vars: Record<string, string>): Promise<void> {
-		this.env = { ...this.env, ...vars };
+	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {
+		if (options?.onlyIfUnset) {
+			this.envDefaults = { ...this.envDefaults, ...vars };
+		} else {
+			this.env = { ...this.env, ...vars };
+		}
 	}
 
 	async mountBucket(_options: MountBucketOptions): Promise<void> {
@@ -328,7 +335,9 @@ class LocalSandboxInstance implements SandboxInstance {
 		const cwd = options?.cwd ? this.mapPath(options.cwd) : this.root;
 		await mkdir(cwd, { recursive: true });
 
-		const child = spawn('sh', ['-c', command], {
+		// Forced vars ride spawn's env; defaults can't (a spawn env entry always
+		// wins), so they go in as a guarded prefix that defers to the host env.
+		const child = spawn('sh', ['-c', withEnvPrefix(command, {}, this.envDefaults)], {
 			cwd,
 			env: { ...process.env, ...this.env, ...options?.env },
 			detached: true,

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -230,6 +230,32 @@ describe('ModalCompute', () => {
 		expect(sandbox.execCalls[0].options?.env).toEqual({ A: '1', B: '2' });
 	});
 
+	it('applies onlyIfUnset vars as a guarded prefix, not exec env', async () => {
+		const world = makeWorld();
+		const sandbox = new FakeSandbox();
+		sandbox.execImpl = () => processResult(0, '', '');
+		world.existing.set(SANDBOX_ID, sandbox);
+		const instance = makeCompute(world).create(SANDBOX_ID);
+		await instance.setEnvVars({ A: '1' });
+		await instance.setEnvVars({ CACHE: '/tmp/c' }, { onlyIfUnset: true });
+
+		await instance.exec('run');
+
+		expect(sandbox.execCalls[0].command).toEqual([
+			'sh',
+			'-lc',
+			'[ -n "${CACHE:-}" ] || export CACHE=\'/tmp/c\'; run',
+		]);
+		expect(sandbox.execCalls[0].options?.env).toEqual({ A: '1' });
+
+		await instance.startProcess('serve');
+		const started = sandbox.execCalls.at(-1)!;
+		expect(started.command[2].startsWith('[ -n "${CACHE:-}" ] || export CACHE=\'/tmp/c\'; ')).toBe(
+			true,
+		);
+		expect(started.options?.env).toEqual({ A: '1' });
+	});
+
 	it('streams raw stdout without enabling PTY mode', async () => {
 		const world = makeWorld();
 		const sandbox = new FakeSandbox();

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -5,6 +5,7 @@ import {
 	buildGitCloneCommand,
 	mapWithConcurrency,
 	shellQuote,
+	withEnvPrefix,
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
 import { SandboxId } from '@marimo-hub/core';
@@ -25,6 +26,7 @@ import type {
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
+	SetEnvVarsOptions,
 	StartProcessOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
@@ -189,6 +191,7 @@ let processSequence = 0;
 class ModalSandboxInstance implements SandboxInstance {
 	private sandboxPromise?: Promise<ModalSandboxLike>;
 	private env: Record<string, string> = {};
+	private envDefaults: Record<string, string> = {};
 
 	constructor(
 		private readonly id: SandboxId,
@@ -254,11 +257,11 @@ class ModalSandboxInstance implements SandboxInstance {
 	}
 
 	async exec(cmd: string): Promise<ExecResult> {
-		return runProcess(await this.spawn(['sh', '-lc', cmd]));
+		return runProcess(await this.spawn(['sh', '-lc', this.withDefaults(cmd)]));
 	}
 
 	async execStream(cmd: string, options?: ExecStreamOptions): Promise<ReadableStream> {
-		const process = await this.spawn(['sh', '-lc', cmd], {
+		const process = await this.spawn(['sh', '-lc', this.withDefaults(cmd)], {
 			timeout: options?.timeout,
 		});
 		void readStream(process.stderr).catch(() => {});
@@ -316,8 +319,18 @@ class ModalSandboxInstance implements SandboxInstance {
 		if (!result.success) throw new Error(`git checkout failed: ${result.stderr}`);
 	}
 
-	async setEnvVars(vars: Record<string, string>): Promise<void> {
-		this.env = { ...this.env, ...vars };
+	async setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void> {
+		if (options?.onlyIfUnset) {
+			this.envDefaults = { ...this.envDefaults, ...vars };
+		} else {
+			this.env = { ...this.env, ...vars };
+		}
+	}
+
+	// Forced vars ride the exec `env` option; defaults can't (that channel always
+	// overwrites), so they go in as a guarded shell prefix instead.
+	private withDefaults(cmd: string): string {
+		return withEnvPrefix(cmd, {}, this.envDefaults);
 	}
 
 	async mountBucket(_options: MountBucketOptions): Promise<void> {
@@ -335,7 +348,7 @@ class ModalSandboxInstance implements SandboxInstance {
 			`printf '%s %s\\n' "$$" "\${20}" > ${shellQuote(pidPath)}`,
 			`exec sh -lc ${shellQuote(cmd)}`,
 		].join('; ');
-		const process = await this.spawn(['sh', '-lc', trackedCommand], {
+		const process = await this.spawn(['sh', '-lc', this.withDefaults(trackedCommand)], {
 			cwd: options?.cwd,
 			env: options?.env,
 			timeout: options?.timeout,

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -96,6 +96,11 @@ export interface SandboxFileWrite {
 	content: string | Uint8Array;
 }
 
+export interface SetEnvVarsOptions {
+	/** Apply each var only when the sandbox does not already define it. */
+	onlyIfUnset?: boolean;
+}
+
 export interface SandboxInstance {
 	exec(cmd: string): Promise<ExecResult>;
 	execStream(cmd: string, options?: ExecStreamOptions): Promise<ReadableStream>;
@@ -112,7 +117,13 @@ export interface SandboxInstance {
 	 */
 	writeFiles(files: readonly SandboxFileWrite[]): Promise<void>;
 	gitCheckout(repo: string, options?: GitCheckoutOptions): Promise<void>;
-	setEnvVars(vars: Record<string, string>): Promise<void>;
+	/**
+	 * Set env vars for every subsequent command and process in the sandbox.
+	 * `onlyIfUnset` makes each var a fallback: the sandbox keeps its own value
+	 * (image ENV, profile) when one is already defined. A key set both ways gets
+	 * the forced value.
+	 */
+	setEnvVars(vars: Record<string, string>, options?: SetEnvVarsOptions): Promise<void>;
 	mountBucket(options: MountBucketOptions): Promise<void>;
 	unmountBucket(mountPath: string): Promise<void>;
 	startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess>;

--- a/packages/core/src/services/marimoConfig.test.ts
+++ b/packages/core/src/services/marimoConfig.test.ts
@@ -106,10 +106,15 @@ describe('marimoSharingDisabled', () => {
 describe('marimoConfigToSessionEnv', () => {
 	it('writes marimo.toml under the injected XDG_CONFIG_HOME', () => {
 		const env = marimoConfigToSessionEnv([marimoNotebookDefaults]);
-		expect(env.vars.XDG_CONFIG_HOME).toBe('/tmp/marimohub-config');
+		expect(env.vars).toEqual({ XDG_CONFIG_HOME: '/tmp/marimohub-config' });
+		expect(env.defaults).toEqual({
+			XDG_CACHE_HOME: '/tmp/marimohub-cache',
+			XDG_STATE_HOME: '/tmp/marimohub-state',
+		});
 		expect(env.files).toHaveLength(1);
-		expect(env.files[0].path).toBe('/tmp/marimohub-config/marimo/marimo.toml');
-		expect(parse(env.files[0].content)).toEqual({
+		const [file] = env.files ?? [];
+		expect(file?.path).toBe('/tmp/marimohub-config/marimo/marimo.toml');
+		expect(parse(file?.content ?? '')).toEqual({
 			display: { default_width: 'medium' },
 			runtime: { default_sql_output: 'native' },
 		});

--- a/packages/core/src/services/marimoConfig.ts
+++ b/packages/core/src/services/marimoConfig.ts
@@ -2,9 +2,20 @@ import { stringify } from 'smol-toml';
 import type { TomlTable, TomlValue } from 'smol-toml';
 import type { SessionEnv } from './runtime/SandboxProvisioner';
 
+export type { TomlTable };
+
 export type MarimoConfigContributor = () => TomlTable;
 
 const XDG_CONFIG_HOME = '/tmp/marimohub-config';
+// marimo also writes logs to XDG_CACHE_HOME and recent-files/server state to
+// XDG_STATE_HOME (`~/.cache`, `~/.local/state` by default). Redirect both to
+// /tmp so ephemeral runtime state never lands under $HOME, where a deployment
+// whose workdir overlaps the home directory would sweep it into the workspace
+// capture and filesystem snapshots. Unlike XDG_CONFIG_HOME (forced — it
+// carries policy config), these are fallbacks: an image that sets its own
+// cache/state locations keeps them.
+const XDG_CACHE_HOME = '/tmp/marimohub-cache';
+const XDG_STATE_HOME = '/tmp/marimohub-state';
 
 function isTomlTable(value: TomlValue | undefined): value is TomlTable {
 	return (
@@ -60,5 +71,6 @@ export function marimoConfigToSessionEnv(
 			},
 		],
 		vars: { XDG_CONFIG_HOME },
+		defaults: { XDG_CACHE_HOME, XDG_STATE_HOME },
 	};
 }

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -216,6 +216,42 @@ describe('SandboxProvisioner', () => {
 			expect(calls.sequence).toEqual(['writeFiles', 'setEnvVars', 'startProcess']);
 		});
 
+		it('injects sessionEnv defaults with onlyIfUnset, before the kernel starts', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			await provisioner.provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				sessionEnv: { defaults: { XDG_CACHE_HOME: '/tmp/marimohub-cache' } },
+			});
+
+			expect(calls.setEnvDefaults).toEqual([{ XDG_CACHE_HOME: '/tmp/marimohub-cache' }]);
+			expect(calls.setEnvVars).toHaveLength(0);
+			expect(calls.sequence).toEqual(['setEnvDefaults', 'startProcess']);
+		});
+
+		it('skips the env calls when sessionEnv holds only empty objects', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			await provisioner.provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				sessionEnv: { vars: {}, defaults: {}, files: [] },
+			});
+
+			expect(calls.setEnvVars).toHaveLength(0);
+			expect(calls.setEnvDefaults).toHaveLength(0);
+			expect(calls.sequence).toEqual(['startProcess']);
+		});
+
 		it('does not call setEnvVars/writeFile when sessionEnv is omitted', async () => {
 			const { instance, calls } = makeFakeSandbox();
 			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -49,6 +49,12 @@ export interface BucketConfig {
 /** Env vars + files injected into a sandbox before the kernel starts. */
 export interface SessionEnv {
 	vars?: Record<string, string>;
+	/**
+	 * Fallback vars, applied with `onlyIfUnset`: the sandbox image's own value
+	 * wins when it defines one. Use `vars` for anything policy- or
+	 * credential-bearing — a default the image can shadow is not a control.
+	 */
+	defaults?: Record<string, string>;
 	files?: { path: string; content: string }[];
 }
 
@@ -368,12 +374,16 @@ export class SandboxProvisioner {
 		using _inject = sw.span('inject');
 		try {
 			// The credential files go in one write; env vars are a separate channel, so
-			// the two round-trips overlap.
+			// the round-trips overlap.
 			const files = sessionEnv.files ?? [];
 			const vars = sessionEnv.vars;
+			const defaults = sessionEnv.defaults;
 			await Promise.all([
 				files.length > 0 ? sandbox.writeFiles(files) : undefined,
 				vars && Object.keys(vars).length > 0 ? sandbox.setEnvVars(vars) : undefined,
+				defaults && Object.keys(defaults).length > 0
+					? sandbox.setEnvVars(defaults, { onlyIfUnset: true })
+					: undefined,
 			]);
 		} catch (err) {
 			throw provisionFailure('injecting session credentials', err);

--- a/packages/core/src/testing/fakes.ts
+++ b/packages/core/src/testing/fakes.ts
@@ -12,6 +12,7 @@ import type {
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
+	SetEnvVarsOptions,
 	StartProcessOptions,
 } from '../ports/sandbox';
 
@@ -29,6 +30,8 @@ export interface SandboxCalls {
 	/** One entry per `writeFiles` call (the set sent in that call) — for batching assertions. */
 	writeFiles: SandboxFileWrite[][];
 	setEnvVars: Record<string, string>[];
+	/** Vars set with `onlyIfUnset` (`SessionEnv.defaults`), recorded separately. */
+	setEnvDefaults: Record<string, string>[];
 	readFile: string[];
 	waitForPort: number[];
 	destroy: number;
@@ -63,6 +66,7 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 		writeFile: [],
 		writeFiles: [],
 		setEnvVars: [],
+		setEnvDefaults: [],
 		readFile: [],
 		waitForPort: [],
 		destroy: 0,
@@ -103,9 +107,14 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 			calls.sequence.push('writeFiles');
 		},
 		gitCheckout: async () => {},
-		setEnvVars: async (vars: Record<string, string>) => {
-			calls.setEnvVars.push(vars);
-			calls.sequence.push('setEnvVars');
+		setEnvVars: async (vars: Record<string, string>, options?: SetEnvVarsOptions) => {
+			if (options?.onlyIfUnset) {
+				calls.setEnvDefaults.push(vars);
+				calls.sequence.push('setEnvDefaults');
+			} else {
+				calls.setEnvVars.push(vars);
+				calls.sequence.push('setEnvVars');
+			}
 		},
 		mountBucket: async (options: MountBucketOptions) => {
 			calls.mountBucket.push(options);
@@ -189,6 +198,7 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 		writeFile: [],
 		writeFiles: [],
 		setEnvVars: [],
+		setEnvDefaults: [],
 		readFile: [],
 		waitForPort: [],
 		destroy: 0,


### PR DESCRIPTION
- Sessions inject `XDG_CACHE_HOME`/`XDG_STATE_HOME=/tmp/marimohub-{cache,state}` so marimo logs/state never land under `$HOME` — a workdir that overlaps the home directory (the prod misconfig behind home dotfiles appearing in notebook workspaces) would otherwise sweep them into the workspace capture.
- `setEnvVars` gains `{ onlyIfUnset: true }`: every adapter applies such vars as a guarded shell export (`[ -n "${K:-}" ] || export K=…`), so an image that defines its own value keeps it. `XDG_CONFIG_HOME` stays forced — it carries policy config (sharing off, managed AI).
- Fixes two pre-existing typecheck errors (`TomlTable` re-export, optional `SessionEnv` fields in tests).
