### PR TITLE
feat(web): stale-version warnings and GitHub metadata for git-synced notebooks

### DIFF
--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -671,6 +671,8 @@ components:
           $ref: '#/components/schemas/SnapshotDescriptor'
         session_snapshot:
           $ref: '#/components/schemas/SnapshotDescriptor'
+        commit:
+          type: string
       required:
         - version_id
         - notebook_id

--- a/packages/api/src/routes/gitSync.test.ts
+++ b/packages/api/src/routes/gitSync.test.ts
@@ -120,6 +120,12 @@ describe('Git sync routes', () => {
 			await request('GET', `/projects/${projectId}/notebooks/${notebookId}/content`),
 		);
 		expect(content.code).toBe('print("synced")');
+
+		// The cut version exposes the commit it mirrors (for the UI's GitHub links).
+		const versions = await expectOk<{ items: { commit?: string; message: string }[] }>(
+			await request('GET', `/projects/${projectId}/notebooks/${notebookId}/versions`),
+		);
+		expect(versions.items[0]?.commit).toBe('abc123');
 	});
 
 	it("rejects a valid sync token used against a DIFFERENT notebook's path (401 IDOR)", async () => {

--- a/packages/api/src/routes/gitSync.test.ts
+++ b/packages/api/src/routes/gitSync.test.ts
@@ -63,6 +63,20 @@ describe('Git sync routes', () => {
 		'X-Marimohub-Commit': 'abc123',
 	});
 
+	it('rejects creating a synced notebook whose repo is not owner/repo (400)', async () => {
+		await expectError(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Bad repo',
+				description: 'd',
+				repo: 'git@github.com:org/repo.git',
+				branch: 'main',
+				entry_notebook: 'app.py',
+			}),
+			400,
+			'BAD_REQUEST',
+		);
+	});
+
 	it('rejects a request with no Authorization header (401)', async () => {
 		const { notebookId } = await createSyncedNotebook();
 		await expectError(await syncRequest({ notebookId }), 401, 'UNAUTHORIZED');

--- a/packages/api/src/routes/sessions.appMode.test.ts
+++ b/packages/api/src/routes/sessions.appMode.test.ts
@@ -66,6 +66,11 @@ describe('Session routes (app mode)', () => {
 		expect(same.source_version_id).toBe(source.current_version_id);
 	});
 
+	it('does not stamp source_version_id on an edit session for a local notebook', async () => {
+		const edit = await expectOk<any>(await owner('POST', sessionsPath()));
+		expect(edit.source_version_id).toBeUndefined();
+	});
+
 	it('writes the app claim at create and releases it on delete', async () => {
 		const app = await expectOk<any>(await owner('POST', sessionsPath(), { mode: 'app' }));
 		expect(await appClaimHolder(bucket, pid, nid)).toBe(app.session_id);
@@ -618,5 +623,55 @@ describe('Session routes (app mode)', () => {
 		expect(app.status).toBe('running');
 		const { source } = await services.notebooks.getNotebook(pid, meta.id as NotebookId);
 		expect(app.source_version_id).toBe(source.current_version_id);
+	});
+
+	it('stamps source_version_id on an EDIT session for a git-synced notebook', async () => {
+		const services = createServices(bucket);
+		const { meta } = await services.notebooks.synced.create(
+			pid,
+			{
+				title: 'Git NB',
+				description: 'd',
+				repo: 'owner/repo',
+				branch: 'main',
+				entry_notebook: 'app.py',
+			},
+			ACTOR,
+		);
+		const gitNid = meta.id as NotebookId;
+		await services.notebooks.synced.sync(pid, gitNid, {
+			repo: 'owner/repo',
+			branch: 'main',
+			root_path: '',
+			commit: 'commit-aaaa',
+			files: [{ path: 'app.py', bytes: enc('import marimo') }],
+		});
+
+		const edit = await expectOk<any>(await owner('POST', sessionsPath('', gitNid)));
+		expect(edit.mode).toBe('edit');
+		const { source } = await services.notebooks.getNotebook(pid, gitNid);
+		expect(edit.source_version_id).toBe(source.current_version_id);
+
+		// A background push advances the head; the session's provenance stays put.
+		await services.notebooks.synced.sync(pid, gitNid, {
+			repo: 'owner/repo',
+			branch: 'main',
+			root_path: '',
+			commit: 'commit-bbbb',
+			files: [{ path: 'app.py', bytes: enc('import marimo  # updated') }],
+		});
+		const after = await services.notebooks.getNotebook(pid, gitNid);
+		expect(after.source.current_version_id).not.toBe(edit.source_version_id);
+		const same = await expectOk<any>(
+			await owner('GET', sessionsPath(`/${edit.session_id}`, gitNid)),
+		);
+		expect(same.source_version_id).toBe(edit.source_version_id);
+
+		// Reopening the notebook attaches to the live session, provenance intact —
+		// the reconnect the client's staleness banner fires on.
+		const reattached = await expectOk<any>(await owner('POST', sessionsPath('', gitNid)));
+		expect(reattached.reused).toBe(true);
+		expect(reattached.session_id).toBe(edit.session_id);
+		expect(reattached.source_version_id).toBe(edit.source_version_id);
 	});
 });

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -476,12 +476,16 @@ app.openapi(createSession, async (c) => {
 	const workspacePrefix = syncedVersionId
 		? paths.project(pid).notebook(nid).version(syncedVersionId).workspacePrefix
 		: undefined;
-	// Staleness provenance: a non-persisting mode serves a frozen snapshot, so
-	// stamp the head committed version it was provisioned from — what the client
-	// compares for the "app is stale" banner.
-	const sourceVersionId = MODE_POLICY[mode].persistsEdits
-		? undefined
-		: (notebook.source.current_version_id ?? undefined);
+	// Staleness provenance: a session that serves a frozen snapshot — a
+	// non-persisting mode (`app`), or any mode on a synced source (a read-only
+	// mirror, even under `edit`) — is stamped with the head committed version it
+	// was provisioned from. The client compares it against the live head for the
+	// "session is stale" banners.
+	const sourceVersionId =
+		syncedVersionId ??
+		(MODE_POLICY[mode].persistsEdits
+			? undefined
+			: (notebook.source.current_version_id ?? undefined));
 
 	const { compute, bucket: bucketHandle, sandbox } = deps;
 	// The notebook's stored choice, resolved leniently: "default"/absent → first

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -631,6 +631,7 @@ export const NotebookVersionResponseSchema = z
 		parent_id: z.string().nullable(),
 		html_snapshot: SnapshotDescriptorResponseSchema.optional(),
 		session_snapshot: SnapshotDescriptorResponseSchema.optional(),
+		commit: z.string().optional(),
 	})
 	.openapi('NotebookVersion');
 

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -3865,6 +3865,7 @@ export interface components {
 			parent_id: string | null;
 			html_snapshot?: components['schemas']['SnapshotDescriptor'];
 			session_snapshot?: components['schemas']['SnapshotDescriptor'];
+			commit?: string;
 		};
 		SnapshotDescriptor: {
 			/**

--- a/packages/core/src/integrations/syncedSource.ts
+++ b/packages/core/src/integrations/syncedSource.ts
@@ -62,6 +62,11 @@ function timingSafeEqual(a: string, b: string): boolean {
 	return diff === 0;
 }
 
+// Plain `owner/repo` coordinates — not a clone URL or `git@` remote (a bare
+// "anything/anything" check would admit both). The UI builds host links
+// (github.com/{repo}/…) from this, so a looser shape would produce broken URLs.
+const OWNER_REPO_PATTERN = /^[A-Za-z0-9_-]+\/[A-Za-z0-9._-]+$/;
+
 export function normalizeGitSourceConfig(input: {
 	repo: string;
 	branch: string;
@@ -71,6 +76,9 @@ export function normalizeGitSourceConfig(input: {
 	const repo = input.repo.trim();
 	if (!repo) {
 		throw new BadRequestError('repo is required');
+	}
+	if (!OWNER_REPO_PATTERN.test(repo)) {
+		throw new BadRequestError('repo must use the owner/repo format, e.g. acme/analytics');
 	}
 	const branch = input.branch.trim();
 	if (!branch) {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -419,6 +419,9 @@ export const VersionSchema = z.object({
 	// so no migration of existing version.json objects is required.
 	html_snapshot: SnapshotDescriptorSchema.optional(),
 	session_snapshot: SnapshotDescriptorSchema.optional(),
+	// The git commit a sync-cut version mirrors (git-synced sources only; the
+	// UI links it to the host). Forward-tolerant like the snapshots above.
+	commit: z.string().optional(),
 });
 
 export type Version = z.infer<typeof VersionSchema>;

--- a/packages/core/src/services/content/SyncedNotebookService.test.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.test.ts
@@ -68,6 +68,19 @@ describe('SyncedNotebookService', () => {
 			const p = (await catalog.getCurrentSnapshot()).projects.find((pr) => pr.id === projectId);
 			expect(p?.notebook_count).toBe(1);
 		});
+
+		it('rejects a repo that is not plain owner/repo', async () => {
+			for (const repo of [
+				'https://gitlab.com/group/project',
+				'git@github.com:owner/repo.git',
+				'just-a-name',
+				'a/b/c',
+			]) {
+				await expect(
+					notebooks.synced.create(projectId, { ...CREATE_INPUT, repo }, ACTOR),
+				).rejects.toThrow('repo must use the owner/repo format');
+			}
+		});
 	});
 
 	describe('verifyToken / rotateToken', () => {
@@ -90,6 +103,23 @@ describe('SyncedNotebookService', () => {
 	});
 
 	describe('updateSource', () => {
+		it('rejects a repo that is not plain owner/repo', async () => {
+			const { meta } = await notebooks.synced.create(projectId, CREATE_INPUT, ACTOR);
+			await expect(
+				notebooks.synced.updateSource(
+					projectId,
+					meta.id,
+					{
+						repo: 'git@github.com:owner/repo.git',
+						branch: 'main',
+						root_path: '',
+						entry_notebook: 'app.py',
+					},
+					ACTOR,
+				),
+			).rejects.toThrow('repo must use the owner/repo format');
+		});
+
 		it('updates an unsynced draft immediately', async () => {
 			const { meta } = await notebooks.synced.create(projectId, CREATE_INPUT, ACTOR);
 

--- a/packages/core/src/services/content/SyncedNotebookService.test.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.test.ts
@@ -193,6 +193,11 @@ describe('SyncedNotebookService', () => {
 				expect(nb.source.current_version_id).not.toBeNull();
 			}
 
+			// The cut version records the commit it mirrors (the UI links it).
+			const [version] = await notebooks.listVersions(projectId, meta.id);
+			expect(version?.commit).toBe('commit-aaaa');
+			expect(version?.message).toBe('Sync commit-aaaa');
+
 			const e = await entry(meta.id);
 			expect(e?.status).toBe('active');
 		});

--- a/packages/core/src/services/content/SyncedNotebookService.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.ts
@@ -220,6 +220,7 @@ export class SyncedNotebookService {
 			author: actor,
 			message: `Sync ${prepared.commit.slice(0, 12)}`,
 			parentId: syncedSource.current_version_id,
+			commit: prepared.commit,
 		});
 		let versionToKeep = versionId;
 

--- a/packages/core/src/services/content/notebookMeta.ts
+++ b/packages/core/src/services/content/notebookMeta.ts
@@ -45,6 +45,8 @@ interface BuildVersionArgs {
 	author: UserId;
 	message: string;
 	parentId: VersionId | null;
+	/** The synced git commit, on versions cut by a push. */
+	commit?: string;
 }
 
 /**
@@ -61,6 +63,7 @@ export function buildVersion(args: BuildVersionArgs): Version {
 		author: args.author,
 		message: args.message,
 		parent_id: args.parentId,
+		...(args.commit ? { commit: args.commit } : {}),
 	};
 }
 

--- a/packages/web/src/api/hooks.test.tsx
+++ b/packages/web/src/api/hooks.test.tsx
@@ -6,6 +6,7 @@ import {
 	useCapabilitiesQuery,
 	useDownloadWorkspace,
 	useNotebookHtmlQuery,
+	useNotebookQuery,
 	useProjectSecretsQuery,
 	useRestartApp,
 	useRestartSession,
@@ -148,6 +149,44 @@ describe('useUserSearchQuery', () => {
 		releaseSecond();
 		await waitFor(() => expect(result.current.data?.[0]?.id).toBe('u2'));
 		expect(result.current.isPlaceholderData).toBe(false);
+	});
+});
+
+describe('useNotebookQuery', () => {
+	const notebookDetail = (sourceType: 'local' | 'git') => ({
+		meta: { id: NID, title: 'NB', author: 'me' },
+		source: { type: sourceType, current_version_id: 'ver-head' },
+	});
+
+	it('function-form refetchIntervalMs polls when the fetched detail asks for it', async () => {
+		const fetchMock = stubFetch(async () => jsonOk(notebookDetail('git')));
+
+		renderHookWithClient(
+			() =>
+				useNotebookQuery(PID, NID, {
+					refetchIntervalMs: (n) => (n?.source.type === 'git' ? 20 : undefined),
+				}),
+			{ toaster: false },
+		);
+
+		await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(3));
+	});
+
+	it('function-form refetchIntervalMs returning undefined never polls', async () => {
+		const fetchMock = stubFetch(async () => jsonOk(notebookDetail('local')));
+
+		const { result } = renderHookWithClient(
+			() =>
+				useNotebookQuery(PID, NID, {
+					refetchIntervalMs: (n) => (n?.source.type === 'git' ? 20 : undefined),
+				}),
+			{ toaster: false },
+		);
+
+		await waitFor(() => expect(result.current.data).toBeDefined());
+		// Long enough for several 20ms ticks to have fired if polling were armed.
+		await act(() => new Promise((resolve) => setTimeout(resolve, 100)));
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -4,7 +4,7 @@ import { useApiMutation } from './mutation';
 import { isApiErrorCode, isNotFoundError, notebookPath } from './request';
 import { sanitizeFilename, triggerDownload } from '../lib/download';
 import { userKeys, projectKeys, notebookKeys, sessionKeys, systemKeys } from './queryKeys';
-import type { ResolvedUser, ProjectFederation, ProjectRole } from '../types';
+import type { NotebookDetail, ResolvedUser, ProjectFederation, ProjectRole } from '../types';
 
 /** How often the notebook table re-polls runtime status, in ms. */
 const SESSIONS_POLL_INTERVAL_MS = 5_000;
@@ -350,13 +350,19 @@ export function useNotebooksQuery(projectId: string) {
 export function useNotebookQuery(
 	projectId: string,
 	notebookId: string,
-	// Freshness options for consumers that compare against the notebook HEAD (the
-	// app page's staleness banner): versions are committed server-side
-	// (snapshotter, teardown), which no client-side invalidation ever observes.
-	// `refetchIntervalMs` polls for a long-lived view; `staleTime: 0` re-reads on
-	// mount instead, for a short-lived one that must not trust the shared cache.
-	options: { refetchIntervalMs?: number; staleTime?: number } = {},
+	// Freshness options for consumers that compare against the notebook HEAD
+	// (the staleness banners): versions are committed server-side (snapshotter,
+	// teardown, git push), which no client-side invalidation ever observes.
+	// `refetchIntervalMs` polls for a long-lived view — pass a function when the
+	// interval depends on the fetched detail (e.g. poll only git-synced sources);
+	// `staleTime: 0` re-reads on mount instead, for a short-lived one that must
+	// not trust the shared cache.
+	options: {
+		refetchIntervalMs?: number | ((notebook: NotebookDetail | undefined) => number | undefined);
+		staleTime?: number;
+	} = {},
 ) {
+	const { refetchIntervalMs } = options;
 	return useQuery({
 		queryKey: notebookKeys.detail(projectId, notebookId),
 		queryFn: () =>
@@ -366,7 +372,10 @@ export function useNotebookQuery(
 				}),
 			),
 		staleTime: options.staleTime ?? 5 * 60 * 1000,
-		refetchInterval: options.refetchIntervalMs,
+		refetchInterval:
+			typeof refetchIntervalMs === 'function'
+				? (query) => refetchIntervalMs(query.state.data)
+				: refetchIntervalMs,
 	});
 }
 

--- a/packages/web/src/components/Notebook/GitSourcePopover.test.tsx
+++ b/packages/web/src/components/Notebook/GitSourcePopover.test.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GitSourcePopover } from './GitSourcePopover';
+
+const PID = 'proj-1';
+const NID = 'nb-1';
+
+function renderPopover(source: Record<string, unknown>) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						success: true,
+						data: { meta: { id: NID, title: 'NB', author: 'u-1' }, source },
+					}),
+					{ headers: { 'content-type': 'application/json' } },
+				),
+		),
+	);
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+	return render(<GitSourcePopover projectId={PID} notebookId={NID} trigger={<span>git</span>} />, {
+		wrapper,
+	});
+}
+
+const GIT_SOURCE = {
+	type: 'git',
+	provider: 'github',
+	repo: 'acme/analytics',
+	branch: 'main',
+	root_path: 'apps',
+	entry_notebook: 'dashboard.py',
+	commit: 'abc123def456',
+	current_version_id: 'v1',
+	last_synced_at: '2026-07-01T10:00:00Z',
+};
+
+beforeEach(() => {
+	vi.stubGlobal('matchMedia', (query: string) => ({
+		matches: false,
+		media: query,
+		onchange: null,
+		addEventListener: () => {},
+		removeEventListener: () => {},
+		addListener: () => {},
+		removeListener: () => {},
+		dispatchEvent: () => false,
+	}));
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('GitSourcePopover', () => {
+	it('links repo, commit, and source for a GitHub owner/repo source', async () => {
+		renderPopover(GIT_SOURCE);
+		await userEvent.click(screen.getByRole('button'));
+
+		expect(await screen.findByRole('link', { name: 'acme/analytics' })).toHaveAttribute(
+			'href',
+			'https://github.com/acme/analytics',
+		);
+		expect(screen.getByRole('link', { name: 'abc123d' })).toHaveAttribute(
+			'href',
+			'https://github.com/acme/analytics/commit/abc123def456',
+		);
+		expect(screen.getByRole('link', { name: /View source on GitHub/ })).toHaveAttribute(
+			'href',
+			'https://github.com/acme/analytics/blob/abc123def456/apps/dashboard.py',
+		);
+	});
+
+	it('renders metadata without links when the repo is not plain owner/repo', async () => {
+		renderPopover({ ...GIT_SOURCE, repo: 'git@github.com:acme/analytics.git' });
+		await userEvent.click(screen.getByRole('button'));
+
+		expect(await screen.findByText('git@github.com:acme/analytics.git')).toBeInTheDocument();
+		expect(screen.getByText('abc123d')).toBeInTheDocument();
+		expect(screen.getByText('apps/dashboard.py')).toBeInTheDocument();
+		expect(screen.queryByRole('link')).toBeNull();
+	});
+});

--- a/packages/web/src/components/Notebook/GitSourcePopover.test.tsx
+++ b/packages/web/src/components/Notebook/GitSourcePopover.test.tsx
@@ -70,6 +70,14 @@ describe('GitSourcePopover', () => {
 			'href',
 			'https://github.com/acme/analytics',
 		);
+		expect(screen.getByRole('link', { name: 'main' })).toHaveAttribute(
+			'href',
+			'https://github.com/acme/analytics/tree/main',
+		);
+		expect(screen.getByRole('link', { name: 'apps/dashboard.py' })).toHaveAttribute(
+			'href',
+			'https://github.com/acme/analytics/blob/abc123def456/apps/dashboard.py',
+		);
 		expect(screen.getByRole('link', { name: 'abc123d' })).toHaveAttribute(
 			'href',
 			'https://github.com/acme/analytics/commit/abc123def456',

--- a/packages/web/src/components/Notebook/GitSourcePopover.tsx
+++ b/packages/web/src/components/Notebook/GitSourcePopover.tsx
@@ -1,0 +1,106 @@
+import type { ReactNode } from 'react';
+import { ExternalLink } from 'lucide-react';
+import { useNotebookQuery } from '@/api/hooks';
+import { Popover } from '@/components/ui';
+import { formatRelative } from '@/lib/time';
+import {
+	gitEntryPath,
+	githubCommitUrl,
+	githubRepoUrl,
+	githubSourceUrl,
+	shortCommit,
+} from '@/lib/github';
+
+const LINK_CLASSES = 'text-primary underline-offset-2 hover:underline';
+
+function GitSourceDetails({ projectId, notebookId }: { projectId: string; notebookId: string }) {
+	// Lazy (popover-open only) fetch; `staleTime: 0` because a background push
+	// can advance the source underneath a cached read and nothing invalidates it.
+	const { data: notebook, isError } = useNotebookQuery(projectId, notebookId, { staleTime: 0 });
+	const source = notebook?.source.type === 'git' ? notebook.source : undefined;
+
+	if (isError) {
+		return <p className="text-xs text-destructive">Failed to load sync details.</p>;
+	}
+	if (!source) {
+		return <p className="text-xs text-muted-foreground">Loading sync details...</p>;
+	}
+	return (
+		<div className="flex min-w-[14rem] flex-col gap-2 text-xs">
+			<div className="font-medium text-foreground">Synced from GitHub</div>
+			<dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-muted-foreground">
+				<dt>Repository</dt>
+				<dd className="min-w-0 truncate">
+					<a
+						href={githubRepoUrl(source.repo)}
+						target="_blank"
+						rel="noreferrer"
+						className={LINK_CLASSES}
+					>
+						{source.repo}
+					</a>
+				</dd>
+				<dt>Branch</dt>
+				<dd className="min-w-0 truncate text-foreground">{source.branch}</dd>
+				<dt>File</dt>
+				<dd className="min-w-0 truncate text-foreground">{gitEntryPath(source)}</dd>
+				{source.commit && (
+					<>
+						<dt>Commit</dt>
+						<dd>
+							<a
+								href={githubCommitUrl(source.repo, source.commit)}
+								target="_blank"
+								rel="noreferrer"
+								className={`font-mono ${LINK_CLASSES}`}
+							>
+								{shortCommit(source.commit)}
+							</a>
+						</dd>
+					</>
+				)}
+				<dt>Synced</dt>
+				<dd className="text-foreground">
+					{source.last_synced_at ? formatRelative(source.last_synced_at) : 'Not synced yet'}
+				</dd>
+			</dl>
+			<a
+				href={githubSourceUrl(source)}
+				target="_blank"
+				rel="noreferrer"
+				className={`flex items-center gap-1 pt-0.5 font-medium ${LINK_CLASSES}`}
+			>
+				View source on GitHub
+				<ExternalLink className="size-3" />
+			</a>
+		</div>
+	);
+}
+
+/**
+ * GitHub metadata behind a compact trigger (the project row's git tile, the
+ * editor's repo chip): repo/branch/file/commit with links, loaded only while
+ * the popover is open.
+ */
+export function GitSourcePopover({
+	projectId,
+	notebookId,
+	trigger,
+	triggerClassName,
+}: {
+	projectId: string;
+	notebookId: string;
+	trigger: ReactNode;
+	triggerClassName?: string;
+}) {
+	return (
+		<Popover
+			label="Synced from GitHub — details"
+			tooltip="Synced from GitHub"
+			trigger={trigger}
+			triggerClassName={triggerClassName}
+		>
+			<GitSourceDetails projectId={projectId} notebookId={notebookId} />
+		</Popover>
+	);
+}

--- a/packages/web/src/components/Notebook/GitSourcePopover.tsx
+++ b/packages/web/src/components/Notebook/GitSourcePopover.tsx
@@ -6,6 +6,7 @@ import { formatRelative } from '@/lib/time';
 import {
 	gitEntryPath,
 	githubCommitUrl,
+	githubCoords,
 	githubRepoUrl,
 	githubSourceUrl,
 	shortCommit,
@@ -18,6 +19,9 @@ function GitSourceDetails({ projectId, notebookId }: { projectId: string; notebo
 	// can advance the source underneath a cached read and nothing invalidates it.
 	const { data: notebook, isError } = useNotebookQuery(projectId, notebookId, { staleTime: 0 });
 	const source = notebook?.source.type === 'git' ? notebook.source : undefined;
+	// Null when no trustworthy GitHub link exists (non-github provider, or a repo
+	// that isn't plain owner/repo) — metadata then renders without links.
+	const coords = githubCoords(notebook?.source);
 
 	if (isError) {
 		return <p className="text-xs text-destructive">Failed to load sync details.</p>;
@@ -31,14 +35,18 @@ function GitSourceDetails({ projectId, notebookId }: { projectId: string; notebo
 			<dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-muted-foreground">
 				<dt>Repository</dt>
 				<dd className="min-w-0 truncate">
-					<a
-						href={githubRepoUrl(source.repo)}
-						target="_blank"
-						rel="noreferrer"
-						className={LINK_CLASSES}
-					>
-						{source.repo}
-					</a>
+					{coords ? (
+						<a
+							href={githubRepoUrl(coords.repo)}
+							target="_blank"
+							rel="noreferrer"
+							className={LINK_CLASSES}
+						>
+							{source.repo}
+						</a>
+					) : (
+						<span className="text-foreground">{source.repo}</span>
+					)}
 				</dd>
 				<dt>Branch</dt>
 				<dd className="min-w-0 truncate text-foreground">{source.branch}</dd>
@@ -48,14 +56,18 @@ function GitSourceDetails({ projectId, notebookId }: { projectId: string; notebo
 					<>
 						<dt>Commit</dt>
 						<dd>
-							<a
-								href={githubCommitUrl(source.repo, source.commit)}
-								target="_blank"
-								rel="noreferrer"
-								className={`font-mono ${LINK_CLASSES}`}
-							>
-								{shortCommit(source.commit)}
-							</a>
+							{coords ? (
+								<a
+									href={githubCommitUrl(coords.repo, source.commit)}
+									target="_blank"
+									rel="noreferrer"
+									className={`font-mono ${LINK_CLASSES}`}
+								>
+									{shortCommit(source.commit)}
+								</a>
+							) : (
+								<span className="font-mono text-foreground">{shortCommit(source.commit)}</span>
+							)}
 						</dd>
 					</>
 				)}
@@ -64,15 +76,17 @@ function GitSourceDetails({ projectId, notebookId }: { projectId: string; notebo
 					{source.last_synced_at ? formatRelative(source.last_synced_at) : 'Not synced yet'}
 				</dd>
 			</dl>
-			<a
-				href={githubSourceUrl(source)}
-				target="_blank"
-				rel="noreferrer"
-				className={`flex items-center gap-1 pt-0.5 font-medium ${LINK_CLASSES}`}
-			>
-				View source on GitHub
-				<ExternalLink className="size-3" />
-			</a>
+			{coords && (
+				<a
+					href={githubSourceUrl(coords)}
+					target="_blank"
+					rel="noreferrer"
+					className={`flex items-center gap-1 pt-0.5 font-medium ${LINK_CLASSES}`}
+				>
+					View source on GitHub
+					<ExternalLink className="size-3" />
+				</a>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/components/Notebook/GitSourcePopover.tsx
+++ b/packages/web/src/components/Notebook/GitSourcePopover.tsx
@@ -5,6 +5,7 @@ import { Popover } from '@/components/ui';
 import { formatRelative } from '@/lib/time';
 import {
 	gitEntryPath,
+	githubBranchUrl,
 	githubCommitUrl,
 	githubCoords,
 	githubRepoUrl,
@@ -49,9 +50,35 @@ function GitSourceDetails({ projectId, notebookId }: { projectId: string; notebo
 					)}
 				</dd>
 				<dt>Branch</dt>
-				<dd className="min-w-0 truncate text-foreground">{source.branch}</dd>
+				<dd className="min-w-0 truncate">
+					{coords ? (
+						<a
+							href={githubBranchUrl(coords.repo, coords.branch)}
+							target="_blank"
+							rel="noreferrer"
+							className={LINK_CLASSES}
+						>
+							{source.branch}
+						</a>
+					) : (
+						<span className="text-foreground">{source.branch}</span>
+					)}
+				</dd>
 				<dt>File</dt>
-				<dd className="min-w-0 truncate text-foreground">{gitEntryPath(source)}</dd>
+				<dd className="min-w-0 truncate">
+					{coords ? (
+						<a
+							href={githubSourceUrl(coords)}
+							target="_blank"
+							rel="noreferrer"
+							className={LINK_CLASSES}
+						>
+							{gitEntryPath(source)}
+						</a>
+					) : (
+						<span className="text-foreground">{gitEntryPath(source)}</span>
+					)}
+				</dd>
 				{source.commit && (
 					<>
 						<dt>Commit</dt>

--- a/packages/web/src/components/Notebook/SyncSettingsDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncSettingsDialog.tsx
@@ -34,7 +34,7 @@ interface SyncSettingsDialogProps {
 
 const settingsSchema = z.object({
 	repo: requiredText('Repository').regex(
-		/^[^/\s]+\/[^/\s]+$/,
+		/^[A-Za-z0-9_-]+\/[A-Za-z0-9._-]+$/,
 		'Use the owner/repo format, e.g. acme/analytics',
 	),
 	branch: requiredText('Branch'),

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
@@ -28,7 +28,7 @@ export interface SyncedNotebookDialogProps {
 const syncedSchema = z.object({
 	title: requiredText('Notebook name'),
 	repo: requiredText('Repository').regex(
-		/^[^/\s]+\/[^/\s]+$/,
+		/^[A-Za-z0-9_-]+\/[A-Za-z0-9._-]+$/,
 		'Use the owner/repo format, e.g. acme/analytics',
 	),
 	branch: requiredText('Branch'),

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
@@ -68,10 +68,13 @@ function makeFetch({
 	versions = VERSIONS,
 	listResponse,
 	restoreResponse,
+	source = { type: 'local', current_version_id: 'v3' },
 }: {
 	versions?: NotebookVersion[];
 	listResponse?: Response;
 	restoreResponse?: Response;
+	/** The notebook detail's source (git enables the per-version commit links). */
+	source?: Record<string, unknown>;
 } = {}) {
 	const calls: { url: string; method: string }[] = [];
 	const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -88,12 +91,25 @@ function makeFetch({
 		}
 		if (url.includes(`/notebooks/${NID}/versions`))
 			return listResponse ?? ok({ items: versions, next_cursor: null });
+		if (url.endsWith(`/notebooks/${NID}`))
+			return ok({ meta: { id: NID, title: 'my_analysis', author: 'u-1' }, source });
 		if (url.includes('/users')) return ok(DIRECTORY);
 		throw new Error(`unexpected fetch: ${method} ${url}`);
 	});
 	vi.stubGlobal('fetch', impl);
 	return calls;
 }
+
+const GIT_SOURCE = {
+	type: 'git',
+	repo: 'org/repo',
+	branch: 'main',
+	root_path: '',
+	entry_notebook: 'app.py',
+	commit: 'deadbeefcafe0123',
+	current_version_id: 'v3',
+	last_synced_at: '2026-07-01T10:00:00Z',
+};
 
 function renderDialog({
 	sourceType = 'local' as const,
@@ -156,6 +172,34 @@ describe('VersionHistoryDialog', () => {
 		expect(within(rows[2]).getByText('first save')).toBeInTheDocument();
 		expect(within(rows[1]).queryByText('Current')).not.toBeInTheDocument();
 		await waitFor(() => expect(within(rows[0]).getByText('Ana Author')).toBeInTheDocument());
+	});
+
+	it('links sync versions to their GitHub commits for a git-synced notebook', async () => {
+		makeFetch({
+			versions: [
+				{
+					...version('v2', '2026-07-01T10:00:00Z', 'Sync deadbeefcafe'),
+					commit: 'deadbeefcafe0123',
+				},
+				// A version written before the commit field existed: parsed from the message.
+				version('v1', '2026-06-30T10:00:00Z', 'Sync abc123def456'),
+			],
+			source: GIT_SOURCE,
+		});
+		renderDialog({ sourceType: 'git' });
+
+		const stamped = await screen.findByRole('link', { name: 'deadbee' });
+		expect(stamped).toHaveAttribute('href', 'https://github.com/org/repo/commit/deadbeefcafe0123');
+		const legacy = screen.getByRole('link', { name: 'abc123d' });
+		expect(legacy).toHaveAttribute('href', 'https://github.com/org/repo/commit/abc123def456');
+	});
+
+	it('shows no commit links for a local notebook', async () => {
+		makeFetch();
+		renderDialog();
+
+		await screen.findAllByTestId('version-row');
+		expect(screen.queryByTitle('View commit on GitHub')).toBeNull();
 	});
 
 	it('defaults the diff to previous → current', async () => {

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
@@ -102,6 +102,7 @@ function makeFetch({
 
 const GIT_SOURCE = {
 	type: 'git',
+	provider: 'github',
 	repo: 'org/repo',
 	branch: 'main',
 	root_path: '',

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
@@ -20,7 +20,7 @@ import {
 import type { UserDirectory } from '@/api/hooks';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { toastError } from '@/lib/errors';
-import { githubCommitUrl, shortCommit, versionCommit } from '@/lib/github';
+import { githubCommitUrl, githubCoords, shortCommit, versionCommit } from '@/lib/github';
 import { formatRelative } from '@/lib/time';
 import { cn } from '@/lib/utils';
 import type { NotebookEntry, NotebookVersion } from '@/types';
@@ -169,14 +169,15 @@ export function VersionHistoryDialog({
 	const ids = new Set(versions.map((v) => v.version_id));
 
 	// The repo behind each sync version's commit link. The dialog mounts only
-	// while open, so this fetch is on-demand; local notebooks just get no chips.
+	// while open, so this fetch is on-demand; local notebooks (and git sources
+	// without a trustworthy GitHub repo) just get no chips.
 	const { data: detail } = useNotebookQuery(projectId, notebook.id);
-	const gitRepo = detail?.source.type === 'git' ? detail.source.repo : undefined;
+	const coords = githubCoords(detail?.source);
 	const commitLinkFor = (v: NotebookVersion): { href: string; label: string } | undefined => {
-		if (!gitRepo) return undefined;
+		if (!coords) return undefined;
 		const commit = versionCommit(v);
 		return commit
-			? { href: githubCommitUrl(gitRepo, commit), label: shortCommit(commit) }
+			? { href: githubCommitUrl(coords.repo, commit), label: shortCommit(commit) }
 			: undefined;
 	};
 

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
@@ -11,6 +11,7 @@ import {
 	UserLabel,
 } from '@/components/ui';
 import {
+	useNotebookQuery,
 	useNotebookVersionQuery,
 	useNotebookVersionsQuery,
 	useRestoreVersion,
@@ -19,6 +20,7 @@ import {
 import type { UserDirectory } from '@/api/hooks';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { toastError } from '@/lib/errors';
+import { githubCommitUrl, shortCommit, versionCommit } from '@/lib/github';
 import { formatRelative } from '@/lib/time';
 import { cn } from '@/lib/utils';
 import type { NotebookEntry, NotebookVersion } from '@/types';
@@ -76,6 +78,8 @@ interface VersionListItemProps {
 	users: UserDirectory | undefined;
 	usersLoading: boolean;
 	showRestore: boolean;
+	/** GitHub link for the synced commit this version mirrors, when known. */
+	commitLink?: { href: string; label: string };
 	onSelect: () => void;
 	onRestore: () => void;
 }
@@ -88,6 +92,7 @@ function VersionListItem({
 	users,
 	usersLoading,
 	showRestore,
+	commitLink,
 	onSelect,
 	onRestore,
 }: VersionListItemProps) {
@@ -120,6 +125,17 @@ function VersionListItem({
 					className="max-w-full text-xs text-muted-foreground"
 				/>
 			</button>
+			{commitLink && (
+				<a
+					href={commitLink.href}
+					target="_blank"
+					rel="noreferrer"
+					title="View commit on GitHub"
+					className="shrink-0 rounded font-mono text-[11px] text-muted-foreground underline-offset-2 hover:text-primary hover:underline"
+				>
+					{commitLink.label}
+				</a>
+			)}
 			{showRestore && (
 				<Button variant="ghost" size="sm" onPress={onRestore} className="shrink-0">
 					Restore
@@ -151,6 +167,18 @@ export function VersionHistoryDialog({
 	const versionsQuery = useNotebookVersionsQuery(projectId, notebook.id);
 	const versions = versionsQuery.data ?? [];
 	const ids = new Set(versions.map((v) => v.version_id));
+
+	// The repo behind each sync version's commit link. The dialog mounts only
+	// while open, so this fetch is on-demand; local notebooks just get no chips.
+	const { data: detail } = useNotebookQuery(projectId, notebook.id);
+	const gitRepo = detail?.source.type === 'git' ? detail.source.repo : undefined;
+	const commitLinkFor = (v: NotebookVersion): { href: string; label: string } | undefined => {
+		if (!gitRepo) return undefined;
+		const commit = versionCommit(v);
+		return commit
+			? { href: githubCommitUrl(gitRepo, commit), label: shortCommit(commit) }
+			: undefined;
+	};
 
 	const effectiveCompare =
 		compareId && ids.has(compareId) ? compareId : (versions[0]?.version_id ?? null);
@@ -257,6 +285,7 @@ export function VersionHistoryDialog({
 										users={users}
 										usersLoading={usersLoading}
 										showRestore={restorable && i !== 0}
+										commitLink={commitLinkFor(v)}
 										onSelect={() => {
 											setBaseId(v.version_id);
 											setCompareId(null);

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -100,6 +100,7 @@ function makeFetch(opts: FetchOptions) {
 					opts.sourceType === 'git'
 						? {
 								type: 'git',
+								provider: 'github',
 								repo: 'org/repo',
 								branch: 'main',
 								root_path: '',

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -43,6 +43,8 @@ interface FetchOptions {
 	projectSessions?: Session[];
 	/** The notebook's current head version (staleness comparisons). */
 	headVersion?: string;
+	/** The notebook's source type; `git` models a GitHub-synced notebook. */
+	sourceType?: 'local' | 'git';
 	/** When set, POST .../sessions fails with this error code at this status. */
 	createError?: { code: string; message: string; status: number };
 	computeProfiles?: { name: string; cpu?: number; memory_bytes?: number }[];
@@ -94,7 +96,19 @@ function makeFetch(opts: FetchOptions) {
 					author: 'me',
 					...(opts.computeProfile ? { compute_profile: opts.computeProfile } : {}),
 				},
-				source: { type: 'local', current_version_id: opts.headVersion ?? 'ver-head' },
+				source:
+					opts.sourceType === 'git'
+						? {
+								type: 'git',
+								repo: 'org/repo',
+								branch: 'main',
+								root_path: '',
+								entry_notebook: 'app.py',
+								commit: 'deadbeefcafe0123',
+								last_synced_at: '2026-07-01T10:00:00Z',
+								current_version_id: opts.headVersion ?? 'ver-head',
+							}
+						: { type: 'local', current_version_id: opts.headVersion ?? 'ver-head' },
 			});
 		}
 		if (url.includes('/capabilities')) {
@@ -266,6 +280,122 @@ describe('NotebookPage viewer modes', () => {
 	});
 });
 
+describe('NotebookPage git-synced editor', () => {
+	const gitEditSession = (overrides: Partial<Session> = {}) =>
+		runningSession({ source_version_id: 'ver-head', ...overrides });
+
+	it('shows the updated-on-GitHub banner when the session trails the head', async () => {
+		makeFetch({
+			role: 'editor',
+			sourceType: 'git',
+			session: gitEditSession({ source_version_id: 'ver-old' }),
+			headVersion: 'ver-head',
+		});
+		renderPage();
+
+		await waitFor(() => expect(screen.getByText(/updated on GitHub/)).toBeInTheDocument());
+		expect(screen.getByText('Restart to update')).toBeInTheDocument();
+	});
+
+	it('shows no banner when the session serves the synced head', async () => {
+		makeFetch({ role: 'editor', sourceType: 'git', session: gitEditSession() });
+		const { container } = renderPage();
+
+		await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull());
+		expect(screen.queryByText(/updated on GitHub/)).toBeNull();
+	});
+
+	it('header shows the repo chip whose popover links to the source on GitHub', async () => {
+		const user = userEvent.setup();
+		makeFetch({ role: 'editor', sourceType: 'git', session: gitEditSession() });
+		renderPage();
+
+		await user.click(await screen.findByRole('button', { name: 'Synced from GitHub — details' }));
+		const popover = await screen.findByRole('dialog');
+		expect(within(popover).getByRole('link', { name: 'org/repo' })).toHaveAttribute(
+			'href',
+			'https://github.com/org/repo',
+		);
+		expect(within(popover).getByRole('link', { name: 'deadbee' })).toHaveAttribute(
+			'href',
+			'https://github.com/org/repo/commit/deadbeefcafe0123',
+		);
+		expect(within(popover).getByRole('link', { name: /View source on GitHub/ })).toHaveAttribute(
+			'href',
+			'https://github.com/org/repo/blob/deadbeefcafe0123/app.py',
+		);
+	});
+
+	it('the app view shows no repo chip', async () => {
+		makeFetch({
+			role: 'editor',
+			sourceType: 'git',
+			session: gitEditSession({ mode: 'app' }),
+		});
+		const { container } = renderPage('app');
+
+		await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull());
+		expect(screen.queryByRole('button', { name: 'Synced from GitHub — details' })).toBeNull();
+	});
+
+	it('shows the banner without a restart CTA when the caller cannot stop the session', async () => {
+		makeFetch({
+			role: 'editor',
+			sourceType: 'git',
+			session: gitEditSession({
+				source_version_id: 'ver-old',
+				can: { attach: true, stop: false },
+			}),
+			headVersion: 'ver-head',
+		});
+		renderPage();
+
+		await waitFor(() => expect(screen.getByText(/updated on GitHub/)).toBeInTheDocument());
+		expect(screen.queryByText('Restart to update')).toBeNull();
+	});
+
+	it('shows no banner on a local notebook even when versions differ', async () => {
+		makeFetch({
+			role: 'editor',
+			session: gitEditSession({ source_version_id: 'ver-old' }),
+			headVersion: 'ver-head',
+		});
+		const { container } = renderPage();
+
+		await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull());
+		expect(screen.queryByText(/updated on GitHub/)).toBeNull();
+	});
+
+	it('Restart to update confirms (cancel is a no-op), then tears down and starts fresh', async () => {
+		const user = userEvent.setup();
+		const impl = makeFetch({
+			role: 'editor',
+			sourceType: 'git',
+			session: gitEditSession({ source_version_id: 'ver-old' }),
+			headVersion: 'ver-head',
+		});
+		const { container } = renderPage();
+		await waitFor(() => expect(screen.getByText('Restart to update')).toBeInTheDocument());
+
+		await user.click(screen.getByText('Restart to update'));
+		// The dialog, not a teardown, is what a click produces.
+		expect(sessionPosts(impl)).toHaveLength(1);
+		let dialog = await screen.findByRole('dialog');
+		expect(within(dialog).getByText(/latest version from GitHub/)).toBeInTheDocument();
+
+		await user.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+		expect(impl.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(false);
+		expect(container.querySelector('iframe')).not.toBeNull();
+
+		await user.click(screen.getByText('Restart to update'));
+		dialog = await screen.findByRole('dialog');
+		await user.click(within(dialog).getByRole('button', { name: 'Restart' }));
+		await waitFor(() => expect(sessionPosts(impl)).toHaveLength(2));
+		const deletes = impl.mock.calls.filter(([, init]) => init?.method === 'DELETE');
+		expect(deletes).toHaveLength(1);
+	});
+});
+
 describe('NotebookPage app variant', () => {
 	const appSession = (overrides: Partial<Session> = {}) =>
 		runningSession({ mode: 'app', source_version_id: 'ver-head', ...overrides });
@@ -310,6 +440,19 @@ describe('NotebookPage app variant', () => {
 
 		await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull());
 		await waitFor(() => expect(screen.queryByText(/serving an older version/)).toBeNull());
+	});
+
+	it('does not suppress the banner during editing on a git-synced notebook', async () => {
+		makeFetch({
+			role: 'editor',
+			sourceType: 'git',
+			session: appSession({ source_version_id: 'ver-old' }),
+			headVersion: 'ver-head',
+			projectSessions: [runningSession({ session_id: 'sess-edit', mode: 'edit' })],
+		});
+		renderPage('app');
+
+		await waitFor(() => expect(screen.getByText(/serving an older version/)).toBeInTheDocument());
 	});
 
 	it('shows no staleness banner when the app serves the head version', async () => {

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -1,6 +1,14 @@
 import { useMemo } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
-import { AlertTriangle, AppWindow, ArrowLeft, Eye, Pencil, RefreshCw } from 'lucide-react';
+import {
+	AlertTriangle,
+	AppWindow,
+	ArrowLeft,
+	Eye,
+	GitBranch,
+	Pencil,
+	RefreshCw,
+} from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
 	Button,
@@ -23,12 +31,12 @@ import { useNotebookSession } from '@/hooks/useNotebookSession';
 import type { SessionEnded } from '@/hooks/useNotebookSession';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { useDisclosure } from '@/hooks/useDisclosure';
+import { GitSourcePopover } from '@/components/Notebook/GitSourcePopover';
 import { RenameNotebookDialog } from '@/components/Notebook/RenameNotebookDialog';
 import { effectiveComputeProfile } from '@/components/Notebook/computeProfiles';
 import { ComputeProfileIndicator } from '@/components/Notebook/ComputeProfileIndicator';
 import { StaticNotebookView } from '@/components/NotebookPage/StaticNotebookView';
-import { isAppStale } from '@/components/Project/AppSessionIndicator';
-import { appConnectionHint, sessionsByNotebook } from '@/lib/sessions';
+import { appConnectionHint, isSessionStale, sessionsByNotebook } from '@/lib/sessions';
 import { useTheme } from '@/context/ThemeContext';
 import type { Theme } from '@/context/ThemeContext';
 
@@ -77,6 +85,8 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 	const renameModal = useDisclosure();
 	// Stop/Restart disconnect everyone using the shared app, so both confirm first.
 	const confirmAppAction = useDialogTarget<'stop' | 'restart'>();
+	// Restarting a git-synced editor discards its sandbox scratch state, so confirm.
+	const confirmEditRestart = useDisclosure();
 
 	// The viewer branch (server-enforced regardless): editors get a session as
 	// always; a viewer gets an edit kernel only when the deployment's evaluated
@@ -129,14 +139,13 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 
 	// Metadata for the "created by" line — loaded lazily so it never blocks the
 	// kernel from starting. The author id is resolved to a name via the directory.
-	// On the app page it also carries the head version for the staleness banner,
-	// which must track versions committed server-side (snapshotter, teardown) —
-	// hence the poll; a cached-once head would never fire (or mis-fire) the banner.
-	const { data: notebook } = useNotebookQuery(
-		pid!,
-		nid!,
-		isApp ? { refetchIntervalMs: 30_000 } : {},
-	);
+	// It also carries the head version for the staleness banners, which must track
+	// versions committed server-side (snapshotter, teardown, git push) — hence the
+	// poll; a cached-once head would never fire (or mis-fire) a banner. Edit pages
+	// poll only git-synced sources — the one head that can move mid-edit.
+	const { data: notebook } = useNotebookQuery(pid!, nid!, {
+		refetchIntervalMs: isApp ? 30_000 : (n) => (n?.source.type === 'git' ? 30_000 : undefined),
+	});
 	const author = notebook?.meta.author;
 	// Prefer the canonical title once detail loads, so a rename reflects immediately.
 	const title = notebook?.meta.title ?? notebookTitle;
@@ -151,8 +160,22 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 	const { data: projectSessions } = useProjectSessionsQuery(pid!, isApp && !ended);
 	const sessionByNotebook = useMemo(() => sessionsByNotebook(projectSessions), [projectSessions]);
 	const editActive = isApp && !!sessionByNotebook.get(nid!)?.edit;
+	// Suppressed while a LOCAL notebook is being edited — the snapshotter keeps
+	// moving its head. A synced head moves only when a push lands, so an open
+	// editor is no reason to hide the banner there.
+	const suppressForLocalEdit = editActive && notebook?.source.type !== 'git';
 	const appStale =
-		isApp && !!session && !editActive && isAppStale(session, notebook?.source.current_version_id);
+		isApp &&
+		!!session &&
+		!suppressForLocalEdit &&
+		isSessionStale(session, notebook?.source.current_version_id);
+	// No `editActive` suppression here: a synced head moves only when a push
+	// lands, never from typing in the editor.
+	const editStale =
+		!isApp &&
+		!!session &&
+		notebook?.source.type === 'git' &&
+		isSessionStale(session, notebook.source.current_version_id);
 	// A viewer deep-linking to /app gets a plain 403 panel; retrying can only
 	// fail again, so the button is dropped (no retry loop, manual or otherwise).
 	const showRetry = error?.code !== 'FORBIDDEN';
@@ -222,6 +245,19 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 					>
 						<Pencil className="size-3.5" />
 					</IconButton>
+				)}
+				{!isApp && notebook?.source.type === 'git' && (
+					<GitSourcePopover
+						projectId={pid!}
+						notebookId={nid!}
+						triggerClassName="shrink-0 cursor-pointer rounded-full"
+						trigger={
+							<span className="flex max-w-[16rem] items-center gap-1 rounded-full border border-input px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:border-primary hover:text-primary">
+								<GitBranch className="size-3 shrink-0" />
+								<span className="truncate">{notebook.source.repo}</span>
+							</span>
+						}
+					/>
 				)}
 				{author && (
 					<span className="hidden items-center gap-1 text-xs text-muted-foreground sm:flex">
@@ -331,6 +367,27 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 							)}
 						</div>
 					)}
+					{editStale && (
+						<div
+							aria-live="polite"
+							className="flex items-center gap-1.5 border-b bg-amber-500/10 px-3 py-1.5 text-xs text-muted-foreground"
+						>
+							<AlertTriangle className="size-3.5 shrink-0 text-amber-600 dark:text-amber-500" />
+							<span>
+								This notebook was updated on GitHub since this session started — you're viewing an
+								older version.
+							</span>
+							{session?.can?.stop && (
+								<Button
+									variant="unstyled"
+									className="ml-1 shrink-0 rounded text-xs font-medium text-primary underline-offset-2 hover:underline"
+									onPress={confirmEditRestart.open}
+								>
+									Restart to update
+								</Button>
+							)}
+						</div>
+					)}
 					<div className="flex-1 overflow-hidden">
 						<iframe
 							className="size-full border-0"
@@ -404,6 +461,20 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 					onClose={renameModal.close}
 					projectId={pid!}
 					notebook={{ id: nid!, title }}
+				/>
+			)}
+
+			{!isApp && (
+				<ConfirmDialog
+					isOpen={confirmEditRestart.isOpen}
+					onClose={confirmEditRestart.close}
+					title="Restart Session"
+					description={`Restart the session for "${title}" to load the latest version from GitHub? Changes made in this sandbox aren't synced back and will be lost.`}
+					confirmLabel="Restart"
+					onConfirm={() => {
+						confirmEditRestart.close();
+						restart();
+					}}
 				/>
 			)}
 

--- a/packages/web/src/components/Project/AppSessionIndicator.test.tsx
+++ b/packages/web/src/components/Project/AppSessionIndicator.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { Session } from '@/types';
 import type { ComputeProfile } from '@/components/Notebook/computeProfiles';
-import { AppSessionIndicator, isAppStale } from './AppSessionIndicator';
+import { AppSessionIndicator } from './AppSessionIndicator';
 
 function makeAppSession(overrides: Partial<Session> = {}): Session {
 	return {
@@ -29,6 +29,7 @@ function renderIndicator(
 		canOpen = false,
 		editActive = false,
 		headVersion = 'ver-head',
+		sourceType = 'local',
 		profiles = [],
 		computeProfile,
 		allowComputeOverride = false,
@@ -40,6 +41,7 @@ function renderIndicator(
 		editActive?: boolean;
 		/** A function to model a head that moves between popover opens. */
 		headVersion?: string | (() => string);
+		sourceType?: 'local' | 'git';
 		profiles?: ComputeProfile[];
 		computeProfile?: string;
 		allowComputeOverride?: boolean;
@@ -69,7 +71,7 @@ function renderIndicator(
 							...(computeProfile ? { compute_profile: computeProfile } : {}),
 						},
 						source: {
-							type: 'local',
+							type: sourceType,
 							current_version_id: typeof headVersion === 'function' ? headVersion() : headVersion,
 						},
 					}
@@ -115,16 +117,6 @@ beforeEach(() => {
 afterEach(() => {
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
-});
-
-describe('isAppStale', () => {
-	it('is stale only when both versions are known and differ', () => {
-		expect(isAppStale({ source_version_id: 'a' }, 'b')).toBe(true);
-		expect(isAppStale({ source_version_id: 'a' }, 'a')).toBe(false);
-		expect(isAppStale({ source_version_id: undefined }, 'b')).toBe(false);
-		expect(isAppStale({ source_version_id: 'a' }, null)).toBe(false);
-		expect(isAppStale({ source_version_id: 'a' }, undefined)).toBe(false);
-	});
 });
 
 describe('AppSessionIndicator', () => {
@@ -178,6 +170,17 @@ describe('AppSessionIndicator', () => {
 	it('shows the stale hint when the app trails the notebook head', async () => {
 		renderIndicator(makeAppSession({ source_version_id: 'ver-old' }), {
 			headVersion: 'ver-head',
+		});
+		await userEvent.click(screen.getByRole('button'));
+
+		expect(await screen.findByText(/Restart to update/)).toBeInTheDocument();
+	});
+
+	it('does not suppress the stale hint during editing on a git-synced notebook', async () => {
+		renderIndicator(makeAppSession({ source_version_id: 'ver-old' }), {
+			headVersion: 'ver-head',
+			sourceType: 'git',
+			editActive: true,
 		});
 		await userEvent.click(screen.getByRole('button'));
 

--- a/packages/web/src/components/Project/AppSessionIndicator.tsx
+++ b/packages/web/src/components/Project/AppSessionIndicator.tsx
@@ -4,6 +4,7 @@ import { useNotebookQuery, useUsersQuery } from '@/api/hooks';
 import { Button, Popover, UserLabel } from '@/components/ui';
 import { useNow } from '@/hooks/useNow';
 import { cn } from '@/lib/utils';
+import { isSessionStale } from '@/lib/sessions';
 import { formatDuration, formatRelative } from '@/lib/time';
 import {
 	computeSessionPresentation,
@@ -20,24 +21,6 @@ const APP_STATUS: Partial<
 	starting: { className: 'text-amber-500', label: 'App starting', pulse: true },
 	terminating: { className: 'text-orange-500', label: 'App stopping', pulse: true },
 };
-
-/**
- * Whether the app session is serving an older version than the notebook's
- * current head. NOTE: the periodic snapshotter commits a fresh version every
- * ~2 minutes while someone is editing, so callers must also suppress the hint
- * while an edit session is live on the notebook (`editActive`) — otherwise it
- * flaps for the whole editing session.
- */
-export function isAppStale(
-	session: Pick<Session, 'source_version_id'>,
-	currentVersionId: string | null | undefined,
-): boolean {
-	return (
-		!!session.source_version_id &&
-		!!currentVersionId &&
-		currentVersionId !== session.source_version_id
-	);
-}
 
 function AppSessionDetails({
 	session,
@@ -71,8 +54,12 @@ function AppSessionDetails({
 	const { data: notebook } = useNotebookQuery(session.project_id, session.notebook_id, {
 		staleTime: 0,
 	});
-	// Suppressed while the notebook is being edited — the head is still moving.
-	const stale = !editActive && isAppStale(session, notebook?.source.current_version_id);
+	// Suppressed while a LOCAL notebook is being edited — the snapshotter keeps
+	// moving its head. A synced head moves only when a push lands, so an open
+	// editor is no reason to hide the hint there.
+	const suppressForLocalEdit = editActive && notebook?.source.type !== 'git';
+	const stale =
+		!suppressForLocalEdit && isSessionStale(session, notebook?.source.current_version_id);
 	const connections = session.active_connections;
 	const storedProfileName = notebook ? notebook.meta.compute_profile : selectedProfileName;
 	const selectedProfile = effectiveComputeProfile(
@@ -183,7 +170,7 @@ export function AppSessionIndicator({
 	canControl: boolean;
 	/** The caller may open the app (viewers, when the viewer mode grants apps). */
 	canOpen?: boolean;
-	/** An edit session is live on the notebook — suppresses the stale hint. */
+	/** An edit session is live on the notebook — suppresses the stale hint (local sources only). */
 	editActive?: boolean;
 	onStop: () => void;
 	onRestart: () => void;

--- a/packages/web/src/components/Project/Project.test.tsx
+++ b/packages/web/src/components/Project/Project.test.tsx
@@ -582,6 +582,27 @@ describe('Project — Notebook Actions', () => {
 		);
 	});
 
+	it("a git row's source tile opens a popover with GitHub links", async () => {
+		const user = userEvent.setup();
+		makeFetch({ notebooks: [{ ...notebook(), source_type: 'git' }] });
+		await renderProject();
+
+		const trigger = screen.getByRole('button', { name: 'Synced from GitHub — details' });
+		// Outside the row anchor — RowLink's no-buttons-in-<a> invariant.
+		expect(trigger.closest('a')).toBeNull();
+		await user.click(trigger);
+		const popover = await screen.findByRole('dialog');
+		expect(within(popover).getByRole('link', { name: 'acme/analytics' })).toHaveAttribute(
+			'href',
+			'https://github.com/acme/analytics',
+		);
+		expect(within(popover).getByText('apps/dashboard.py')).toBeInTheDocument();
+		expect(within(popover).getByRole('link', { name: /View source on GitHub/ })).toHaveAttribute(
+			'href',
+			'https://github.com/acme/analytics/blob/abc123/apps/dashboard.py',
+		);
+	});
+
 	it('rotates a sync token and shows the write-once token', async () => {
 		const user = userEvent.setup();
 		const calls = makeFetch({ notebooks: [{ ...notebook(), source_type: 'git' }] });

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -80,6 +80,7 @@ import {
 	computeProfileOptions,
 	DEFAULT_COMPUTE_PROFILE,
 } from '@/components/Notebook/computeProfiles';
+import { GitSourcePopover } from '@/components/Notebook/GitSourcePopover';
 import { SyncedNotebookDialog } from '@/components/Notebook/SyncedNotebookDialog';
 import type { SyncedNotebookCreated } from '@/components/Notebook/SyncedNotebookDialog';
 import { SyncSettingsDialog } from '@/components/Notebook/SyncSettingsDialog';
@@ -578,6 +579,20 @@ export function Project() {
 								state={{ title: nb.title }}
 								label={nb.title}
 								contentClassName="items-center justify-between gap-3 py-3.5"
+								leading={
+									nb.source_type === 'git' ? (
+										<GitSourcePopover
+											projectId={pid!}
+											notebookId={nb.id}
+											triggerClassName="shrink-0 cursor-pointer rounded-lg"
+											trigger={
+												<span className="flex size-9 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
+													<GitBranch className="size-4" />
+												</span>
+											}
+										/>
+									) : undefined
+								}
 								actions={
 									<>
 										{/* Primary shutdown stays edit-only: the inline Power button
@@ -621,13 +636,11 @@ export function Project() {
 								}
 							>
 								<div className="flex min-w-0 items-center gap-3">
-									<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
-										{nb.source_type === 'git' ? (
-											<GitBranch className="size-4" />
-										) : (
+									{nb.source_type !== 'git' && (
+										<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
 											<FileText className="size-4" />
-										)}
-									</span>
+										</span>
+									)}
 									<span className="truncate text-sm font-medium">{nb.title}</span>
 									{badges.map((badge) => (
 										<span

--- a/packages/web/src/components/ui/RowLink.tsx
+++ b/packages/web/src/components/ui/RowLink.tsx
@@ -10,6 +10,8 @@ export interface RowLinkProps {
 	/** Accessible name for the link when the visible content isn't self-describing. */
 	label?: string;
 	children: ReactNode;
+	/** Leading control rendered OUTSIDE the anchor (valid HTML — no buttons in `<a>`). */
+	leading?: ReactNode;
 	/** Trailing controls rendered OUTSIDE the anchor (valid HTML — no buttons in `<a>`). */
 	actions?: ReactNode;
 	/** Layout classes for the anchor's content (e.g. `flex-col gap-1` or `justify-between`). */
@@ -28,6 +30,7 @@ export function RowLink({
 	state,
 	label,
 	children,
+	leading,
 	actions,
 	contentClassName,
 	testId,
@@ -37,12 +40,14 @@ export function RowLink({
 			data-testid={testId}
 			className="group relative flex items-center border-b border-l-2 border-l-transparent transition-colors last:border-b-0 hover:border-l-primary hover:bg-accent/60"
 		>
+			{leading && <div className="relative flex shrink-0 items-center pl-4">{leading}</div>}
 			<Link
 				to={to}
 				state={state}
 				aria-label={label}
 				className={cn(
 					'flex min-w-0 flex-1 px-4 py-3 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+					leading && 'pl-3',
 					contentClassName,
 				)}
 			>

--- a/packages/web/src/lib/github.test.ts
+++ b/packages/web/src/lib/github.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
+import type { NotebookDetail } from '@/types';
 import {
 	gitEntryPath,
 	githubCommitUrl,
+	githubCoords,
 	githubRepoUrl,
 	githubSourceUrl,
 	shortCommit,
@@ -65,6 +67,40 @@ describe('github link builders', () => {
 		expect(githubSourceUrl({ ...SOURCE, commit: null, branch: 'feature/x y' })).toBe(
 			'https://github.com/acme/analytics/blob/feature/x%20y/app.py',
 		);
+	});
+});
+
+describe('githubCoords', () => {
+	const gitSource = (overrides: Record<string, unknown> = {}) =>
+		({
+			type: 'git',
+			provider: 'github',
+			repo: 'acme/analytics',
+			branch: 'main',
+			root_path: '',
+			entry_notebook: 'app.py',
+			sync_mode: 'push',
+			current_version_id: 'v1',
+			commit: 'abc123',
+			last_synced_at: null,
+			...overrides,
+		}) as NotebookDetail['source'];
+
+	it('returns coordinates for a GitHub source with an owner/repo shape', () => {
+		expect(githubCoords(gitSource())).toMatchObject({ repo: 'acme/analytics', commit: 'abc123' });
+	});
+
+	it('returns null for non-git, undefined, or non-github-provider sources', () => {
+		expect(githubCoords(undefined)).toBeNull();
+		expect(githubCoords({ type: 'local', current_version_id: 'v1' })).toBeNull();
+		expect(githubCoords(gitSource({ provider: 'gitlab' }))).toBeNull();
+	});
+
+	it('returns null when repo is not plain owner/repo (never a wrong link)', () => {
+		expect(githubCoords(gitSource({ repo: 'https://gitlab.com/group/project' }))).toBeNull();
+		expect(githubCoords(gitSource({ repo: 'git@github.com:acme/analytics.git' }))).toBeNull();
+		expect(githubCoords(gitSource({ repo: 'just-a-name' }))).toBeNull();
+		expect(githubCoords(gitSource({ repo: 'a/b/c' }))).toBeNull();
 	});
 });
 

--- a/packages/web/src/lib/github.test.ts
+++ b/packages/web/src/lib/github.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import type { NotebookDetail } from '@/types';
 import {
 	gitEntryPath,
+	githubBranchUrl,
 	githubCommitUrl,
 	githubCoords,
 	githubRepoUrl,
@@ -19,10 +20,13 @@ const SOURCE = {
 };
 
 describe('github link builders', () => {
-	it('builds repo and commit urls', () => {
+	it('builds repo, commit, and branch urls', () => {
 		expect(githubRepoUrl('acme/analytics')).toBe('https://github.com/acme/analytics');
 		expect(githubCommitUrl('acme/analytics', 'abc123')).toBe(
 			'https://github.com/acme/analytics/commit/abc123',
+		);
+		expect(githubBranchUrl('acme/analytics', 'feature/x y')).toBe(
+			'https://github.com/acme/analytics/tree/feature/x%20y',
 		);
 	});
 

--- a/packages/web/src/lib/github.test.ts
+++ b/packages/web/src/lib/github.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+	gitEntryPath,
+	githubCommitUrl,
+	githubRepoUrl,
+	githubSourceUrl,
+	shortCommit,
+	versionCommit,
+} from './github';
+
+const SOURCE = {
+	repo: 'acme/analytics',
+	branch: 'main',
+	root_path: '',
+	entry_notebook: 'app.py',
+	commit: 'abc123def4567890',
+};
+
+describe('github link builders', () => {
+	it('builds repo and commit urls', () => {
+		expect(githubRepoUrl('acme/analytics')).toBe('https://github.com/acme/analytics');
+		expect(githubCommitUrl('acme/analytics', 'abc123')).toBe(
+			'https://github.com/acme/analytics/commit/abc123',
+		);
+	});
+
+	it('joins root_path into the entry path only when set', () => {
+		expect(gitEntryPath(SOURCE)).toBe('app.py');
+		expect(gitEntryPath({ ...SOURCE, root_path: 'apps' })).toBe('apps/app.py');
+	});
+
+	it('pins the source url to the synced commit, falling back to the branch', () => {
+		expect(githubSourceUrl(SOURCE)).toBe(
+			'https://github.com/acme/analytics/blob/abc123def4567890/app.py',
+		);
+		expect(githubSourceUrl({ ...SOURCE, commit: null })).toBe(
+			'https://github.com/acme/analytics/blob/main/app.py',
+		);
+	});
+
+	it('abbreviates commits to 7 characters', () => {
+		expect(shortCommit('abc123def4567890')).toBe('abc123d');
+	});
+
+	it('percent-encodes reserved characters per segment, keeping / separators', () => {
+		expect(
+			githubSourceUrl({
+				...SOURCE,
+				commit: null,
+				branch: 'release?rc',
+				root_path: 'reports',
+				entry_notebook: 'q#1 final.py',
+			}),
+		).toBe('https://github.com/acme/analytics/blob/release%3Frc/reports/q%231%20final.py');
+		expect(githubSourceUrl({ ...SOURCE, entry_notebook: 'アプリ.py' })).toBe(
+			'https://github.com/acme/analytics/blob/abc123def4567890/%E3%82%A2%E3%83%97%E3%83%AA.py',
+		);
+		expect(githubRepoUrl('acme/repo#2')).toBe('https://github.com/acme/repo%232');
+		expect(githubCommitUrl('acme/repo', 'abc#123')).toBe(
+			'https://github.com/acme/repo/commit/abc%23123',
+		);
+	});
+
+	it('a branch containing slashes keeps them as separators', () => {
+		expect(githubSourceUrl({ ...SOURCE, commit: null, branch: 'feature/x y' })).toBe(
+			'https://github.com/acme/analytics/blob/feature/x%20y/app.py',
+		);
+	});
+});
+
+describe('versionCommit', () => {
+	it('prefers the stamped commit field', () => {
+		expect(versionCommit({ commit: 'abc123def456', message: 'Sync deadbeefcafe' })).toBe(
+			'abc123def456',
+		);
+	});
+
+	it('falls back to parsing the legacy "Sync <sha>" message', () => {
+		expect(versionCommit({ message: 'Sync deadbeefcafe' })).toBe('deadbeefcafe');
+	});
+
+	it('returns null for non-sync messages', () => {
+		expect(versionCommit({ message: 'Session save' })).toBeNull();
+		expect(versionCommit({ message: 'Sync not-a-sha!' })).toBeNull();
+		expect(versionCommit({ message: '' })).toBeNull();
+	});
+});

--- a/packages/web/src/lib/github.ts
+++ b/packages/web/src/lib/github.ts
@@ -2,7 +2,7 @@
 // (content arrives by push), but the sole `provider` today is GitHub, so links
 // are built for it directly.
 
-import type { NotebookVersion } from '@/types';
+import type { NotebookDetail, NotebookVersion } from '@/types';
 
 /** The git-source coordinates the link builders need (a subset of GitSource). */
 export interface GitSourceCoords {
@@ -11,6 +11,28 @@ export interface GitSourceCoords {
 	root_path: string;
 	entry_notebook: string;
 	commit: string | null;
+}
+
+// Server-validated on new sources; older or API-written records may carry a
+// clone URL or `git@` remote, which must degrade to "no link", never a wrong one.
+// Mirrors the server's OWNER_REPO_PATTERN (syncedSource.ts).
+const OWNER_REPO_PATTERN = /^[A-Za-z0-9_-]+\/[A-Za-z0-9._-]+$/;
+
+/**
+ * The coordinates to build GitHub links from, or null when no trustworthy link
+ * exists: a non-git source, a future non-GitHub provider (the stored `provider`
+ * is a claim, not verified), or a repo that isn't plain `owner/repo`.
+ */
+export function githubCoords(source: NotebookDetail['source'] | undefined): GitSourceCoords | null {
+	if (source?.type !== 'git' || source.provider !== 'github') return null;
+	if (!OWNER_REPO_PATTERN.test(source.repo)) return null;
+	return {
+		repo: source.repo,
+		branch: source.branch,
+		root_path: source.root_path,
+		entry_notebook: source.entry_notebook,
+		commit: source.commit,
+	};
 }
 
 /**

--- a/packages/web/src/lib/github.ts
+++ b/packages/web/src/lib/github.ts
@@ -52,6 +52,10 @@ export function githubCommitUrl(repo: string, commit: string): string {
 	return `${githubRepoUrl(repo)}/commit/${encodeURIComponent(commit)}`;
 }
 
+export function githubBranchUrl(repo: string, branch: string): string {
+	return `${githubRepoUrl(repo)}/tree/${encodePath(branch)}`;
+}
+
 /** The repo-relative path of the synced entry notebook. */
 export function gitEntryPath(
 	source: Pick<GitSourceCoords, 'root_path' | 'entry_notebook'>,

--- a/packages/web/src/lib/github.ts
+++ b/packages/web/src/lib/github.ts
@@ -1,0 +1,62 @@
+// GitHub URL builders for git-synced notebooks. The platform is host-agnostic
+// (content arrives by push), but the sole `provider` today is GitHub, so links
+// are built for it directly.
+
+import type { NotebookVersion } from '@/types';
+
+/** The git-source coordinates the link builders need (a subset of GitSource). */
+export interface GitSourceCoords {
+	repo: string;
+	branch: string;
+	root_path: string;
+	entry_notebook: string;
+	commit: string | null;
+}
+
+/**
+ * Percent-encode each segment while keeping `/` separators — repos, branches,
+ * and file paths may carry URL-reserved characters (`#`, `?`, spaces, …) that
+ * would otherwise truncate or reroute the link.
+ */
+function encodePath(path: string): string {
+	return path.split('/').map(encodeURIComponent).join('/');
+}
+
+export function githubRepoUrl(repo: string): string {
+	return `https://github.com/${encodePath(repo)}`;
+}
+
+export function githubCommitUrl(repo: string, commit: string): string {
+	return `${githubRepoUrl(repo)}/commit/${encodeURIComponent(commit)}`;
+}
+
+/** The repo-relative path of the synced entry notebook. */
+export function gitEntryPath(
+	source: Pick<GitSourceCoords, 'root_path' | 'entry_notebook'>,
+): string {
+	return source.root_path ? `${source.root_path}/${source.entry_notebook}` : source.entry_notebook;
+}
+
+/**
+ * Link to the entry file on GitHub — pinned to the synced commit when known
+ * (stable even if the branch moves on), falling back to the branch before the
+ * first push.
+ */
+export function githubSourceUrl(source: GitSourceCoords): string {
+	const ref = source.commit ?? source.branch;
+	return `${githubRepoUrl(source.repo)}/blob/${encodePath(ref)}/${encodePath(gitEntryPath(source))}`;
+}
+
+export function shortCommit(commit: string): string {
+	return commit.slice(0, 7);
+}
+
+/**
+ * The synced commit behind a version: the stamped `commit` field, or — for
+ * versions written before the field existed — the sha parsed back out of the
+ * `Sync <sha12>` message the sync path has always written.
+ */
+export function versionCommit(version: Pick<NotebookVersion, 'message' | 'commit'>): string | null {
+	if (version.commit) return version.commit;
+	return /^Sync ([0-9a-f]{7,40})$/.exec(version.message)?.[1] ?? null;
+}

--- a/packages/web/src/lib/sessions.test.ts
+++ b/packages/web/src/lib/sessions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Session } from '@/types';
-import { rankSession, sessionsByNotebook } from './sessions';
+import { isSessionStale, rankSession, sessionsByNotebook } from './sessions';
 
 function session(
 	notebookId: string,
@@ -30,6 +30,16 @@ describe('rankSession', () => {
 		expect(rankSession(undefined)).toBe(0);
 		expect(rankSession('expired')).toBe(0);
 		expect(rankSession('garbage')).toBe(0);
+	});
+});
+
+describe('isSessionStale', () => {
+	it('is stale only when both versions are known and differ', () => {
+		expect(isSessionStale({ source_version_id: 'a' }, 'b')).toBe(true);
+		expect(isSessionStale({ source_version_id: 'a' }, 'a')).toBe(false);
+		expect(isSessionStale({ source_version_id: undefined }, 'b')).toBe(false);
+		expect(isSessionStale({ source_version_id: 'a' }, null)).toBe(false);
+		expect(isSessionStale({ source_version_id: 'a' }, undefined)).toBe(false);
 	});
 });
 

--- a/packages/web/src/lib/sessions.ts
+++ b/packages/web/src/lib/sessions.ts
@@ -21,6 +21,26 @@ export interface NotebookSessions {
 }
 
 /**
+ * Whether a frozen-snapshot session (the shared app, or any session on a
+ * git-synced notebook) is serving an older version than the notebook's current
+ * head. NOTE: for app sessions on local notebooks the periodic snapshotter
+ * commits a fresh version every ~2 minutes while someone is editing, so callers
+ * must also suppress the hint while an edit session is live on the notebook
+ * (`editActive`) — otherwise it flaps for the whole editing session. Git-synced
+ * heads move only when a push lands, so no such suppression applies there.
+ */
+export function isSessionStale(
+	session: Pick<Session, 'source_version_id'>,
+	currentVersionId: string | null | undefined,
+): boolean {
+	return (
+		!!session.source_version_id &&
+		!!currentVersionId &&
+		currentVersionId !== session.source_version_id
+	);
+}
+
+/**
  * "~N people are connected" for the stop/restart-app confirms — the number is
  * the lifecycle sweep's last probe, so it's approximate; omitted when unknown
  * or zero.


### PR DESCRIPTION
A background GitHub push can advance a synced notebook's head while an open session keeps serving the frozen mirror it started from. This PR warns about that in the editor (like the existing app-mode banner) and surfaces GitHub provenance across the UI.

## Stale-version warnings
- Sessions on synced sources now stamp `source_version_id` in every mode (previously app-only), so clients can compare against the live head. Reconnects keep the original stamp.
- Git-synced edit pages poll the head (30s) and show an "updated on GitHub" banner with a confirmed **Restart to update** CTA.
- App staleness is no longer suppressed while an edit session is live for git sources — a synced head moves only on push, never from typing.

## GitHub metadata
- Sync-cut versions record their commit (`Version.commit`, optional/forward-tolerant); version history links each sync to its GitHub commit, parsing legacy `Sync <sha>` messages as a fallback.
- New `GitSourcePopover` (repo, branch, file, commit, last synced — all linked) behind the project row's git tile and a new editor-header repo chip. Not shown in the app view.
- `RowLink` gains a `leading` slot so the popover trigger stays outside the row anchor (no buttons in `<a>`).
- GitHub URL builders percent-encode path segments (`#`, `?`, spaces, Unicode).

## Tests
Coverage at every layer: session stamping incl. reuse-after-push (API), commit stamping (core + API), URL builders/encoding, banner show/hide/CTA/confirm flows, git-vs-local suppression, and popover links (web). `pnpm check`, `pnpm typecheck`, and the full suite pass.