### PR TITLE
perf(runtime): cut sandbox startup round-trips and split the create metric

### DIFF
--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -781,6 +781,11 @@ app.openapi(createSession, async (c) => {
 					for (const [phase, ms] of Object.entries(provisionResult.timings)) {
 						observer.tag(`provision_${phase}_ms`, ms);
 					}
+					// Counts, not durations: workspace objects/bytes copied, and the
+					// command round-trips the provision spent.
+					for (const [name, value] of Object.entries(provisionResult.counters)) {
+						observer.tag(`provision_${name}`, value);
+					}
 					// Whether the files phase mounted the bucket (false) or copied it in
 					// (true) — files is the largest phase, so this says which path to optimize.
 					observer.tag('provision_used_fallback', usedFallback);

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -448,16 +448,23 @@ describe('CoreWeaveCompute', () => {
 			expect(entry.fake.startCalls.at(-1)).toEqual(['sh', '-lc', 'uv run marimo edit --port 2718']);
 		});
 
-		it('a kernel that dies on launch is reported without burning the timeout', async () => {
-			// Launch setup rides the kernel command, so a broken env exits the process
-			// immediately; the port would otherwise never open and the wait would run
-			// the full (2 minute) timeout.
-			const world = makeWorld({ procExitCode: 1 });
-			const proc = await makeCompute(world).create(SANDBOX_ID).startProcess('marimo edit');
-			await expect(proc.waitForPort(2718, { timeout: 120_000 })).rejects.toThrow(
-				/exited before port 2718/,
-			);
-		});
+		// Launch setup rides the kernel command, so a broken env kills the process
+		// outright; the port then never opens and the wait would otherwise run the
+		// full (2 minute) timeout. The SDK records an exit code ONLY on a clean exit,
+		// so `failed` (a gRPC stream reset — see RUNBOOK H1) and `cancelled` have to
+		// be recognised by status or they sail past a poll()-based check.
+		it.each(['exited', 'failed', 'cancelled'] as const)(
+			'a %s kernel is reported without burning the timeout',
+			async (status) => {
+				const world = makeWorld({
+					proc: { status, ...(status === 'exited' ? { exitCode: 1 } : {}) },
+				});
+				const proc = await makeCompute(world).create(SANDBOX_ID).startProcess('marimo edit');
+				await expect(proc.waitForPort(2718, { timeout: 120_000 })).rejects.toThrow(
+					new RegExp(`${status} before port 2718`),
+				);
+			},
+		);
 
 		it('a waiter that fails instantly is reported, not re-issued until the deadline', async () => {
 			// A broken waiter (no python3/date on the image) exits non-zero without

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -4,7 +4,7 @@ import type { SandboxInfo } from '@coreweave/cwsandbox';
 import type { SandboxId, SandboxProvider } from '@marimo-hub/core';
 import { computeContract } from '@marimo-hub/core/testing/compute-contract';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
-import { coreWeaveProfileResources, CoreWeaveCompute } from './index';
+import { coreWeaveProfileResources, CoreWeaveCompute, portWaitCommand } from './index';
 import type { CoreWeaveClient, CoreWeaveConfig } from './index';
 import { fakeProcess, makeWorld, procResult } from './testWorld';
 
@@ -56,7 +56,9 @@ describe('CoreWeaveCompute', () => {
 			});
 			expect(opts.tags).toEqual(['marimohub', ID_TAG]);
 			expect(opts.containerImage).toBe('my-image');
-			expect(opts.waitUntilRunning).toBe(true);
+			// The readiness wait is issued separately (see "boot wait"), so create
+			// itself returns as soon as the backend accepts the start request.
+			expect(opts.waitUntilRunning).toBe(false);
 		});
 
 		it('reuses the cached sandbox across calls (one create)', async () => {
@@ -193,15 +195,16 @@ describe('CoreWeaveCompute', () => {
 			expect(calls[0][2]).toContain('addressing_style = virtual');
 		});
 
-		it('bootstraps the AWS config for virtual-hosted addressing on fresh create', async () => {
+		it('bootstraps the AWS config on the first command, not a round-trip of its own', async () => {
 			const world = makeWorld();
 			await makeCompute(world, { ...baseConfig, objectStorageBuckets: ['org-data'] })
 				.create(SANDBOX_ID)
 				.exec('true');
 			const calls = world.registry.get('cw-1')!.fake.runCalls;
+			expect(calls).toHaveLength(1);
 			expect(calls[0][2]).toContain('addressing_style = virtual');
 			expect(calls[0][2]).toContain('AWS_ENDPOINT_URL_S3');
-			expect(calls).toHaveLength(2); // bootstrap, then the exec
+			expect(calls[0][2]).toContain('fi; true');
 		});
 
 		it('skips the AWS config bootstrap without CAIOS configuration and on reconnect', async () => {
@@ -219,17 +222,15 @@ describe('CoreWeaveCompute', () => {
 			expect(bare.registry.get('cw-1')!.fake.runCalls).toHaveLength(1);
 		});
 
-		it('survives a failing AWS config bootstrap', async () => {
-			const world = makeWorld({
-				runImpl: async (command) => {
-					if (command[2].includes('addressing_style')) throw new Error('exec transport lost');
-					return procResult();
-				},
-			});
+		it('a failing AWS config bootstrap does not sink the command it rides on', async () => {
+			const world = makeWorld();
 			const result = await makeCompute(world, { ...baseConfig, objectStorageBuckets: ['org-data'] })
 				.create(SANDBOX_ID)
 				.exec('true');
 			expect(result.success).toBe(true);
+			// Separated by `;`, never `&&`: the bootstrap is best-effort, so a non-zero
+			// exit inside it must not short-circuit the command it was spliced onto.
+			expect(world.registry.get('cw-1')!.fake.runCalls[0][2]).not.toContain('fi && ');
 		});
 	});
 
@@ -301,16 +302,67 @@ describe('CoreWeaveCompute', () => {
 	});
 
 	describe('drainTimings()', () => {
-		it('returns the last ensure create/find ms, then clears', async () => {
+		it('returns the last ensure find/create/boot ms, then clears', async () => {
 			const world = makeWorld();
 			const inst = makeCompute(world).create(SANDBOX_ID, { reuse: false });
 			await inst.exec('true'); // triggers ensure()
 			const timings = inst.drainTimings!();
-			expect(timings).toHaveProperty('create');
+			// `boot` is split from `create` so the wide event can tell a real container
+			// start apart from time spent waiting on a status poll.
 			expect(timings).toHaveProperty('find');
+			expect(timings).toHaveProperty('create');
+			expect(timings).toHaveProperty('boot');
 			expect(typeof timings.create).toBe('number');
 			// Drained once — a second drain is empty.
 			expect(inst.drainTimings!()).toEqual({});
+		});
+	});
+
+	describe('drainCounters()', () => {
+		it('counts blocking commands, then clears', async () => {
+			const world = makeWorld();
+			const inst = makeCompute(world).create(SANDBOX_ID, { reuse: false });
+			await inst.exec('true');
+			await inst.exec('true');
+			expect(inst.drainCounters!()).toEqual({ execs: 2 });
+			expect(inst.drainCounters!()).toEqual({ execs: 0 });
+		});
+	});
+
+	describe('portWaitCommand()', () => {
+		it('loops in-sandbox on its own deadline instead of returning per probe', () => {
+			const cmd = portWaitCommand(2718, 30);
+			expect(cmd).toContain("connect_ex(('127.0.0.1',2718))");
+			// Bounded in-sandbox, exits 0 the moment the port answers.
+			expect(cmd).toContain('+ 30 ');
+			expect(cmd).toContain('&& exit 0');
+			expect(cmd).toMatch(/exit 1$/);
+			// Sub-second granularity is the point: a 1s sleep would reintroduce the
+			// quantization this replaced. The `|| sleep 1` is the fallback for an image
+			// whose sleep takes only whole seconds.
+			expect(cmd).toContain('sleep 0.05 || sleep 1');
+		});
+	});
+
+	describe('boot wait', () => {
+		it('waits explicitly with a tighter interval than the SDK default', async () => {
+			const world = makeWorld();
+			await makeCompute(world).create(SANDBOX_ID, { reuse: false }).exec('true');
+
+			// The SDK's built-in waitUntilRunning polls every 1s, rounding every boot
+			// up to the next second; we run the same wait on a tighter interval.
+			expect(world.created[0]).toMatchObject({ waitUntilRunning: false });
+			const waits = world.registry.get('cw-1')!.fake.waitCalls;
+			expect(waits).toHaveLength(1);
+			expect(waits[0].intervalMs).toBeLessThan(1000);
+		});
+
+		it('does not re-wait when reconnecting to a live sandbox', async () => {
+			const world = makeWorld();
+			const compute = makeCompute(world);
+			await compute.create(SANDBOX_ID).exec('true');
+			await compute.create(SANDBOX_ID).exec('true'); // reconnects to cw-1
+			expect(world.registry.get('cw-1')!.fake.waitCalls).toHaveLength(1);
 		});
 	});
 
@@ -378,23 +430,51 @@ describe('CoreWeaveCompute', () => {
 	});
 
 	describe('startProcess().waitForPort()', () => {
-		it('polls an in-sandbox probe until the port is ready', async () => {
-			let probes = 0;
-			const world = makeWorld({
-				runImpl: async (cmd) => {
-					if (cmd.join(' ').includes('connect_ex')) {
-						probes++;
-						return procResult({ exitCode: probes >= 2 ? 0 : 1 });
-					}
-					return procResult();
-				},
-			});
+		it('waits in ONE in-sandbox command rather than one round-trip per probe', async () => {
+			const world = makeWorld();
 			const inst = makeCompute(world).create(SANDBOX_ID);
 			const proc = await inst.startProcess('uv run marimo edit --port 2718');
 			await proc.waitForPort(2718, { timeout: 5_000 });
-			expect(probes).toBeGreaterThanOrEqual(2);
+
+			// Probing from here cost a command round-trip per attempt on top of the
+			// poll interval, which quantized the wait to that interval; the loop now
+			// runs inside the sandbox and returns the moment the port binds.
+			const waits = world.registry
+				.get('cw-1')!
+				.fake.runCalls.filter((c) => c[2].includes('connect_ex'));
+			expect(waits).toHaveLength(1);
+			expect(waits[0][2]).toContain('while');
 			const entry = [...world.registry.values()][0];
 			expect(entry.fake.startCalls.at(-1)).toEqual(['sh', '-lc', 'uv run marimo edit --port 2718']);
+		});
+
+		it('a kernel that dies on launch is reported without burning the timeout', async () => {
+			// Launch setup rides the kernel command, so a broken env exits the process
+			// immediately; the port would otherwise never open and the wait would run
+			// the full (2 minute) timeout.
+			const world = makeWorld({ procExitCode: 1 });
+			const proc = await makeCompute(world).create(SANDBOX_ID).startProcess('marimo edit');
+			await expect(proc.waitForPort(2718, { timeout: 120_000 })).rejects.toThrow(
+				/exited before port 2718/,
+			);
+		});
+
+		it('a waiter that fails instantly is reported, not re-issued until the deadline', async () => {
+			// A broken waiter (no python3/date on the image) exits non-zero without
+			// burning its chunk; retrying would hammer the command channel for the
+			// whole timeout.
+			const world = makeWorld({
+				runImpl: async (cmd) =>
+					cmd.join(' ').includes('connect_ex') ? procResult({ exitCode: 1 }) : procResult(),
+			});
+			const proc = await makeCompute(world).create(SANDBOX_ID).startProcess('marimo edit');
+			await expect(proc.waitForPort(2718, { timeout: 5_000 })).rejects.toThrow(/timed out/);
+			const waits = world.registry
+				.get('cw-1')!
+				.fake.runCalls.filter((c) => c[2].includes('connect_ex'));
+			// Bounded by the chunk count, not by re-issuing until the deadline (which
+			// at ~220ms per round-trip would be hundreds of commands).
+			expect(waits.length).toBeLessThanOrEqual(3);
 		});
 	});
 
@@ -673,6 +753,7 @@ describe('CoreWeaveCompute', () => {
 			const client: CoreWeaveClient = {
 				create: async () => ({
 					sandboxId: 'cw-x',
+					wait: async () => {},
 					commands: { run: async () => procResult(), start: async () => fakeProcess() },
 					files: { readText: async () => '', write: async () => {} },
 					delete: async () => {
@@ -681,6 +762,7 @@ describe('CoreWeaveCompute', () => {
 				}),
 				fromId: async (id) => ({
 					sandboxId: id,
+					wait: async () => {},
 					commands: { run: async () => procResult(), start: async () => fakeProcess() },
 					files: { readText: async () => '', write: async () => {} },
 					delete: async () => {},
@@ -697,6 +779,7 @@ describe('CoreWeaveCompute', () => {
 	describe('reconnect / dead-status handling', () => {
 		const bareSandbox = (sandboxId: string) => ({
 			sandboxId,
+			wait: async () => {},
 			commands: { run: async () => procResult(), start: async () => fakeProcess() },
 			files: { readText: async () => '', write: async () => {} },
 			delete: async () => {},

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -52,7 +52,6 @@ import {
 	buildGitCloneCommand,
 	iterableToStream,
 	parseFindFilesOutput,
-	pollUntilReady,
 	removeUndefined,
 	shellQuote,
 	withEnvPrefix,
@@ -84,6 +83,47 @@ const DEFAULT_KERNEL_PORT = 2718;
 const DEFAULT_OWNER_TAG = 'marimohub';
 /** Prefix for the per-sandbox tag that encodes our `SandboxId`. */
 const ID_TAG_PREFIX = 'mh-sbx-';
+
+/** Longest a single in-sandbox port wait may block before we re-issue it. */
+const PORT_WAIT_CHUNK_MS = 30_000;
+/** First such chunk, kept short so a kernel that dies on launch is caught quickly. */
+const PORT_WAIT_FIRST_CHUNK_MS = 2_000;
+/**
+ * How often to poll a fresh sandbox for `running`. The SDK's own default is 1s,
+ * which rounds every boot up to the next second; each poll is one control-plane
+ * round-trip, so this trades a few extra polls for that rounding.
+ */
+const BOOT_POLL_INTERVAL_MS = 100;
+
+/**
+ * Shell that blocks until `port` accepts a connection, for at most `seconds`.
+ * Exits 0 as soon as it does, 1 on its own deadline. `sleep 0.05 || sleep 1`
+ * degrades to whole seconds on an image whose sleep is POSIX-integer-only,
+ * rather than spinning hot. Assumes `python3` and `date` (see INTEGRATION
+ * SURFACE above).
+ */
+export function portWaitCommand(port: number, seconds: number): string {
+	const probe =
+		`python3 -c "import socket,sys; s=socket.socket(); s.settimeout(1); ` +
+		`sys.exit(0 if s.connect_ex(('127.0.0.1',${port}))==0 else 1)"`;
+	return (
+		`end=$(( $(date +%s) + ${seconds} )); ` +
+		`while [ "$(date +%s)" -lt "$end" ]; do ${probe} && exit 0; sleep 0.05 || sleep 1; done; exit 1`
+	);
+}
+
+/**
+ * CAIOS rejects path-style requests, and boto3 defaults to path style for a
+ * custom endpoint with no env var to change it — only the AWS config file works.
+ * Runs once per fresh create and leaves an image-supplied config alone. Trailing
+ * `;`, never `&&`: best-effort, so a failure must not short-circuit the command
+ * this gets spliced ahead of.
+ */
+const AWS_CONFIG_BOOTSTRAP =
+	'if [ -n "${AWS_ENDPOINT_URL_S3:-}" ] && [ ! -e "$HOME/.aws/config" ]; then' +
+	' mkdir -p "$HOME/.aws" &&' +
+	' printf \'[default]\\ns3 =\\n    addressing_style = virtual\\n\' > "$HOME/.aws/config";' +
+	' fi;';
 
 export function coreWeaveProfileResources(
 	resources: ComputeResources | undefined,
@@ -207,6 +247,8 @@ export interface CoreWeaveClient {
 /** The slice of the SDK's `Sandbox` handle this adapter uses. */
 export interface CoreWeaveSandbox {
 	readonly sandboxId: string;
+	/** Block until the sandbox reaches `running`; see `BOOT_POLL_INTERVAL_MS`. */
+	wait(options?: { intervalMs?: number }): Promise<unknown>;
 	readonly commands: {
 		run(command: readonly string[], options?: { cwd?: string }): Promise<ProcessResult>;
 		start(command: readonly string[], options?: { cwd?: string }): Promise<CommandProcess>;
@@ -233,6 +275,12 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	private env: Record<string, string> = {};
 	private envDefaults: Record<string, string> = {};
 	private lastEnsureTimings?: Timings;
+	/** Shell snippet to splice onto the next command; see `takeBootstrap`. */
+	private pendingBootstrap?: string;
+	/** Directories already `mkdir -p`'d in this sandbox, so re-issuing is skipped. */
+	private readonly createdDirs = new Set<string>();
+	/** Blocking commands sent to this sandbox — one wide-event field per provision. */
+	private execCount = 0;
 
 	constructor(
 		private readonly id: SandboxId,
@@ -253,20 +301,28 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	 */
 	private async ensure(): Promise<CoreWeaveSandbox> {
 		if (this.sandbox) return this.sandbox;
-		// Split the lazy resolve (the provisioner's `reachable` = this + the first
-		// command): find_ms is the reconnect lookup, create_ms is create +
-		// waitUntilRunning — cold-start + image pull, the dominant startup cost.
+		// find = the reconnect lookup, create = the API accepting the start request,
+		// boot = reaching `running` (cold start + image pull). create and boot are
+		// split because only that says whether the dominant startup cost is a real
+		// container start or time spent waiting on a poll.
 		const t0 = Date.now();
 		const existing = this.reuse ? await this.findByOurId() : undefined;
 		const t1 = Date.now();
+		// Create-then-wait is what the SDK does internally for
+		// `waitUntilRunning: true`, except its wait takes the default 1s poll
+		// interval — which rounds every boot up to the next whole second.
 		this.sandbox = existing
 			? await this.client.fromId(existing.sandboxId)
 			: await this.client.create(this.createOptions());
-		if (!existing && this.needsAwsConfigBootstrap()) {
-			await this.bootstrapAwsConfig(this.sandbox);
-		}
 		const t2 = Date.now();
-		this.lastEnsureTimings = { create: t2 - t1, find: t1 - t0 };
+		if (!existing) await this.sandbox.wait({ intervalMs: BOOT_POLL_INTERVAL_MS });
+		const t3 = Date.now();
+		// Armed, not run: the snippet is spliced onto the first command we were going
+		// to send anyway, so it costs no round-trip of its own.
+		if (!existing && this.needsAwsConfigBootstrap()) {
+			this.pendingBootstrap = AWS_CONFIG_BOOTSTRAP;
+		}
+		this.lastEnsureTimings = { find: t1 - t0, create: t2 - t1, boot: t3 - t2 };
 		console.warn(
 			JSON.stringify({
 				ts: new Date().toISOString(),
@@ -275,15 +331,27 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				reconnected: Boolean(existing),
 				find_ms: t1 - t0,
 				create_ms: t2 - t1,
+				boot_ms: t3 - t2,
 			}),
 		);
 		return this.sandbox;
+	}
+
+	/** Resolve the sandbox without spending a command round-trip to prove it is up. */
+	async ready(): Promise<void> {
+		await this.ensure();
 	}
 
 	drainTimings(): Timings {
 		const t = this.lastEnsureTimings ?? {};
 		this.lastEnsureTimings = undefined;
 		return t;
+	}
+
+	drainCounters(): Record<string, number> {
+		const counters = { execs: this.execCount };
+		this.execCount = 0;
+		return counters;
 	}
 
 	/** Find a live sandbox tagged with our id (tags are a request-side filter only). */
@@ -311,7 +379,9 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				? { maxLifetimeSeconds: this.config.maxLifetimeSeconds }
 				: {}),
 			...this.objectStorageOptions(),
-			waitUntilRunning: true,
+			// `ensure` runs the readiness wait itself, on a tighter poll interval than
+			// the SDK's built-in one.
+			waitUntilRunning: false,
 		};
 	}
 
@@ -342,39 +412,25 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	}
 
 	/**
-	 * CAIOS rejects path-style requests, and boto3 defaults to path style for a
-	 * custom endpoint with no env var to change it — only the AWS config file
-	 * works. Written once per fresh create (any POSIX-shell image, per the
-	 * sandbox contract); skipped when the image already ships an AWS config.
-	 * Best-effort: a failure only costs plain-client ergonomics, not the kernel.
+	 * Claim the armed bootstrap (at most once) and splice it ahead of `cmd`. It
+	 * needs a shell — it resolves `$HOME` and tests for an existing config — so it
+	 * rides a command instead of being written as a file, costing no round-trip.
 	 */
-	private async bootstrapAwsConfig(sandbox: CoreWeaveSandbox): Promise<void> {
-		const cmd =
-			'if [ -n "${AWS_ENDPOINT_URL_S3:-}" ] && [ ! -e "$HOME/.aws/config" ]; then' +
-			' mkdir -p "$HOME/.aws" &&' +
-			' printf \'[default]\\ns3 =\\n    addressing_style = virtual\\n\' > "$HOME/.aws/config";' +
-			' fi';
-		try {
-			await sandbox.commands.run(['sh', '-lc', cmd]);
-		} catch (err) {
-			console.warn(
-				JSON.stringify({
-					ts: new Date().toISOString(),
-					event: 'aws_config_bootstrap_failed',
-					sandbox_id: this.id,
-					error: String(err),
-				}),
-			);
-		}
+	private takeBootstrap(cmd: string): string {
+		const bootstrap = this.pendingBootstrap;
+		if (!bootstrap) return cmd;
+		this.pendingBootstrap = undefined;
+		return `${bootstrap} ${cmd}`;
 	}
 
 	/** Prefix accumulated env vars onto a shell command (the SDK has no per-command env). */
 	private withEnv(cmd: string): string {
-		return withEnvPrefix(cmd, this.env, this.envDefaults);
+		return withEnvPrefix(this.takeBootstrap(cmd), this.env, this.envDefaults);
 	}
 
 	async exec(cmd: string): Promise<ExecResult> {
 		const sandbox = await this.ensure();
+		this.execCount++;
 		const res = await sandbox.commands.run(['sh', '-lc', this.withEnv(cmd)]);
 		return { success: res.exitCode === 0, stdout: res.stdout, stderr: res.stderr };
 	}
@@ -401,13 +457,16 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		// The SDK's files.write does not create parent dirs, so mkdir first — once for
 		// every parent, not per file. Its multi-file write is Promise.all over per-file
 		// RPCs, so collapsing these execs (not the writes) is what removes round-trips.
+		// Dirs already created in this sandbox are skipped, so a workspace restored in
+		// N byte-bounded batches pays one mkdir rather than N.
 		const dirs = new Set<string>();
 		for (const f of files) {
 			const dir = f.path.slice(0, f.path.lastIndexOf('/'));
-			if (dir) dirs.add(dir);
+			if (dir && !this.createdDirs.has(dir)) dirs.add(dir);
 		}
 		if (dirs.size > 0) {
 			await this.exec(`mkdir -p ${[...dirs].map(shellQuote).join(' ')}`);
+			for (const dir of dirs) this.createdDirs.add(dir);
 		}
 		// The SDK's FileContent is `string | Uint8Array`, so bytes pass straight through.
 		await sandbox.files.write(files.map((f) => ({ path: f.path, content: f.content })));
@@ -490,17 +549,31 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 			},
 			async waitForPort(port: number, opts?: WaitForPortOptions): Promise<void> {
 				const timeout = opts?.timeout ?? 30_000;
-				// In-sandbox TCP probe (the SDK exposes no waitForPort). Mirrors the
-				// local adapter's tcpReady poll, run via exec.
-				const probe =
-					`python3 -c "import socket,sys; s=socket.socket(); s.settimeout(1); ` +
-					`sys.exit(0 if s.connect_ex(('127.0.0.1',${port}))==0 else 1)"`;
-				await pollUntilReady(async () => (await exec(probe)).success, {
-					timeoutMs: timeout,
-					intervalMs: 500,
-					timeoutMessage: () =>
-						`timed out waiting for port ${port} after ${timeout}ms.\n${stderr || stdout}`,
-				});
+				// The SDK exposes no waitForPort, so probe in-sandbox — and loop there
+				// too: probing from here cost a command round-trip per attempt on top of
+				// the poll interval, quantizing the wait to that grid.
+				//
+				// Chunked rather than one command spanning the whole timeout, because
+				// the gateway's per-command cap is unverified (see INTEGRATION SURFACE
+				// above) and each boundary is where a dead kernel gets noticed — the
+				// first chunk is short so a launch that fails outright reports fast.
+				// `attempts` bounds the loop if the waiter itself returns instantly.
+				const deadline = Date.now() + timeout;
+				const attempts = Math.ceil(timeout / PORT_WAIT_CHUNK_MS) + 1;
+				let chunkMs = PORT_WAIT_FIRST_CHUNK_MS;
+				for (let i = 0; i < attempts && Date.now() < deadline; i++) {
+					if (proc.poll() !== undefined) {
+						throw new Error(
+							`process exited before port ${port} opened.\n${stderr || stdout}`.trim(),
+						);
+					}
+					const seconds = Math.max(1, Math.ceil(Math.min(chunkMs, deadline - Date.now()) / 1000));
+					chunkMs = PORT_WAIT_CHUNK_MS;
+					if ((await exec(portWaitCommand(port, seconds))).success) return;
+				}
+				throw new Error(
+					`timed out waiting for port ${port} after ${timeout}ms.\n${stderr || stdout}`,
+				);
 			},
 			async getLogs(): Promise<{ stdout: string; stderr: string }> {
 				return { stdout, stderr };

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -39,6 +39,7 @@
 import { CWSandboxNotFoundError } from '@coreweave/cwsandbox';
 import type {
 	CommandProcess,
+	CommandProcessStatus,
 	FileWrites,
 	ListSandboxesResult,
 	ProcessResult,
@@ -94,6 +95,13 @@ const PORT_WAIT_FIRST_CHUNK_MS = 2_000;
  * round-trip, so this trades a few extra polls for that rounding.
  */
 const BOOT_POLL_INTERVAL_MS = 100;
+
+/**
+ * Process states a kernel never comes back from. `failed` is a stream fault (a
+ * transient gRPC reset shows up here), `cancelled` a teardown mid-wait; neither
+ * carries an exit code, so only the status distinguishes them from `running`.
+ */
+const TERMINAL_PROCESS_STATUSES = new Set<CommandProcessStatus>(['exited', 'failed', 'cancelled']);
 
 /**
  * Shell that blocks until `port` accepts a connection, for at most `seconds`.
@@ -562,9 +570,12 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				const attempts = Math.ceil(timeout / PORT_WAIT_CHUNK_MS) + 1;
 				let chunkMs = PORT_WAIT_FIRST_CHUNK_MS;
 				for (let i = 0; i < attempts && Date.now() < deadline; i++) {
-					if (proc.poll() !== undefined) {
+					// Status, not poll(): the SDK sets an exit code only on a clean exit,
+					// so a stream fault (`failed`) or a cancel leaves poll() undefined and
+					// would otherwise burn the whole timeout before reporting.
+					if (TERMINAL_PROCESS_STATUSES.has(proc.status)) {
 						throw new Error(
-							`process exited before port ${port} opened.\n${stderr || stdout}`.trim(),
+							`process ${proc.status} before port ${port} opened.\n${stderr || stdout}`.trim(),
 						);
 					}
 					const seconds = Math.max(1, Math.ceil(Math.min(chunkMs, deadline - Date.now()) / 1000));

--- a/packages/compute-coreweave/src/testWorld.ts
+++ b/packages/compute-coreweave/src/testWorld.ts
@@ -26,19 +26,20 @@ export function procResult(over: Partial<ProcessResult> = {}): ProcessResult {
 	};
 }
 
-export function fakeProcess(): CommandProcess {
+/** `exitCode` set = a process that has already exited, for the died-on-launch paths. */
+export function fakeProcess(exitCode?: number): CommandProcess {
 	async function* empty(): AsyncGenerator<string> {
 		// no output
 	}
 	return {
 		command: ['sh'] as unknown as CommandProcess['command'],
-		exitCode: undefined,
-		status: 'running',
+		exitCode,
+		status: exitCode === undefined ? 'running' : 'exited',
 		stdout: empty(),
 		stderr: empty(),
 		cancel: async () => {},
-		poll: () => {},
-		wait: async () => procResult(),
+		poll: () => exitCode,
+		wait: async () => procResult({ exitCode }),
 	};
 }
 
@@ -50,6 +51,8 @@ export interface FakeSandbox {
 	batchWrites: { path: string; content: unknown }[][];
 	reads: Record<string, string>;
 	deleted: number;
+	/** One entry per `wait()` call, carrying the options the adapter passed. */
+	waitCalls: { intervalMs?: number }[];
 }
 
 // `FileWrites` also admits a path→content record, but the adapter only ever
@@ -63,7 +66,11 @@ function recordWrite(fake: FakeSandbox) {
 	};
 }
 
-export function makeWorld(opts?: { runImpl?: (cmd: readonly string[]) => Promise<ProcessResult> }) {
+export function makeWorld(opts?: {
+	runImpl?: (cmd: readonly string[]) => Promise<ProcessResult>;
+	/** Exit code for started processes; omit to leave them running. */
+	procExitCode?: number;
+}) {
 	const created: NonNullable<Parameters<CoreWeaveClient['create']>[0]>[] = [];
 	const deleted: string[] = [];
 	const listCalls: (readonly string[])[] = [];
@@ -79,9 +86,13 @@ export function makeWorld(opts?: { runImpl?: (cmd: readonly string[]) => Promise
 			batchWrites: [],
 			reads: {},
 			deleted: 0,
+			waitCalls: [],
 		};
 		const sandbox = {
 			sandboxId,
+			wait: async (options?: { intervalMs?: number }) => {
+				fake.waitCalls.push(options ?? {});
+			},
 			commands: {
 				run: async (command: readonly string[]) => {
 					fake.runCalls.push([...command]);
@@ -89,7 +100,7 @@ export function makeWorld(opts?: { runImpl?: (cmd: readonly string[]) => Promise
 				},
 				start: async (command: readonly string[]) => {
 					fake.startCalls.push([...command]);
-					return fakeProcess();
+					return fakeProcess(opts?.procExitCode);
 				},
 			},
 			files: {

--- a/packages/compute-coreweave/src/testWorld.ts
+++ b/packages/compute-coreweave/src/testWorld.ts
@@ -5,7 +5,13 @@
  * The fake keeps a registry of created sandboxes keyed by the CoreWeave id it
  * assigns, so reconnect/list/delete-by-tag behave realistically.
  */
-import type { CommandProcess, FileWrites, ProcessResult, SandboxInfo } from '@coreweave/cwsandbox';
+import type {
+	CommandProcess,
+	CommandProcessStatus,
+	FileWrites,
+	ProcessResult,
+	SandboxInfo,
+} from '@coreweave/cwsandbox';
 import type { CoreWeaveClient } from './index';
 
 export function procResult(over: Partial<ProcessResult> = {}): ProcessResult {
@@ -26,15 +32,27 @@ export function procResult(over: Partial<ProcessResult> = {}): ProcessResult {
 	};
 }
 
-/** `exitCode` set = a process that has already exited, for the died-on-launch paths. */
-export function fakeProcess(exitCode?: number): CommandProcess {
+/** How a started process should present itself: still running unless told otherwise. */
+export interface FakeProcessState {
+	exitCode?: number;
+	status?: CommandProcessStatus;
+}
+
+/**
+ * Mirrors the SDK's own state machine: an exit code is recorded ONLY on a clean
+ * exit, so a `failed` (stream fault) or `cancelled` process reports its status
+ * with `exitCode`/`poll()` left undefined.
+ */
+export function fakeProcess(state?: FakeProcessState): CommandProcess {
 	async function* empty(): AsyncGenerator<string> {
 		// no output
 	}
+	const status = state?.status ?? (state?.exitCode === undefined ? 'running' : 'exited');
+	const exitCode = status === 'exited' ? state?.exitCode : undefined;
 	return {
 		command: ['sh'] as unknown as CommandProcess['command'],
 		exitCode,
-		status: exitCode === undefined ? 'running' : 'exited',
+		status,
 		stdout: empty(),
 		stderr: empty(),
 		cancel: async () => {},
@@ -68,8 +86,8 @@ function recordWrite(fake: FakeSandbox) {
 
 export function makeWorld(opts?: {
 	runImpl?: (cmd: readonly string[]) => Promise<ProcessResult>;
-	/** Exit code for started processes; omit to leave them running. */
-	procExitCode?: number;
+	/** State for started processes; omit to leave them running. */
+	proc?: FakeProcessState;
 }) {
 	const created: NonNullable<Parameters<CoreWeaveClient['create']>[0]>[] = [];
 	const deleted: string[] = [];
@@ -100,7 +118,7 @@ export function makeWorld(opts?: {
 				},
 				start: async (command: readonly string[]) => {
 					fake.startCalls.push([...command]);
-					return fakeProcess(opts?.procExitCode);
+					return fakeProcess(opts?.proc);
 				},
 			},
 			files: {

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -102,6 +102,13 @@ export interface SetEnvVarsOptions {
 }
 
 export interface SandboxInstance {
+	/**
+	 * Resolve the backing sandbox without running anything in it, so an adapter
+	 * that creates lazily pays its create here rather than inside whichever call
+	 * touches it first. Optional: callers fall back to a no-op `exec`, which forces
+	 * the same resolution at the cost of a command round-trip.
+	 */
+	ready?(): Promise<void>;
 	exec(cmd: string): Promise<ExecResult>;
 	execStream(cmd: string, options?: ExecStreamOptions): Promise<ReadableStream>;
 	readFile(path: string): Promise<ReadFileResult>;
@@ -135,6 +142,11 @@ export interface SandboxInstance {
 	 * actually spent. Optional; the provisioner folds them into its own timings.
 	 */
 	drainTimings?(): Timings;
+	/**
+	 * Return and CLEAR non-duration counters the adapter accumulated — e.g. how
+	 * many blocking commands a provision sent. Optional.
+	 */
+	drainCounters?(): Record<string, number>;
 }
 
 export interface ActiveSandbox {

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -300,6 +300,84 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess).toHaveLength(1);
 		});
 
+		// A command round-trip is the dominant unit of startup cost on a remote
+		// backend (~220ms each on CoreWeave), so these lock in the count. Each was a
+		// measured regression: a duplicate mkdir, a reachability no-op, and a setup
+		// exec that the kernel command can carry itself.
+		describe('command round-trips', () => {
+			it('a copy-path provision spends no exec at all', async () => {
+				const { instance, calls } = makeFakeSandbox({ failMount: true });
+				const bucketHandle = new MemoryBucket();
+				const nb = paths.project(projectId).notebook(notebookId);
+				await bucketHandle.put(nb.code, 'import marimo as mo');
+				await bucketHandle.put(nb.workspaceFile('data/cars.csv'), 'a,b\n1,2\n');
+				// `ready()` stands in for an adapter that resolves lazily (CoreWeave).
+				instance.ready = async () => {};
+
+				await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					bucketHandle,
+				});
+
+				// writeFiles creates parents, ready() replaces the exec('true') probe,
+				// and setup rides the kernel command.
+				expect(calls.exec).toEqual([]);
+				expect(calls.startProcess).toHaveLength(1);
+			});
+
+			it('prefers ready() over a no-op exec, and falls back when absent', async () => {
+				const withReady = makeFakeSandbox();
+				let readied = 0;
+				withReady.instance.ready = async () => {
+					readied++;
+				};
+				await new SandboxProvisioner(fakeComputeFrom(withReady.instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				});
+				expect(readied).toBe(1);
+				expect(withReady.calls.exec).not.toContain('true');
+
+				const withoutReady = makeFakeSandbox();
+				await new SandboxProvisioner(fakeComputeFrom(withoutReady.instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				});
+				expect(withoutReady.calls.exec).toContain('true');
+			});
+
+			it('carries launch setup on the kernel command instead of a separate exec', async () => {
+				const { instance, calls } = makeFakeSandbox();
+				instance.ready = async () => {};
+
+				await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				});
+
+				expect(calls.exec).toEqual([]);
+				// `uv sync` (setup) and `marimo edit` (start) travel together, joined by
+				// `&&` so a failed setup cannot leave marimo on a half-built env.
+				const cmd = calls.startProcess[0].cmd;
+				expect(cmd).toContain('uv sync');
+				expect(cmd).toContain('marimo edit');
+				expect(cmd).toMatch(/uv sync[\s\S]*&&[\s\S]*marimo edit/);
+			});
+		});
+
 		it('mount failure without a bucket handle rejects instead of starting an empty workspace', async () => {
 			const { instance, calls } = makeFakeSandbox({ failMount: true });
 			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
@@ -349,13 +427,13 @@ describe('SandboxProvisioner', () => {
 				copyOnly: {
 					async load(ctx) {
 						selected.push(`copy:${ctx.projectId}:${ctx.notebookId}`);
-						return true;
+						return { usedFallback: true, stats: { objectCount: 2, bytes: 40 } };
 					},
 				},
 				mountOrCopy: {
 					async load() {
 						selected.push('mount');
-						return false;
+						return { usedFallback: false };
 					},
 				},
 			};
@@ -374,6 +452,9 @@ describe('SandboxProvisioner', () => {
 			expect(selected).toEqual([`copy:${projectId}:${notebookId}`]);
 			expect(calls.mountBucket).toHaveLength(0);
 			expect(calls.startProcess).toHaveLength(1);
+			// What the copy moved rides the same wide event, so a slow `files` phase is
+			// attributable to workspace size rather than guesswork.
+			expect(result.counters).toMatchObject({ files_objects: 2, files_bytes: 40 });
 		});
 
 		it('unreachable sandbox: exec("true") throws -> provision rejects with "not available"', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -19,7 +19,7 @@ import { captureFilesystemSnapshot, createOrRestoreSandbox } from '../content/fi
 import { buildMarimoLaunch } from './marimoLaunch';
 import type { NotebookService } from '../content/NotebookService';
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
-import { shellQuote } from './shell';
+import type { WorkspaceRestoreStats } from './sandboxFiles';
 
 /**
  * How long to wait for marimo to bind its port. Generous because a cold sandbox
@@ -132,8 +132,14 @@ export interface ProvisionResult {
 	url: string;
 	/** Whether files were loaded via manual copy (true) or bucket mount (false) */
 	usedFallback: boolean;
-	/** Per-phase ms: create, reachable, files, setup, start, waitport, expose. */
+	/** Per-phase ms: handle, reachable, files, inject, start, waitport, expose. */
 	timings: Timings;
+	/**
+	 * Non-duration measurements for the same wide event — workspace objects/bytes
+	 * copied, command round-trips. Kept apart from `timings` so nothing here gets
+	 * reported as milliseconds.
+	 */
+	counters: Record<string, number>;
 }
 
 /**
@@ -184,8 +190,15 @@ export interface WorkspaceLoadContext {
 	workspacePrefix: string;
 }
 
+export interface WorkspaceLoadResult {
+	/** Files were copied in (true) rather than bucket-mounted (false). */
+	usedFallback: boolean;
+	/** What the copy moved; absent when the workspace was mounted instead. */
+	stats?: WorkspaceRestoreStats;
+}
+
 export interface WorkspaceLoadStrategy {
-	load(ctx: WorkspaceLoadContext): Promise<boolean>;
+	load(ctx: WorkspaceLoadContext): Promise<WorkspaceLoadResult>;
 }
 
 export interface WorkspaceLoadStrategies {
@@ -199,7 +212,7 @@ class CopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 		bucketHandle,
 		workspacePrefix,
 		mountPath,
-	}: WorkspaceLoadContext): Promise<boolean> {
+	}: WorkspaceLoadContext): Promise<WorkspaceLoadResult> {
 		if (!bucketHandle) {
 			throw provisionFailure(
 				'restoring the notebook workspace into the sandbox',
@@ -207,8 +220,8 @@ class CopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 			);
 		}
 		try {
-			await restoreWorkspace(sandbox, bucketHandle, workspacePrefix, mountPath);
-			return true;
+			const stats = await restoreWorkspace(sandbox, bucketHandle, workspacePrefix, mountPath);
+			return { usedFallback: true, stats };
 		} catch (err) {
 			throw provisionFailure('restoring the notebook workspace into the sandbox', err);
 		}
@@ -218,7 +231,7 @@ class CopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 class MountOrCopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 	constructor(private copyFallback: WorkspaceLoadStrategy) {}
 
-	async load(ctx: WorkspaceLoadContext): Promise<boolean> {
+	async load(ctx: WorkspaceLoadContext): Promise<WorkspaceLoadResult> {
 		try {
 			await ctx.sandbox.mountBucket({
 				bucketName: ctx.bucket.name,
@@ -227,7 +240,7 @@ class MountOrCopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 				prefix: ctx.workspacePrefix,
 				credentials: ctx.bucket.credentials,
 			});
-			return false;
+			return { usedFallback: false };
 		} catch (err) {
 			if (!ctx.bucketHandle) {
 				throw provisionFailure('mounting the notebook workspace into the sandbox', err);
@@ -262,7 +275,9 @@ export class SandboxProvisioner {
 		const createMs = Date.now() - createStart;
 		try {
 			const result = await this.provisionInto(sandbox, options);
-			result.timings.create = createMs;
+			// Constructing the (usually lazy) handle, NOT the backend's create — that
+			// lands in `reachable_create` once the adapter resolves it.
+			result.timings.handle = createMs;
 			return result;
 		} catch (err) {
 			// Provisioning failed partway — destroy any partial sandbox before
@@ -326,13 +341,25 @@ export class SandboxProvisioner {
 			},
 		});
 
-		return { sandbox, url: expose, usedFallback: load, timings: sw.timings };
+		const counters: Record<string, number> = {};
+		if (load.stats) {
+			counters.files_objects = load.stats.objectCount;
+			counters.files_bytes = load.stats.bytes;
+		}
+		// Last: the adapter's command count is only final once every phase has run.
+		Object.assign(counters, sandbox.drainCounters?.() ?? {});
+
+		return { sandbox, url: expose, usedFallback: load.usedFallback, timings: sw.timings, counters };
 	}
 
 	private async ensureReachable(sandbox: SandboxInstance, sw: Stopwatch): Promise<void> {
 		using _drained = drainTimingsInto(sandbox, sw, 'reachable');
 		try {
-			await sw.time('reachable', () => sandbox.exec('true'));
+			// Adapters without `ready()` fall back to a no-op command, which proves the
+			// same thing at the cost of a round-trip.
+			await sw.time('reachable', async () => {
+				await (sandbox.ready?.() ?? sandbox.exec('true'));
+			});
 		} catch (err) {
 			throw new UnavailableError(
 				`Sandbox container is not available. Is Docker running? ` +
@@ -347,7 +374,7 @@ export class SandboxProvisioner {
 		mountPath: string,
 		workspacePrefix: string,
 		sw: Stopwatch,
-	): Promise<boolean> {
+	): Promise<WorkspaceLoadResult> {
 		using _files = sw.span('files');
 		const strategy =
 			options.workspaceLoadMode === 'copy-only'
@@ -406,21 +433,14 @@ export class SandboxProvisioner {
 		});
 		let process: SandboxProcess | undefined;
 		try {
-			// cwd is the loaded workspace so marimo resolves relative imports and files
-			// beside the notebook. exec takes no cwd, so setup commands cd in first.
-			await sw.time('setup', async () => {
-				for (const cmd of launch.setup) {
-					const res = await sandbox.exec(`cd ${shellQuote(mountPath)} && ${cmd}`);
-					if (!res.success) {
-						throw new Error(`marimo launch setup failed (${cmd}): ${res.stderr || res.stdout}`);
-					}
-				}
-			});
-			const proc = await sw.time('start', () =>
-				sandbox.startProcess(launch.start, { cwd: mountPath }),
-			);
+			// Setup rides the kernel command instead of spending its own exec, and
+			// failures still surface through the process log read below. `&&` so a
+			// failed setup never leaves marimo running against a half-built env;
+			// marimoLaunch decides what is fatal.
+			const command = [...launch.setup, launch.start].join(' && ');
+			const proc = await sw.time('start', () => sandbox.startProcess(command, { cwd: mountPath }));
 			process = proc;
-			// `waitport` is where a slow kernel env (install/build) shows up.
+			// Covers setup as well, so a slow kernel env (install/build) shows up here.
 			await sw.time('waitport', () =>
 				proc.waitForPort(MARIMO_PORT, { timeout: MARIMO_PORT_TIMEOUT_MS }),
 			);

--- a/packages/core/src/services/runtime/sandboxFiles.test.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.test.ts
@@ -24,7 +24,7 @@ function nbCtx() {
 const decode = (b: Uint8Array) => new TextDecoder().decode(b);
 
 describe('restoreWorkspace', () => {
-	it('creates every parent in ONE mkdir, then restores every workspace key', async () => {
+	it('restores every workspace key without spending a mkdir exec', async () => {
 		const { nb } = nbCtx();
 		const bucket = new MemoryBucket();
 		await bucket.put(nb.code, 'import marimo');
@@ -32,17 +32,27 @@ describe('restoreWorkspace', () => {
 		await bucket.put(nb.workspaceFile('data/cars.csv'), 'a,b\n1,2\n');
 		const { instance, fs, calls } = makeFsSandbox();
 
-		await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT);
+		const stats = await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT);
 
-		// One exec covers the working dir AND every nested parent (SDK writeFile won't
-		// make parents), rather than one mkdir per file.
-		const mkdirs = calls.exec.filter((c) => c.startsWith('mkdir -p '));
-		expect(mkdirs).toHaveLength(1);
-		expect(mkdirs[0]).toContain(`'${MOUNT}'`);
-		expect(mkdirs[0]).toContain(`'${MOUNT}/data'`);
+		// `writeFiles` creates parents (port contract), so restore spends no exec of
+		// its own — a command round-trip is the expensive unit on a remote backend.
+		expect(calls.exec.filter((c) => c.startsWith('mkdir -p '))).toHaveLength(0);
 		expect(decode(fs.get('notebook.py')!)).toBe('import marimo');
 		expect(decode(fs.get('pyproject.toml')!)).toBe('[project]\nname = "nb"');
 		expect(decode(fs.get('data/cars.csv')!)).toBe('a,b\n1,2\n');
+		expect(stats.objectCount).toBe(3);
+		expect(stats.bytes).toBe(('import marimo' + '[project]\nname = "nb"' + 'a,b\n1,2\n').length);
+	});
+
+	it('empty workspace: still creates the working dir marimo runs in', async () => {
+		const { nb } = nbCtx();
+		const { instance, calls } = makeFsSandbox();
+
+		const stats = await restoreWorkspace(instance, new MemoryBucket(), nb.workspacePrefix, MOUNT);
+
+		// Nothing is written, so nothing else would create the cwd.
+		expect(calls.exec.filter((c) => c.startsWith('mkdir -p '))).toEqual([`mkdir -p '${MOUNT}'`]);
+		expect(stats).toEqual({ objectCount: 0, bytes: 0 });
 	});
 
 	it('writes the whole workspace in one batched call', async () => {

--- a/packages/core/src/services/runtime/sandboxFiles.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.ts
@@ -100,6 +100,12 @@ function isExcluded(rel: string): boolean {
 	);
 }
 
+/** What a workspace restore actually moved into the sandbox. */
+export interface WorkspaceRestoreStats {
+	objectCount: number;
+	bytes: number;
+}
+
 /**
  * Restore a workspace mirror (every key under `sourcePrefix`) from the bucket into
  * the sandbox working directory. Unconditional and binary-safe: every object is
@@ -107,13 +113,16 @@ function isExcluded(rel: string): boolean {
  * parent directories as needed. `sourcePrefix` is the local notebook's mutable
  * `workspace/` for editable sources, or an immutable `versions/{vid}/workspace/`
  * for synced read-only sources — the restore logic is identical either way.
+ *
+ * Returns what was copied, so the provisioning wide event can attribute a slow
+ * `files` phase to workspace size rather than leaving it to guesswork.
  */
 export async function restoreWorkspace(
 	sandbox: SandboxInstance,
 	bucket: Bucket,
 	sourcePrefix: string,
 	workingDir: string,
-): Promise<void> {
+): Promise<WorkspaceRestoreStats> {
 	// Select from the LISTING (sizes included) so an oversized object is skipped
 	// before `bucket.get()` buffers its body — the size check must never use the
 	// fetched object.
@@ -138,17 +147,19 @@ export async function restoreWorkspace(
 		wanted.push({ key: obj.key, dest: `${workingDir}/${rel}`, size: obj.size });
 	}
 
-	// One mkdir for every parent (deduped), derived from the listing rather than
-	// one exec per file. workingDir is always included so an empty workspace still
-	// yields the cwd marimo runs in. Paths are bounded by the file-count cap, so
-	// this can't approach ARG_MAX.
-	const dirs = new Set<string>([workingDir]);
-	for (const f of wanted) dirs.add(f.dest.slice(0, f.dest.lastIndexOf('/')) || workingDir);
-	await withRetry(() => sandbox.exec(`mkdir -p ${[...dirs].map(shellQuote).join(' ')}`));
+	// `writeFiles` creates parent directories (port contract), so the only case
+	// still needing an explicit mkdir is an empty workspace — nothing gets written,
+	// yet marimo still needs the cwd it runs in to exist.
+	if (wanted.length === 0) {
+		await withRetry(() => sandbox.exec(`mkdir -p ${shellQuote(workingDir)}`));
+		return { objectCount: 0, bytes: 0 };
+	}
 
 	// Fetch + write in byte-bounded batches, so only a slice of the workspace is
 	// ever resident. Raw bytes go straight to the port — nothing is base64-armored
 	// through a shell, and there is no temp file to decode.
+	let objectCount = 0;
+	let bytes = 0;
 	for (const batch of batchByBytes(wanted, RESTORE_BATCH_BYTES)) {
 		const fetched = await mapWithConcurrency(batch, SANDBOX_FILE_CONCURRENCY, async (f) => {
 			const body = await bucket.get(f.key);
@@ -157,7 +168,10 @@ export async function restoreWorkspace(
 		});
 		const files = fetched.filter((f) => f !== undefined);
 		if (files.length > 0) await withRetry(() => sandbox.writeFiles(files));
+		objectCount += files.length;
+		for (const f of files) bytes += f.content.byteLength;
 	}
+	return { objectCount, bytes };
 }
 
 /**


### PR DESCRIPTION
Reduce number of requests made to coreweave-compute for faster startup times. 