### PR TITLE
feat(integrations): import (copy) an integration from another project

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -129,6 +129,13 @@ can see the list and redacted configs; **`admin`** manages them — as does a
 - **Enable / disable** — disabled integrations are skipped at session launch.
   This is also the escape hatch when a broken config is failing sessions.
 - **Delete** — removes the instance and its entire version history.
+- **Import** — copy an integration from another project (**Add integration** →
+  **Import from another project**, or `POST …/integrations/import`). You need
+  the `admin` role on **both** projects; a super admin qualifies everywhere.
+  The copy takes the source's current config — secrets included, re-encrypted
+  for the destination — and starts its own version history at v1. The two are
+  independent afterwards: editing or deleting one never affects the other. The
+  audit trail records the import with its source project and integration.
 
 New sessions pick up config changes; running sessions keep what they launched
 with (restart the session to apply).

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -1067,6 +1067,23 @@ components:
         - kind_schema_version
         - created_by
         - created_at
+    IntegrationImportRequest:
+      type: object
+      properties:
+        source_project_id:
+          type: string
+          pattern: ^proj-[0-9a-z]{16}$
+          example: proj-7h2k9qm4xz7rp3w8
+        source_integration_id:
+          type: string
+          pattern: ^intg-[0-9a-z]{16}$
+          example: intg-7h2k9qm4xz7rp3w8
+        name:
+          type: string
+          minLength: 1
+      required:
+        - source_project_id
+        - source_integration_id
     IntegrationTestResult:
       type: object
       properties:
@@ -4653,6 +4670,81 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Insufficient role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/integrations/import:
+    post:
+      tags:
+        - Integrations
+      summary: Copy an integration from another project (admin of both projects)
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationImportRequest'
+      responses:
+        '201':
+          description: Integration copied (config redacted; secrets re-encrypted for this
+            project)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/IntegrationDetail'
+                required:
+                  - success
+                  - data
         '401':
           description: Authentication required
           content:

--- a/packages/api/src/routes/integrations.test.ts
+++ b/packages/api/src/routes/integrations.test.ts
@@ -795,8 +795,9 @@ describe('Integration import route', () => {
 	});
 
 	it('requires admin on BOTH projects — dest-only admins are refused', async () => {
-		// An outsider who owns only the destination cannot pull configs out of a
-		// source project they hold no admin role on.
+		// An outsider who owns only the destination cannot even LEARN that the
+		// source exists: an invisible source answers the same 404 as a missing one,
+		// so the import route is not a project-id existence oracle.
 		const asOutsider = createTestApi({ bucket, userId: OUTSIDER, deps }).request;
 		const foreign = (
 			await expectOk<{ id: string }>(
@@ -806,10 +807,10 @@ describe('Integration import route', () => {
 		).id;
 		await expectError(
 			await asOutsider('POST', `/projects/${foreign}/integrations/import`, importBody()),
-			403,
+			404,
 		);
 
-		// Editor on the source is still not enough.
+		// Editor on the source can see it but still cannot export it: 403.
 		await expectOk(
 			await asOwner('POST', `/projects/${sourcePid}/members`, {
 				user_id: OUTSIDER,

--- a/packages/api/src/routes/integrations.test.ts
+++ b/packages/api/src/routes/integrations.test.ts
@@ -727,3 +727,143 @@ describe('Org integrations routes', () => {
 		);
 	});
 });
+
+describe('Integration import route', () => {
+	const ROOT = uid('user_import_root');
+	const OUTSIDER = uid('user_import_outsider');
+	let bucket: MemoryBucket;
+	let deps: ReturnType<typeof integrationsDeps> & { policy: { superAdmins: string[] } };
+	let asOwner: ReturnType<typeof createTestApi>['request'];
+	let sourcePid: string;
+	let targetPid: string;
+	let sourceIid: string;
+
+	beforeEach(async () => {
+		bucket = await createInitializedBucket();
+		deps = { ...integrationsDeps(bucket), policy: { superAdmins: [ROOT] } };
+		asOwner = createTestApi({ bucket, userId: ACTOR, deps }).request;
+		const createProject = async (name: string) =>
+			(
+				await expectOk<{ id: string }>(
+					await asOwner('POST', '/projects', { name, description: 'd' }),
+					201,
+				)
+			).id;
+		sourcePid = await createProject('source');
+		targetPid = await createProject('target');
+		sourceIid = (
+			await expectOk<{ id: string }>(
+				await asOwner('POST', `/projects/${sourcePid}/integrations`, {
+					kind: 'postgres',
+					name: 'prod',
+					config: PG_CONFIG,
+				}),
+				201,
+			)
+		).id;
+	});
+
+	const importBody = (over: Record<string, unknown> = {}) => ({
+		source_project_id: sourcePid,
+		source_integration_id: sourceIid,
+		...over,
+	});
+
+	it('admin of both projects copies the integration; secrets stay redacted', async () => {
+		const detail = await expectOk<Record<string, unknown>>(
+			await asOwner('POST', `/projects/${targetPid}/integrations/import`, importBody()),
+			201,
+		);
+		expect(detail).toMatchObject({
+			kind: 'postgres',
+			name: 'prod',
+			current_version: 1,
+			config: { host: 'db.internal', password: { $secret: { set: true } } },
+		});
+		expect(detail.id).not.toBe(sourceIid);
+		expect(JSON.stringify(detail)).not.toContain('sup3r-secret');
+
+		const events = await expectOk<Record<string, unknown>[]>(
+			await asOwner('GET', `/projects/${targetPid}/events`),
+		);
+		const imported = events.find((e) => e.event === 'integration.import');
+		expect(imported).toMatchObject({
+			source_project_id: sourcePid,
+			source_integration_id: sourceIid,
+		});
+		expect(JSON.stringify(events)).not.toContain('sup3r-secret');
+	});
+
+	it('requires admin on BOTH projects — dest-only admins are refused', async () => {
+		// An outsider who owns only the destination cannot pull configs out of a
+		// source project they hold no admin role on.
+		const asOutsider = createTestApi({ bucket, userId: OUTSIDER, deps }).request;
+		const foreign = (
+			await expectOk<{ id: string }>(
+				await asOutsider('POST', '/projects', { name: 'mine', description: 'd' }),
+				201,
+			)
+		).id;
+		await expectError(
+			await asOutsider('POST', `/projects/${foreign}/integrations/import`, importBody()),
+			403,
+		);
+
+		// Editor on the source is still not enough.
+		await expectOk(
+			await asOwner('POST', `/projects/${sourcePid}/members`, {
+				user_id: OUTSIDER,
+				role: 'editor',
+			}),
+			201,
+		);
+		await expectError(
+			await asOutsider('POST', `/projects/${foreign}/integrations/import`, importBody()),
+			403,
+		);
+
+		// A super admin who is a member of neither project passes both gates.
+		const asRoot = createTestApi({ bucket, userId: ROOT, deps }).request;
+		await expectOk(
+			await asRoot('POST', `/projects/${targetPid}/integrations/import`, importBody()),
+			201,
+		);
+	});
+
+	it('404s on unknown sources and 422s on a destination name conflict', async () => {
+		await expectError(
+			await asOwner(
+				'POST',
+				`/projects/${targetPid}/integrations/import`,
+				importBody({ source_project_id: 'proj-0000000000000000' }),
+			),
+			404,
+		);
+		await expectError(
+			await asOwner(
+				'POST',
+				`/projects/${targetPid}/integrations/import`,
+				importBody({ source_integration_id: 'intg-0000000000000000' }),
+			),
+			404,
+		);
+
+		await expectOk(
+			await asOwner('POST', `/projects/${targetPid}/integrations/import`, importBody()),
+			201,
+		);
+		await expectError(
+			await asOwner('POST', `/projects/${targetPid}/integrations/import`, importBody()),
+			422,
+		);
+		const renamed = await expectOk<Record<string, unknown>>(
+			await asOwner(
+				'POST',
+				`/projects/${targetPid}/integrations/import`,
+				importBody({ name: 'prod-copy' }),
+			),
+			201,
+		);
+		expect(renamed.name).toBe('prod-copy');
+	});
+});

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -4,6 +4,7 @@ import {
 	IntegrationId,
 	NotFoundError,
 	ProjectId,
+	requireRole,
 	ResourceExhaustedError,
 } from '@marimo-hub/core';
 import type {
@@ -25,6 +26,7 @@ import {
 	ifMatchToken,
 	jsonBody,
 	jsonContent,
+	loadVisibleProject,
 	ProjectIdParam,
 	SuccessResponseSchema,
 } from '../shared';
@@ -625,13 +627,16 @@ app.openapi(importIntegration, async (c) => {
 	// the caller must hold admin on BOTH sides (a super admin is admin
 	// everywhere). Destination first: its 404/403 must not confirm the source.
 	await assertProjectRole(deps.services.projects, pid, user, 'admin', deps.policy);
-	await assertProjectRole(
+	// Visibility before role for the SOURCE: any destination admin can probe an
+	// arbitrary id here, so a project the caller cannot see answers the same 404
+	// as one that does not exist; 403 is reserved for projects they can see.
+	const source = await loadVisibleProject(
 		deps.services.projects,
 		body.source_project_id,
 		user,
-		'admin',
 		deps.policy,
 	);
+	requireRole(source, user, 'admin', deps.policy);
 	const detail = await integrations.copy(
 		body.source_project_id,
 		body.source_integration_id,

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -3,6 +3,7 @@ import {
 	INTEGRATION_CATEGORIES,
 	IntegrationId,
 	NotFoundError,
+	ProjectId,
 	ResourceExhaustedError,
 } from '@marimo-hub/core';
 import type {
@@ -147,6 +148,23 @@ const TestIntegrationBody = z
 	])
 	.openapi('IntegrationTestRequest');
 
+const ImportIntegrationBody = z
+	.object({
+		source_project_id: z
+			.string()
+			.regex(ProjectId.regex)
+			.refine(ProjectId.is)
+			.openapi({ example: 'proj-7h2k9qm4xz7rp3w8' }),
+		source_integration_id: z
+			.string()
+			.regex(IntegrationId.regex)
+			.refine(IntegrationId.is)
+			.openapi({ example: 'intg-7h2k9qm4xz7rp3w8' }),
+		/** Name for the copy; defaults to the source instance's name. */
+		name: z.string().min(1).optional(),
+	})
+	.openapi('IntegrationImportRequest');
+
 const listKinds = createRoute({
 	method: 'get',
 	path: '/integrations/kinds',
@@ -260,6 +278,22 @@ const listIntegrationVersions = createRoute({
 		),
 		...commonErrors(),
 		...errorResponses(400, 403, 404),
+	},
+});
+
+const importIntegration = createRoute({
+	method: 'post',
+	path: '/projects/{pid}/integrations/import',
+	tags: ['Integrations'],
+	summary: 'Copy an integration from another project (admin of both projects)',
+	request: { params: ProjectIdParam, body: jsonBody(ImportIntegrationBody) },
+	responses: {
+		201: jsonContent(
+			z.object({ success: z.literal(true), data: IntegrationDetailSchema }),
+			'Integration copied (config redacted; secrets re-encrypted for this project)',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404),
 	},
 });
 
@@ -580,6 +614,45 @@ function assertTestBudget(userId: string): void {
 export function trackedTestBudgets(): number {
 	return recentTestsByUser.size;
 }
+
+app.openapi(importIntegration, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { pid } = c.req.valid('param');
+	const integrations = requireIntegrations(deps);
+	const body = c.req.valid('json');
+	// The copy moves decrypted secret material across the project boundary, so
+	// the caller must hold admin on BOTH sides (a super admin is admin
+	// everywhere). Destination first: its 404/403 must not confirm the source.
+	await assertProjectRole(deps.services.projects, pid, user, 'admin', deps.policy);
+	await assertProjectRole(
+		deps.services.projects,
+		body.source_project_id,
+		user,
+		'admin',
+		deps.policy,
+	);
+	const detail = await integrations.copy(
+		body.source_project_id,
+		body.source_integration_id,
+		pid,
+		{ name: body.name },
+		user.id,
+	);
+	await deps.services.events
+		.append({
+			event: 'integration.import',
+			actor: user.id,
+			project_id: pid,
+			integration_id: detail.id,
+			integration_kind: detail.kind,
+			integration_name: detail.name,
+			source_project_id: body.source_project_id,
+			source_integration_id: body.source_integration_id,
+		})
+		.catch(() => {});
+	return c.json({ success: true, data: detailResponse(detail) }, 201);
+});
 
 app.openapi(testIntegration, async (c) => {
 	const deps = c.get('deps');

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -3817,6 +3817,99 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/projects/{pid}/integrations/import': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/** Copy an integration from another project (admin of both projects) */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					pid: string;
+				};
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					'application/json': components['schemas']['IntegrationImportRequest'];
+				};
+			};
+			responses: {
+				/** @description Integration copied (config redacted; secrets re-encrypted for this project) */
+				201: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['IntegrationDetail'];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Insufficient role */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/projects/{pid}/integrations/test': {
 		parameters: {
 			query?: never;
@@ -5391,6 +5484,13 @@ export interface components {
 			created_by: string;
 			created_at: string;
 			change_note?: string;
+		};
+		IntegrationImportRequest: {
+			/** @example proj-7h2k9qm4xz7rp3w8 */
+			source_project_id: string;
+			/** @example intg-7h2k9qm4xz7rp3w8 */
+			source_integration_id: string;
+			name?: string;
 		};
 		IntegrationTestResult: {
 			ok: boolean;

--- a/packages/core/src/ports/integrations.ts
+++ b/packages/core/src/ports/integrations.ts
@@ -159,6 +159,11 @@ export type TestIntegrationRequest =
 	| { kind: string; config: Record<string, unknown> }
 	| { id: IntegrationId };
 
+export interface CopyIntegrationOptions {
+	/** Name for the copy; defaults to the source instance's name. */
+	name?: string;
+}
+
 export interface SessionRenderContext {
 	sessionId: SessionId;
 	principal: { userId: UserId; email: string };
@@ -210,6 +215,21 @@ export interface IntegrationsProvider {
 		page?: IntegrationVersionPageRequest,
 	): Promise<IntegrationVersionPage>;
 	test(projectId: ProjectId, request: TestIntegrationRequest): Promise<TestResult>;
+	/**
+	 * Copies the source integration's CURRENT config into `targetProjectId` as a
+	 * new integration (history starts at version 1). Secret fields are decrypted
+	 * and re-sealed for the destination — envelopes are bound to their head path,
+	 * so a byte copy could never decrypt — which is why this is a server-side
+	 * operation and not a client GET+POST (reads always redact). The API layer
+	 * must gate BOTH projects; the provider carries no authorization.
+	 */
+	copy(
+		sourceProjectId: ProjectId,
+		id: IntegrationId,
+		targetProjectId: ProjectId,
+		options: CopyIntegrationOptions,
+		actor: UserId,
+	): Promise<IntegrationDetail>;
 	/**
 	 * Server-only render path. Failures name the instance but no values and abort
 	 * provisioning rather than starting a sandbox with partial configuration.

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -1284,6 +1284,97 @@ describe('ProjectIntegrationsStore', () => {
 		await store.create(pid, { kind: 'echo', name: 'prod', config: { token: 'c' } }, ACTOR);
 	});
 
+	describe('copy between projects', () => {
+		it('re-seals secrets for the destination: the copy outlives the source', async () => {
+			const store = makeStore(bucket);
+			const target = createProjectId();
+			const source = await store.create(
+				pid,
+				{ kind: 'echo', name: 'prod', config: { greeting: 'hello', token: 'sekret' } },
+				ACTOR,
+			);
+			await store.update(pid, source.id, { config: { greeting: 'v2', token: 'sekret' } }, ACTOR);
+
+			const copy = await store.copy(pid, source.id, target, {}, ACTOR);
+			expect(copy.id).not.toBe(source.id);
+			expect(copy).toMatchObject({
+				name: 'prod',
+				enabled: true,
+				// The current config lands as a fresh history, not the source's numbering.
+				current_version: 1,
+				config: { greeting: 'v2', token: { $secret: { set: true } } },
+			});
+			expect(copy.change_note).toContain(`from project ${pid}`);
+			// Plaintext still never reaches the bucket.
+			for (const object of (await bucket.list({})).objects) {
+				const body = await bucket.get(object.key);
+				expect(await body?.text(), object.key).not.toContain('sekret');
+			}
+
+			// Deleting the source must not break the copy — a byte-copied envelope
+			// (bound to the source head path) would have.
+			await store.delete(pid, source.id);
+			const render = await store.resolveForSession(target, renderContext(createSessionId()));
+			expect(render?.vars.ECHO_PROD_TOKEN).toBe('sekret');
+			expect(render?.vars.ECHO_PROD_GREETING).toBe('v2');
+		});
+
+		it('honors a rename and rejects a name already taken in the destination', async () => {
+			const store = makeStore(bucket);
+			const target = createProjectId();
+			const source = await store.create(
+				pid,
+				{ kind: 'echo', name: 'prod', config: { token: 't' } },
+				ACTOR,
+			);
+			await store.create(target, { kind: 'echo', name: 'prod', config: { token: 'x' } }, ACTOR);
+
+			await expect(store.copy(pid, source.id, target, {}, ACTOR)).rejects.toThrow(
+				/already exists in this project/,
+			);
+			const renamed = await store.copy(pid, source.id, target, { name: 'prod-copy' }, ACTOR);
+			expect(renamed.name).toBe('prod-copy');
+		});
+
+		it('404s on an unknown source and fails without a codec for secret configs', async () => {
+			const store = makeStore(bucket);
+			const target = createProjectId();
+			await expect(
+				store.copy(pid, 'intg-0000000000000000' as never, target, {}, ACTOR),
+			).rejects.toThrow(NotFoundError);
+
+			const source = await store.create(
+				pid,
+				{ kind: 'echo', name: 'prod', config: { token: 't' } },
+				ACTOR,
+			);
+			await expect(
+				makeStore(bucket, false).copy(pid, source.id, target, {}, ACTOR),
+			).rejects.toThrow(/MARIMOHUB_SECRETS_KEK/);
+		});
+
+		it('the copy and the source evolve independently', async () => {
+			const store = makeStore(bucket);
+			const target = createProjectId();
+			const source = await store.create(
+				pid,
+				{ kind: 'echo', name: 'prod', config: { greeting: 'a', token: 't' } },
+				ACTOR,
+			);
+			const copy = await store.copy(pid, source.id, target, {}, ACTOR);
+
+			await store.update(
+				pid,
+				source.id,
+				{ config: { greeting: 'source-edit', token: 't' } },
+				ACTOR,
+			);
+			expect((await store.get(target, copy.id)).config.greeting).toBe('a');
+			await store.update(target, copy.id, { config: { greeting: 'copy-edit', token: 't' } }, ACTOR);
+			expect((await store.get(pid, source.id)).config.greeting).toBe('source-edit');
+		});
+	});
+
 	it('listKinds describes the default registry serializably', () => {
 		const store = new ProjectIntegrationsStore({ bucket, registry: defaultRegistry(), codec });
 		const kinds = store.listKinds();

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -16,6 +16,7 @@ import type { Bucket } from '../../ports/bucket';
 import { noopMetrics } from '../../ports/metrics';
 import type { Metrics } from '../../ports/metrics';
 import type {
+	CopyIntegrationOptions,
 	CreateIntegrationInput,
 	IntegrationDetail,
 	IntegrationEntry,
@@ -561,6 +562,31 @@ class ScopedIntegrationsStore {
 		};
 	}
 
+	async copy(
+		source: IntegrationScope,
+		id: IntegrationId,
+		target: IntegrationScope,
+		options: CopyIntegrationOptions,
+		actor: UserId,
+	): Promise<IntegrationDetail> {
+		const head = await this.getHead(source, id);
+		const { def, config } = await this.loadCurrent(source, head);
+		// Envelopes are bound to the SOURCE head path, so decrypt here and let
+		// `create` re-seal under the destination's context. The plaintext exists
+		// only in this frame — never in a response or a bucket object.
+		const resolved = await this.open(source, head.id, def, config);
+		return this.create(
+			target,
+			{
+				kind: head.kind,
+				name: options.name ?? head.name,
+				config: resolved,
+				change_note: `Imported "${head.name}" from project ${source.projectId ?? 'org'}`,
+			},
+			actor,
+		);
+	}
+
 	async test(scope: IntegrationScope, request: TestIntegrationRequest): Promise<TestResult> {
 		let def: IntegrationDefinition;
 		let resolved: Record<string, unknown>;
@@ -1019,6 +1045,22 @@ export class ProjectIntegrationsStore implements IntegrationsProvider {
 
 	test(projectId: ProjectId, request: TestIntegrationRequest): Promise<TestResult> {
 		return this.store.test(projectScope(projectId), request);
+	}
+
+	copy(
+		sourceProjectId: ProjectId,
+		id: IntegrationId,
+		targetProjectId: ProjectId,
+		options: CopyIntegrationOptions,
+		actor: UserId,
+	): Promise<IntegrationDetail> {
+		return this.store.copy(
+			projectScope(sourceProjectId),
+			id,
+			projectScope(targetProjectId),
+			options,
+			actor,
+		);
 	}
 
 	async resolveForSession(

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -505,12 +505,30 @@ export function useImportIntegration(projectId: string) {
 	);
 }
 
-/** Non-suspense twin of `useProjectsQuery` for pickers rendered inside dialogs. */
+/**
+ * Non-suspense project list for pickers rendered inside dialogs. Walks every
+ * page (unlike the first-page home list) so projects beyond the first page
+ * stay selectable; the sweep is bounded rather than unbounded on a cursor bug.
+ */
 export function useProjectPickerQuery(enabled: boolean) {
 	return useQuery({
-		queryKey: projectKeys.list(),
+		queryKey: projectKeys.pickerList(),
 		enabled,
-		queryFn: async () => (await apiData(apiClient.GET('/api/v1/projects'))).items,
+		queryFn: async () => {
+			const items = [];
+			let cursor: string | undefined;
+			for (let page = 0; page < 40; page++) {
+				const data = await apiData(
+					apiClient.GET('/api/v1/projects', {
+						params: { query: { limit: 500, ...(cursor ? { cursor } : {}) } },
+					}),
+				);
+				items.push(...data.items);
+				if (!data.next_cursor) break;
+				cursor = data.next_cursor;
+			}
+			return items;
+		},
 	});
 }
 

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -491,6 +491,41 @@ export function useDeleteIntegration(scope: IntegrationsScope) {
 	);
 }
 
+/** Copies an integration from another project; the server re-encrypts secrets. */
+export function useImportIntegration(projectId: string) {
+	return useApiMutation(
+		(body: { source_project_id: string; source_integration_id: string; name?: string }) =>
+			apiData(
+				apiClient.POST('/api/v1/projects/{pid}/integrations/import', {
+					params: { path: { pid: projectId } },
+					body,
+				}),
+			),
+		() => [projectKeys.integrations(projectId)],
+	);
+}
+
+/** Non-suspense twin of `useProjectsQuery` for pickers rendered inside dialogs. */
+export function useProjectPickerQuery(enabled: boolean) {
+	return useQuery({
+		queryKey: projectKeys.list(),
+		enabled,
+		queryFn: async () => (await apiData(apiClient.GET('/api/v1/projects'))).items,
+	});
+}
+
+/** Non-suspense project detail, used to check the caller's role before importing. */
+export function useProjectRoleQuery(projectId: string | undefined) {
+	return useQuery({
+		queryKey: projectKeys.detail(projectId ?? ''),
+		enabled: Boolean(projectId),
+		queryFn: () =>
+			apiData(
+				apiClient.GET('/api/v1/projects/{pid}', { params: { path: { pid: projectId ?? '' } } }),
+			),
+	});
+}
+
 /** Tests either an unsaved config or a stored integration by id. */
 export function useTestIntegration(scope: IntegrationsScope) {
 	return useMutation({

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -507,8 +507,10 @@ export function useImportIntegration(projectId: string) {
 
 /**
  * Non-suspense project list for pickers rendered inside dialogs. Walks every
- * page (unlike the first-page home list) so projects beyond the first page
- * stay selectable; the sweep is bounded rather than unbounded on a cursor bug.
+ * page (unlike the first-page home list) so the roster is COMPLETE — a
+ * truncated result would silently hide older projects from the picker. The
+ * loop is bounded by a cycle guard instead of a page cap: a repeated cursor
+ * (the realistic paging bug) fails the query loudly rather than truncating.
  */
 export function useProjectPickerQuery(enabled: boolean) {
 	return useQuery({
@@ -516,17 +518,23 @@ export function useProjectPickerQuery(enabled: boolean) {
 		enabled,
 		queryFn: async () => {
 			const items = [];
+			const followed = new Set<string>();
 			let cursor: string | undefined;
-			for (let page = 0; page < 40; page++) {
+			do {
 				const data = await apiData(
 					apiClient.GET('/api/v1/projects', {
 						params: { query: { limit: 500, ...(cursor ? { cursor } : {}) } },
 					}),
 				);
 				items.push(...data.items);
-				if (!data.next_cursor) break;
-				cursor = data.next_cursor;
-			}
+				cursor = data.next_cursor ?? undefined;
+				if (cursor !== undefined) {
+					if (followed.has(cursor)) {
+						throw new Error('Project listing did not advance; refusing a partial roster.');
+					}
+					followed.add(cursor);
+				}
+			} while (cursor !== undefined);
 			return items;
 		},
 	});

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -11,6 +11,8 @@ export const userKeys = {
 export const projectKeys = {
 	all: ['projects'] as const,
 	list: () => [...projectKeys.all, 'list'] as const,
+	/** Full multi-page roster for pickers; distinct from the first-page `list`. */
+	pickerList: () => [...projectKeys.all, 'list', 'all'] as const,
 	detail: (projectId: string) => [...projectKeys.all, 'detail', projectId] as const,
 	members: (projectId: string) => [...projectKeys.all, 'members', projectId] as const,
 	secrets: (projectId: string) => [...projectKeys.all, 'secrets', projectId] as const,

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -99,6 +99,8 @@ interface FetchOpts {
 	sourceProject?: { id: string; name: string; your_role: string; entries: IntegrationEntry[] };
 	/** Serve the source project on a SECOND /projects page. */
 	pagedProjects?: boolean;
+	/** Every /projects page repeats the same next_cursor (a paging bug). */
+	loopingProjects?: boolean;
 	/** Delay the source project's detail (role) response. */
 	slowRole?: boolean;
 }
@@ -112,6 +114,7 @@ function makeFetch({
 	orgEntries = [],
 	sourceProject,
 	pagedProjects = false,
+	loopingProjects = false,
 	slowRole = false,
 }: FetchOpts) {
 	const calls: {
@@ -160,6 +163,9 @@ function makeFetch({
 			(url.endsWith('/api/v1/projects') || url.includes('/api/v1/projects?')) &&
 			method === 'GET'
 		) {
+			if (loopingProjects) {
+				return ok({ items: [{ id: PID, name: 'Demo' }], next_cursor: 'stuck' });
+			}
 			if (pagedProjects && sourceProject) {
 				return url.includes('cursor=')
 					? ok({
@@ -676,6 +682,15 @@ describe('ProjectIntegrationsDialog — import from another project', () => {
 		setup({}, { kinds: [postgresKind], entries: [], sourceProject: SOURCE, pagedProjects: true });
 		await openImport(user);
 		expect(await screen.findByTestId('import-source-row')).toBeInTheDocument();
+	});
+
+	it('a cursor that never advances fails the picker loudly, not with a partial roster', async () => {
+		const user = userEvent.setup();
+		setup({}, { kinds: [postgresKind], entries: [], sourceProject: SOURCE, loopingProjects: true });
+		await user.click(await screen.findByRole('button', { name: /Add integration/ }));
+		await user.click(await screen.findByRole('button', { name: /Import from another project/ }));
+		expect(await screen.findByText(/Could not load the project list/)).toBeInTheDocument();
+		expect(screen.queryByRole('combobox', { name: 'Source project' })).not.toBeInTheDocument();
 	});
 
 	it('never shows the pick/submit form before the source role resolves', async () => {

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -95,6 +95,8 @@ interface FetchOpts {
 	details?: Record<string, IntegrationDetail>;
 	patchError?: boolean;
 	orgEntries?: IntegrationEntry[];
+	/** A second project offered by the import picker. */
+	sourceProject?: { id: string; name: string; your_role: string; entries: IntegrationEntry[] };
 }
 
 /** Routes the dialog's list, detail, and probe requests through one mock. */
@@ -104,6 +106,7 @@ function makeFetch({
 	details = {},
 	patchError = false,
 	orgEntries = [],
+	sourceProject,
 }: FetchOpts) {
 	const calls: {
 		url: string;
@@ -146,6 +149,39 @@ function makeFetch({
 		}
 		if (url.includes(`/projects/${PID}/integrations/test`) && method === 'POST') {
 			return ok({ ok: true, latency_ms: 5 });
+		}
+		if (url.endsWith('/api/v1/projects') && method === 'GET') {
+			const items = [
+				{ id: PID, name: 'Demo' },
+				...(sourceProject ? [{ id: sourceProject.id, name: sourceProject.name }] : []),
+			];
+			return ok({ items, next_cursor: null });
+		}
+		if (sourceProject && url.endsWith(`/projects/${sourceProject.id}`) && method === 'GET') {
+			return ok({
+				id: sourceProject.id,
+				name: sourceProject.name,
+				your_role: sourceProject.your_role,
+			});
+		}
+		if (sourceProject && url.includes(`/projects/${sourceProject.id}/integrations`)) {
+			return ok(sourceProject.entries);
+		}
+		if (url.includes(`/projects/${PID}/integrations/import`) && method === 'POST') {
+			return ok(
+				{
+					id: 'imported_1',
+					kind: 'postgres',
+					name: body?.name,
+					enabled: true,
+					current_version: 1,
+					created_by: 'u',
+					created_at: '',
+					updated_at: '',
+					config: {},
+				},
+				201,
+			);
 		}
 		if (url.includes(`/projects/${PID}/integrations/`)) {
 			const iid = url.split(`/projects/${PID}/integrations/`)[1];
@@ -576,5 +612,75 @@ describe('OrgIntegrationsDialog', () => {
 			expect(post!.url).not.toContain('/projects/');
 			expect(post!.body).toMatchObject({ kind: 'postgres', name: 'warehouse' });
 		});
+	});
+});
+
+describe('ProjectIntegrationsDialog — import from another project', () => {
+	const SOURCE = {
+		id: 'p_2',
+		name: 'Analytics',
+		your_role: 'admin',
+		entries: [entry({ id: 'i_src', name: 'prod-db' })],
+	};
+
+	async function openImport(user: ReturnType<typeof userEvent.setup>) {
+		await user.click(await screen.findByRole('button', { name: /Add integration/ }));
+		await user.click(await screen.findByRole('button', { name: /Import from another project/ }));
+		await user.type(screen.getByRole('combobox', { name: 'Source project' }), 'Analytics');
+		await user.click(await screen.findByRole('option', { name: 'Analytics' }));
+	}
+
+	it('POSTs to …/integrations/import with the picked source and name', async () => {
+		const user = userEvent.setup();
+		const { calls } = setup({}, { kinds: [postgresKind], entries: [], sourceProject: SOURCE });
+		await openImport(user);
+
+		await user.click(await screen.findByTestId('import-source-row'));
+		const nameField = screen.getByLabelText('Name in this project');
+		await user.clear(nameField);
+		await user.type(nameField, 'analytics-db');
+		await user.click(screen.getByRole('button', { name: 'Import integration' }));
+
+		await waitFor(() => {
+			const post = calls.find((c) => c.method === 'POST' && c.url.includes('/import'));
+			expect(post).toBeTruthy();
+			expect(post!.url).toContain(`/projects/${PID}/integrations/import`);
+			expect(post!.body).toEqual({
+				source_project_id: 'p_2',
+				source_integration_id: 'i_src',
+				name: 'analytics-db',
+			});
+		});
+	});
+
+	it('explains that admin is required on the source project', async () => {
+		const user = userEvent.setup();
+		setup(
+			{},
+			{
+				kinds: [postgresKind],
+				entries: [],
+				sourceProject: { ...SOURCE, your_role: 'viewer' },
+			},
+		);
+		await openImport(user);
+		expect(await screen.findByText(/on both projects/)).toBeInTheDocument();
+		expect(screen.queryByTestId('import-source-row')).not.toBeInTheDocument();
+	});
+
+	it('does not offer the import entry point in the org dialog', async () => {
+		const user = userEvent.setup();
+		makeFetch({ kinds: [postgresKind], entries: [], orgEntries: [] });
+		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		render(<OrgIntegrationsDialog isOpen onClose={vi.fn()} />, {
+			wrapper: ({ children }: { children: ReactNode }) => (
+				<QueryClientProvider client={client}>{children}</QueryClientProvider>
+			),
+		});
+		await user.click(await screen.findByRole('button', { name: /Add integration/ }));
+		expect(await screen.findAllByTestId('kind-card')).not.toHaveLength(0);
+		expect(
+			screen.queryByRole('button', { name: /Import from another project/ }),
+		).not.toBeInTheDocument();
 	});
 });

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -97,6 +97,10 @@ interface FetchOpts {
 	orgEntries?: IntegrationEntry[];
 	/** A second project offered by the import picker. */
 	sourceProject?: { id: string; name: string; your_role: string; entries: IntegrationEntry[] };
+	/** Serve the source project on a SECOND /projects page. */
+	pagedProjects?: boolean;
+	/** Delay the source project's detail (role) response. */
+	slowRole?: boolean;
 }
 
 /** Routes the dialog's list, detail, and probe requests through one mock. */
@@ -107,6 +111,8 @@ function makeFetch({
 	patchError = false,
 	orgEntries = [],
 	sourceProject,
+	pagedProjects = false,
+	slowRole = false,
 }: FetchOpts) {
 	const calls: {
 		url: string;
@@ -150,7 +156,18 @@ function makeFetch({
 		if (url.includes(`/projects/${PID}/integrations/test`) && method === 'POST') {
 			return ok({ ok: true, latency_ms: 5 });
 		}
-		if (url.endsWith('/api/v1/projects') && method === 'GET') {
+		if (
+			(url.endsWith('/api/v1/projects') || url.includes('/api/v1/projects?')) &&
+			method === 'GET'
+		) {
+			if (pagedProjects && sourceProject) {
+				return url.includes('cursor=')
+					? ok({
+							items: [{ id: sourceProject.id, name: sourceProject.name }],
+							next_cursor: null,
+						})
+					: ok({ items: [{ id: PID, name: 'Demo' }], next_cursor: 'page-2' });
+			}
 			const items = [
 				{ id: PID, name: 'Demo' },
 				...(sourceProject ? [{ id: sourceProject.id, name: sourceProject.name }] : []),
@@ -158,6 +175,7 @@ function makeFetch({
 			return ok({ items, next_cursor: null });
 		}
 		if (sourceProject && url.endsWith(`/projects/${sourceProject.id}`) && method === 'GET') {
+			if (slowRole) await new Promise((resolve) => setTimeout(resolve, 50));
 			return ok({
 				id: sourceProject.id,
 				name: sourceProject.name,
@@ -651,6 +669,32 @@ describe('ProjectIntegrationsDialog — import from another project', () => {
 				name: 'analytics-db',
 			});
 		});
+	});
+
+	it('offers projects from every /projects page, not just the first', async () => {
+		const user = userEvent.setup();
+		setup({}, { kinds: [postgresKind], entries: [], sourceProject: SOURCE, pagedProjects: true });
+		await openImport(user);
+		expect(await screen.findByTestId('import-source-row')).toBeInTheDocument();
+	});
+
+	it('never shows the pick/submit form before the source role resolves', async () => {
+		const user = userEvent.setup();
+		setup(
+			{},
+			{
+				kinds: [postgresKind],
+				entries: [],
+				sourceProject: { ...SOURCE, your_role: 'viewer' },
+				slowRole: true,
+			},
+		);
+		await openImport(user);
+		// While the role check is in flight, nothing selectable renders…
+		expect(screen.queryByTestId('import-source-row')).not.toBeInTheDocument();
+		// …and a viewer lands on the explanation, never a submittable form.
+		expect(await screen.findByText(/on both projects/)).toBeInTheDocument();
+		expect(screen.queryByTestId('import-source-row')).not.toBeInTheDocument();
 	});
 
 	it('explains that admin is required on the source project', async () => {

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
@@ -622,7 +622,10 @@ function ImportView({
 	const projectsQuery = useProjectPickerQuery(true);
 	const sourceProject = useProjectRoleQuery(sourcePid);
 	const isSourceAdmin = sourceProject.data?.your_role === 'admin';
-	const entriesQuery = useIntegrationsQuery({ pid: sourcePid ?? '' }, Boolean(sourcePid));
+	// Entries (and with them the pick/submit form) wait for a RESOLVED admin
+	// role — otherwise a viewer could select and submit before the role check
+	// lands and get a failed POST instead of the explanation below.
+	const entriesQuery = useIntegrationsQuery({ pid: sourcePid ?? '' }, isSourceAdmin);
 	const importIntegration = useImportIntegration(pid);
 	const kindsByName = new Map(kinds.map((kind) => [kind.kind, kind]));
 
@@ -689,7 +692,7 @@ function ImportView({
 				</p>
 			) : sourcePid && (entriesQuery.isError || sourceProject.isError) ? (
 				<p className="text-destructive">Could not load that project's integrations.</p>
-			) : sourcePid && entriesQuery.data !== undefined ? (
+			) : sourcePid && isSourceAdmin && entriesQuery.data !== undefined ? (
 				entries.length === 0 ? (
 					<p className="text-muted-foreground">That project has no integrations of its own.</p>
 				) : (

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
@@ -6,6 +6,7 @@ import {
 	Database,
 	FlaskConical,
 	Flame,
+	FolderInput,
 	HardDrive,
 	Library,
 	Network,
@@ -19,6 +20,7 @@ import {
 } from 'lucide-react';
 import {
 	Button,
+	ComboBox,
 	ConfirmDialog,
 	DialogModal,
 	IconButton,
@@ -36,9 +38,12 @@ import type { JsonSchemaNode, UiHints } from '@/components/form/schema-form';
 import {
 	useCreateIntegration,
 	useDeleteIntegration,
+	useImportIntegration,
 	useIntegrationDetailQuery,
 	useIntegrationKindsQuery,
 	useIntegrationsQuery,
+	useProjectPickerQuery,
+	useProjectRoleQuery,
 	useTestIntegration,
 	useUpdateIntegration,
 } from '@/api/hooks';
@@ -120,6 +125,7 @@ function getKindPresentation(kind: IntegrationKind | undefined) {
 type View =
 	| { mode: 'list' }
 	| { mode: 'catalog' }
+	| { mode: 'import' }
 	| { mode: 'create'; kind: IntegrationKind }
 	| { mode: 'edit'; entry: IntegrationEntry };
 
@@ -179,13 +185,15 @@ function IntegrationsDialog({
 	const title =
 		view.mode === 'catalog'
 			? 'Add integration'
-			: view.mode === 'create'
-				? `Add ${view.kind.title}`
-				: view.mode === 'edit'
-					? `Edit ${view.entry.name}`
-					: scope === 'org'
-						? 'Org integrations'
-						: 'Integrations';
+			: view.mode === 'import'
+				? 'Import integration'
+				: view.mode === 'create'
+					? `Add ${view.kind.title}`
+					: view.mode === 'edit'
+						? `Edit ${view.entry.name}`
+						: scope === 'org'
+							? 'Org integrations'
+							: 'Integrations';
 
 	return (
 		<DialogModal
@@ -199,7 +207,13 @@ function IntegrationsDialog({
 					<button
 						type="button"
 						className="flex w-fit items-center gap-1 rounded-sm text-xs font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-						onClick={() => setView(view.mode === 'create' ? { mode: 'catalog' } : { mode: 'list' })}
+						onClick={() =>
+							setView(
+								view.mode === 'create' || view.mode === 'import'
+									? { mode: 'catalog' }
+									: { mode: 'list' },
+							)
+						}
 					>
 						<ArrowLeft className="size-3.5" aria-hidden />
 						Back
@@ -225,7 +239,16 @@ function IntegrationsDialog({
 						onEdit={(entry) => setView({ mode: 'edit', entry })}
 					/>
 				) : view.mode === 'catalog' ? (
-					<CatalogView kinds={kinds} onPick={(kind) => setView({ mode: 'create', kind })} />
+					<CatalogView
+						kinds={kinds}
+						onPick={(kind) => setView({ mode: 'create', kind })}
+						onImport={scope === 'org' ? undefined : () => setView({ mode: 'import' })}
+					/>
+				) : view.mode === 'import' ? (
+					// Unreachable for the org scope: the catalog never offers Import there.
+					scope !== 'org' ? (
+						<ImportView pid={scope.pid} kinds={kinds} onDone={() => setView({ mode: 'list' })} />
+					) : null
 				) : view.mode === 'create' ? (
 					<EditorView scope={scope} kind={view.kind} onDone={() => setView({ mode: 'list' })} />
 				) : (
@@ -447,9 +470,11 @@ function ListView({
 function CatalogView({
 	kinds,
 	onPick,
+	onImport,
 }: {
 	kinds: IntegrationKind[];
 	onPick: (kind: IntegrationKind) => void;
+	onImport?: () => void;
 }) {
 	const [query, setQuery] = useState('');
 	const [category, setCategory] = useState<'all' | IntegrationCategory>('all');
@@ -470,7 +495,7 @@ function CatalogView({
 	return (
 		<>
 			<div className="flex flex-col gap-3 border-b pb-4">
-				<div>
+				<div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
 					<SearchField
 						aria-label="Search integration catalog"
 						placeholder="Search by name, category, or package…"
@@ -478,6 +503,12 @@ function CatalogView({
 						onChange={setQuery}
 						className="w-full sm:max-w-md"
 					/>
+					{onImport && (
+						<Button variant="ghost" onPress={onImport} className="shrink-0">
+							<FolderInput className="size-4" aria-hidden />
+							Import from another project
+						</Button>
+					)}
 				</div>
 				<fieldset className="flex flex-wrap gap-2">
 					<legend className="sr-only">Filter integration categories</legend>
@@ -571,6 +602,164 @@ function CatalogView({
 				</ul>
 			)}
 		</>
+	);
+}
+
+function ImportView({
+	pid,
+	kinds,
+	onDone,
+}: {
+	pid: string;
+	kinds: IntegrationKind[];
+	onDone: () => void;
+}) {
+	const [projectInput, setProjectInput] = useState('');
+	const [sourcePid, setSourcePid] = useState<string>();
+	const [sourceEntry, setSourceEntry] = useState<IntegrationEntry>();
+	const [name, setName] = useState('');
+	const [nameError, setNameError] = useState<string>();
+	const projectsQuery = useProjectPickerQuery(true);
+	const sourceProject = useProjectRoleQuery(sourcePid);
+	const isSourceAdmin = sourceProject.data?.your_role === 'admin';
+	const entriesQuery = useIntegrationsQuery({ pid: sourcePid ?? '' }, Boolean(sourcePid));
+	const importIntegration = useImportIntegration(pid);
+	const kindsByName = new Map(kinds.map((kind) => [kind.kind, kind]));
+
+	const projectOptions = (projectsQuery.data ?? [])
+		.filter((p) => p.id !== pid)
+		.filter((p) => p.name.toLowerCase().includes(projectInput.trim().toLowerCase()))
+		.map((p) => ({ id: p.id, textValue: p.name }));
+
+	// Only the source project's own instances: inherited org entries already
+	// reach the destination through inheritance.
+	const entries = (entriesQuery.data ?? []).filter((e) => e.scope !== 'org');
+
+	const pickProject = (id: string) => {
+		setSourcePid(id);
+		setSourceEntry(undefined);
+		setProjectInput(projectsQuery.data?.find((p) => p.id === id)?.name ?? id);
+	};
+
+	const submit = async () => {
+		if (!sourcePid || !sourceEntry) return;
+		const trimmed = name.trim();
+		if (!NAME_RE.test(trimmed)) {
+			setNameError('Lowercase letters, digits, and hyphens; starting with a letter.');
+			return;
+		}
+		setNameError(undefined);
+		try {
+			await importIntegration.mutateAsync({
+				source_project_id: sourcePid,
+				source_integration_id: sourceEntry.id,
+				name: trimmed,
+			});
+			toast.success(`Imported ${trimmed}`);
+			onDone();
+		} catch (err) {
+			toastError(err);
+		}
+	};
+
+	return (
+		<div className="flex flex-col gap-4">
+			<p className="max-w-3xl text-muted-foreground">
+				Copy an integration's current config from a project you administer. Secrets are re-encrypted
+				for this project; the copy starts its own version history.
+			</p>
+			<ComboBox
+				label="Source project"
+				placeholder="Search projects…"
+				inputValue={projectInput}
+				onInputChange={(value) => {
+					setProjectInput(value);
+					setSourcePid(undefined);
+					setSourceEntry(undefined);
+				}}
+				options={projectOptions}
+				onSelect={pickProject}
+				renderOption={(option) => <span className="truncate text-sm">{option.textValue}</span>}
+				emptyState="No matching projects"
+			/>
+
+			{sourcePid && sourceProject.data && !isSourceAdmin ? (
+				<p className="text-muted-foreground">
+					You need the <code>admin</code> role on both projects to import an integration.
+				</p>
+			) : sourcePid && (entriesQuery.isError || sourceProject.isError) ? (
+				<p className="text-destructive">Could not load that project's integrations.</p>
+			) : sourcePid && entriesQuery.data !== undefined ? (
+				entries.length === 0 ? (
+					<p className="text-muted-foreground">That project has no integrations of its own.</p>
+				) : (
+					<fieldset className="flex flex-col gap-2">
+						<legend className="pb-1 text-xs font-medium text-muted-foreground">
+							Integration to copy
+						</legend>
+						<ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+							{entries.map((entry) => {
+								const kind = kindsByName.get(entry.kind);
+								const presentation = getKindPresentation(kind);
+								const { Icon } = presentation;
+								const selected = sourceEntry?.id === entry.id;
+								return (
+									<li key={entry.id}>
+										<button
+											type="button"
+											data-testid="import-source-row"
+											aria-pressed={selected}
+											onClick={() => {
+												setSourceEntry(entry);
+												setName(entry.name);
+												setNameError(undefined);
+											}}
+											className={`flex w-full items-center gap-3 rounded-xl border bg-card p-3 text-left shadow-xs transition-colors hover:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${selected ? 'border-primary/40 ring-1 ring-primary/30' : 'border-input'}`}
+										>
+											<span
+												className={`flex size-9 shrink-0 items-center justify-center rounded-lg ${presentation.iconClassName}`}
+											>
+												<Icon className="size-4.5" aria-hidden />
+											</span>
+											<span className="flex min-w-0 flex-col">
+												<code className="truncate text-xs font-medium">{entry.name}</code>
+												<span className="truncate text-xs text-muted-foreground">
+													{kind?.title ?? entry.kind}
+												</span>
+											</span>
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+					</fieldset>
+				)
+			) : sourcePid ? (
+				<Skeleton className="h-16" />
+			) : null}
+
+			{sourceEntry && (
+				<form
+					className="flex flex-col gap-4 border-t pt-4"
+					onSubmit={(e) => {
+						e.preventDefault();
+						void submit();
+					}}
+				>
+					<TextField
+						label="Name in this project"
+						value={name}
+						onChange={setName}
+						error={nameError}
+					/>
+					<div className="flex justify-end">
+						<Button type="submit" variant="primary" isDisabled={importIntegration.isPending}>
+							{importIntegration.isPending ? 'Importing…' : 'Import integration'}
+						</Button>
+					</div>
+				</form>
+			)}
+		</div>
 	);
 }
 

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
@@ -671,20 +671,27 @@ function ImportView({
 				Copy an integration's current config from a project you administer. Secrets are re-encrypted
 				for this project; the copy starts its own version history.
 			</p>
-			<ComboBox
-				label="Source project"
-				placeholder="Search projects…"
-				inputValue={projectInput}
-				onInputChange={(value) => {
-					setProjectInput(value);
-					setSourcePid(undefined);
-					setSourceEntry(undefined);
-				}}
-				options={projectOptions}
-				onSelect={pickProject}
-				renderOption={(option) => <span className="truncate text-sm">{option.textValue}</span>}
-				emptyState="No matching projects"
-			/>
+			{/* An errored roster must not masquerade as "no matching projects". */}
+			{projectsQuery.isError ? (
+				<p className="text-destructive">Could not load the project list. Go back and retry.</p>
+			) : (
+				<ComboBox
+					label="Source project"
+					placeholder="Search projects…"
+					inputValue={projectInput}
+					onInputChange={(value) => {
+						setProjectInput(value);
+						setSourcePid(undefined);
+						setSourceEntry(undefined);
+					}}
+					options={projectOptions}
+					onSelect={pickProject}
+					renderOption={(option) => <span className="truncate text-sm">{option.textValue}</span>}
+					emptyState={
+						projectsQuery.data === undefined ? 'Loading projects…' : 'No matching projects'
+					}
+				/>
+			)}
 
 			{sourcePid && sourceProject.data && !isSourceAdmin ? (
 				<p className="text-muted-foreground">


### PR DESCRIPTION
Adds `POST /projects/{pid}/integrations/import`: copy another project's integration — current config, secrets included — into this project as a new integration with a fresh version history.

## How it works

- **Server-side re-seal.** Secret envelopes are cryptographically bound to their head path, so a byte copy could never decrypt and a client-driven GET+POST is impossible (reads always redact). The store decrypts under the source scope and re-seals via the existing `create` saga under the destination. Plaintext exists only in that frame — tests prove the copy outlives source deletion and that source/copy evolve independently.
- **Authz: admin of both projects.** Destination checked first (its 404/403 can't confirm the source exists). A super admin qualifies everywhere via `effectiveRole`.
- **Audit.** `integration.import` event on the destination with `source_project_id`/`source_integration_id`, plus an auto `change_note` on the copy naming its source.
- **UI.** "Import from another project" in the add-integration catalog (project dialogs only): project picker → admin-role check → source integration picker → optional rename → import. Inherited org entries are excluded from the source list — they reach the destination through inheritance already.

## Notes

- Name conflicts answer the usual 422; the rename option resolves them.
- No new records or env vars — the copy is an ordinary project integration; provenance lives in the audit trail.
- Follow-up left open: importing an org integration into a project as a pre-filled override (same seam, org source scope).

Tests: core (re-seal independence, rename/conflict, 404s, missing-KEK), API (both-admins matrix incl. editor-on-source refusal and super-admin pass, redaction, events), web (full import flow, non-admin source message, no import entry in the org dialog).