### PR TITLE
feat(schemas): committed bucket/integration specs with oasdiff breaking-change CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Breaking-change allowlists suppress the schemas CI gate, so changes to them
+# require a maintainer's review rather than riding along in the same PR.
+/internal/schemas/allowed-breaking/ @mscolnick

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -1,0 +1,72 @@
+name: Schemas
+
+# Breaking-change gate for the committed specs (see internal/schemas/README.md).
+# Freshness is enforced by the drift tests in `vp run -r test`; this job only
+# diffs each spec against the base branch. Vetted breaks are allowlisted per
+# spec in internal/schemas/allowed-breaking/.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/api/openapi.yaml'
+      - 'internal/schemas/**'
+      - '.github/workflows/schemas.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  breaking:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch --no-tags --depth=1 origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+      # Single static binary, checksum-pinned like the SHA-pinned actions above.
+      - name: Install oasdiff
+        env:
+          OASDIFF_VERSION: 1.27.0
+          OASDIFF_SHA256: 335de79be8df706735f7ab3edc35186e853c8add93d489d67e4e7fd70a07d08a
+        run: |
+          curl -fsSL -o /tmp/oasdiff.tar.gz "https://github.com/oasdiff/oasdiff/releases/download/v${OASDIFF_VERSION}/oasdiff_${OASDIFF_VERSION}_linux_amd64.tar.gz"
+          echo "${OASDIFF_SHA256}  /tmp/oasdiff.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/oasdiff.tar.gz -C /tmp oasdiff
+          sudo install /tmp/oasdiff /usr/local/bin/oasdiff
+      - name: Diff specs against base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          base="origin/$BASE_REF"
+          failed=0
+          for entry in \
+            'packages/api/openapi.yaml api' \
+            'internal/schemas/bucket.yml bucket' \
+            'internal/schemas/integrations.yml integrations'
+          do
+            spec="${entry% *}"
+            name="${entry#* }"
+            if ! git cat-file -e "$base:$spec" 2>/dev/null; then
+              echo "::notice file=$spec::no $base baseline yet; skipping breaking-change check"
+              continue
+            fi
+            if git diff --quiet "$base" -- "$spec"; then
+              continue
+            fi
+            git show "$base:$spec" > "/tmp/base-$name.yml"
+            ignore=()
+            allow="internal/schemas/allowed-breaking/$name.md"
+            if [ -f "$allow" ]; then
+              ignore=(--err-ignore "$allow" --warn-ignore "$allow")
+            fi
+            {
+              echo "## \`$spec\`"
+              oasdiff changelog "/tmp/base-$name.yml" "$spec" --format markdown
+            } >> "$GITHUB_STEP_SUMMARY"
+            oasdiff breaking "/tmp/base-$name.yml" "$spec" \
+              --fail-on ERR --format githubactions "${ignore[@]}" || failed=1
+          done
+          exit "$failed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,11 @@ the only places concrete adapters are imported. **Reject PRs that violate this**
   exception: routes serving raw content (e.g. the notebook HTML snapshot at
   `GET …/notebooks/{nid}/html`) return the bytes directly on success; their
   errors still use the envelope.
+- **Committed specs.** `packages/api/openapi.yaml` and
+  `internal/schemas/{bucket,integrations}.yml` are generated from the zod
+  schemas; drift tests fail the build when they are stale. Regenerate with
+  `pnpm schemas:generate`. CI diffs each spec against `main` with oasdiff and
+  fails on breaking changes. See `internal/schemas/README.md`.
 - **Frontend** (`packages/web`) is a React 19 SPA using Tailwind v4
   (`@tailwindcss/vite`) with shadcn-style UI (`class-variance-authority`,
   `clsx`, `tailwind-merge`, `lucide-react`, `sonner`) plus

--- a/internal/schemas/README.md
+++ b/internal/schemas/README.md
@@ -1,0 +1,58 @@
+# Committed schema specs
+
+OpenAPI 3.1 renderings of marimohub's persisted-data and API contracts,
+committed so every contract change shows up in review as a plain-text diff and
+CI can flag the breaking ones.
+
+| Spec                                                                 | Contract                                  | Generated from                                             |
+| -------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------- |
+| [`bucket.yml`](./bucket.yml)                                         | Every JSON object persisted in the bucket | zod schemas in `packages/core/src/schema.ts` + `paths.ts`  |
+| [`integrations.yml`](./integrations.yml)                             | Every integration kind's config schema    | `defaultRegistry()` (`core/…/services/integrations/kinds`) |
+| [`../../packages/api/openapi.yaml`](../../packages/api/openapi.yaml) | The HTTP API                              | `@hono/zod-openapi` routes in `packages/api`               |
+
+The API spec stays in `packages/api` (it is published at `/openapi.yaml` and
+feeds `@marimo-hub/client` codegen) but is covered by the same CI gate.
+
+## Regenerating
+
+```sh
+pnpm schemas:generate
+```
+
+Never edit the yml files by hand. Drift tests
+(`packages/core/src/specs/internal-schemas.spec.test.ts` and
+`packages/api/src/openapi.spec.test.ts`) fail the build when a committed spec
+no longer matches the code, so a schema change cannot land without its spec
+diff.
+
+## How bucket.yml and integrations.yml are modeled
+
+These are not HTTP APIs — OpenAPI is used as a diffable schema container:
+
+- Each bucket object (or integration kind) is a path whose template is derived
+  from `paths.ts`. **GET** models what readers must accept; **PUT** models
+  what writers produce. Both reference one component schema, so oasdiff's
+  breaking-change rules map onto stored-data compatibility in both directions:
+  removing or narrowing a field breaks readers (GET), and a new required
+  field invalidates already-stored objects (PUT).
+- Schemas use zod's input io, matching what `parseStored` accepts (defaulted
+  fields stay optional).
+- `x-mutability`/`x-owner` mirror the write-ownership invariants in CLAUDE.md.
+  `x-secret-paths` tracks where secret envelopes live; moving one requires a
+  decrypt-and-reseal migration.
+- Each integration kind is its own path: retiring a kind is breaking, adding
+  one is additive.
+
+## Breaking-change CI
+
+`.github/workflows/schemas.yml` runs on PRs touching any spec. For each spec
+that differs from the base branch it posts an oasdiff changelog to the job
+summary and fails on error-level breaking changes
+(`oasdiff breaking --fail-on ERR`).
+
+To land a vetted breaking change, add a line to the matching file in
+[`allowed-breaking/`](./allowed-breaking). A line suppresses a finding when it
+contains both the endpoint (e.g. `GET /example/{id}`) and the finding's
+description text, backticks included. Remove the line once the PR merges —
+the finding disappears from the new baseline, and a stale entry would mask a
+future accidental break.

--- a/internal/schemas/README.md
+++ b/internal/schemas/README.md
@@ -37,7 +37,7 @@ These are not HTTP APIs — OpenAPI is used as a diffable schema container:
   field invalidates already-stored objects (PUT).
 - Schemas use zod's input io, matching what `parseStored` accepts (defaulted
   fields stay optional).
-- `x-mutability`/`x-owner` mirror the write-ownership invariants in CLAUDE.md.
+- `x-mutability`/`x-owner` mirror the write-ownership invariants in AGENTS.md.
   `x-secret-paths` tracks where secret envelopes live; moving one requires a
   decrypt-and-reseal migration.
 - Each integration kind is its own path: retiring a kind is breaking, adding

--- a/internal/schemas/allowed-breaking/api.md
+++ b/internal/schemas/allowed-breaking/api.md
@@ -1,0 +1,5 @@
+# Allowed breaking changes — packages/api/openapi.yaml
+
+One line per accepted finding: the endpoint plus the finding's description,
+backticks included (format details in `../README.md`). Remove entries after
+the PR merges — a stale entry masks future accidental breaks.

--- a/internal/schemas/allowed-breaking/bucket.md
+++ b/internal/schemas/allowed-breaking/bucket.md
@@ -1,0 +1,9 @@
+# Allowed breaking changes — internal/schemas/bucket.yml
+
+One line per accepted finding: the endpoint plus the finding's description,
+backticks included (format details in `../README.md`). Remove entries after
+the PR merges — a stale entry masks future accidental breaks.
+
+A break here means already-stored bucket objects stop parsing or readers lose
+required fields — allowlist one only with a migration or upgrade seam in place
+(see development_docs/migrations.md).

--- a/internal/schemas/allowed-breaking/integrations.md
+++ b/internal/schemas/allowed-breaking/integrations.md
@@ -1,0 +1,9 @@
+# Allowed breaking changes — internal/schemas/integrations.yml
+
+One line per accepted finding: the endpoint plus the finding's description,
+backticks included (format details in `../README.md`). Remove entries after
+the PR merges — a stale entry masks future accidental breaks.
+
+A break here means stored integration configs stop validating, or a secret
+path moved — the latter always needs a decrypt-and-reseal migration (bump the
+kind's `schemaVersion` and add a `migrate` step).

--- a/internal/schemas/bucket.yml
+++ b/internal/schemas/bucket.yml
@@ -1,0 +1,1703 @@
+openapi: 3.1.0
+info:
+  title: marimohub bucket objects
+  version: 1.0.0
+  description: |-
+    Machine-checkable description of every JSON object marimohub persists in
+    its storage bucket, generated from the zod schemas in
+    `packages/core/src/schema.ts` and the key templates in
+    `packages/core/src/paths.ts`. This is not an HTTP API: paths are bucket
+    key templates, GET models what readers must accept, PUT models what
+    writers produce. `x-mutability`/`x-owner` mirror the write-ownership
+    invariants in CLAUDE.md and development_docs/bucket_spec.md.
+
+    Deliberately excluded (no zod schema; internal operational records or
+    non-JSON artifacts): idempotency records, integration name claims,
+    reconcile orphan markers, advisory locks, and version/workspace file
+    artifacts (notebook.py, pyproject.toml, notebook.html, session.json,
+    README.md, workspace files).
+tags:
+  - name: catalog
+    description: Catalog pointer and snapshots (`_system/`)
+  - name: project
+    description: Per-project records (`projects/{pid}/`)
+  - name: notebook
+    description: Per-notebook records
+  - name: integration
+    description: Project- and org-scoped integration records
+  - name: session
+    description: Session records and sandbox claims
+  - name: auth
+    description: Identities and personal access tokens
+  - name: ops
+    description: Operational records
+paths:
+  /_system/catalog.json:
+    summary: The one mutable pointer in the catalog snapshot chain.
+    parameters: []
+    x-mutability: cas
+    x-owner: CatalogService.mutateSnapshot
+    get:
+      operationId: read_system_catalog_json
+      summary: Read Catalog
+      tags:
+        - catalog
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Catalog'
+    put:
+      operationId: write_system_catalog_json
+      summary: Write Catalog
+      tags:
+        - catalog
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Catalog'
+      responses:
+        '204':
+          description: Stored.
+  /_system/snapshots/{snapshot_id}.json:
+    summary: Immutable full-catalog snapshot addressed by the catalog pointer.
+    parameters:
+      - name: snapshot_id
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: immutable
+    get:
+      operationId: read_system_snapshots_json
+      summary: Read Snapshot
+      tags:
+        - catalog
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Snapshot'
+    put:
+      operationId: write_system_snapshots_json
+      summary: Write Snapshot
+      tags:
+        - catalog
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Snapshot'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/project.json:
+    summary: 'Project record: members, federation opt-in, status.'
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: last-writer-wins
+    get:
+      operationId: read_projects_project_json
+      summary: Read Project
+      tags:
+        - project
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+    put:
+      operationId: write_projects_project_json
+      summary: Write Project
+      tags:
+        - project
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Project'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/secrets/{name}.json:
+    summary: 'Project-scoped secret: an external reference or an encrypted managed
+      value.'
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: last-writer-wins
+    get:
+      operationId: read_projects_secrets_json
+      summary: Read StoredSecret
+      tags:
+        - project
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StoredSecret'
+    put:
+      operationId: write_projects_secrets_json
+      summary: Write StoredSecret
+      tags:
+        - project
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StoredSecret'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/notebooks/{nid}/meta.json:
+    summary: Notebook metadata record.
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: nid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: last-writer-wins
+    get:
+      operationId: read_projects_notebooks_meta_json
+      summary: Read NotebookMeta
+      tags:
+        - notebook
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotebookMeta'
+    put:
+      operationId: write_projects_notebooks_meta_json
+      summary: Write NotebookMeta
+      tags:
+        - notebook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotebookMeta'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/notebooks/{nid}/source.json:
+    summary: 'Notebook source descriptor: local head pointer or git-sync state.'
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: nid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: last-writer-wins
+    get:
+      operationId: read_projects_notebooks_source_json
+      summary: Read Source
+      tags:
+        - notebook
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Source'
+    put:
+      operationId: write_projects_notebooks_source_json
+      summary: Write Source
+      tags:
+        - notebook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Source'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/notebooks/{nid}/versions/{vid}/version.json:
+    summary: Immutable saved-version record beside the version folder.
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: nid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: vid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: immutable
+    get:
+      operationId: read_projects_notebooks_versions_version_json
+      summary: Read Version
+      tags:
+        - notebook
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Version'
+    put:
+      operationId: write_projects_notebooks_versions_version_json
+      summary: Write Version
+      tags:
+        - notebook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Version'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/notebooks/{nid}/fs_snapshot.json:
+    summary: Pointer to the notebook’s current provider-native filesystem snapshot.
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: nid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: last-writer-wins
+    get:
+      operationId: read_projects_notebooks_fs_snapshot_json
+      summary: Read FsSnapshot
+      tags:
+        - notebook
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FsSnapshot'
+    put:
+      operationId: write_projects_notebooks_fs_snapshot_json
+      summary: Write FsSnapshot
+      tags:
+        - notebook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FsSnapshot'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/notebooks/{nid}/integration_sync_token.json:
+    summary: Hashed push-sync token for a git-synced notebook.
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: nid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: last-writer-wins
+    get:
+      operationId: read_projects_notebooks_integration_sync_token_json
+      summary: Read SyncTokenRecord
+      tags:
+        - notebook
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyncTokenRecord'
+    put:
+      operationId: write_projects_notebooks_integration_sync_token_json
+      summary: Write SyncTokenRecord
+      tags:
+        - notebook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyncTokenRecord'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/integrations/{iid}/integration.json:
+    summary: 'Project integration head: kind, name, enabled, current_version pointer.'
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: iid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: cas
+    x-owner: ProjectIntegrationsStore
+    get:
+      operationId: read_projects_integrations_integration_json
+      summary: Read IntegrationRecord
+      tags:
+        - integration
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationRecord'
+    put:
+      operationId: write_projects_integrations_integration_json
+      summary: Write IntegrationRecord
+      tags:
+        - integration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationRecord'
+      responses:
+        '204':
+          description: Stored.
+  /projects/{pid}/integrations/{iid}/versions/{n}.json:
+    summary: Immutable integration config revision (secret fields sealed as envelopes).
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: iid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: n
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: immutable
+    get:
+      operationId: read_projects_integrations_versions_json
+      summary: Read IntegrationVersionRecord
+      tags:
+        - integration
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationVersionRecord'
+    put:
+      operationId: write_projects_integrations_versions_json
+      summary: Write IntegrationVersionRecord
+      tags:
+        - integration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationVersionRecord'
+      responses:
+        '204':
+          description: Stored.
+  /_system/integrations/{iid}/integration.json:
+    summary: Org integration head, inherited by every project.
+    parameters:
+      - name: iid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: cas
+    x-owner: OrgIntegrationsStore
+    get:
+      operationId: read_system_integrations_integration_json
+      summary: Read IntegrationRecord
+      tags:
+        - integration
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationRecord'
+    put:
+      operationId: write_system_integrations_integration_json
+      summary: Write IntegrationRecord
+      tags:
+        - integration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationRecord'
+      responses:
+        '204':
+          description: Stored.
+  /_system/integrations/{iid}/versions/{n}.json:
+    summary: Immutable org integration config revision.
+    parameters:
+      - name: iid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: n
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: immutable
+    get:
+      operationId: read_system_integrations_versions_json
+      summary: Read IntegrationVersionRecord
+      tags:
+        - integration
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IntegrationVersionRecord'
+    put:
+      operationId: write_system_integrations_versions_json
+      summary: Write IntegrationVersionRecord
+      tags:
+        - integration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationVersionRecord'
+      responses:
+        '204':
+          description: Stored.
+  /_system/sessions/{pid}/{sid}.json:
+    summary: Session lifecycle record, partitioned by project.
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: sid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: cas
+    x-owner: SessionService
+    get:
+      operationId: read_system_sessions_json
+      summary: Read Session
+      tags:
+        - session
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+    put:
+      operationId: write_system_sessions_json
+      summary: Write Session
+      tags:
+        - session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Session'
+      responses:
+        '204':
+          description: Stored.
+  /_system/apps/{pid}/{nid}.json:
+    summary: Per-notebook app-sandbox singleton claim.
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: nid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: cas
+    x-owner: SessionService.claimApp/releaseApp
+    get:
+      operationId: read_system_apps_json
+      summary: Read AppClaim
+      tags:
+        - session
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppClaim'
+    put:
+      operationId: write_system_apps_json
+      summary: Write AppClaim
+      tags:
+        - session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AppClaim'
+      responses:
+        '204':
+          description: Stored.
+  /_system/editors/{pid}/{nid}.json:
+    summary: Per-notebook editor claim, including takeover transfer state.
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: nid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: cas
+    x-owner: SessionService
+    get:
+      operationId: read_system_editors_json
+      summary: Read EditorClaim
+      tags:
+        - session
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EditorClaim'
+    put:
+      operationId: write_system_editors_json
+      summary: Write EditorClaim
+      tags:
+        - session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EditorClaim'
+      responses:
+        '204':
+          description: Stored.
+  /_system/identities/{uid}.json:
+    summary: User directory record mapping the auth sub to its display identity.
+    parameters:
+      - name: uid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: last-writer-wins
+    get:
+      operationId: read_system_identities_json
+      summary: Read Identity
+      tags:
+        - auth
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Identity'
+    put:
+      operationId: write_system_identities_json
+      summary: Write Identity
+      tags:
+        - auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Identity'
+      responses:
+        '204':
+          description: Stored.
+  /_system/tokens/{tid}.json:
+    summary: Personal access token record (hash only; the secret never lands here).
+    parameters:
+      - name: tid
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: last-writer-wins
+    get:
+      operationId: read_system_tokens_json
+      summary: Read Token
+      tags:
+        - auth
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Token'
+    put:
+      operationId: write_system_tokens_json
+      summary: Write Token
+      tags:
+        - auth
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Token'
+      responses:
+        '204':
+          description: Stored.
+  /_system/events/{date}/{id}.json:
+    summary: Append-only audit event.
+    parameters:
+      - name: date
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: append-only
+    get:
+      operationId: read_system_events_json
+      summary: Read Event
+      tags:
+        - ops
+      responses:
+        '200':
+          description: The stored object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+    put:
+      operationId: write_system_events_json
+      summary: Write Event
+      tags:
+        - ops
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Event'
+      responses:
+        '204':
+          description: Stored.
+components:
+  schemas:
+    Catalog:
+      type: object
+      properties:
+        version:
+          type: number
+          const: 1
+        updated_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        current_snapshot_id:
+          type: string
+        current_snapshot_key:
+          type: string
+        previous_snapshot_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+      required:
+        - version
+        - updated_at
+        - current_snapshot_id
+        - current_snapshot_key
+        - previous_snapshot_id
+    Snapshot:
+      type: object
+      properties:
+        snapshot_id:
+          type: string
+        schema_version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        created_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        operation:
+          type: string
+        actor:
+          type: string
+        projects:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              description:
+                type: string
+              owner:
+                type: string
+              status:
+                default: active
+                type: string
+                enum:
+                  - active
+                  - deleted
+              created_at:
+                type: string
+                format: date-time
+                pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+              updated_at:
+                type: string
+                format: date-time
+                pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+              notebook_count:
+                type: integer
+                minimum: 0
+                maximum: 9007199254740991
+              notebooks:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    title:
+                      type: string
+                    description:
+                      type: string
+                    status:
+                      type: string
+                      enum:
+                        - draft
+                        - active
+                        - archived
+                        - deleted
+                    source_type:
+                      type: string
+                      enum:
+                        - local
+                        - git
+                    author:
+                      type: string
+                    created_at:
+                      type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+                    updated_at:
+                      type: string
+                      format: date-time
+                      pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+                    tags:
+                      type: array
+                      items:
+                        type: string
+                    last_run_at:
+                      anyOf:
+                        - type: string
+                          format: date-time
+                          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+                        - type: 'null'
+                    compute_profile:
+                      type: string
+                    key_prefix:
+                      type: string
+                  required:
+                    - id
+                    - title
+                    - description
+                    - status
+                    - source_type
+                    - author
+                    - created_at
+                    - updated_at
+                    - tags
+                    - last_run_at
+                    - key_prefix
+                  additionalProperties: {}
+              member_ids:
+                type: array
+                items:
+                  type: string
+              member_emails:
+                type: array
+                items:
+                  type: string
+            required:
+              - id
+              - name
+              - description
+              - owner
+              - created_at
+              - updated_at
+              - notebook_count
+              - notebooks
+            additionalProperties: {}
+      required:
+        - snapshot_id
+        - schema_version
+        - created_at
+        - operation
+        - actor
+        - projects
+      additionalProperties: {}
+    Project:
+      type: object
+      properties:
+        schema_version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        owner:
+          type: string
+        members:
+          type: array
+          items:
+            type: object
+            properties:
+              user_id:
+                type: string
+              email:
+                type: string
+              role:
+                type: string
+                enum:
+                  - admin
+                  - editor
+                  - viewer
+            required:
+              - role
+        federation:
+          type: object
+          properties:
+            enabled:
+              type: boolean
+            target:
+              type: string
+          required:
+            - enabled
+        status:
+          default: active
+          type: string
+          enum:
+            - active
+            - deleted
+        created_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updated_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        tags:
+          type: array
+          items:
+            type: string
+      required:
+        - schema_version
+        - id
+        - name
+        - description
+        - owner
+        - members
+        - created_at
+        - updated_at
+        - tags
+    StoredSecret:
+      oneOf:
+        - type: object
+          properties:
+            kind:
+              type: string
+              const: reference
+            backend:
+              type: string
+            locator:
+              type: string
+            expand:
+              type: string
+              const: json
+            prefix:
+              type: string
+            name:
+              type: string
+            created_by:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            updated_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+          required:
+            - kind
+            - backend
+            - locator
+            - name
+            - created_by
+            - created_at
+            - updated_at
+        - type: object
+          properties:
+            kind:
+              type: string
+              const: managed
+            envelope:
+              type: object
+              properties:
+                kek_id:
+                  type: string
+                alg:
+                  type: string
+                  const: A256GCM
+                iv:
+                  type: string
+                ciphertext:
+                  type: string
+              required:
+                - kek_id
+                - alg
+                - iv
+                - ciphertext
+            name:
+              type: string
+            created_by:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            updated_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+          required:
+            - kind
+            - envelope
+            - name
+            - created_by
+            - created_at
+            - updated_at
+    NotebookMeta:
+      type: object
+      properties:
+        schema_version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        id:
+          type: string
+        project_id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        status:
+          type: string
+          enum:
+            - draft
+            - active
+            - archived
+            - deleted
+        author:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updated_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        last_run_at:
+          anyOf:
+            - type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            - type: 'null'
+        tags:
+          type: array
+          items:
+            type: string
+        runtime:
+          type: object
+          properties:
+            python_version:
+              type: string
+            marimo_version:
+              type: string
+        base_image:
+          type: string
+        compute_profile:
+          type: string
+      required:
+        - schema_version
+        - id
+        - project_id
+        - title
+        - description
+        - status
+        - author
+        - created_at
+        - updated_at
+        - last_run_at
+        - tags
+    Source:
+      oneOf:
+        - type: object
+          properties:
+            schema_version:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            type:
+              type: string
+              const: local
+            current_version_id:
+              type: string
+          required:
+            - schema_version
+            - type
+            - current_version_id
+        - type: object
+          properties:
+            schema_version:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            type:
+              type: string
+              const: git
+            provider:
+              type: string
+              const: github
+            repo:
+              type: string
+            branch:
+              type: string
+            root_path:
+              type: string
+            entry_notebook:
+              type: string
+            pending_config:
+              type: object
+              properties:
+                repo:
+                  type: string
+                branch:
+                  type: string
+                root_path:
+                  type: string
+                entry_notebook:
+                  type: string
+              required:
+                - repo
+                - branch
+                - root_path
+                - entry_notebook
+            sync_mode:
+              type: string
+              const: push
+            current_version_id:
+              anyOf:
+                - type: string
+                - type: 'null'
+            commit:
+              anyOf:
+                - type: string
+                - type: 'null'
+            last_synced_at:
+              anyOf:
+                - type: string
+                  format: date-time
+                  pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+                - type: 'null'
+          required:
+            - schema_version
+            - type
+            - provider
+            - repo
+            - branch
+            - root_path
+            - entry_notebook
+            - sync_mode
+            - current_version_id
+            - commit
+            - last_synced_at
+    Version:
+      type: object
+      properties:
+        schema_version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        version_id:
+          type: string
+        notebook_id:
+          type: string
+        saved_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        author:
+          type: string
+        message:
+          type: string
+        parent_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+        html_snapshot:
+          type: object
+          properties:
+            captured_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            size_bytes:
+              type: integer
+              minimum: 0
+              maximum: 9007199254740991
+          required:
+            - captured_at
+            - size_bytes
+        session_snapshot:
+          type: object
+          properties:
+            captured_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            size_bytes:
+              type: integer
+              minimum: 0
+              maximum: 9007199254740991
+          required:
+            - captured_at
+            - size_bytes
+        commit:
+          type: string
+      required:
+        - schema_version
+        - version_id
+        - notebook_id
+        - saved_at
+        - author
+        - message
+        - parent_id
+    FsSnapshot:
+      type: object
+      properties:
+        snapshot_id:
+          type: string
+        captured_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        size_bytes:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        compute_profile:
+          type: string
+        compute_resources:
+          type: object
+          properties:
+            cpu:
+              type: number
+            memory_bytes:
+              type: number
+        owner_user_id:
+          type: string
+      required:
+        - snapshot_id
+        - captured_at
+    SyncTokenRecord:
+      type: object
+      properties:
+        schema_version:
+          type: number
+          const: 1
+        token_sha256:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+      required:
+        - schema_version
+        - token_sha256
+        - created_at
+    IntegrationRecord:
+      type: object
+      properties:
+        id:
+          type: string
+        project_id:
+          type: string
+        kind:
+          type: string
+        name:
+          type: string
+        enabled:
+          type: boolean
+        current_version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        updated_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+      required:
+        - id
+        - kind
+        - name
+        - enabled
+        - current_version
+        - created_by
+        - created_at
+        - updated_at
+      additionalProperties: {}
+    IntegrationVersionRecord:
+      type: object
+      properties:
+        schema_version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        kind:
+          type: string
+        kind_schema_version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        config:
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties: {}
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        change_note:
+          type: string
+      required:
+        - schema_version
+        - version
+        - kind
+        - kind_schema_version
+        - config
+        - created_by
+        - created_at
+    Session:
+      type: object
+      properties:
+        session_id:
+          type: string
+        notebook_id:
+          type: string
+        project_id:
+          type: string
+        user_id:
+          type: string
+        status:
+          type: string
+          enum:
+            - starting
+            - running
+            - terminating
+            - terminated
+            - failed
+            - expired
+        started_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        last_heartbeat:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        expires_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        last_snapshot_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        sandbox_reclaimed_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        takeover_capture_completed_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        ephemeral:
+          type: boolean
+        editor_sandbox_sharing:
+          type: string
+          enum:
+            - shared
+            - exclusive
+        ended_reason:
+          type: string
+          enum:
+            - takeover
+        ended_by_user_id:
+          type: string
+        mode:
+          type: string
+          enum:
+            - edit
+            - app
+        source_version_id:
+          type: string
+        active_connections:
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        connections_checked_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        runtime:
+          type: object
+          properties:
+            python_version:
+              type: string
+            marimo_version:
+              type: string
+        sandbox_id:
+          type: string
+        sandbox_url:
+          type: string
+        compute_profile:
+          type: string
+        compute_resources:
+          type: object
+          properties:
+            cpu:
+              type: number
+            memory_bytes:
+              type: number
+        compute_from_snapshot:
+          type: boolean
+        sandbox_origin_url:
+          type: string
+        used_fallback:
+          type: boolean
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+          required:
+            - code
+            - message
+        integrations:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+              kind:
+                type: string
+              version:
+                type: integer
+                exclusiveMinimum: 0
+                maximum: 9007199254740991
+            required:
+              - id
+              - name
+              - kind
+              - version
+      required:
+        - session_id
+        - notebook_id
+        - project_id
+        - user_id
+        - status
+        - started_at
+        - last_heartbeat
+      additionalProperties: {}
+    AppClaim:
+      type: object
+      properties:
+        session_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+        claimed_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+      required:
+        - session_id
+        - claimed_at
+    EditorClaim:
+      type: object
+      properties:
+        session_id:
+          anyOf:
+            - type: string
+            - type: 'null'
+        sharing:
+          type: string
+          enum:
+            - shared
+            - exclusive
+        claimed_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        transfer:
+          type: object
+          properties:
+            takeover_id:
+              type: string
+              minLength: 1
+              maxLength: 255
+            requested_by:
+              type: string
+            expected_activity:
+              type: string
+              enum:
+                - active
+                - idle
+                - unknown
+                - starting
+            phase:
+              type: string
+              enum:
+                - requested
+                - draining
+                - ready
+            requested_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            drain_lease_id:
+              type: string
+              minLength: 1
+              maxLength: 255
+            drain_lease_expires_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            drain_lease_stage:
+              type: string
+              enum:
+                - capturing
+                - snapshotting
+                - destroying
+                - finalizing
+            drain_lease_progress_deadline_at:
+              type: string
+              format: date-time
+              pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+            replacement_session_id:
+              type: string
+          required:
+            - takeover_id
+            - requested_by
+            - expected_activity
+            - phase
+            - requested_at
+          additionalProperties: {}
+      required:
+        - session_id
+        - sharing
+        - claimed_at
+      additionalProperties: {}
+    Identity:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+      required:
+        - id
+        - email
+        - name
+        - updated_at
+    Token:
+      type: object
+      properties:
+        id:
+          type: string
+        user_id:
+          type: string
+        name:
+          type: string
+        hash:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        expires_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        last_used_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+      required:
+        - id
+        - user_id
+        - name
+        - hash
+        - created_at
+      additionalProperties: {}
+    Event:
+      type: object
+      properties:
+        schema_version:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        ts:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        event:
+          type: string
+        actor:
+          type: string
+      required:
+        - schema_version
+        - ts
+        - event
+        - actor
+      additionalProperties: {}

--- a/internal/schemas/bucket.yml
+++ b/internal/schemas/bucket.yml
@@ -9,7 +9,7 @@ info:
     `packages/core/src/paths.ts`. This is not an HTTP API: paths are bucket
     key templates, GET models what readers must accept, PUT models what
     writers produce. `x-mutability`/`x-owner` mirror the write-ownership
-    invariants in CLAUDE.md and development_docs/bucket_spec.md.
+    invariants in AGENTS.md and development_docs/bucket_spec.md.
 
     Deliberately excluded (no zod schema; internal operational records or
     non-JSON artifacts): idempotency records, integration name claims,

--- a/internal/schemas/integrations.yml
+++ b/internal/schemas/integrations.yml
@@ -1,0 +1,3619 @@
+openapi: 3.1.0
+info:
+  title: marimohub integration kinds
+  version: 1.0.0
+  description: |-
+    Machine-checkable description of every integration kind registered in
+    `defaultRegistry()` (`packages/core/src/services/integrations/kinds/`),
+    generated from each kind’s zod config schema (input io, so defaulted
+    fields stay optional). This is not an HTTP API: each path stands for a
+    kind, and its component schema is the config contract stored in
+    `versions/{n}.json` records and rendered into sandboxes.
+paths:
+  /kinds/custom_env/config:
+    summary: Custom environment
+    description: Inject arbitrary environment variables — plain or secret — into
+      every session.
+    x-kind-schema-version: 1
+    x-category: other
+    x-secret-paths:
+      - secrets.*.value
+    x-supports-test: false
+    x-requirements: []
+    get:
+      operationId: read_custom_env_config
+      summary: Stored custom_env config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/custom_env'
+    put:
+      operationId: write_custom_env_config
+      summary: Input custom_env config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/custom_env'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/iceberg_bigquery/config:
+    summary: Iceberg BigQuery Metastore Catalog
+    description: Use Google BigQuery as the Iceberg metastore.
+    x-kind-schema-version: 1
+    x-category: catalog
+    x-secret-paths:
+      - credentials.credentials_json
+      - storage.credentials.access_key_id
+      - storage.credentials.secret_access_key
+      - storage.credentials.session_token
+      - storage.auth.token
+      - storage.auth.connection_string
+      - storage.auth.account_key
+      - storage.auth.sas_token
+      - storage.auth.client_secret
+      - storage.auth.credential
+      - storage.token
+    x-supports-test: false
+    x-requirements:
+      - pyiceberg[pyarrow,bigquery,gcsfs,s3fs,adlfs,hf]>=0.11
+    get:
+      operationId: read_iceberg_bigquery_config
+      summary: Stored iceberg_bigquery config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/iceberg_bigquery'
+    put:
+      operationId: write_iceberg_bigquery_config
+      summary: Input iceberg_bigquery config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iceberg_bigquery'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/iceberg_dynamodb/config:
+    summary: Iceberg DynamoDB Catalog
+    description: Use an AWS DynamoDB table as the Iceberg catalog.
+    x-kind-schema-version: 1
+    x-category: catalog
+    x-secret-paths:
+      - credentials.access_key_id
+      - credentials.secret_access_key
+      - credentials.session_token
+      - unified_credentials.access_key_id
+      - unified_credentials.secret_access_key
+      - unified_credentials.session_token
+      - storage.credentials.access_key_id
+      - storage.credentials.secret_access_key
+      - storage.credentials.session_token
+      - storage.auth.token
+      - storage.auth.connection_string
+      - storage.auth.account_key
+      - storage.auth.sas_token
+      - storage.auth.client_secret
+      - storage.auth.credential
+      - storage.token
+    x-supports-test: false
+    x-requirements:
+      - pyiceberg[pyarrow,dynamodb,s3fs,gcsfs,adlfs,hf]>=0.11
+    get:
+      operationId: read_iceberg_dynamodb_config
+      summary: Stored iceberg_dynamodb config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/iceberg_dynamodb'
+    put:
+      operationId: write_iceberg_dynamodb_config
+      summary: Input iceberg_dynamodb config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iceberg_dynamodb'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/iceberg_glue/config:
+    summary: Iceberg AWS Glue Catalog
+    description: Use AWS Glue as the Iceberg metastore with ambient, profile, or
+      static credentials.
+    x-kind-schema-version: 1
+    x-category: catalog
+    x-secret-paths:
+      - credentials.access_key_id
+      - credentials.secret_access_key
+      - credentials.session_token
+      - unified_credentials.access_key_id
+      - unified_credentials.secret_access_key
+      - unified_credentials.session_token
+      - storage.credentials.access_key_id
+      - storage.credentials.secret_access_key
+      - storage.credentials.session_token
+      - storage.auth.token
+      - storage.auth.connection_string
+      - storage.auth.account_key
+      - storage.auth.sas_token
+      - storage.auth.client_secret
+      - storage.auth.credential
+      - storage.token
+    x-supports-test: false
+    x-requirements:
+      - pyiceberg[pyarrow,glue,s3fs,gcsfs,adlfs,hf]>=0.11
+    get:
+      operationId: read_iceberg_glue_config
+      summary: Stored iceberg_glue config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/iceberg_glue'
+    put:
+      operationId: write_iceberg_glue_config
+      summary: Input iceberg_glue config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iceberg_glue'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/iceberg_hive/config:
+    summary: Iceberg Hive Catalog
+    description: Connect PyIceberg to a Hive Metastore over Thrift.
+    x-kind-schema-version: 1
+    x-category: catalog
+    x-secret-paths:
+      - ugi
+      - storage.credentials.access_key_id
+      - storage.credentials.secret_access_key
+      - storage.credentials.session_token
+      - storage.auth.token
+      - storage.auth.connection_string
+      - storage.auth.account_key
+      - storage.auth.sas_token
+      - storage.auth.client_secret
+      - storage.auth.credential
+      - storage.token
+    x-supports-test: false
+    x-requirements:
+      - pyiceberg[pyarrow,hive,hive-kerberos,s3fs,gcsfs,adlfs,hf]>=0.11
+    get:
+      operationId: read_iceberg_hive_config
+      summary: Stored iceberg_hive config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/iceberg_hive'
+    put:
+      operationId: write_iceberg_hive_config
+      summary: Input iceberg_hive config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iceberg_hive'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/iceberg_rest/config:
+    summary: Iceberg REST Catalog
+    description: Connect to an Iceberg REST catalog such as Polaris, Unity,
+      Gravitino, or Glue.
+    x-kind-schema-version: 2
+    x-category: catalog
+    x-secret-paths:
+      - auth.token
+      - auth.password
+      - auth.client_secret
+      - auth.credentials_json
+      - storage.credentials.access_key_id
+      - storage.credentials.secret_access_key
+      - storage.credentials.session_token
+      - storage.auth.token
+      - storage.auth.connection_string
+      - storage.auth.account_key
+      - storage.auth.sas_token
+      - storage.auth.client_secret
+      - storage.auth.credential
+      - storage.token
+      - tls.client_key
+    x-supports-test: true
+    x-requirements:
+      - pyiceberg[pyarrow,s3fs,gcsfs,adlfs,hf,rest-sigv4,gcp-auth,entra-auth]>=0.11
+    get:
+      operationId: read_iceberg_rest_config
+      summary: Stored iceberg_rest config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/iceberg_rest'
+    put:
+      operationId: write_iceberg_rest_config
+      summary: Input iceberg_rest config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iceberg_rest'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/iceberg_sql/config:
+    summary: Iceberg SQL Catalog
+    description: Store Iceberg catalog metadata in PostgreSQL or SQLite through SQLAlchemy.
+    x-kind-schema-version: 1
+    x-category: catalog
+    x-secret-paths:
+      - uri
+      - storage.credentials.access_key_id
+      - storage.credentials.secret_access_key
+      - storage.credentials.session_token
+      - storage.auth.token
+      - storage.auth.connection_string
+      - storage.auth.account_key
+      - storage.auth.sas_token
+      - storage.auth.client_secret
+      - storage.auth.credential
+      - storage.token
+    x-supports-test: false
+    x-requirements:
+      - pyiceberg[pyarrow,sql-postgres,sql-sqlite,s3fs,gcsfs,adlfs,hf]>=0.11
+    get:
+      operationId: read_iceberg_sql_config
+      summary: Stored iceberg_sql config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/iceberg_sql'
+    put:
+      operationId: write_iceberg_sql_config
+      summary: Input iceberg_sql config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/iceberg_sql'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/postgres/config:
+    summary: PostgreSQL
+    description: Direct Postgres connection for SQL cells and SQLAlchemy.
+    x-kind-schema-version: 2
+    x-category: database
+    x-secret-paths:
+      - password
+    x-supports-test: false
+    x-requirements:
+      - sqlalchemy>=2
+      - psycopg2-binary>=2.9
+    get:
+      operationId: read_postgres_config
+      summary: Stored postgres config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/postgres'
+    put:
+      operationId: write_postgres_config
+      summary: Input postgres config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/postgres'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/pyspark/config:
+    summary: PySpark (Spark Connect)
+    description: Remote PySpark DataFrame sessions over Spark Connect.
+    x-kind-schema-version: 1
+    x-category: engine
+    x-secret-paths:
+      - auth.token
+      - metadata.*.value
+      - secret_spark_config.*.value
+    x-supports-test: false
+    x-requirements:
+      - pyspark[connect]>=4.2
+    get:
+      operationId: read_pyspark_config
+      summary: Stored pyspark config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pyspark'
+    put:
+      operationId: write_pyspark_config
+      summary: Input pyspark config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/pyspark'
+      responses:
+        '204':
+          description: Accepted.
+  /kinds/trino/config:
+    summary: Trino
+    description: Trino DBAPI and SQLAlchemy connection with authentication and
+      session options.
+    x-kind-schema-version: 2
+    x-category: engine
+    x-secret-paths:
+      - auth.password
+      - auth.token
+      - auth.client_key
+      - http_headers.*.value
+      - extra_credentials.*.value
+    x-supports-test: true
+    x-requirements:
+      - trino[sqlalchemy,kerberos,gssapi]>=0.330
+    get:
+      operationId: read_trino_config
+      summary: Stored trino config
+      responses:
+        '200':
+          description: A stored config every reader and migration must accept.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/trino'
+    put:
+      operationId: write_trino_config
+      summary: Input trino config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/trino'
+      responses:
+        '204':
+          description: Accepted.
+components:
+  schemas:
+    custom_env:
+      type: object
+      properties:
+        vars:
+          default: {}
+          description: Plain environment variables, visible to project admins
+          type: object
+          propertyNames:
+            type: string
+            pattern: ^[A-Z_][A-Z0-9_]*$
+          additionalProperties:
+            type: string
+        secrets:
+          default: []
+          description: Secret environment variables, write-only after save
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                pattern: ^[A-Z_][A-Z0-9_]*$
+              value:
+                type: string
+                minLength: 1
+                x-marimohub-secret: true
+            required:
+              - name
+              - value
+    iceberg_bigquery:
+      type: object
+      properties:
+        project_id:
+          type: string
+          minLength: 1
+        location:
+          type: string
+          minLength: 1
+        warehouse:
+          type: string
+          minLength: 1
+        credentials:
+          default:
+            method: ambient
+          oneOf:
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: ambient
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: service_account_json
+                credentials_json:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - credentials_json
+        storage:
+          default:
+            scheme: catalog
+          oneOf:
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: catalog
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: s3
+                region:
+                  type: string
+                  minLength: 1
+                endpoint:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                credentials:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: static
+                        access_key_id:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        secret_access_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        session_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - access_key_id
+                        - secret_access_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: profile
+                        profile_name:
+                          type: string
+                          minLength: 1
+                      required:
+                        - method
+                        - profile_name
+                role_arn:
+                  type: string
+                  minLength: 1
+                role_session_name:
+                  type: string
+                  minLength: 1
+                signer:
+                  type: string
+                  minLength: 1
+                signer_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                signer_endpoint:
+                  type: string
+                  minLength: 1
+                resolve_region:
+                  default: false
+                  type: boolean
+                proxy_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                connect_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                request_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                force_virtual_addressing:
+                  default: false
+                  type: boolean
+                anonymous:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: gcs
+                project_id:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: oauth_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        token_expires_at_ms:
+                          type: integer
+                          exclusiveMinimum: 0
+                          maximum: 9007199254740991
+                      required:
+                        - method
+                        - token
+                access:
+                  default: full_control
+                  type: string
+                  enum:
+                    - read_only
+                    - read_write
+                    - full_control
+                consistency:
+                  default: none
+                  type: string
+                  enum:
+                    - none
+                    - size
+                    - md5
+                cache_timeout:
+                  type: number
+                  minimum: 0
+                requester_pays:
+                  default: false
+                  type: boolean
+                session_kwargs:
+                  default: {}
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: string
+                service_host:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                default_location:
+                  type: string
+                  minLength: 1
+                version_aware:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: adls
+                account_name:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: connection_string
+                        connection_string:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - connection_string
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: account_key
+                        account_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - account_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: sas_token
+                        sas_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - sas_token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: service_principal
+                        tenant_id:
+                          type: string
+                          minLength: 1
+                        client_id:
+                          type: string
+                          minLength: 1
+                        client_secret:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - tenant_id
+                        - client_id
+                        - client_secret
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: access_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: credential
+                        credential:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - credential
+                account_host:
+                  type: string
+                  minLength: 1
+                blob_storage_authority:
+                  type: string
+                  minLength: 1
+                dfs_storage_authority:
+                  type: string
+                  minLength: 1
+                blob_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+                dfs_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hdfs
+                host:
+                  type: string
+                  minLength: 1
+                port:
+                  default: 8020
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 65535
+                user:
+                  type: string
+                  minLength: 1
+                kerberos_ticket:
+                  type: string
+                  minLength: 1
+              required:
+                - scheme
+                - host
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hugging_face
+                endpoint:
+                  default: https://huggingface.co
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - scheme
+        runtime:
+          default: {}
+          type: object
+          properties:
+            max_workers:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            legacy_current_snapshot_id:
+              type: boolean
+            downcast_ns_timestamp_to_us_on_write:
+              type: boolean
+            pyarrow_use_large_types_on_read:
+              type: boolean
+        extra_properties:
+          default: {}
+          description: Raw PyIceberg catalog properties not represented by typed fields
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+      required:
+        - project_id
+        - warehouse
+    iceberg_dynamodb:
+      type: object
+      properties:
+        table_name:
+          default: iceberg
+          type: string
+          minLength: 1
+        warehouse:
+          type: string
+          minLength: 1
+        region:
+          type: string
+          minLength: 1
+        credentials:
+          default:
+            method: ambient
+          oneOf:
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: ambient
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: static
+                access_key_id:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                secret_access_key:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                session_token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - access_key_id
+                - secret_access_key
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: profile
+                profile_name:
+                  type: string
+                  minLength: 1
+              required:
+                - method
+                - profile_name
+        unified_credentials:
+          default:
+            method: none
+          oneOf:
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: none
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: static
+                region:
+                  type: string
+                  minLength: 1
+                access_key_id:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                secret_access_key:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                session_token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - access_key_id
+                - secret_access_key
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: profile
+                region:
+                  type: string
+                  minLength: 1
+                profile_name:
+                  type: string
+                  minLength: 1
+              required:
+                - method
+                - profile_name
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: role
+                region:
+                  type: string
+                  minLength: 1
+                role_arn:
+                  type: string
+                  minLength: 1
+                role_session_name:
+                  type: string
+                  minLength: 1
+              required:
+                - method
+                - role_arn
+        storage:
+          default:
+            scheme: catalog
+          oneOf:
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: catalog
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: s3
+                region:
+                  type: string
+                  minLength: 1
+                endpoint:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                credentials:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: static
+                        access_key_id:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        secret_access_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        session_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - access_key_id
+                        - secret_access_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: profile
+                        profile_name:
+                          type: string
+                          minLength: 1
+                      required:
+                        - method
+                        - profile_name
+                role_arn:
+                  type: string
+                  minLength: 1
+                role_session_name:
+                  type: string
+                  minLength: 1
+                signer:
+                  type: string
+                  minLength: 1
+                signer_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                signer_endpoint:
+                  type: string
+                  minLength: 1
+                resolve_region:
+                  default: false
+                  type: boolean
+                proxy_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                connect_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                request_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                force_virtual_addressing:
+                  default: false
+                  type: boolean
+                anonymous:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: gcs
+                project_id:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: oauth_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        token_expires_at_ms:
+                          type: integer
+                          exclusiveMinimum: 0
+                          maximum: 9007199254740991
+                      required:
+                        - method
+                        - token
+                access:
+                  default: full_control
+                  type: string
+                  enum:
+                    - read_only
+                    - read_write
+                    - full_control
+                consistency:
+                  default: none
+                  type: string
+                  enum:
+                    - none
+                    - size
+                    - md5
+                cache_timeout:
+                  type: number
+                  minimum: 0
+                requester_pays:
+                  default: false
+                  type: boolean
+                session_kwargs:
+                  default: {}
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: string
+                service_host:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                default_location:
+                  type: string
+                  minLength: 1
+                version_aware:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: adls
+                account_name:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: connection_string
+                        connection_string:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - connection_string
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: account_key
+                        account_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - account_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: sas_token
+                        sas_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - sas_token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: service_principal
+                        tenant_id:
+                          type: string
+                          minLength: 1
+                        client_id:
+                          type: string
+                          minLength: 1
+                        client_secret:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - tenant_id
+                        - client_id
+                        - client_secret
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: access_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: credential
+                        credential:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - credential
+                account_host:
+                  type: string
+                  minLength: 1
+                blob_storage_authority:
+                  type: string
+                  minLength: 1
+                dfs_storage_authority:
+                  type: string
+                  minLength: 1
+                blob_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+                dfs_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hdfs
+                host:
+                  type: string
+                  minLength: 1
+                port:
+                  default: 8020
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 65535
+                user:
+                  type: string
+                  minLength: 1
+                kerberos_ticket:
+                  type: string
+                  minLength: 1
+              required:
+                - scheme
+                - host
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hugging_face
+                endpoint:
+                  default: https://huggingface.co
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - scheme
+        runtime:
+          default: {}
+          type: object
+          properties:
+            max_workers:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            legacy_current_snapshot_id:
+              type: boolean
+            downcast_ns_timestamp_to_us_on_write:
+              type: boolean
+            pyarrow_use_large_types_on_read:
+              type: boolean
+        extra_properties:
+          default: {}
+          description: Raw PyIceberg catalog properties not represented by typed fields
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+    iceberg_glue:
+      type: object
+      properties:
+        warehouse:
+          type: string
+          minLength: 1
+        catalog_id:
+          type: string
+          pattern: ^\d{12}$
+        region:
+          type: string
+          minLength: 1
+        endpoint:
+          type: string
+          pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+        credentials:
+          default:
+            method: ambient
+          oneOf:
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: ambient
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: static
+                access_key_id:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                secret_access_key:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                session_token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - access_key_id
+                - secret_access_key
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: profile
+                profile_name:
+                  type: string
+                  minLength: 1
+              required:
+                - method
+                - profile_name
+        unified_credentials:
+          default:
+            method: none
+          oneOf:
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: none
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: static
+                region:
+                  type: string
+                  minLength: 1
+                access_key_id:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                secret_access_key:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                session_token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - access_key_id
+                - secret_access_key
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: profile
+                region:
+                  type: string
+                  minLength: 1
+                profile_name:
+                  type: string
+                  minLength: 1
+              required:
+                - method
+                - profile_name
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: role
+                region:
+                  type: string
+                  minLength: 1
+                role_arn:
+                  type: string
+                  minLength: 1
+                role_session_name:
+                  type: string
+                  minLength: 1
+              required:
+                - method
+                - role_arn
+        skip_archive:
+          default: true
+          type: boolean
+        max_retries:
+          default: 10
+          type: integer
+          minimum: 0
+          maximum: 9007199254740991
+        retry_mode:
+          default: standard
+          type: string
+          enum:
+            - legacy
+            - standard
+            - adaptive
+        storage:
+          default:
+            scheme: catalog
+          oneOf:
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: catalog
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: s3
+                region:
+                  type: string
+                  minLength: 1
+                endpoint:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                credentials:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: static
+                        access_key_id:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        secret_access_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        session_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - access_key_id
+                        - secret_access_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: profile
+                        profile_name:
+                          type: string
+                          minLength: 1
+                      required:
+                        - method
+                        - profile_name
+                role_arn:
+                  type: string
+                  minLength: 1
+                role_session_name:
+                  type: string
+                  minLength: 1
+                signer:
+                  type: string
+                  minLength: 1
+                signer_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                signer_endpoint:
+                  type: string
+                  minLength: 1
+                resolve_region:
+                  default: false
+                  type: boolean
+                proxy_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                connect_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                request_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                force_virtual_addressing:
+                  default: false
+                  type: boolean
+                anonymous:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: gcs
+                project_id:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: oauth_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        token_expires_at_ms:
+                          type: integer
+                          exclusiveMinimum: 0
+                          maximum: 9007199254740991
+                      required:
+                        - method
+                        - token
+                access:
+                  default: full_control
+                  type: string
+                  enum:
+                    - read_only
+                    - read_write
+                    - full_control
+                consistency:
+                  default: none
+                  type: string
+                  enum:
+                    - none
+                    - size
+                    - md5
+                cache_timeout:
+                  type: number
+                  minimum: 0
+                requester_pays:
+                  default: false
+                  type: boolean
+                session_kwargs:
+                  default: {}
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: string
+                service_host:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                default_location:
+                  type: string
+                  minLength: 1
+                version_aware:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: adls
+                account_name:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: connection_string
+                        connection_string:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - connection_string
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: account_key
+                        account_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - account_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: sas_token
+                        sas_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - sas_token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: service_principal
+                        tenant_id:
+                          type: string
+                          minLength: 1
+                        client_id:
+                          type: string
+                          minLength: 1
+                        client_secret:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - tenant_id
+                        - client_id
+                        - client_secret
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: access_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: credential
+                        credential:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - credential
+                account_host:
+                  type: string
+                  minLength: 1
+                blob_storage_authority:
+                  type: string
+                  minLength: 1
+                dfs_storage_authority:
+                  type: string
+                  minLength: 1
+                blob_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+                dfs_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hdfs
+                host:
+                  type: string
+                  minLength: 1
+                port:
+                  default: 8020
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 65535
+                user:
+                  type: string
+                  minLength: 1
+                kerberos_ticket:
+                  type: string
+                  minLength: 1
+              required:
+                - scheme
+                - host
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hugging_face
+                endpoint:
+                  default: https://huggingface.co
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - scheme
+        runtime:
+          default: {}
+          type: object
+          properties:
+            max_workers:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            legacy_current_snapshot_id:
+              type: boolean
+            downcast_ns_timestamp_to_us_on_write:
+              type: boolean
+            pyarrow_use_large_types_on_read:
+              type: boolean
+        extra_properties:
+          default: {}
+          description: Raw PyIceberg catalog properties not represented by typed fields
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+    iceberg_hive:
+      type: object
+      properties:
+        uri:
+          type: string
+          pattern: ^thrift:\/\/(?![^/?#]*@)\S+$
+        warehouse:
+          type: string
+          minLength: 1
+        hive2_compatible:
+          default: false
+          type: boolean
+        kerberos:
+          default:
+            enabled: false
+            service_name: hive
+          type: object
+          properties:
+            enabled:
+              default: false
+              type: boolean
+            service_name:
+              default: hive
+              type: string
+              minLength: 1
+        ugi:
+          description: Hadoop user/group identity
+          type: string
+          minLength: 1
+          x-marimohub-secret: true
+        storage:
+          default:
+            scheme: catalog
+          oneOf:
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: catalog
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: s3
+                region:
+                  type: string
+                  minLength: 1
+                endpoint:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                credentials:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: static
+                        access_key_id:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        secret_access_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        session_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - access_key_id
+                        - secret_access_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: profile
+                        profile_name:
+                          type: string
+                          minLength: 1
+                      required:
+                        - method
+                        - profile_name
+                role_arn:
+                  type: string
+                  minLength: 1
+                role_session_name:
+                  type: string
+                  minLength: 1
+                signer:
+                  type: string
+                  minLength: 1
+                signer_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                signer_endpoint:
+                  type: string
+                  minLength: 1
+                resolve_region:
+                  default: false
+                  type: boolean
+                proxy_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                connect_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                request_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                force_virtual_addressing:
+                  default: false
+                  type: boolean
+                anonymous:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: gcs
+                project_id:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: oauth_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        token_expires_at_ms:
+                          type: integer
+                          exclusiveMinimum: 0
+                          maximum: 9007199254740991
+                      required:
+                        - method
+                        - token
+                access:
+                  default: full_control
+                  type: string
+                  enum:
+                    - read_only
+                    - read_write
+                    - full_control
+                consistency:
+                  default: none
+                  type: string
+                  enum:
+                    - none
+                    - size
+                    - md5
+                cache_timeout:
+                  type: number
+                  minimum: 0
+                requester_pays:
+                  default: false
+                  type: boolean
+                session_kwargs:
+                  default: {}
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: string
+                service_host:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                default_location:
+                  type: string
+                  minLength: 1
+                version_aware:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: adls
+                account_name:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: connection_string
+                        connection_string:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - connection_string
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: account_key
+                        account_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - account_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: sas_token
+                        sas_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - sas_token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: service_principal
+                        tenant_id:
+                          type: string
+                          minLength: 1
+                        client_id:
+                          type: string
+                          minLength: 1
+                        client_secret:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - tenant_id
+                        - client_id
+                        - client_secret
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: access_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: credential
+                        credential:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - credential
+                account_host:
+                  type: string
+                  minLength: 1
+                blob_storage_authority:
+                  type: string
+                  minLength: 1
+                dfs_storage_authority:
+                  type: string
+                  minLength: 1
+                blob_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+                dfs_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hdfs
+                host:
+                  type: string
+                  minLength: 1
+                port:
+                  default: 8020
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 65535
+                user:
+                  type: string
+                  minLength: 1
+                kerberos_ticket:
+                  type: string
+                  minLength: 1
+              required:
+                - scheme
+                - host
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hugging_face
+                endpoint:
+                  default: https://huggingface.co
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - scheme
+        runtime:
+          default: {}
+          type: object
+          properties:
+            max_workers:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            legacy_current_snapshot_id:
+              type: boolean
+            downcast_ns_timestamp_to_us_on_write:
+              type: boolean
+            pyarrow_use_large_types_on_read:
+              type: boolean
+        extra_properties:
+          default: {}
+          description: Raw PyIceberg catalog properties not represented by typed fields
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+      required:
+        - uri
+    iceberg_rest:
+      type: object
+      properties:
+        uri:
+          type: string
+          pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+          description: REST catalog base URI, e.g. https://catalog.internal/api/catalog
+        warehouse:
+          description: Warehouse name/path if the server hosts several
+          type: string
+        allow_insecure_transport:
+          default: false
+          description: Allow http:// endpoints to carry credentials — local development only
+          type: boolean
+        auth:
+          oneOf:
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: none
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: bearer_token
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - token
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: basic
+                username:
+                  type: string
+                  minLength: 1
+                password:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - username
+                - password
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: oauth2_client_credentials
+                token_endpoint:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                client_id:
+                  type: string
+                  minLength: 1
+                client_secret:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+                scope:
+                  default: catalog
+                  type: string
+                refresh_margin_seconds:
+                  default: 60
+                  type: integer
+                  minimum: 0
+                  maximum: 9007199254740991
+                expires_in_seconds:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 9007199254740991
+              required:
+                - method
+                - token_endpoint
+                - client_id
+                - client_secret
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: sigv4
+                region:
+                  type: string
+                  minLength: 1
+                signing_name:
+                  default: execute-api
+                  type: string
+                  minLength: 1
+              required:
+                - method
+                - region
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: google
+                scopes:
+                  description: Comma-separated OAuth scopes; uses Google ADC
+                  type: string
+                credentials_json:
+                  description: Google service-account JSON
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: entra
+                scopes:
+                  description: Comma-separated OAuth scopes; uses Azure credentials
+                  type: string
+                managed_identity_client_id:
+                  type: string
+                  minLength: 1
+              required:
+                - method
+        storage:
+          default:
+            scheme: catalog
+          oneOf:
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: catalog
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: s3
+                region:
+                  type: string
+                  minLength: 1
+                endpoint:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                credentials:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: static
+                        access_key_id:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        secret_access_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        session_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - access_key_id
+                        - secret_access_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: profile
+                        profile_name:
+                          type: string
+                          minLength: 1
+                      required:
+                        - method
+                        - profile_name
+                role_arn:
+                  type: string
+                  minLength: 1
+                role_session_name:
+                  type: string
+                  minLength: 1
+                signer:
+                  type: string
+                  minLength: 1
+                signer_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                signer_endpoint:
+                  type: string
+                  minLength: 1
+                resolve_region:
+                  default: false
+                  type: boolean
+                proxy_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                connect_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                request_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                force_virtual_addressing:
+                  default: false
+                  type: boolean
+                anonymous:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: gcs
+                project_id:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: oauth_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        token_expires_at_ms:
+                          type: integer
+                          exclusiveMinimum: 0
+                          maximum: 9007199254740991
+                      required:
+                        - method
+                        - token
+                access:
+                  default: full_control
+                  type: string
+                  enum:
+                    - read_only
+                    - read_write
+                    - full_control
+                consistency:
+                  default: none
+                  type: string
+                  enum:
+                    - none
+                    - size
+                    - md5
+                cache_timeout:
+                  type: number
+                  minimum: 0
+                requester_pays:
+                  default: false
+                  type: boolean
+                session_kwargs:
+                  default: {}
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: string
+                service_host:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                default_location:
+                  type: string
+                  minLength: 1
+                version_aware:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: adls
+                account_name:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: connection_string
+                        connection_string:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - connection_string
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: account_key
+                        account_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - account_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: sas_token
+                        sas_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - sas_token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: service_principal
+                        tenant_id:
+                          type: string
+                          minLength: 1
+                        client_id:
+                          type: string
+                          minLength: 1
+                        client_secret:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - tenant_id
+                        - client_id
+                        - client_secret
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: access_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: credential
+                        credential:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - credential
+                account_host:
+                  type: string
+                  minLength: 1
+                blob_storage_authority:
+                  type: string
+                  minLength: 1
+                dfs_storage_authority:
+                  type: string
+                  minLength: 1
+                blob_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+                dfs_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hdfs
+                host:
+                  type: string
+                  minLength: 1
+                port:
+                  default: 8020
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 65535
+                user:
+                  type: string
+                  minLength: 1
+                kerberos_ticket:
+                  type: string
+                  minLength: 1
+              required:
+                - scheme
+                - host
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hugging_face
+                endpoint:
+                  default: https://huggingface.co
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - scheme
+        runtime:
+          default: {}
+          type: object
+          properties:
+            max_workers:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            legacy_current_snapshot_id:
+              type: boolean
+            downcast_ns_timestamp_to_us_on_write:
+              type: boolean
+            pyarrow_use_large_types_on_read:
+              type: boolean
+        access_delegation:
+          default: vended_credentials
+          type: string
+          enum:
+            - none
+            - vended_credentials
+            - remote_signing
+            - both
+        tls:
+          default: {}
+          type: object
+          properties:
+            ca_bundle:
+              type: string
+              minLength: 1
+            client_certificate:
+              type: string
+              minLength: 1
+            client_key:
+              type: string
+              minLength: 1
+              x-marimohub-secret: true
+        rest:
+          default:
+            snapshot_loading_mode: all
+            metrics_reporting_enabled: true
+            view_endpoints_supported: false
+            scan_planning_mode: client
+            namespace_separator: '%1F'
+            table_cache_expire_after_write_ms: 300000
+            table_cache_max_entries: 100
+          type: object
+          properties:
+            snapshot_loading_mode:
+              default: all
+              type: string
+              enum:
+                - all
+                - refs
+            metrics_reporting_enabled:
+              default: true
+              type: boolean
+            page_size:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            view_endpoints_supported:
+              default: false
+              type: boolean
+            scan_planning_mode:
+              default: client
+              type: string
+              enum:
+                - client
+                - server
+            namespace_separator:
+              default: '%1F'
+              type: string
+              minLength: 1
+            table_cache_expire_after_write_ms:
+              default: 300000
+              type: integer
+              minimum: 0
+              maximum: 9007199254740991
+            table_cache_max_entries:
+              default: 100
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+        headers:
+          default: {}
+          description: Additional HTTP headers sent to the REST catalog
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+        extra_properties:
+          default: {}
+          description: Raw PyIceberg catalog properties not represented by typed fields
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+      required:
+        - uri
+        - auth
+    iceberg_sql:
+      type: object
+      properties:
+        uri:
+          type: string
+          minLength: 1
+          x-marimohub-secret: true
+          description: SQLAlchemy URI for PostgreSQL or SQLite
+        warehouse:
+          type: string
+          minLength: 1
+        init_catalog_tables:
+          default: true
+          type: boolean
+        echo:
+          default: false
+          type: boolean
+        pool_pre_ping:
+          default: false
+          type: boolean
+        storage:
+          default:
+            scheme: catalog
+          oneOf:
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: catalog
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: s3
+                region:
+                  type: string
+                  minLength: 1
+                endpoint:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                credentials:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: static
+                        access_key_id:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        secret_access_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        session_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - access_key_id
+                        - secret_access_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: profile
+                        profile_name:
+                          type: string
+                          minLength: 1
+                      required:
+                        - method
+                        - profile_name
+                role_arn:
+                  type: string
+                  minLength: 1
+                role_session_name:
+                  type: string
+                  minLength: 1
+                signer:
+                  type: string
+                  minLength: 1
+                signer_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                signer_endpoint:
+                  type: string
+                  minLength: 1
+                resolve_region:
+                  default: false
+                  type: boolean
+                proxy_uri:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                connect_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                request_timeout:
+                  type: number
+                  exclusiveMinimum: 0
+                force_virtual_addressing:
+                  default: false
+                  type: boolean
+                anonymous:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: gcs
+                project_id:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: oauth_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                        token_expires_at_ms:
+                          type: integer
+                          exclusiveMinimum: 0
+                          maximum: 9007199254740991
+                      required:
+                        - method
+                        - token
+                access:
+                  default: full_control
+                  type: string
+                  enum:
+                    - read_only
+                    - read_write
+                    - full_control
+                consistency:
+                  default: none
+                  type: string
+                  enum:
+                    - none
+                    - size
+                    - md5
+                cache_timeout:
+                  type: number
+                  minimum: 0
+                requester_pays:
+                  default: false
+                  type: boolean
+                session_kwargs:
+                  default: {}
+                  type: object
+                  propertyNames:
+                    type: string
+                  additionalProperties:
+                    type: string
+                service_host:
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                default_location:
+                  type: string
+                  minLength: 1
+                version_aware:
+                  default: false
+                  type: boolean
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: adls
+                account_name:
+                  type: string
+                  minLength: 1
+                auth:
+                  default:
+                    method: ambient
+                  oneOf:
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: ambient
+                      required:
+                        - method
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: connection_string
+                        connection_string:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - connection_string
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: account_key
+                        account_key:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - account_key
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: sas_token
+                        sas_token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - sas_token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: service_principal
+                        tenant_id:
+                          type: string
+                          minLength: 1
+                        client_id:
+                          type: string
+                          minLength: 1
+                        client_secret:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - tenant_id
+                        - client_id
+                        - client_secret
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: access_token
+                        token:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - token
+                    - type: object
+                      properties:
+                        method:
+                          type: string
+                          const: credential
+                        credential:
+                          type: string
+                          minLength: 1
+                          x-marimohub-secret: true
+                      required:
+                        - method
+                        - credential
+                account_host:
+                  type: string
+                  minLength: 1
+                blob_storage_authority:
+                  type: string
+                  minLength: 1
+                dfs_storage_authority:
+                  type: string
+                  minLength: 1
+                blob_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+                dfs_storage_scheme:
+                  default: https
+                  type: string
+                  enum:
+                    - http
+                    - https
+              required:
+                - scheme
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hdfs
+                host:
+                  type: string
+                  minLength: 1
+                port:
+                  default: 8020
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 65535
+                user:
+                  type: string
+                  minLength: 1
+                kerberos_ticket:
+                  type: string
+                  minLength: 1
+              required:
+                - scheme
+                - host
+            - type: object
+              properties:
+                scheme:
+                  type: string
+                  const: hugging_face
+                endpoint:
+                  default: https://huggingface.co
+                  type: string
+                  pattern: ^https?:\/\/(?![^/?#]*@)\S+$
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - scheme
+        runtime:
+          default: {}
+          type: object
+          properties:
+            max_workers:
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            legacy_current_snapshot_id:
+              type: boolean
+            downcast_ns_timestamp_to_us_on_write:
+              type: boolean
+            pyarrow_use_large_types_on_read:
+              type: boolean
+        extra_properties:
+          default: {}
+          description: Raw PyIceberg catalog properties not represented by typed fields
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+      required:
+        - uri
+    postgres:
+      type: object
+      properties:
+        host:
+          type: string
+          pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$|^[0-9A-Fa-f.:]+$
+          description: Server hostname, e.g. db.internal
+        port:
+          default: 5432
+          type: integer
+          minimum: 1
+          maximum: 65535
+        database:
+          type: string
+          minLength: 1
+        username:
+          type: string
+          minLength: 1
+        password:
+          type: string
+          minLength: 1
+          x-marimohub-secret: true
+          description: Password for the database user
+        ssl:
+          default:
+            mode: verify-full
+          description: libpq sslmode; `verify-full` checks the CA chain and the hostname
+          oneOf:
+            - type: object
+              properties:
+                mode:
+                  type: string
+                  const: disable
+              required:
+                - mode
+            - type: object
+              properties:
+                mode:
+                  type: string
+                  const: prefer
+              required:
+                - mode
+            - type: object
+              properties:
+                mode:
+                  type: string
+                  const: require
+              required:
+                - mode
+            - type: object
+              properties:
+                mode:
+                  type: string
+                  const: verify-ca
+                ca_bundle:
+                  description: PEM CA bundle to trust, written into the session
+                  type: string
+                  minLength: 1
+                ca_path:
+                  description: Absolute path to a CA bundle the runtime already ships (default
+                    /etc/ssl/certs/ca-certificates.crt)
+                  type: string
+                  minLength: 1
+              required:
+                - mode
+            - type: object
+              properties:
+                mode:
+                  type: string
+                  const: verify-full
+                ca_bundle:
+                  description: PEM CA bundle to trust, written into the session
+                  type: string
+                  minLength: 1
+                ca_path:
+                  description: Absolute path to a CA bundle the runtime already ships (default
+                    /etc/ssl/certs/ca-certificates.crt)
+                  type: string
+                  minLength: 1
+              required:
+                - mode
+      required:
+        - host
+        - database
+        - username
+        - password
+    pyspark:
+      type: object
+      properties:
+        host:
+          type: string
+          pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+        port:
+          default: 15002
+          type: integer
+          minimum: 1
+          maximum: 65535
+        use_ssl:
+          default: true
+          type: boolean
+        auth:
+          default:
+            method: none
+          oneOf:
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: none
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: token
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - token
+        user_id:
+          type: string
+          minLength: 1
+        user_agent:
+          type: string
+          minLength: 1
+          maxLength: 512
+        app_name:
+          type: string
+          minLength: 1
+        keepalive:
+          default:
+            enabled: true
+            time_ms: 60000
+            timeout_ms: 20000
+            without_calls: true
+          type: object
+          properties:
+            enabled:
+              default: true
+              type: boolean
+            time_ms:
+              default: 60000
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            timeout_ms:
+              default: 20000
+              type: integer
+              exclusiveMinimum: 0
+              maximum: 9007199254740991
+            without_calls:
+              default: true
+              type: boolean
+        metadata:
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                minLength: 1
+              value:
+                type: string
+                minLength: 1
+                x-marimohub-secret: true
+            required:
+              - name
+              - value
+        spark_config:
+          default: {}
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+        secret_spark_config:
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                minLength: 1
+              value:
+                type: string
+                minLength: 1
+                x-marimohub-secret: true
+            required:
+              - name
+              - value
+      required:
+        - host
+    trino:
+      type: object
+      properties:
+        host:
+          type: string
+          pattern: ^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$
+          description: Coordinator hostname, e.g. trino.internal
+        port:
+          default: 443
+          type: integer
+          minimum: 1
+          maximum: 65535
+        http_scheme:
+          default: https
+          type: string
+          enum:
+            - https
+            - http
+        user:
+          description: Query user; defaults to the signed-in user
+          type: string
+          minLength: 1
+        auth:
+          oneOf:
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: none
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: basic
+                username:
+                  type: string
+                  minLength: 1
+                password:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - username
+                - password
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: jwt
+                token:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - token
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: oauth2
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: certificate
+                client_certificate:
+                  type: string
+                  minLength: 1
+                client_key:
+                  type: string
+                  minLength: 1
+                  x-marimohub-secret: true
+              required:
+                - method
+                - client_certificate
+                - client_key
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: kerberos
+                krb5_config:
+                  type: string
+                  minLength: 1
+                service_name:
+                  type: string
+                  minLength: 1
+                mutual_authentication:
+                  default: required
+                  type: string
+                  enum:
+                    - required
+                    - optional
+                    - disabled
+                force_preemptive:
+                  default: false
+                  type: boolean
+                hostname_override:
+                  type: string
+                  minLength: 1
+                sanitize_mutual_error_response:
+                  default: true
+                  type: boolean
+                principal:
+                  type: string
+                  minLength: 1
+                delegate:
+                  default: false
+                  type: boolean
+              required:
+                - method
+            - type: object
+              properties:
+                method:
+                  type: string
+                  const: gssapi
+                krb5_config:
+                  type: string
+                  minLength: 1
+                service_name:
+                  type: string
+                  minLength: 1
+                mutual_authentication:
+                  default: disabled
+                  type: string
+                  enum:
+                    - required
+                    - optional
+                    - disabled
+                force_preemptive:
+                  default: false
+                  type: boolean
+                hostname_override:
+                  type: string
+                  minLength: 1
+                sanitize_mutual_error_response:
+                  default: true
+                  type: boolean
+                principal:
+                  type: string
+                  minLength: 1
+                delegate:
+                  default: false
+                  type: boolean
+              required:
+                - method
+        tls:
+          default:
+            verification: system
+          oneOf:
+            - type: object
+              properties:
+                verification:
+                  type: string
+                  const: system
+              required:
+                - verification
+            - type: object
+              properties:
+                verification:
+                  type: string
+                  const: disabled
+              required:
+                - verification
+            - type: object
+              properties:
+                verification:
+                  type: string
+                  const: custom_ca
+                ca_bundle:
+                  type: string
+                  minLength: 1
+              required:
+                - verification
+                - ca_bundle
+        default_catalog:
+          type: string
+          pattern: ^[A-Za-z0-9_.-]+$
+        default_schema:
+          type: string
+          pattern: ^[A-Za-z0-9_.-]+$
+        source:
+          type: string
+          minLength: 1
+        session_properties:
+          default: {}
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+        roles:
+          default: {}
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+        client_tags:
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              value:
+                type: string
+                minLength: 1
+            required:
+              - value
+        http_headers:
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                minLength: 1
+              value:
+                type: string
+                minLength: 1
+                x-marimohub-secret: true
+            required:
+              - name
+              - value
+        extra_credentials:
+          default: []
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                pattern: ^[A-Za-z0-9_.-]+$
+              value:
+                type: string
+                minLength: 1
+                x-marimohub-secret: true
+            required:
+              - name
+              - value
+        timezone:
+          type: string
+          pattern: ^[A-Za-z0-9_+.-]+(?:\/[A-Za-z0-9_+.-]+)*$
+        encoding:
+          minItems: 1
+          type: array
+          items:
+            type: object
+            properties:
+              value:
+                type: string
+                enum:
+                  - json
+                  - json+lz4
+                  - json+zstd
+            required:
+              - value
+        max_attempts:
+          type: integer
+          exclusiveMinimum: 0
+          maximum: 9007199254740991
+        request_timeout_seconds:
+          type: number
+          exclusiveMinimum: 0
+        heartbeat_interval_seconds:
+          type: number
+          exclusiveMinimum: 0
+        isolation_level:
+          default: AUTOCOMMIT
+          type: string
+          enum:
+            - AUTOCOMMIT
+            - READ_UNCOMMITTED
+            - READ_COMMITTED
+            - REPEATABLE_READ
+            - SERIALIZABLE
+        legacy_primitive_types:
+          default: false
+          type: boolean
+        legacy_prepared_statements:
+          type: boolean
+      required:
+        - host
+        - auth

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"test:coverage:web": "pnpm --filter @marimo-hub/web test --coverage",
 		"audit:prod": "node scripts/audit-production.mjs",
 		"e2e": "pnpm --filter @marimo-hub/e2e e2e",
+		"schemas:generate": "pnpm --filter @marimo-hub/api openapi:generate && pnpm --filter @marimo-hub/core schemas:generate && vp fmt internal/schemas",
 		"build": "vp run -r build",
 		"release": "node scripts/release.mjs",
 		"prepare": "vp config"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
 		"build": "vp pack",
 		"test": "vp test",
 		"check": "vp check",
+		"schemas:generate": "UPDATE_SCHEMAS=1 vp test internal-schemas.spec",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -499,6 +499,49 @@ export const IntegrationVersionRecordSchema = z.object({
 
 export type IntegrationVersionRecord = z.infer<typeof IntegrationVersionRecordSchema>;
 
+// --- Secret ---
+
+// The encrypted box for a `managed` secret value. Mirrors the `SecretEnvelope`
+// port interface (ports/secrets.ts); `AesGcmSecretCodec` is the producer.
+export const SecretEnvelopeSchema = z.object({
+	kek_id: z.string(),
+	alg: z.literal('A256GCM'),
+	/** base64 */
+	iv: z.string(),
+	/** base64 */
+	ciphertext: z.string(),
+});
+
+export type SecretEnvelopeRecord = z.infer<typeof SecretEnvelopeSchema>;
+
+// The stored object at `projects/{pid}/secrets/<name>.json`, discriminated by
+// kind. Written last-writer-wins (no CAS) by `ProjectSecretsStore`, which
+// derives its record type from this schema.
+export const StoredSecretSchema = z.discriminatedUnion('kind', [
+	z.object({
+		kind: z.literal('reference'),
+		backend: z.string(),
+		locator: z.string(),
+		/** `'json'` fans the resolved JSON object out into one env var per key. */
+		expand: z.literal('json').optional(),
+		prefix: z.string().optional(),
+		name: z.string(),
+		created_by: UserIdSchema,
+		created_at: z.iso.datetime(),
+		updated_at: z.iso.datetime(),
+	}),
+	z.object({
+		kind: z.literal('managed'),
+		envelope: SecretEnvelopeSchema,
+		name: z.string(),
+		created_by: UserIdSchema,
+		created_at: z.iso.datetime(),
+		updated_at: z.iso.datetime(),
+	}),
+]);
+
+export type StoredSecret = z.infer<typeof StoredSecretSchema>;
+
 // --- Session ---
 
 // `looseObject` for the same rolling-deploy reason as TokenSchema: every status

--- a/packages/core/src/services/secrets/ProjectSecretsStore.ts
+++ b/packages/core/src/services/secrets/ProjectSecretsStore.ts
@@ -2,7 +2,6 @@ import type { Bucket } from '../../ports/bucket';
 import type {
 	ManagedSecretCodec,
 	SecretEntryMeta,
-	SecretEnvelope,
 	SecretInput,
 	SecretResolver,
 	SecretsProvider,
@@ -12,31 +11,9 @@ import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
 import { ValidationError } from '../../errors';
 import type { ProjectId, UserId } from '../../ids';
 import { paths } from '../../paths';
+import type { StoredSecret } from '../../schema';
 import { listAllObjects } from '../catalog/storage';
 import { assertValidSecretName } from './secretName';
-
-/** The stored object at `projects/{pid}/secrets/<name>.json`, discriminated by kind. */
-type StoredSecret =
-	| {
-			kind: 'reference';
-			backend: string;
-			locator: string;
-			/** `'json'` fans the resolved JSON object out into one env var per key. */
-			expand?: 'json';
-			prefix?: string;
-			name: string;
-			created_by: UserId;
-			created_at: string;
-			updated_at: string;
-	  }
-	| {
-			kind: 'managed';
-			envelope: SecretEnvelope;
-			name: string;
-			created_by: UserId;
-			created_at: string;
-			updated_at: string;
-	  };
 
 export interface ProjectSecretsStoreOptions {
 	bucket: Bucket;

--- a/packages/core/src/specs/bucketSpec.ts
+++ b/packages/core/src/specs/bucketSpec.ts
@@ -1,0 +1,331 @@
+import { z } from 'zod';
+import type {
+	IntegrationId,
+	NotebookId,
+	ProjectId,
+	SessionId,
+	SnapshotId,
+	TokenId,
+	UserId,
+	VersionId,
+} from '../ids';
+import { SyncTokenRecordSchema } from '../integrations/syncedSource';
+import { paths } from '../paths';
+import {
+	AppClaimSchema,
+	CatalogSchema,
+	EditorClaimSchema,
+	EventSchema,
+	FsSnapshotSchema,
+	IdentitySchema,
+	IntegrationRecordSchema,
+	IntegrationVersionRecordSchema,
+	NotebookMetaSchema,
+	ProjectSchema,
+	SessionSchema,
+	SnapshotSchema,
+	SourceSchema,
+	StoredSecretSchema,
+	TokenSchema,
+	VersionSchema,
+} from '../schema';
+
+// Placeholder ids threaded through the real `paths` builders, so the templates
+// cannot drift from paths.ts. The brands are compile-time only; the casts are safe.
+const PID = '{pid}' as ProjectId;
+const NID = '{nid}' as NotebookId;
+const VID = '{vid}' as VersionId;
+const SID = '{sid}' as SessionId;
+const IID = '{iid}' as IntegrationId;
+const TID = '{tid}' as TokenId;
+const UID = '{uid}' as UserId;
+const SNAPSHOT_ID = '{snapshot_id}' as SnapshotId;
+
+// Some path builders encodeURIComponent their segment, which mangles the
+// placeholder braces; restore them.
+const template = (key: string) => key.replaceAll('%7B', '{').replaceAll('%7D', '}');
+
+type Mutability = 'cas' | 'immutable' | 'last-writer-wins' | 'append-only';
+
+interface BucketObject {
+	/** Component name in `components.schemas`. */
+	name: string;
+	/** Bucket key template (no leading slash). */
+	key: string;
+	schema: z.ZodType;
+	summary: string;
+	mutability: Mutability;
+	/** The sole writer, for CAS-managed records (see CLAUDE.md "Key invariant"). */
+	owner?: string;
+	tag: string;
+}
+
+const project = paths.project(PID);
+const notebook = project.notebook(NID);
+const projectIntegration = project.integration(IID);
+const orgIntegration = paths.orgIntegration(IID);
+
+// `version(n)` zero-pads to 6 digits; widen the padded 0 back into a template.
+const integrationVersionTemplate = (key: string) => key.replace('000000', '{n}');
+
+const OBJECTS: BucketObject[] = [
+	{
+		name: 'Catalog',
+		key: paths.catalog,
+		schema: CatalogSchema,
+		summary: 'The one mutable pointer in the catalog snapshot chain.',
+		mutability: 'cas',
+		owner: 'CatalogService.mutateSnapshot',
+		tag: 'catalog',
+	},
+	{
+		name: 'Snapshot',
+		key: paths.snapshot(SNAPSHOT_ID),
+		schema: SnapshotSchema,
+		summary: 'Immutable full-catalog snapshot addressed by the catalog pointer.',
+		mutability: 'immutable',
+		tag: 'catalog',
+	},
+	{
+		name: 'Project',
+		key: project.meta,
+		schema: ProjectSchema,
+		summary: 'Project record: members, federation opt-in, status.',
+		mutability: 'last-writer-wins',
+		tag: 'project',
+	},
+	{
+		name: 'StoredSecret',
+		key: template(project.secret('{name}')),
+		schema: StoredSecretSchema,
+		summary: 'Project-scoped secret: an external reference or an encrypted managed value.',
+		mutability: 'last-writer-wins',
+		tag: 'project',
+	},
+	{
+		name: 'NotebookMeta',
+		key: notebook.meta,
+		schema: NotebookMetaSchema,
+		summary: 'Notebook metadata record.',
+		mutability: 'last-writer-wins',
+		tag: 'notebook',
+	},
+	{
+		name: 'Source',
+		key: notebook.source,
+		schema: SourceSchema,
+		summary: 'Notebook source descriptor: local head pointer or git-sync state.',
+		mutability: 'last-writer-wins',
+		tag: 'notebook',
+	},
+	{
+		name: 'Version',
+		key: notebook.version(VID).meta,
+		schema: VersionSchema,
+		summary: 'Immutable saved-version record beside the version folder.',
+		mutability: 'immutable',
+		tag: 'notebook',
+	},
+	{
+		name: 'FsSnapshot',
+		key: notebook.fsSnapshot,
+		schema: FsSnapshotSchema,
+		summary: 'Pointer to the notebook’s current provider-native filesystem snapshot.',
+		mutability: 'last-writer-wins',
+		tag: 'notebook',
+	},
+	{
+		name: 'SyncTokenRecord',
+		key: notebook.integrationSyncToken,
+		schema: SyncTokenRecordSchema,
+		summary: 'Hashed push-sync token for a git-synced notebook.',
+		mutability: 'last-writer-wins',
+		tag: 'notebook',
+	},
+	{
+		name: 'IntegrationRecord',
+		key: projectIntegration.head,
+		schema: IntegrationRecordSchema,
+		summary: 'Project integration head: kind, name, enabled, current_version pointer.',
+		mutability: 'cas',
+		owner: 'ProjectIntegrationsStore',
+		tag: 'integration',
+	},
+	{
+		name: 'IntegrationVersionRecord',
+		key: integrationVersionTemplate(projectIntegration.version(0)),
+		schema: IntegrationVersionRecordSchema,
+		summary: 'Immutable integration config revision (secret fields sealed as envelopes).',
+		mutability: 'immutable',
+		tag: 'integration',
+	},
+	{
+		name: 'IntegrationRecord',
+		key: orgIntegration.head,
+		schema: IntegrationRecordSchema,
+		summary: 'Org integration head, inherited by every project.',
+		mutability: 'cas',
+		owner: 'OrgIntegrationsStore',
+		tag: 'integration',
+	},
+	{
+		name: 'IntegrationVersionRecord',
+		key: integrationVersionTemplate(orgIntegration.version(0)),
+		schema: IntegrationVersionRecordSchema,
+		summary: 'Immutable org integration config revision.',
+		mutability: 'immutable',
+		tag: 'integration',
+	},
+	{
+		name: 'Session',
+		key: paths.session(PID, SID),
+		schema: SessionSchema,
+		summary: 'Session lifecycle record, partitioned by project.',
+		mutability: 'cas',
+		owner: 'SessionService',
+		tag: 'session',
+	},
+	{
+		name: 'AppClaim',
+		key: paths.appClaim(PID, NID),
+		schema: AppClaimSchema,
+		summary: 'Per-notebook app-sandbox singleton claim.',
+		mutability: 'cas',
+		owner: 'SessionService.claimApp/releaseApp',
+		tag: 'session',
+	},
+	{
+		name: 'EditorClaim',
+		key: paths.editorClaim(PID, NID),
+		schema: EditorClaimSchema,
+		summary: 'Per-notebook editor claim, including takeover transfer state.',
+		mutability: 'cas',
+		owner: 'SessionService',
+		tag: 'session',
+	},
+	{
+		name: 'Identity',
+		key: template(paths.identity(UID)),
+		schema: IdentitySchema,
+		summary: 'User directory record mapping the auth sub to its display identity.',
+		mutability: 'last-writer-wins',
+		tag: 'auth',
+	},
+	{
+		name: 'Token',
+		key: paths.token(TID),
+		schema: TokenSchema,
+		summary: 'Personal access token record (hash only; the secret never lands here).',
+		mutability: 'last-writer-wins',
+		tag: 'auth',
+	},
+	{
+		name: 'Event',
+		key: paths.event('{date}', '{id}'),
+		schema: EventSchema,
+		summary: 'Append-only audit event.',
+		mutability: 'append-only',
+		tag: 'ops',
+	},
+];
+
+function jsonSchema(schema: z.ZodType): Record<string, unknown> {
+	// `io: 'input'` — the stored bytes are what parse must accept, so defaulted
+	// fields stay optional and transforms describe their pre-parse shape.
+	const { $schema: _, ...rest } = z.toJSONSchema(schema, { io: 'input' }) as Record<
+		string,
+		unknown
+	>;
+	return rest;
+}
+
+const pathParams = (key: string) =>
+	[...key.matchAll(/\{([a-z_]+)\}/g)].map(([, name]) => ({
+		name,
+		in: 'path',
+		required: true,
+		schema: { type: 'string' },
+	}));
+
+/**
+ * OpenAPI 3.1 description of every JSON object persisted in the bucket, built
+ * from the same zod schemas the services parse with. Each object is modeled as
+ * a path with a GET (the shape every reader must accept — removing or narrowing
+ * a field is breaking) and a PUT (the shape writers produce — a new required
+ * field invalidates already-stored objects, so it is breaking too). CI diffs
+ * the committed rendering against main with oasdiff.
+ */
+export function buildBucketSpec(): Record<string, unknown> {
+	const specPaths: Record<string, unknown> = {};
+	const schemas: Record<string, unknown> = {};
+
+	for (const obj of OBJECTS) {
+		schemas[obj.name] ??= jsonSchema(obj.schema);
+		const ref = { $ref: `#/components/schemas/${obj.name}` };
+		const opSuffix = obj.key
+			.replaceAll(/\{[a-z_]+\}/g, '')
+			.replaceAll(/[^a-zA-Z0-9]+/g, '_')
+			.replaceAll(/^_+|_+$/g, '');
+		specPaths[`/${obj.key}`] = {
+			summary: obj.summary,
+			parameters: pathParams(obj.key),
+			'x-mutability': obj.mutability,
+			...(obj.owner ? { 'x-owner': obj.owner } : {}),
+			get: {
+				operationId: `read_${opSuffix}`,
+				summary: `Read ${obj.name}`,
+				tags: [obj.tag],
+				responses: {
+					'200': {
+						description: 'The stored object.',
+						content: { 'application/json': { schema: ref } },
+					},
+				},
+			},
+			put: {
+				operationId: `write_${opSuffix}`,
+				summary: `Write ${obj.name}`,
+				tags: [obj.tag],
+				requestBody: {
+					required: true,
+					content: { 'application/json': { schema: ref } },
+				},
+				responses: { '204': { description: 'Stored.' } },
+			},
+		};
+	}
+
+	return {
+		openapi: '3.1.0',
+		info: {
+			title: 'marimohub bucket objects',
+			version: '1.0.0',
+			description: [
+				'Machine-checkable description of every JSON object marimohub persists in',
+				'its storage bucket, generated from the zod schemas in',
+				'`packages/core/src/schema.ts` and the key templates in',
+				'`packages/core/src/paths.ts`. This is not an HTTP API: paths are bucket',
+				'key templates, GET models what readers must accept, PUT models what',
+				'writers produce. `x-mutability`/`x-owner` mirror the write-ownership',
+				'invariants in CLAUDE.md and development_docs/bucket_spec.md.',
+				'',
+				'Deliberately excluded (no zod schema; internal operational records or',
+				'non-JSON artifacts): idempotency records, integration name claims,',
+				'reconcile orphan markers, advisory locks, and version/workspace file',
+				'artifacts (notebook.py, pyproject.toml, notebook.html, session.json,',
+				'README.md, workspace files).',
+			].join('\n'),
+		},
+		tags: [
+			{ name: 'catalog', description: 'Catalog pointer and snapshots (`_system/`)' },
+			{ name: 'project', description: 'Per-project records (`projects/{pid}/`)' },
+			{ name: 'notebook', description: 'Per-notebook records' },
+			{ name: 'integration', description: 'Project- and org-scoped integration records' },
+			{ name: 'session', description: 'Session records and sandbox claims' },
+			{ name: 'auth', description: 'Identities and personal access tokens' },
+			{ name: 'ops', description: 'Operational records' },
+		],
+		paths: specPaths,
+		components: { schemas },
+	};
+}

--- a/packages/core/src/specs/bucketSpec.ts
+++ b/packages/core/src/specs/bucketSpec.ts
@@ -55,7 +55,7 @@ interface BucketObject {
 	schema: z.ZodType;
 	summary: string;
 	mutability: Mutability;
-	/** The sole writer, for CAS-managed records (see CLAUDE.md "Key invariant"). */
+	/** The sole writer, for CAS-managed records (see AGENTS.md "Key invariant"). */
 	owner?: string;
 	tag: string;
 }
@@ -307,7 +307,7 @@ export function buildBucketSpec(): Record<string, unknown> {
 				'`packages/core/src/paths.ts`. This is not an HTTP API: paths are bucket',
 				'key templates, GET models what readers must accept, PUT models what',
 				'writers produce. `x-mutability`/`x-owner` mirror the write-ownership',
-				'invariants in CLAUDE.md and development_docs/bucket_spec.md.',
+				'invariants in AGENTS.md and development_docs/bucket_spec.md.',
 				'',
 				'Deliberately excluded (no zod schema; internal operational records or',
 				'non-JSON artifacts): idempotency records, integration name claims,',

--- a/packages/core/src/specs/integrationsSpec.ts
+++ b/packages/core/src/specs/integrationsSpec.ts
@@ -1,0 +1,70 @@
+import { defaultRegistry } from '../services/integrations/kinds';
+
+/**
+ * OpenAPI 3.1 description of every registered integration kind's config
+ * schema, one literal path per kind: a removed kind diffs as a removed
+ * endpoint (breaking), a new kind as additive. PUT models the input config the
+ * API accepts; GET models what stored configs must still satisfy.
+ * `x-secret-paths` tracks where secret envelopes live — they are
+ * cryptographically bound to their field path, so moving one needs a
+ * decrypt-and-reseal migration.
+ */
+export function buildIntegrationsSpec(): Record<string, unknown> {
+	const registry = defaultRegistry();
+	const descriptors = [...registry.describeAll()].sort((a, b) => a.kind.localeCompare(b.kind));
+
+	const specPaths: Record<string, unknown> = {};
+	const schemas: Record<string, unknown> = {};
+
+	for (const d of descriptors) {
+		const { $schema: _, ...schema } = d.json_schema;
+		schemas[d.kind] = schema;
+		const ref = { $ref: `#/components/schemas/${d.kind}` };
+		specPaths[`/kinds/${d.kind}/config`] = {
+			summary: d.title,
+			description: d.description,
+			'x-kind-schema-version': d.schema_version,
+			'x-category': d.category,
+			'x-secret-paths': registry.secretPathsOf(d.kind).map((p) => p.join('.')),
+			'x-supports-test': d.supports_test,
+			'x-requirements': d.requirements,
+			get: {
+				operationId: `read_${d.kind}_config`,
+				summary: `Stored ${d.kind} config`,
+				responses: {
+					'200': {
+						description: 'A stored config every reader and migration must accept.',
+						content: { 'application/json': { schema: ref } },
+					},
+				},
+			},
+			put: {
+				operationId: `write_${d.kind}_config`,
+				summary: `Input ${d.kind} config`,
+				requestBody: {
+					required: true,
+					content: { 'application/json': { schema: ref } },
+				},
+				responses: { '204': { description: 'Accepted.' } },
+			},
+		};
+	}
+
+	return {
+		openapi: '3.1.0',
+		info: {
+			title: 'marimohub integration kinds',
+			version: '1.0.0',
+			description: [
+				'Machine-checkable description of every integration kind registered in',
+				'`defaultRegistry()` (`packages/core/src/services/integrations/kinds/`),',
+				'generated from each kind’s zod config schema (input io, so defaulted',
+				'fields stay optional). This is not an HTTP API: each path stands for a',
+				'kind, and its component schema is the config contract stored in',
+				'`versions/{n}.json` records and rendered into sandboxes.',
+			].join('\n'),
+		},
+		paths: specPaths,
+		components: { schemas },
+	};
+}

--- a/packages/core/src/specs/internal-schemas.spec.test.ts
+++ b/packages/core/src/specs/internal-schemas.spec.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+import { parse, stringify } from 'yaml';
+import { buildBucketSpec } from './bucketSpec';
+import { buildIntegrationsSpec } from './integrationsSpec';
+
+/**
+ * Generator and drift guard for the committed specs under `internal/schemas/`
+ * (same pattern as the API's openapi.spec.test.ts): UPDATE_SCHEMAS rewrites
+ * the files, otherwise the build fails when they no longer match the zod
+ * schemas they are rendered from.
+ *
+ * Regenerate with:  pnpm schemas:generate
+ */
+const SPECS = [
+	{ file: 'bucket.yml', doc: buildBucketSpec() },
+	{ file: 'integrations.yml', doc: buildIntegrationsSpec() },
+];
+
+const specPath = (file: string) =>
+	fileURLToPath(new URL(`../../../../internal/schemas/${file}`, import.meta.url));
+
+if (process.env.UPDATE_SCHEMAS) {
+	for (const { file, doc } of SPECS) {
+		mkdirSync(dirname(specPath(file)), { recursive: true });
+		// The docs reuse `$ref` objects, which would otherwise serialize as YAML
+		// aliases (`*a1`) — valid, but mishandled by some OpenAPI tooling.
+		writeFileSync(specPath(file), stringify(doc, { aliasDuplicateObjects: false }));
+	}
+}
+
+describe.each(SPECS)('internal/schemas/$file', ({ file, doc }) => {
+	it('is in sync with the zod schemas (run `pnpm schemas:generate` to update)', () => {
+		const committed = parse(readFileSync(specPath(file), 'utf8'));
+		expect(committed).toEqual(doc);
+	});
+
+	// zod emits `#/$defs/…` refs for cyclic schemas; inside an OpenAPI component
+	// such a ref resolves against the document root and dangles. None of our
+	// schemas are cyclic today — if one becomes so, hoist its defs instead.
+	it('is self-contained (no document-root $defs refs)', () => {
+		expect(JSON.stringify(doc)).not.toContain('#/$defs');
+	});
+});


### PR DESCRIPTION
Adds committed, diffable OpenAPI specs for our persisted-data contracts and a CI gate that fails on breaking changes vs \`main\`.

- **\`internal/schemas/bucket.yml\`** — every bucket JSON object, rendered from the zod schemas in \`core/schema.ts\` with path templates derived from \`paths.ts\`. GET = what readers must accept, PUT = what writers produce, so oasdiff flags stored-data breaks in both directions. \`x-mutability\`/\`x-owner\` mirror the CAS-ownership invariants.
- **\`internal/schemas/integrations.yml\`** — one path per integration kind (removing a kind = breaking), with \`x-secret-paths\` so a moved secret envelope shows up in review.
- **\`schemas.yml\` workflow** — diffs changed specs (incl. \`packages/api/openapi.yaml\`) against the base branch with a checksum-pinned oasdiff, posts a changelog to the job summary, fails on error-level breaks; vetted breaks are allowlisted in \`internal/schemas/allowed-breaking/\`.
- **Drift-guarded** like the API spec: \`pnpm schemas:generate\` regenerates, and a vitest test fails the build if a committed spec goes stale.
- Bonus: stored secrets get a real zod schema (\`StoredSecretSchema\`); \`ProjectSecretsStore\` derives its type from it.

See \`internal/schemas/README.md\` for details.