### PR TITLE
chore(renovate): give marimo sandbox update its own daily group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,6 +28,8 @@
 			"matchDatasources": ["pypi"],
 			"matchPackageNames": ["marimo"],
 			"matchFileNames": ["images/marimo-sandbox/Dockerfile"],
+			"groupName": "marimo sandbox image",
+			"groupSlug": "marimo-sandbox",
 			"schedule": ["* 0-4 * * *"]
 		}
 	]


### PR DESCRIPTION
The daily schedule on the marimo sandbox Dockerfile bump never took effect.

**Root cause:** `group:allNonMajor` (inherited via `local>marimo-team/.github:renovate-config`) matches every minor/patch update on `*`, so it swept the marimo bump into the `all non-major dependencies` group. Our rule set a daily `schedule` but no `groupName`, so marimo stayed in that group — which follows the monthly global schedule (`schedule:monthly`).

**Fix:** add a dedicated `groupName`/`groupSlug` so the marimo update splits into its own branch, where the daily schedule applies cleanly.