### PR TITLE
ci: cache Vite task cache securely across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,26 @@ jobs:
           cache: true
           run-install: |
             - args: ['--frozen-lockfile']
+
+      # Forks must not read the shared cache; only main pushes can update it.
+      - name: Restore Vite Task cache
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        id: vite-task-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: node_modules/.vite/task-cache
+          key: vite-task-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            vite-task-${{ runner.os }}-${{ runner.arch }}-
+
       - run: vp check
       - run: vp run audit:prod
       - run: vp run -r test
       - run: vp run -r build
+
+      - name: Save Vite Task cache
+        if: success() && github.event_name == 'push'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Forks must not read the shared cache; only main pushes can update it.
       - name: Restore Vite Task cache
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         id: vite-task-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:


### PR DESCRIPTION
## Summary
- Restore the Vite task cache (`node_modules/.vite/task-cache`) between CI runs to speed up `vp check`/`test`/`build`.
- Restore only for pushes and **same-repo** PRs, so forks cannot read or poison the shared cache.
- Save the cache only on `main` (push) runs after a successful job.

## Notes
- Uses `actions/cache/restore` + `actions/cache/save` (pinned by SHA) with a per-run key and OS/arch `restore-keys` fallback.