### PR TITLE
test: speed up vitest with threads pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"ready": "vp fmt && vp lint && pnpm typecheck && vp run -r test && vp run -r build",
 		"check": "vp check",
 		"typecheck": "vp run -r typecheck",
-		"test": "vp run -r test",
+		"test": "vp run -r test --configLoader=runner --pool=threads",
 		"test:coverage": "pnpm test:coverage:root && pnpm test:coverage:web",
 		"test:coverage:root": "vp test --coverage",
 		"test:coverage:web": "pnpm --filter @marimo-hub/web test --coverage",

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react-swc';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, lazyPlugins } from 'vite-plus';
@@ -11,7 +12,7 @@ export default defineConfig({
 	plugins: lazyPlugins(() => [react(), tailwindcss()]),
 	resolve: {
 		alias: {
-			'@': path.resolve(__dirname, './src'),
+			'@': path.resolve(fileURLToPath(new URL('.', import.meta.url)), './src'),
 		},
 	},
 	server: {
@@ -43,6 +44,7 @@ export default defineConfig({
 	// (lib/*) run fine here too. `setup.ts` wires jest-dom matchers + auto-cleanup.
 	test: {
 		environment: 'jsdom',
+		pool: 'threads',
 		setupFiles: ['./src/test/setup.ts'],
 		include: ['src/**/*.test.{ts,tsx}'],
 		// The root config excludes this package from its coverage run (the `@/`


### PR DESCRIPTION
Run vitest with the `threads` pool (via `--pool=threads` at the root and `pool: 'threads'` in the web config) to speed up the test suite.

Also switch the web config `@` alias to `fileURLToPath(new URL(...))` so it resolves correctly under the runner config loader.