### PR TITLE
feat(compute): preflight Docker/Podman availability with actionable errors

### DIFF
--- a/docs/deploying/single-instance.md
+++ b/docs/deploying/single-instance.md
@@ -45,7 +45,7 @@ the control plane (XSS). Run this recipe for a team you trust. See
 [Security → Kernel exposure](../security.md#kernel-exposure).
 :::
 
-## Image — add the `docker` CLI
+## Add the `docker` CLI to the image
 
 The published image (`ghcr.io/marimo-team/marimohub`) does not ship the `docker`
 CLI the compute backend shells out to. Add the static CLI in a small derived
@@ -197,9 +197,10 @@ single replica means a few seconds of downtime; data on the volume is untouched.
 ## Validate
 
 1. Check `https://hub.example.com/api/health`.
-2. In the startup logs, expect a **non-fatal** preflight warning that `fs`
-   storage enforces conditional writes within one process — the single-replica
-   reminder.
+2. In the startup logs, confirm the `compute` `preflight_check` is not a failure
+   (a missing CLI or unmounted socket prints one with the fix), and expect a
+   **non-fatal** warning that `fs` storage enforces conditional writes within one
+   process — the single-replica reminder.
 3. Sign in through your OIDC provider.
 4. Create a project and notebook, then start a kernel — a sandbox container
    appears in `docker ps`, published on `127.0.0.1`.

--- a/docs/setup/compute/docker.md
+++ b/docs/setup/compute/docker.md
@@ -13,6 +13,10 @@ MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=127.0.0.1    # keep tokenless kernel ports on
 # MARIMOHUB_COMPUTE_DOCKER_NETWORK=marimo         # optional network to attach kernels to
 ```
 
+At boot the server shells out `docker info` as a preflight: a missing CLI
+(`spawn docker ENOENT`) or an unreachable daemon is reported as a **non-fatal**
+`preflight_check` log line with the fix, before anyone opens a notebook.
+
 For browsers on another machine, keep the loopback binding and use
 [`MARIMOHUB_SANDBOX_EXPOSURE=proxy`](/security#proxy-forwarded-through-the-app)
 so kernel traffic goes through the hub's authentication and per-session

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,6 +72,19 @@ it, or set `*`.
 `MARIMOHUB_COMPUTE_BACKEND=none` — notebooks are browsable but kernels can't
 start. Pick a real backend. See [Compute](/compute).
 
+### Docker/Podman: "compute unreachable" or `spawn docker ENOENT`
+
+The `docker`/`podman` backend shells out to that CLI, which the published image
+does not ship. Add the static CLI to a derived image **and** give it the daemon —
+mount `/var/run/docker.sock` (or set `DOCKER_HOST`). The boot `preflight_check`
+for `compute` names which half is missing:
+
+- `CLI is not installed or is not on PATH` → add the CLI to the image.
+- `daemon is unavailable` → mount the socket, or fix `DOCKER_HOST`.
+
+See the derived Dockerfile in
+[Deploying on a single instance](/deploying/single-instance#add-the-docker-cli-to-the-image).
+
 ### Kernel never becomes reachable (Kubernetes / CoreWeave)
 
 The browser connects **directly** to the kernel host, so this is almost always

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -276,6 +276,37 @@ describe('DockerCompute', () => {
 		expect(res.stderr).toBeTruthy();
 	});
 
+	it('healthCheck verifies that the Docker daemon is reachable', async () => {
+		const { runner, calls } = fakeRunner(defaultHandler);
+
+		await expect(new DockerCompute({}, runner).healthCheck()).resolves.toBeUndefined();
+		expect(calls).toContainEqual({ args: ['info'], stdin: undefined });
+	});
+
+	it('healthCheck identifies a missing Docker CLI', async () => {
+		const { runner } = fakeRunner(() => ({
+			stdout: '',
+			stderr: 'Error: spawn docker ENOENT',
+			exitCode: 127,
+		}));
+
+		await expect(new DockerCompute({}, runner).healthCheck()).rejects.toThrow(
+			'docker CLI is not installed or is not on PATH',
+		);
+	});
+
+	it('healthCheck identifies an unavailable Docker daemon', async () => {
+		const { runner } = fakeRunner(() => ({
+			stdout: '',
+			stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock',
+			exitCode: 1,
+		}));
+
+		await expect(new DockerCompute({}, runner).healthCheck()).rejects.toThrow(
+			'docker daemon is unavailable: Cannot connect to the Docker daemon',
+		);
+	});
+
 	it('listActive: parses container names into sandbox ids', async () => {
 		const { runner } = fakeRunner((args) => {
 			if (args[0] === 'ps')

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -295,7 +295,7 @@ describe('DockerCompute', () => {
 		);
 	});
 
-	it('healthCheck identifies an unavailable Docker daemon', async () => {
+	it('healthCheck identifies an unreachable Docker daemon', async () => {
 		const { runner } = fakeRunner(() => ({
 			stdout: '',
 			stderr: 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock',
@@ -303,7 +303,19 @@ describe('DockerCompute', () => {
 		}));
 
 		await expect(new DockerCompute({}, runner).healthCheck()).rejects.toThrow(
-			'docker daemon is unavailable: Cannot connect to the Docker daemon',
+			'docker is not reachable: Cannot connect to the Docker daemon',
+		);
+	});
+
+	it('healthCheck distinguishes a non-executable CLI (EACCES) from a missing one', async () => {
+		const { runner } = fakeRunner(() => ({
+			stdout: '',
+			stderr: 'Error: spawn docker EACCES',
+			exitCode: 127,
+		}));
+
+		await expect(new DockerCompute({}, runner).healthCheck()).rejects.toThrow(
+			'docker CLI is not executable (permission denied)',
 		);
 	});
 

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -348,10 +348,16 @@ export class ContainerCompute implements SandboxProvider {
 		if (res.exitCode === 0) return;
 
 		const detail = (res.stderr || res.stdout).trim();
-		if (res.exitCode === 127 || /\bENOENT\b/.test(detail)) {
+		// spawnContainerRunner collapses every spawn failure to exit 127, so key off the OS
+		// error in stderr instead: ENOENT is a missing binary, EACCES one that can't execute.
+		// "not reachable" stays engine-neutral (Podman is daemonless in the common setup).
+		if (/\bENOENT\b/.test(detail)) {
 			throw new Error(`${this.config.engine} CLI is not installed or is not on PATH`);
 		}
-		throw new Error(`${this.config.engine} daemon is unavailable${detail ? `: ${detail}` : ''}`);
+		if (/\bEACCES\b/.test(detail)) {
+			throw new Error(`${this.config.engine} CLI is not executable (permission denied)`);
+		}
+		throw new Error(`${this.config.engine} is not reachable${detail ? `: ${detail}` : ''}`);
 	}
 
 	async listActive(): Promise<ActiveSandbox[]> {

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -343,6 +343,17 @@ export class ContainerCompute implements SandboxProvider {
 		return null;
 	}
 
+	async healthCheck(): Promise<void> {
+		const res = await this.runner.run(['info']);
+		if (res.exitCode === 0) return;
+
+		const detail = (res.stderr || res.stdout).trim();
+		if (res.exitCode === 127 || /\bENOENT\b/.test(detail)) {
+			throw new Error(`${this.config.engine} CLI is not installed or is not on PATH`);
+		}
+		throw new Error(`${this.config.engine} daemon is unavailable${detail ? `: ${detail}` : ''}`);
+	}
+
 	async listActive(): Promise<ActiveSandbox[]> {
 		const res = await this.runner.run([
 			'ps',

--- a/packages/config/src/preflightChecks.test.ts
+++ b/packages/config/src/preflightChecks.test.ts
@@ -190,6 +190,23 @@ describe('compute check', () => {
 		});
 		expect((await run({}, deps)).by('compute')?.status).toBe('fail');
 	});
+
+	it('provides Docker-specific remediation when its probe fails', async () => {
+		const deps = makeDeps({
+			compute: {
+				healthCheck: async () => {
+					throw new Error('docker CLI is not installed or is not on PATH');
+				},
+			} as never,
+		});
+		const { by } = await run({ MARIMOHUB_COMPUTE_BACKEND: 'docker' }, deps);
+
+		expect(by('compute')).toMatchObject({
+			status: 'fail',
+			message: 'docker compute unreachable: docker CLI is not installed or is not on PATH',
+			remediation: expect.stringContaining('/var/run/docker.sock'),
+		});
+	});
 });
 
 describe('wif check', () => {

--- a/packages/config/src/preflightChecks.test.ts
+++ b/packages/config/src/preflightChecks.test.ts
@@ -191,21 +191,71 @@ describe('compute check', () => {
 		expect((await run({}, deps)).by('compute')?.status).toBe('fail');
 	});
 
-	it('provides Docker-specific remediation when its probe fails', async () => {
+	const remediationCases: {
+		name: string;
+		backend: string;
+		error: string;
+		expected: RegExp;
+	}[] = [
+		{
+			name: 'docker missing CLI → install guidance',
+			backend: 'docker',
+			error: 'docker CLI is not installed or is not on PATH',
+			expected: /Install the Docker CLI/i,
+		},
+		{
+			name: 'docker unreachable daemon → check the daemon, not install',
+			backend: 'docker',
+			error: 'docker is not reachable: Cannot connect to the Docker daemon',
+			expected: /Ensure the Docker daemon is running/i,
+		},
+		{
+			name: 'podman missing CLI → install guidance',
+			backend: 'podman',
+			error: 'podman CLI is not installed or is not on PATH',
+			expected: /Install the Podman CLI/i,
+		},
+		{
+			name: 'podman unreachable engine → check the engine, not install',
+			backend: 'podman',
+			error: 'podman is not reachable: rootless storage not configured',
+			expected: /Ensure Podman is configured and reachable/i,
+		},
+		{
+			name: 'unknown backend → generic fallback',
+			backend: 'kubernetes',
+			error: 'unauthorized',
+			expected: /Check the compute backend credentials and endpoint/i,
+		},
+	];
+
+	it.each(remediationCases)('remediation: $name', async ({ backend, error, expected }) => {
 		const deps = makeDeps({
 			compute: {
 				healthCheck: async () => {
-					throw new Error('docker CLI is not installed or is not on PATH');
+					throw new Error(error);
+				},
+			} as never,
+		});
+		const { by } = await run({ MARIMOHUB_COMPUTE_BACKEND: backend } as Env, deps);
+
+		expect(by('compute')).toMatchObject({
+			status: 'fail',
+			message: `${backend} compute unreachable: ${error}`,
+			remediation: expect.stringMatching(expected),
+		});
+	});
+
+	it('unreachable Docker remediation does not lead with "install the CLI"', async () => {
+		const deps = makeDeps({
+			compute: {
+				healthCheck: async () => {
+					throw new Error('docker is not reachable: Cannot connect to the Docker daemon');
 				},
 			} as never,
 		});
 		const { by } = await run({ MARIMOHUB_COMPUTE_BACKEND: 'docker' }, deps);
-
-		expect(by('compute')).toMatchObject({
-			status: 'fail',
-			message: 'docker compute unreachable: docker CLI is not installed or is not on PATH',
-			remediation: expect.stringContaining('/var/run/docker.sock'),
-		});
+		expect(by('compute')?.remediation).not.toMatch(/Install the Docker CLI/i);
 	});
 });
 

--- a/packages/config/src/preflightChecks.ts
+++ b/packages/config/src/preflightChecks.ts
@@ -189,10 +189,16 @@ async function checkCompute(env: Env, deps: ApiDeps): Promise<CheckOutcome> {
 		await probe.call(deps.compute);
 		return { status: 'ok', message: `${backend} compute reachable` };
 	} catch (err) {
+		const remediation =
+			backend === 'docker'
+				? 'Install the Docker CLI in the server environment and ensure it can reach the daemon (mount /var/run/docker.sock or set DOCKER_HOST).'
+				: backend === 'podman'
+					? 'Install the Podman CLI in the server environment and ensure it can reach the Podman service.'
+					: 'Check the compute backend credentials and endpoint.';
 		return {
 			status: 'fail',
 			message: `${backend} compute unreachable: ${errMsg(err)}`,
-			remediation: 'Check the compute backend credentials and endpoint.',
+			remediation,
 		};
 	}
 }

--- a/packages/config/src/preflightChecks.ts
+++ b/packages/config/src/preflightChecks.ts
@@ -189,18 +189,34 @@ async function checkCompute(env: Env, deps: ApiDeps): Promise<CheckOutcome> {
 		await probe.call(deps.compute);
 		return { status: 'ok', message: `${backend} compute reachable` };
 	} catch (err) {
-		const remediation =
-			backend === 'docker'
-				? 'Install the Docker CLI in the server environment and ensure it can reach the daemon (mount /var/run/docker.sock or set DOCKER_HOST).'
-				: backend === 'podman'
-					? 'Install the Podman CLI in the server environment and ensure it can reach the Podman service.'
-					: 'Check the compute backend credentials and endpoint.';
+		const message = errMsg(err);
 		return {
 			status: 'fail',
-			message: `${backend} compute unreachable: ${errMsg(err)}`,
-			remediation,
+			message: `${backend} compute unreachable: ${message}`,
+			remediation: computeRemediation(backend, message),
 		};
 	}
+}
+
+/**
+ * Tailor remediation to what `healthCheck()` actually reported: a missing/broken CLI
+ * needs an install, whereas a present CLI that can't reach its engine needs the
+ * daemon/socket checked. Leading with "install the CLI" for a reachability failure — when
+ * the operator already has the CLI — is the misleading guidance this preflight removed.
+ */
+function computeRemediation(backend: string, message: string): string {
+	const cliProblem = /not installed|not on PATH|not executable/i.test(message);
+	if (backend === 'docker') {
+		return cliProblem
+			? 'Install the Docker CLI in the server environment (then mount /var/run/docker.sock or set DOCKER_HOST so it can reach the daemon).'
+			: 'Ensure the Docker daemon is running and reachable: mount /var/run/docker.sock or set DOCKER_HOST.';
+	}
+	if (backend === 'podman') {
+		return cliProblem
+			? 'Install the Podman CLI in the server environment.'
+			: 'Ensure Podman is configured and reachable (rootless storage and cgroups, or the remote connection if using `podman system service`).';
+	}
+	return 'Check the compute backend credentials and endpoint.';
 }
 
 /**

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -457,7 +457,7 @@ describe('SandboxProvisioner', () => {
 			expect(result.counters).toMatchObject({ files_objects: 2, files_bytes: 40 });
 		});
 
-		it('unreachable sandbox: exec("true") throws -> provision rejects with "not available"', async () => {
+		it('reports the compute backend as unavailable when the reachability probe fails', async () => {
 			const { instance, calls } = makeFakeSandbox({ failExec: 'true' });
 			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
 
@@ -469,7 +469,7 @@ describe('SandboxProvisioner', () => {
 					hostname: 'localhost',
 					bucket: bucketConfig,
 				}),
-			).rejects.toThrow(/not available/i);
+			).rejects.toThrow('Sandbox compute backend is not available');
 
 			// Never got past the reachability check.
 			expect(calls.mountBucket).toHaveLength(0);

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -362,7 +362,7 @@ export class SandboxProvisioner {
 			});
 		} catch (err) {
 			throw new UnavailableError(
-				`Sandbox container is not available. Is Docker running? ` +
+				`Sandbox compute backend is not available. ` +
 					`(${err instanceof Error ? err.message : String(err)})`,
 			);
 		}


### PR DESCRIPTION
## Why

A user hit `Sandbox container is not available. Is Docker running? (... spawn docker ENOENT)` while running the Compose file in a Proxmox VM. The real cause: the `marimohub` container has no Docker CLI. The old error blamed a stopped daemon and only surfaced when a user opened a notebook.

## What

- **`ContainerCompute.healthCheck()`** — runs `docker info` and distinguishes a missing CLI (`spawn docker ENOENT`, exit 127) from an unreachable daemon/socket.
- **Compute preflight** — emits backend-specific remediation for Docker/Podman (mount `/var/run/docker.sock` or set `DOCKER_HOST`) so operators see the problem at startup, not at first notebook open.
- **Generic provisioning error** — drop the misleading "Is Docker running?" wording, which fired for every compute backend.

`pnpm check` and the full test suite pass.