### PR TITLE
release: 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 	"packageManager": "pnpm@10.34.5",
 	"pnpm": {
 		"overrides": {
-			"brace-expansion@>=5.0.0 <5.0.9": "5.0.9"
+			"brace-expansion@>=5.0.0 <5.0.9": "5.0.9",
+			"undici@>=7.0.0 <7.29.0": "^7.29.0"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "marimohub",
-	"version": "0.1.3",
+	"version": "0.2.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,7 @@ catalogs:
 
 overrides:
   brace-expansion@>=5.0.0 <5.0.9: 5.0.9
+  undici@>=7.0.0 <7.29.0: ^7.29.0
 
 importers:
 
@@ -4792,12 +4793,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -7513,7 +7510,7 @@ snapshots:
       openapi-fetch: 0.14.1
       platform: 1.3.6
       tar: 7.5.21
-      undici: 7.28.0
+      undici: 7.29.0
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -7853,7 +7850,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9039,9 +9036,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.2: {}
-
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,6 +69,7 @@ minimumReleaseAgeExclude:
   - brace-expansion
   - postcss
   - tar
+  - undici
 
 onlyBuiltDependencies: []
 


### PR DESCRIPTION
Merging this PR tags `v0.2.0` and publishes the container image and Helm chart to GHCR.