### PR TITLE
feat(core): handle invalid stored files safely, sanitize error logs

### DIFF
--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { HTTPException } from 'hono/http-exception';
 import {
 	ConflictError,
@@ -10,6 +10,10 @@ import {
 	UnavailableError,
 } from '@marimo-hub/core';
 import { createInitializedBucket, createTestApi, expectPage } from './testing';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 // Each row drives exactly one branch of the real `createApi` onError handler.
 // The message is the class name so the snapshot stays readable and deterministic.

--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -53,6 +53,24 @@ describe('createApi onError mapping', () => {
 		expect(res.status).toBe(418);
 		expect(await res.text()).toContain('teapot');
 	});
+
+	it('sanitizes and logs a 5xx HTTPException', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const { app } = createTestApi();
+		app.get('/_throw', () => {
+			throw new HTTPException(503, { message: 'upstream secret do-not-return' });
+		});
+
+		const res = await app.request('/_throw');
+		expect(res.status).toBe(503);
+		expect(await res.json()).toEqual({
+			success: false,
+			error: { code: 'INTERNAL_ERROR', message: 'Internal server error' },
+		});
+		expect(log).toHaveBeenCalledOnce();
+		expect(log.mock.calls[0]?.[0]).toContain('request_error');
+		expect(log.mock.calls[0]?.[0]).not.toContain('do-not-return');
+	});
 });
 
 describe('createApi identity refresh is best-effort', () => {

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -11,7 +11,7 @@ import {
 	SubdomainExposure,
 } from '@marimo-hub/core';
 import type { ApiDeps } from './context';
-import { describeError, logEvent } from './log';
+import { describeError, errorMetadata, logEvent } from './log';
 import { createAiProxy } from './routes/ai';
 import eventsApp from './routes/events';
 import gitSyncApp from './routes/gitSync';
@@ -126,6 +126,19 @@ export function createApi(rawDeps: ApiDeps) {
 				{ 400: 'BAD_REQUEST', 401: 'UNAUTHORIZED', 403: 'FORBIDDEN', 404: 'NOT_FOUND' }[
 					res.status
 				] ?? (res.status >= 500 ? 'INTERNAL_ERROR' : 'BAD_REQUEST');
+			if (res.status >= 500) {
+				logEvent({
+					level: 'error',
+					event: 'request_error',
+					request_id: c.get('requestId') ?? null,
+					method: c.req.method,
+					path: c.req.path,
+					user: c.get('user')?.id ?? null,
+					status: res.status,
+					error: errorMetadata(err),
+				});
+				return fail(c, code, 'Internal server error', res.status);
+			}
 			return fail(c, code, err.message || res.statusText || 'Request failed', res.status);
 		}
 		if (err instanceof DomainError) {
@@ -304,12 +317,13 @@ export function createApi(rawDeps: ApiDeps) {
 			await deps.services.identities.upsert(user);
 		} catch (err) {
 			logEvent({
-				level: 'warn',
+				level: 'error',
 				event: 'identity_upsert_failed',
+				request_id: c.get('requestId') ?? null,
 				method: c.req.method,
 				path: c.req.path,
 				user: user.id,
-				error: describeError(err),
+				error: errorMetadata(err),
 			});
 		}
 

--- a/packages/api/src/log.test.ts
+++ b/packages/api/src/log.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { describeError, logEvent } from './log';
+import { bestEffort, describeError, logEvent } from './log';
 
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -97,5 +97,25 @@ describe('describeError', () => {
 			{ path: 'meta.title', message: 'Required' },
 			{ path: 'status', message: 'Invalid enum value' },
 		]);
+	});
+});
+
+describe('bestEffort', () => {
+	it('logs failures without arbitrary error messages', async () => {
+		const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		await bestEffort('audit_append', { audit_event: 'integration.create' }, () =>
+			Promise.reject(new Error('bucket credential do-not-log')),
+		);
+
+		expect(spy).toHaveBeenCalledOnce();
+		const line = spy.mock.calls[0]?.[0] as string;
+		expect(JSON.parse(line)).toMatchObject({
+			level: 'error',
+			event: 'best_effort_operation_failed',
+			operation: 'audit_append',
+			audit_event: 'integration.create',
+			error: { error_name: 'Error' },
+		});
+		expect(line).not.toContain('do-not-log');
 	});
 });

--- a/packages/api/src/log.test.ts
+++ b/packages/api/src/log.test.ts
@@ -118,4 +118,21 @@ describe('bestEffort', () => {
 		});
 		expect(line).not.toContain('do-not-log');
 	});
+
+	it('does not let context fields override reserved event fields', async () => {
+		const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		await bestEffort(
+			'audit_append',
+			{ level: 'info', event: 'spoofed', operation: 'spoofed', error: 'spoofed', safe: true },
+			() => Promise.reject(new Error('hidden')),
+		);
+
+		expect(JSON.parse(spy.mock.calls[0]?.[0] as string)).toMatchObject({
+			level: 'error',
+			event: 'best_effort_operation_failed',
+			operation: 'audit_append',
+			safe: true,
+			error: { error_name: 'Error' },
+		});
+	});
 });

--- a/packages/api/src/log.ts
+++ b/packages/api/src/log.ts
@@ -23,7 +23,7 @@ export function errorMetadata(err: unknown): Record<string, string | number> {
 		['error_operation', e.operation],
 	] as const) {
 		// Enum-ish identifiers only — anything else is free-form text of unknown origin.
-		if (typeof value === 'number') out[key] = value;
+		if (typeof value === 'number' && Number.isFinite(value)) out[key] = value;
 		if (typeof value === 'string' && value.length <= 64) out[key] = value;
 	}
 	return out;
@@ -37,14 +37,34 @@ export async function bestEffort(
 	try {
 		await action();
 	} catch (err) {
+		const context = { ...fields };
+		for (const key of ['level', 'event', 'operation', 'error']) delete context[key];
 		logEvent({
+			...context,
 			level: 'error',
 			event: 'best_effort_operation_failed',
 			operation,
-			...fields,
 			error: errorMetadata(err),
 		});
 	}
+}
+
+export function appendAudit(
+	request: { requestId?: string; method: string; path: string; userId: string },
+	event: string,
+	action: () => Promise<void>,
+): Promise<void> {
+	return bestEffort(
+		'audit_append',
+		{
+			request_id: request.requestId ?? null,
+			method: request.method,
+			path: request.path,
+			user: request.userId,
+			audit_event: event,
+		},
+		action,
+	);
 }
 
 /**
@@ -80,7 +100,7 @@ export function describeError(err: unknown, depth = 3): Record<string, unknown> 
 	// ZodError (duck-typed): surface the failing field paths so a corrupted stored
 	// object is identifiable from the log instead of a bare stack.
 	if (Array.isArray(e.issues)) {
-		out.issues = e.issues.map((i) => ({
+		out.issues = e.issues.slice(0, 20).map((i) => ({
 			path: Array.isArray(i.path) ? i.path.join('.') : i.path,
 			...(i.code ? { code: i.code } : {}),
 			...(i.message ? { message: i.message } : {}),

--- a/packages/api/src/log.ts
+++ b/packages/api/src/log.ts
@@ -29,6 +29,24 @@ export function errorMetadata(err: unknown): Record<string, string | number> {
 	return out;
 }
 
+export async function bestEffort(
+	operation: string,
+	fields: Record<string, unknown>,
+	action: () => Promise<unknown>,
+): Promise<void> {
+	try {
+		await action();
+	} catch (err) {
+		logEvent({
+			level: 'error',
+			event: 'best_effort_operation_failed',
+			operation,
+			...fields,
+			error: errorMetadata(err),
+		});
+	}
+}
+
 /**
  * Extract a rich, JSON-serializable description of an error for SERVER logs:
  * name, message, stack, and any duck-typed vendor fields (gRPC `transportCode`,
@@ -46,17 +64,27 @@ export function describeError(err: unknown, depth = 3): Record<string, unknown> 
 		transportCode?: unknown;
 		operation?: unknown;
 		cause?: unknown;
-		issues?: { path?: unknown[]; message?: string }[];
+		reason?: unknown;
+		object?: unknown;
+		cause_name?: unknown;
+		issues?: { path?: unknown[] | string; message?: string; code?: string }[];
 	};
 	const out: Record<string, unknown> = { name: e.name, message: e.message };
 	if (e.stack) out.stack = e.stack;
 	if (e.code !== undefined) out.code = e.code;
 	if (e.transportCode !== undefined) out.transportCode = e.transportCode;
 	if (e.operation !== undefined) out.operation = e.operation;
+	if (e.reason !== undefined) out.reason = e.reason;
+	if (e.object !== undefined) out.object = e.object;
+	if (e.cause_name !== undefined) out.cause_name = e.cause_name;
 	// ZodError (duck-typed): surface the failing field paths so a corrupted stored
 	// object is identifiable from the log instead of a bare stack.
 	if (Array.isArray(e.issues)) {
-		out.issues = e.issues.map((i) => ({ path: i.path?.join('.'), message: i.message }));
+		out.issues = e.issues.map((i) => ({
+			path: Array.isArray(i.path) ? i.path.join('.') : i.path,
+			...(i.code ? { code: i.code } : {}),
+			...(i.message ? { message: i.message } : {}),
+		}));
 	}
 	if (e.cause !== undefined && e.cause !== null && depth > 0) {
 		out.cause = describeError(e.cause, depth - 1);

--- a/packages/api/src/routes/integrations.test.ts
+++ b/packages/api/src/routes/integrations.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	AesGcmSecretCodec,
 	defaultRegistry,
+	IntegrationId,
 	OrgIntegrationsStore,
+	paths,
+	ProjectId,
 	ProjectIntegrationsStore,
 } from '@marimo-hub/core';
 import type { UserId } from '@marimo-hub/core';
@@ -105,6 +108,31 @@ describe('Integrations routes', () => {
 		expect(JSON.stringify(events)).not.toContain('sup3r-secret');
 	});
 
+	it('returns a sanitized 500 and logs safe diagnostics for malformed stored JSON', async () => {
+		const pid = await createProject();
+		const created = await createPg(pid);
+		const key = paths
+			.project(ProjectId.parse(pid))
+			.integration(IntegrationId.parse(created.id)).head;
+		await bucket.put(key, '{"password":"stored-secret-do-not-log"');
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+		const res = await request('GET', `/projects/${pid}/integrations/${created.id}`);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(res.status).toBe(500);
+		expect(body).toMatchObject({
+			success: false,
+			error: { code: 'INTERNAL_ERROR', message: 'Internal server error' },
+		});
+		expect(JSON.stringify(body)).not.toContain(key);
+		expect(JSON.stringify(body)).not.toContain('stored-secret-do-not-log');
+		const line = log.mock.calls[0]?.[0] as string;
+		expect(line).toContain('StoredObjectError');
+		expect(line).toContain('invalid_json');
+		expect(line).toContain(key);
+		expect(line).not.toContain('stored-secret-do-not-log');
+	});
+
 	it('update with config appends a version; keep-marker preserves the secret', async () => {
 		const pid = await createProject();
 		const created = await createPg(pid);
@@ -143,6 +171,29 @@ describe('Integrations routes', () => {
 		);
 		expect(events.map((event) => event.event)).toContain('integration.update');
 		expect(JSON.stringify(events)).not.toContain(replacement);
+	});
+
+	it('keeps a committed write successful and logs when its audit append fails', async () => {
+		const pid = await createProject();
+		const local = createTestApi({ bucket, userId: ACTOR, deps: integrationsDeps(bucket) });
+		vi.spyOn(local.deps.services.events, 'append').mockRejectedValue(
+			new Error('storage credential do-not-log'),
+		);
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+		const res = await local.request('POST', `/projects/${pid}/integrations`, {
+			kind: 'postgres',
+			name: 'audit-failure',
+			config: PG_CONFIG,
+		});
+
+		expect(res.status).toBe(201);
+		const line = log.mock.calls.find((call) =>
+			String(call[0]).includes('audit_append'),
+		)?.[0] as string;
+		expect(line).toContain('best_effort_operation_failed');
+		expect(line).toContain('integration.create');
+		expect(line).not.toContain('do-not-log');
 	});
 
 	it('version history paginates newest-first with a cursor', async () => {

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -38,25 +38,7 @@ import {
 	paginate,
 	PaginationQuery,
 } from '../pagination';
-import { bestEffort } from '../log';
-
-function appendAudit(
-	request: { requestId?: string; method: string; path: string; userId: string },
-	event: string,
-	action: () => Promise<void>,
-): Promise<void> {
-	return bestEffort(
-		'audit_append',
-		{
-			request_id: request.requestId ?? null,
-			method: request.method,
-			path: request.path,
-			user: request.userId,
-			audit_event: event,
-		},
-		action,
-	);
-}
+import { appendAudit } from '../log';
 
 const IntegrationIdSchema = z.string().regex(IntegrationId.regex).refine(IntegrationId.is);
 const IntegrationNameSchema = z.string().regex(/^[a-z][a-z0-9-]{0,31}$/);

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -38,6 +38,25 @@ import {
 	paginate,
 	PaginationQuery,
 } from '../pagination';
+import { bestEffort } from '../log';
+
+function appendAudit(
+	request: { requestId?: string; method: string; path: string; userId: string },
+	event: string,
+	action: () => Promise<void>,
+): Promise<void> {
+	return bestEffort(
+		'audit_append',
+		{
+			request_id: request.requestId ?? null,
+			method: request.method,
+			path: request.path,
+			user: request.userId,
+			audit_event: event,
+		},
+		action,
+	);
+}
 
 const IntegrationIdSchema = z.string().regex(IntegrationId.regex).refine(IntegrationId.is);
 const IntegrationNameSchema = z.string().regex(/^[a-z][a-z0-9-]{0,31}$/);
@@ -547,17 +566,20 @@ app.openapi(createIntegration, async (c) => {
 	const body = c.req.valid('json');
 	const detail = await integrations.create(pid, body, user.id);
 	// Audit trail (kind/name only — never config). Best-effort; never fail the write.
-	await deps.services.events
-		.append({
-			event: 'integration.create',
-			actor: user.id,
-			project_id: pid,
-			integration_scope: 'project',
-			integration_id: detail.id,
-			integration_kind: detail.kind,
-			integration_name: detail.name,
-		})
-		.catch(() => {});
+	await appendAudit(
+		{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+		'integration.create',
+		() =>
+			deps.services.events.append({
+				event: 'integration.create',
+				actor: user.id,
+				project_id: pid,
+				integration_scope: 'project',
+				integration_id: detail.id,
+				integration_kind: detail.kind,
+				integration_name: detail.name,
+			}),
+	);
 	return c.json({ success: true, data: detailResponse(detail) }, 201);
 });
 
@@ -581,19 +603,22 @@ app.openapi(updateIntegration, async (c) => {
 	const body = c.req.valid('json');
 	const detail = await integrations.update(pid, iid, body, user.id, ifMatchToken(c));
 	c.header('ETag', etagFor(detail.updated_at));
-	await deps.services.events
-		.append({
-			event: 'integration.update',
-			actor: user.id,
-			project_id: pid,
-			integration_scope: 'project',
-			integration_id: iid,
-			integration_kind: detail.kind,
-			integration_name: detail.name,
-			config_changed: body.config !== undefined,
-			current_version: detail.current_version,
-		})
-		.catch(() => {});
+	await appendAudit(
+		{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+		'integration.update',
+		() =>
+			deps.services.events.append({
+				event: 'integration.update',
+				actor: user.id,
+				project_id: pid,
+				integration_scope: 'project',
+				integration_id: iid,
+				integration_kind: detail.kind,
+				integration_name: detail.name,
+				config_changed: body.config !== undefined,
+				current_version: detail.current_version,
+			}),
+	);
 	return c.json({ success: true, data: detailResponse(detail) }, 200);
 });
 
@@ -607,15 +632,18 @@ app.openapi(deleteIntegration, async (c) => {
 	// but must not fabricate an audit-trail deletion.
 	const deleted = await integrations.delete(pid, iid, ifMatchToken(c));
 	if (deleted) {
-		await deps.services.events
-			.append({
-				event: 'integration.delete',
-				actor: user.id,
-				project_id: pid,
-				integration_scope: 'project',
-				integration_id: iid,
-			})
-			.catch(() => {});
+		await appendAudit(
+			{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+			'integration.delete',
+			() =>
+				deps.services.events.append({
+					event: 'integration.delete',
+					actor: user.id,
+					project_id: pid,
+					integration_scope: 'project',
+					integration_id: iid,
+				}),
+		);
 	}
 	return c.json({ success: true }, 200);
 });
@@ -701,19 +729,22 @@ app.openapi(copyIntegration, async (c) => {
 		{ name: body.name },
 		user.id,
 	);
-	await deps.services.events
-		.append({
-			event: 'integration.copy',
-			actor: user.id,
-			project_id: pid,
-			integration_scope: 'project',
-			integration_id: detail.id,
-			integration_kind: detail.kind,
-			integration_name: detail.name,
-			source_project_id: body.source_project_id,
-			source_integration_id: body.source_integration_id,
-		})
-		.catch(() => {});
+	await appendAudit(
+		{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+		'integration.copy',
+		() =>
+			deps.services.events.append({
+				event: 'integration.copy',
+				actor: user.id,
+				project_id: pid,
+				integration_scope: 'project',
+				integration_id: detail.id,
+				integration_kind: detail.kind,
+				integration_name: detail.name,
+				source_project_id: body.source_project_id,
+				source_integration_id: body.source_integration_id,
+			}),
+	);
 	return c.json({ success: true, data: detailResponse(detail) }, 201);
 });
 
@@ -747,16 +778,19 @@ app.openapi(createOrgIntegration, async (c) => {
 	assertSuperAdmin(user, deps.policy);
 	const body = c.req.valid('json');
 	const detail = await integrations.create(body, user.id);
-	await deps.services.events
-		.append({
-			event: 'integration.create',
-			actor: user.id,
-			integration_scope: 'org',
-			integration_id: detail.id,
-			integration_kind: detail.kind,
-			integration_name: detail.name,
-		})
-		.catch(() => {});
+	await appendAudit(
+		{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+		'integration.create',
+		() =>
+			deps.services.events.append({
+				event: 'integration.create',
+				actor: user.id,
+				integration_scope: 'org',
+				integration_id: detail.id,
+				integration_kind: detail.kind,
+				integration_name: detail.name,
+			}),
+	);
 	return c.json({ success: true, data: detailResponse(detail) }, 201);
 });
 
@@ -779,18 +813,21 @@ app.openapi(updateOrgIntegration, async (c) => {
 	const body = c.req.valid('json');
 	const detail = await integrations.update(iid, body, user.id, ifMatchToken(c));
 	c.header('ETag', etagFor(detail.updated_at));
-	await deps.services.events
-		.append({
-			event: 'integration.update',
-			actor: user.id,
-			integration_scope: 'org',
-			integration_id: iid,
-			integration_kind: detail.kind,
-			integration_name: detail.name,
-			config_changed: body.config !== undefined,
-			current_version: detail.current_version,
-		})
-		.catch(() => {});
+	await appendAudit(
+		{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+		'integration.update',
+		() =>
+			deps.services.events.append({
+				event: 'integration.update',
+				actor: user.id,
+				integration_scope: 'org',
+				integration_id: iid,
+				integration_kind: detail.kind,
+				integration_name: detail.name,
+				config_changed: body.config !== undefined,
+				current_version: detail.current_version,
+			}),
+	);
 	return c.json({ success: true, data: detailResponse(detail) }, 200);
 });
 
@@ -802,14 +839,17 @@ app.openapi(deleteOrgIntegration, async (c) => {
 	assertSuperAdmin(user, deps.policy);
 	const deleted = await integrations.delete(iid, ifMatchToken(c));
 	if (deleted) {
-		await deps.services.events
-			.append({
-				event: 'integration.delete',
-				actor: user.id,
-				integration_scope: 'org',
-				integration_id: iid,
-			})
-			.catch(() => {});
+		await appendAudit(
+			{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+			'integration.delete',
+			() =>
+				deps.services.events.append({
+					event: 'integration.delete',
+					actor: user.id,
+					integration_scope: 'org',
+					integration_id: iid,
+				}),
+		);
 	}
 	return c.json({ success: true }, 200);
 });

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -531,21 +531,25 @@ describe('Session routes', () => {
 			expect(compute.lastCreateOptions).toMatchObject({ image: 'img-b' });
 		});
 
-		it('falls back to the default image (with a warning) when the stored image fell off the list', async () => {
+		it('falls back to the default image and logs without the stored value', async () => {
 			const meta = await createServices(bucket).notebooks.getNotebook(pid, nid);
 			await bucket.put(
 				`projects/${pid}/notebooks/${nid}/meta.json`,
 				JSON.stringify({ ...meta.meta, base_image: 'img-gone' }),
 			);
 
-			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 			try {
 				const compute = makeFakeCompute();
 				await expectOk<ApiSession>(await imageApi(compute)('POST', sessionsPath()));
 				expect(compute.lastCreateOptions).toMatchObject({ image: 'img-a' });
-				expect(warn.mock.calls.some((c) => String(c[0]).includes('img-gone'))).toBe(true);
+				const line = log.mock.calls.find((c) =>
+					String(c[0]).includes('stored_config_fallback'),
+				)?.[0] as string;
+				expect(line).toContain('selection_unavailable');
+				expect(line).not.toContain('img-gone');
 			} finally {
-				warn.mockRestore();
+				log.mockRestore();
 			}
 		});
 
@@ -733,7 +737,7 @@ describe('Session routes', () => {
 			ACTOR,
 		);
 		const compute = makeFakeCompute();
-		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 		try {
 			const request = createTestApi({
 				bucket,
@@ -750,9 +754,13 @@ describe('Session routes', () => {
 			const data = await expectOk<ApiSession>(await request('POST', sessionsPath()));
 			expect(data.compute_profile).toBe('small');
 			expect(compute.lastCreateOptions?.resources).toEqual({ cpu: 1 });
-			expect(warn.mock.calls.some((call) => String(call[0]).includes('removed'))).toBe(true);
+			const line = log.mock.calls.find((call) =>
+				String(call[0]).includes('stored_config_fallback'),
+			)?.[0] as string;
+			expect(line).toContain('selection_unavailable');
+			expect(line).not.toContain('removed');
 		} finally {
-			warn.mockRestore();
+			log.mockRestore();
 		}
 	});
 

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -795,39 +795,28 @@ app.openapi(createSession, async (c) => {
 		(MODE_POLICY[mode].persistsEdits
 			? undefined
 			: (notebook.source.current_version_id ?? undefined));
-
-	const { compute, bucket: bucketHandle, sandbox } = deps;
-	// The notebook's stored choice, resolved leniently: "default"/absent → first
-	// configured image; a choice that fell off the list falls back with a warning
-	// rather than blocking the session.
-	const image = resolveBaseImage(notebook.meta.base_image, sandbox.images ?? [], () =>
+	const logStoredConfigFallback = (config: 'base_image' | 'compute_profile') =>
 		logEvent({
 			level: 'error',
 			event: 'stored_config_fallback',
 			request_id: c.get('requestId') ?? null,
-			config: 'base_image',
+			config,
 			project_id: pid,
 			notebook_id: nid,
 			reason: 'selection_unavailable',
 			recovered: true,
-		}),
+		});
+
+	const { compute, bucket: bucketHandle, sandbox } = deps;
+	const image = resolveBaseImage(notebook.meta.base_image, sandbox.images ?? [], () =>
+		logStoredConfigFallback('base_image'),
 	);
 	const retryWithDefault = mode === 'edit' && body?.compute_profile === 'default';
 	const requestedComputeProfile = resolveComputeProfile(
 		sandbox,
 		retryWithDefault ? undefined : notebook.meta.compute_profile,
 		sandbox.computeProfileOverride === 'editors' && profileOverrideEligible,
-		() =>
-			logEvent({
-				level: 'error',
-				event: 'stored_config_fallback',
-				request_id: c.get('requestId') ?? null,
-				config: 'compute_profile',
-				project_id: pid,
-				notebook_id: nid,
-				reason: 'selection_unavailable',
-				recovered: true,
-			}),
+		() => logStoredConfigFallback('compute_profile'),
 	);
 	const provisioner = new SandboxProvisioner(compute);
 

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -49,7 +49,7 @@ import {
 	workspaceSourcePolicy,
 } from '@marimo-hub/core';
 import { logObserver } from '../saga';
-import { errorMetadata } from '../log';
+import { bestEffort, errorMetadata, logEvent } from '../log';
 import type { ApiDeps, PolicyConfig, SandboxConfig } from '../context';
 import {
 	assertSessionAccess,
@@ -622,16 +622,25 @@ app.openapi(takeoverEditorSession, async (c) => {
 	});
 	let failed = false;
 	const audit = (event: string) =>
-		deps.services.events
-			.append({
-				event,
-				actor: user.id,
-				project_id: pid,
-				notebook_id: nid,
-				session_id: body.expected_holder_session_id,
-				takeover_id: body.takeover_id,
-			})
-			.catch(() => {});
+		bestEffort(
+			'audit_append',
+			{
+				request_id: c.get('requestId') ?? null,
+				method: c.req.method,
+				path: c.req.path,
+				user: user.id,
+				audit_event: event,
+			},
+			() =>
+				deps.services.events.append({
+					event,
+					actor: user.id,
+					project_id: pid,
+					notebook_id: nid,
+					session_id: body.expected_holder_session_id,
+					takeover_id: body.takeover_id,
+				}),
+		);
 	const assertAccess = async () => {
 		const project = await deps.services.projects.getProject(pid);
 		if (project.status === 'deleted') throw new NotFoundError(`Project ${pid} not found`);
@@ -797,15 +806,32 @@ app.openapi(createSession, async (c) => {
 	// The notebook's stored choice, resolved leniently: "default"/absent → first
 	// configured image; a choice that fell off the list falls back with a warning
 	// rather than blocking the session.
-	const image = resolveBaseImage(notebook.meta.base_image, sandbox.images ?? [], (msg) =>
-		console.warn(`[session] ${msg} (project=${pid} notebook=${nid})`),
+	const image = resolveBaseImage(notebook.meta.base_image, sandbox.images ?? [], () =>
+		logEvent({
+			level: 'error',
+			event: 'stored_config_fallback',
+			request_id: c.get('requestId') ?? null,
+			config: 'base_image',
+			project_id: pid,
+			notebook_id: nid,
+			reason: 'selection_unavailable',
+		}),
 	);
 	const retryWithDefault = mode === 'edit' && body?.compute_profile === 'default';
 	const requestedComputeProfile = resolveComputeProfile(
 		sandbox,
 		retryWithDefault ? undefined : notebook.meta.compute_profile,
 		sandbox.computeProfileOverride === 'editors' && profileOverrideEligible,
-		(msg) => console.warn(`[session] ${msg} (project=${pid} notebook=${nid})`),
+		() =>
+			logEvent({
+				level: 'error',
+				event: 'stored_config_fallback',
+				request_id: c.get('requestId') ?? null,
+				config: 'compute_profile',
+				project_id: pid,
+				notebook_id: nid,
+				reason: 'selection_unavailable',
+			}),
 	);
 	const provisioner = new SandboxProvisioner(compute);
 
@@ -1299,15 +1325,24 @@ app.openapi(createSession, async (c) => {
 	// whole admitted audience, so who started it belongs in the project's event log.
 	// Best-effort like every audit append.
 	if (MODE_POLICY[mode].singleton) {
-		await deps.services.events
-			.append({
-				event: 'app.start',
-				actor: user.id,
-				project_id: pid,
-				notebook_id: nid,
-				session_id: session!.session_id,
-			})
-			.catch(() => {});
+		await bestEffort(
+			'audit_append',
+			{
+				request_id: c.get('requestId') ?? null,
+				method: c.req.method,
+				path: c.req.path,
+				user: user.id,
+				audit_event: 'app.start',
+			},
+			() =>
+				deps.services.events.append({
+					event: 'app.start',
+					actor: user.id,
+					project_id: pid,
+					notebook_id: nid,
+					session_id: session!.session_id,
+				}),
+		);
 	}
 
 	return c.json(

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -49,7 +49,7 @@ import {
 	workspaceSourcePolicy,
 } from '@marimo-hub/core';
 import { logObserver } from '../saga';
-import { bestEffort, errorMetadata, logEvent } from '../log';
+import { appendAudit, errorMetadata, logEvent } from '../log';
 import type { ApiDeps, PolicyConfig, SandboxConfig } from '../context';
 import {
 	assertSessionAccess,
@@ -622,15 +622,9 @@ app.openapi(takeoverEditorSession, async (c) => {
 	});
 	let failed = false;
 	const audit = (event: string) =>
-		bestEffort(
-			'audit_append',
-			{
-				request_id: c.get('requestId') ?? null,
-				method: c.req.method,
-				path: c.req.path,
-				user: user.id,
-				audit_event: event,
-			},
+		appendAudit(
+			{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+			event,
 			() =>
 				deps.services.events.append({
 					event,
@@ -815,6 +809,7 @@ app.openapi(createSession, async (c) => {
 			project_id: pid,
 			notebook_id: nid,
 			reason: 'selection_unavailable',
+			recovered: true,
 		}),
 	);
 	const retryWithDefault = mode === 'edit' && body?.compute_profile === 'default';
@@ -831,6 +826,7 @@ app.openapi(createSession, async (c) => {
 				project_id: pid,
 				notebook_id: nid,
 				reason: 'selection_unavailable',
+				recovered: true,
 			}),
 	);
 	const provisioner = new SandboxProvisioner(compute);
@@ -1325,15 +1321,9 @@ app.openapi(createSession, async (c) => {
 	// whole admitted audience, so who started it belongs in the project's event log.
 	// Best-effort like every audit append.
 	if (MODE_POLICY[mode].singleton) {
-		await bestEffort(
-			'audit_append',
-			{
-				request_id: c.get('requestId') ?? null,
-				method: c.req.method,
-				path: c.req.path,
-				user: user.id,
-				audit_event: 'app.start',
-			},
+		await appendAudit(
+			{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+			'app.start',
 			() =>
 				deps.services.events.append({
 					event: 'app.start',

--- a/packages/api/src/routes/tokens.ts
+++ b/packages/api/src/routes/tokens.ts
@@ -3,7 +3,7 @@ import { ForbiddenError, TokenId } from '@marimo-hub/core';
 import type { PublicToken } from '@marimo-hub/core';
 import type { Context } from 'hono';
 import type { HonoEnv } from '../context';
-import { bestEffort } from '../log';
+import { appendAudit } from '../log';
 import {
 	commonErrors,
 	createApp,
@@ -150,15 +150,9 @@ app.openapi(createToken, async (c) => {
 		{ name, expiresInDays: expires_in_days },
 		user.id,
 	);
-	await bestEffort(
-		'audit_append',
-		{
-			request_id: c.get('requestId') ?? null,
-			method: c.req.method,
-			path: c.req.path,
-			user: user.id,
-			audit_event: 'token.create',
-		},
+	await appendAudit(
+		{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+		'token.create',
 		() =>
 			deps.services.events.append({
 				event: 'token.create',
@@ -185,15 +179,9 @@ app.openapi(revokeToken, async (c) => {
 	const { tokenId } = c.req.valid('param');
 
 	await deps.services.tokens.revoke(user.id, tokenId);
-	await bestEffort(
-		'audit_append',
-		{
-			request_id: c.get('requestId') ?? null,
-			method: c.req.method,
-			path: c.req.path,
-			user: user.id,
-			audit_event: 'token.revoke',
-		},
+	await appendAudit(
+		{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+		'token.revoke',
 		() =>
 			deps.services.events.append({
 				event: 'token.revoke',

--- a/packages/api/src/routes/tokens.ts
+++ b/packages/api/src/routes/tokens.ts
@@ -3,6 +3,7 @@ import { ForbiddenError, TokenId } from '@marimo-hub/core';
 import type { PublicToken } from '@marimo-hub/core';
 import type { Context } from 'hono';
 import type { HonoEnv } from '../context';
+import { bestEffort } from '../log';
 import {
 	commonErrors,
 	createApp,
@@ -149,9 +150,23 @@ app.openapi(createToken, async (c) => {
 		{ name, expiresInDays: expires_in_days },
 		user.id,
 	);
-	await deps.services.events
-		.append({ event: 'token.create', actor: user.id, token_id: record.id, token_name: name })
-		.catch(() => {});
+	await bestEffort(
+		'audit_append',
+		{
+			request_id: c.get('requestId') ?? null,
+			method: c.req.method,
+			path: c.req.path,
+			user: user.id,
+			audit_event: 'token.create',
+		},
+		() =>
+			deps.services.events.append({
+				event: 'token.create',
+				actor: user.id,
+				token_id: record.id,
+				token_name: name,
+			}),
+	);
 	return c.json({ success: true, data: { ...toResponse(record), token } }, 201);
 });
 
@@ -170,9 +185,22 @@ app.openapi(revokeToken, async (c) => {
 	const { tokenId } = c.req.valid('param');
 
 	await deps.services.tokens.revoke(user.id, tokenId);
-	await deps.services.events
-		.append({ event: 'token.revoke', actor: user.id, token_id: tokenId })
-		.catch(() => {});
+	await bestEffort(
+		'audit_append',
+		{
+			request_id: c.get('requestId') ?? null,
+			method: c.req.method,
+			path: c.req.path,
+			user: user.id,
+			audit_event: 'token.revoke',
+		},
+		() =>
+			deps.services.events.append({
+				event: 'token.revoke',
+				actor: user.id,
+				token_id: tokenId,
+			}),
+	);
 	return c.json({ success: true }, 200);
 });
 

--- a/packages/core/src/operationalLog.test.ts
+++ b/packages/core/src/operationalLog.test.ts
@@ -45,4 +45,24 @@ describe('logOperationalError', () => {
 			},
 		});
 	});
+
+	it('caps issue metadata, omits non-finite numbers, and protects reserved fields', () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const err = Object.assign(new Error('hidden'), {
+			status: Number.POSITIVE_INFINITY,
+			issues: Array.from({ length: 50 }, (_, i) => ({ path: `items.${i}`, code: 'invalid_type' })),
+		});
+
+		logOperationalError(
+			'stored_object_skipped',
+			{ level: 'info', event: 'spoofed', error: 'spoofed' },
+			err,
+		);
+
+		const line = JSON.parse(spy.mock.calls[0]?.[0] as string) as Record<string, any>;
+		expect(line.level).toBe('error');
+		expect(line.event).toBe('stored_object_skipped');
+		expect(line.error.status).toBeUndefined();
+		expect(line.error.issues).toHaveLength(20);
+	});
 });

--- a/packages/core/src/operationalLog.test.ts
+++ b/packages/core/src/operationalLog.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logOperationalError } from './operationalLog';
+import { StoredObjectError } from './schema';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('logOperationalError', () => {
+	it('emits a structured error without arbitrary exception text', () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		logOperationalError(
+			'stored_object_skipped',
+			{ operation: 'session.scan' },
+			new Error('credential=do-not-log'),
+		);
+
+		expect(spy).toHaveBeenCalledOnce();
+		const line = spy.mock.calls[0]?.[0] as string;
+		expect(JSON.parse(line)).toMatchObject({
+			level: 'error',
+			event: 'stored_object_skipped',
+			operation: 'session.scan',
+			error: { name: 'Error' },
+		});
+		expect(line).not.toContain('do-not-log');
+	});
+
+	it('keeps safe stored-object location and schema issue metadata', () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		logOperationalError(
+			'stored_object_skipped',
+			{ operation: 'event.list' },
+			new StoredObjectError('_system/events/bad.json', 'schema_mismatch', {
+				issues: [{ path: 'actor', code: 'invalid_type' }],
+			}),
+		);
+
+		expect(JSON.parse(spy.mock.calls[0]?.[0] as string)).toMatchObject({
+			error: {
+				name: 'StoredObjectError',
+				reason: 'schema_mismatch',
+				object: '_system/events/bad.json',
+				issues: [{ path: 'actor', code: 'invalid_type' }],
+			},
+		});
+	});
+});

--- a/packages/core/src/operationalLog.test.ts
+++ b/packages/core/src/operationalLog.test.ts
@@ -65,4 +65,22 @@ describe('logOperationalError', () => {
 		expect(line.error.status).toBeUndefined();
 		expect(line.error.issues).toHaveLength(20);
 	});
+
+	it('falls back to a safe payload when context serialization fails', () => {
+		const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const fields: Record<string, unknown> = { secret: 'do-not-log' };
+		fields.self = fields;
+
+		expect(() =>
+			logOperationalError('stored_object_skipped', fields, new Error('also-do-not-log')),
+		).not.toThrow();
+
+		const line = spy.mock.calls[0]?.[0] as string;
+		expect(JSON.parse(line)).toMatchObject({
+			level: 'error',
+			event: 'operational_log_serialization_failed',
+			attempted_event: 'stored_object_skipped',
+		});
+		expect(line).not.toContain('do-not-log');
+	});
 });

--- a/packages/core/src/operationalLog.ts
+++ b/packages/core/src/operationalLog.ts
@@ -1,0 +1,42 @@
+function safeError(err: unknown): Record<string, unknown> {
+	if (!(err instanceof Error)) return { name: `non-error(${typeof err})` };
+	const value = err as Error & {
+		code?: unknown;
+		status?: unknown;
+		operation?: unknown;
+		reason?: unknown;
+		object?: unknown;
+		issues?: { path?: unknown; code?: unknown }[];
+		cause_name?: unknown;
+	};
+	const out: Record<string, unknown> = { name: value.name };
+	for (const key of ['code', 'status', 'operation', 'reason', 'object', 'cause_name'] as const) {
+		const field = value[key];
+		if (typeof field === 'number') out[key] = field;
+		if (typeof field === 'string' && field.length <= 256) out[key] = field;
+	}
+	if (Array.isArray(value.issues)) {
+		out.issues = value.issues.map((issue) => ({
+			path: typeof issue.path === 'string' ? issue.path : undefined,
+			code: typeof issue.code === 'string' ? issue.code : undefined,
+		}));
+	}
+	return out;
+}
+
+/** Emit a fail-open error without serializing arbitrary exception text or stored values. */
+export function logOperationalError(
+	event: string,
+	fields: Record<string, unknown>,
+	err: unknown,
+): void {
+	console.error(
+		JSON.stringify({
+			ts: new Date().toISOString(),
+			level: 'error',
+			event,
+			...fields,
+			error: safeError(err),
+		}),
+	);
+}

--- a/packages/core/src/operationalLog.ts
+++ b/packages/core/src/operationalLog.ts
@@ -12,11 +12,11 @@ function safeError(err: unknown): Record<string, unknown> {
 	const out: Record<string, unknown> = { name: value.name };
 	for (const key of ['code', 'status', 'operation', 'reason', 'object', 'cause_name'] as const) {
 		const field = value[key];
-		if (typeof field === 'number') out[key] = field;
+		if (typeof field === 'number' && Number.isFinite(field)) out[key] = field;
 		if (typeof field === 'string' && field.length <= 256) out[key] = field;
 	}
 	if (Array.isArray(value.issues)) {
-		out.issues = value.issues.map((issue) => ({
+		out.issues = value.issues.slice(0, 20).map((issue) => ({
 			path: typeof issue.path === 'string' ? issue.path : undefined,
 			code: typeof issue.code === 'string' ? issue.code : undefined,
 		}));
@@ -30,12 +30,14 @@ export function logOperationalError(
 	fields: Record<string, unknown>,
 	err: unknown,
 ): void {
+	const context = { ...fields };
+	for (const key of ['ts', 'level', 'event', 'error']) delete context[key];
 	console.error(
 		JSON.stringify({
+			...context,
 			ts: new Date().toISOString(),
 			level: 'error',
 			event,
-			...fields,
 			error: safeError(err),
 		}),
 	);

--- a/packages/core/src/operationalLog.ts
+++ b/packages/core/src/operationalLog.ts
@@ -30,15 +30,30 @@ export function logOperationalError(
 	fields: Record<string, unknown>,
 	err: unknown,
 ): void {
-	const context = { ...fields };
-	for (const key of ['ts', 'level', 'event', 'error']) delete context[key];
-	console.error(
-		JSON.stringify({
+	let line: string;
+	try {
+		const context = { ...fields };
+		for (const key of ['ts', 'level', 'event', 'error']) delete context[key];
+		line = JSON.stringify({
 			...context,
 			ts: new Date().toISOString(),
 			level: 'error',
 			event,
 			error: safeError(err),
-		}),
-	);
+		});
+	} catch {
+		try {
+			line = JSON.stringify({
+				ts: new Date().toISOString(),
+				level: 'error',
+				event: 'operational_log_serialization_failed',
+				attempted_event: typeof event === 'string' ? event.slice(0, 128) : 'unknown',
+			});
+		} catch {
+			line = '{"level":"error","event":"operational_log_serialization_failed"}';
+		}
+	}
+	try {
+		console.error(line);
+	} catch {}
 }

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -72,6 +72,20 @@ describe('parseStored', () => {
 			expect(JSON.stringify(err)).not.toContain('secret bytes');
 		}
 	});
+
+	it('caps retained schema issues', () => {
+		const many = z.array(z.number());
+		try {
+			parseStored(
+				many,
+				Array.from({ length: 50 }, () => 'bad'),
+				'_system/many.json',
+			);
+			expect.unreachable('should have thrown');
+		} catch (err) {
+			expect((err as { issues: unknown[] }).issues).toHaveLength(20);
+		}
+	});
 });
 
 describe('id schemas', () => {

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -12,6 +12,7 @@ import {
 	EventSchema,
 	NotebookIdSchema,
 	parseStored,
+	readStored,
 	ProjectIdSchema,
 	ProjectMemberSchema,
 	ProjectSchema,
@@ -40,16 +41,35 @@ describe('parseStored', () => {
 		expect(parseStored(schema, { a: 1 }, 'thing')).toEqual({ a: 1 });
 	});
 
-	it('throws a labeled error that keeps the ZodError as cause', () => {
+	it('throws a labeled error with value-free schema diagnostics', () => {
 		try {
-			parseStored(schema, { a: 'nope' }, '_system/catalog.json');
+			parseStored(schema, { a: 'do-not-log-this' }, '_system/catalog.json');
 			expect.unreachable('should have thrown');
 		} catch (err) {
 			expect(err).toBeInstanceOf(Error);
 			expect((err as Error).message).toBe('Corrupted stored object: _system/catalog.json');
-			// The ZodError is preserved so logs can surface the failing field path.
-			expect((err as Error).cause).toBeDefined();
-			expect((err as { cause: { issues: unknown[] } }).cause.issues).toHaveLength(1);
+			expect(err).toMatchObject({
+				reason: 'schema_mismatch',
+				object: '_system/catalog.json',
+				issues: [{ path: 'a', code: 'invalid_type' }],
+			});
+			expect(JSON.stringify(err)).not.toContain('do-not-log-this');
+		}
+	});
+
+	it('labels invalid JSON without retaining parser text or bytes', async () => {
+		const body = {
+			json: () => Promise.reject(new SyntaxError('secret bytes at position 7')),
+		};
+		await expect(readStored(schema, body, 'projects/x/project.json')).rejects.toMatchObject({
+			reason: 'invalid_json',
+			object: 'projects/x/project.json',
+			cause_name: 'SyntaxError',
+		});
+		try {
+			await readStored(schema, body, 'projects/x/project.json');
+		} catch (err) {
+			expect(JSON.stringify(err)).not.toContain('secret bytes');
 		}
 	});
 });

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -59,16 +59,62 @@ export const CURRENT_VERSION_VERSION = 1;
 export const CURRENT_EVENT_VERSION = 1;
 
 /**
- * Parse an object read from storage, turning a schema mismatch into a clearly
- * labeled error. A bare `ZodError` reaching the request path becomes an opaque
- * 500; wrapping it with `what` (the object's identity) and keeping the `ZodError`
- * as `cause` means the server log says exactly which stored object is corrupted —
- * while the client still gets the standard sanitized 500.
+ * Parse an object read from storage, turning a schema mismatch into a labeled
+ * error. Diagnostics retain field paths and issue codes, but not stored values
+ * or validator messages.
  */
+export class StoredObjectError extends Error {
+	readonly reason: 'invalid_json' | 'schema_mismatch';
+	readonly object: string;
+	readonly issues?: { path: string; code: string }[];
+	readonly cause_name?: string;
+
+	constructor(
+		what: string,
+		reason: 'invalid_json' | 'schema_mismatch',
+		options?: { issues?: { path: string; code: string }[]; causeName?: string },
+	) {
+		super(`Corrupted stored object: ${what}`);
+		this.name = 'StoredObjectError';
+		this.object = what;
+		this.reason = reason;
+		this.issues = options?.issues;
+		this.cause_name = options?.causeName;
+	}
+}
+
 export function parseStored<T>(schema: z.ZodType<T>, value: unknown, what: string): T {
 	const result = schema.safeParse(value);
 	if (result.success) return result.data;
-	throw new Error(`Corrupted stored object: ${what}`, { cause: result.error });
+	throw new StoredObjectError(what, 'schema_mismatch', {
+		issues: result.error.issues.map((issue) => ({
+			path: issue.path.map(String).join('.'),
+			code: issue.code,
+		})),
+	});
+}
+
+export async function readStored<T>(
+	schema: z.ZodType<T>,
+	body: { json(): Promise<unknown> },
+	what: string,
+): Promise<T> {
+	return parseStored(schema, await readStoredJson(body, what), what);
+}
+
+export async function readStoredJson(
+	body: { json(): Promise<unknown> },
+	what: string,
+): Promise<unknown> {
+	let value: unknown;
+	try {
+		value = await body.json();
+	} catch (err) {
+		throw new StoredObjectError(what, 'invalid_json', {
+			causeName: err instanceof Error ? err.name : `non-error(${typeof err})`,
+		});
+	}
+	return value;
 }
 
 // --- ID schemas ---

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -58,6 +58,8 @@ export const CURRENT_VERSION_VERSION = 1;
 /** Current version stamped onto newly-written events. */
 export const CURRENT_EVENT_VERSION = 1;
 
+const MAX_STORED_OBJECT_ISSUES = 20;
+
 /**
  * Parse an object read from storage, turning a schema mismatch into a labeled
  * error. Diagnostics retain field paths and issue codes, but not stored values
@@ -87,7 +89,7 @@ export function parseStored<T>(schema: z.ZodType<T>, value: unknown, what: strin
 	const result = schema.safeParse(value);
 	if (result.success) return result.data;
 	throw new StoredObjectError(what, 'schema_mismatch', {
-		issues: result.error.issues.map((issue) => ({
+		issues: result.error.issues.slice(0, MAX_STORED_OBJECT_ISSUES).map((issue) => ({
 			path: issue.path.map(String).join('.'),
 			code: issue.code,
 		})),

--- a/packages/core/src/services/catalog/CatalogService.ts
+++ b/packages/core/src/services/catalog/CatalogService.ts
@@ -5,7 +5,7 @@ import { NotInitializedError, PreconditionFailedError } from '../../errors';
 import { createSnapshotId } from '../../ids';
 import type { NotebookId, ProjectId, UserId } from '../../ids';
 import { paths } from '../../paths';
-import { CURRENT_SNAPSHOT_VERSION, CatalogSchema, parseStored, SnapshotSchema } from '../../schema';
+import { CURRENT_SNAPSHOT_VERSION, CatalogSchema, readStored, SnapshotSchema } from '../../schema';
 import type { Catalog, Snapshot, SnapshotNotebookEntry, SnapshotProjectEntry } from '../../schema';
 import { withCasRetry } from './cas';
 import type { EventService } from './EventService';
@@ -94,14 +94,14 @@ export class CatalogService {
 			throw new NotInitializedError('Catalog not found — call initialize() first');
 		}
 
-		const catalog = parseStored(CatalogSchema, await catalogObj.json(), paths.catalog);
+		const catalog = await readStored(CatalogSchema, catalogObj, paths.catalog);
 		const snapshotObj = await this.bucket.get(catalog.current_snapshot_key);
 		if (!snapshotObj) {
 			throw new NotInitializedError(`Snapshot ${catalog.current_snapshot_id} not found`);
 		}
 
 		return upgradeSnapshot(
-			parseStored(SnapshotSchema, await snapshotObj.json(), catalog.current_snapshot_key),
+			await readStored(SnapshotSchema, snapshotObj, catalog.current_snapshot_key),
 		);
 	}
 
@@ -122,7 +122,7 @@ export class CatalogService {
 				}
 
 				const catalogEtag = catalogObj.etag;
-				const catalog = parseStored(CatalogSchema, await catalogObj.json(), paths.catalog);
+				const catalog = await readStored(CatalogSchema, catalogObj, paths.catalog);
 
 				const snapshotObj = await this.bucket.get(catalog.current_snapshot_key);
 				if (!snapshotObj) {
@@ -130,7 +130,7 @@ export class CatalogService {
 				}
 
 				const currentSnapshot = upgradeSnapshot(
-					parseStored(SnapshotSchema, await snapshotObj.json(), catalog.current_snapshot_key),
+					await readStored(SnapshotSchema, snapshotObj, catalog.current_snapshot_key),
 				);
 
 				const newSnapshotId = createSnapshotId();

--- a/packages/core/src/services/catalog/EventService.ts
+++ b/packages/core/src/services/catalog/EventService.ts
@@ -4,7 +4,8 @@ import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
 import { createEventId } from '../../ids';
 import type { UserId } from '../../ids';
 import { paths } from '../../paths';
-import { EventSchema } from '../../schema';
+import { logOperationalError } from '../../operationalLog';
+import { EventSchema, readStored } from '../../schema';
 import type { Event } from '../../schema';
 
 export class EventService {
@@ -47,9 +48,13 @@ export class EventService {
 					// One corrupt/legacy event object must not make the whole day's audit
 					// log unreadable — skip it (logged) rather than throwing.
 					try {
-						return EventSchema.parse(await body.json());
+						return await readStored(EventSchema, body, obj.key);
 					} catch (err) {
-						console.warn(`getEvents: skipping unreadable event ${obj.key}: ${String(err)}`);
+						logOperationalError(
+							'stored_object_skipped',
+							{ operation: 'event.list', object: obj.key },
+							err,
+						);
 						return;
 					}
 				},

--- a/packages/core/src/services/catalog/IdempotencyService.test.ts
+++ b/packages/core/src/services/catalog/IdempotencyService.test.ts
@@ -31,6 +31,31 @@ describe('IdempotencyService', () => {
 		expect(await svc.lookup('u1:POST /projects', 'k1')).toEqual({ data: { id: 'first' } });
 	});
 
+	it('replaces a corrupt record after treating lookup as a miss', async () => {
+		const bucket = new MemoryBucket();
+		const svc = new IdempotencyService(bucket);
+		await svc.record('u1:POST /projects', 'k1', { id: 'first' });
+		const { objects } = await bucket.list({ prefix: paths.idempotencyPrefix });
+		await bucket.put(objects[0].key, '{"secret":"do-not-log"');
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		try {
+			expect(await svc.lookup('u1:POST /projects', 'k1')).toBeNull();
+			await svc.record('u1:POST /projects', 'k1', { id: 'recovered' });
+			expect(await svc.lookup('u1:POST /projects', 'k1')).toEqual({
+				data: { id: 'recovered' },
+			});
+			expect(
+				log.mock.calls.some((call) =>
+					String(call[0]).includes('corrupt_idempotency_record_replaced'),
+				),
+			).toBe(true);
+			expect(log.mock.calls.map((call) => String(call[0])).join('\n')).not.toContain('do-not-log');
+		} finally {
+			log.mockRestore();
+		}
+	});
+
 	it('prune deletes records past the retention window and keeps recent ones', async () => {
 		vi.useFakeTimers();
 		const bucket = new MemoryBucket();

--- a/packages/core/src/services/catalog/IdempotencyService.test.ts
+++ b/packages/core/src/services/catalog/IdempotencyService.test.ts
@@ -4,7 +4,10 @@ import { paths } from '../../paths';
 import { IdempotencyService } from './IdempotencyService';
 
 describe('IdempotencyService', () => {
-	afterEach(() => vi.useRealTimers());
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
 
 	it('returns null before a key is recorded, the data after', async () => {
 		const svc = new IdempotencyService(new MemoryBucket());
@@ -54,6 +57,36 @@ describe('IdempotencyService', () => {
 		} finally {
 			log.mockRestore();
 		}
+	});
+
+	it('keeps repair read failures non-fatal after a lost create race', async () => {
+		const bucket = new MemoryBucket();
+		const svc = new IdempotencyService(bucket);
+		await svc.record('u1:POST /projects', 'k1', { id: 'first' });
+		vi.spyOn(bucket, 'get').mockRejectedValueOnce(new Error('transient read failure'));
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		await expect(svc.record('u1:POST /projects', 'k1', { id: 'second' })).resolves.toBeUndefined();
+		expect(log.mock.calls[0]?.[0]).toContain('idempotency_record_repair_failed');
+	});
+
+	it('keeps repair write failures non-fatal after a corrupt-record race', async () => {
+		const bucket = new MemoryBucket();
+		const svc = new IdempotencyService(bucket);
+		await svc.record('u1:POST /projects', 'k1', { id: 'first' });
+		const { objects } = await bucket.list({ prefix: paths.idempotencyPrefix });
+		await bucket.put(objects[0].key, '{not-json');
+		const originalPut = bucket.put.bind(bucket);
+		vi.spyOn(bucket, 'put').mockImplementation((key, value, options) => {
+			if (options?.onlyIfEtagMatches) return Promise.reject(new Error('transient write failure'));
+			return originalPut(key, value, options);
+		});
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		await expect(
+			svc.record('u1:POST /projects', 'k1', { id: 'recovered' }),
+		).resolves.toBeUndefined();
+		expect(log.mock.calls[0]?.[0]).toContain('idempotency_record_repair_failed');
 	});
 
 	it('prune deletes records past the retention window and keeps recent ones', async () => {

--- a/packages/core/src/services/catalog/IdempotencyService.ts
+++ b/packages/core/src/services/catalog/IdempotencyService.ts
@@ -1,20 +1,23 @@
+import { z } from 'zod';
 import type { Bucket } from '../../ports/bucket';
 import { Millis } from '../../duration';
 import { PreconditionFailedError } from '../../errors';
 import { toHex } from '../../internal/hex';
+import { logOperationalError } from '../../operationalLog';
 import { paths } from '../../paths';
+import { readStored } from '../../schema';
 import { listAllObjects } from './storage';
 
 const DEFAULT_RETENTION_MS = Millis.days(1);
 
-interface IdempotencyRecord {
-	schema_version: 1;
-	/** `${userId}:${routeId}` — stored so a hash collision across scopes can't replay. */
-	scope: string;
-	/** The recorded `data` payload of the original response envelope. */
-	data: unknown;
-	created_at: string;
-}
+const IdempotencyRecordSchema = z.object({
+	schema_version: z.literal(1),
+	scope: z.string(),
+	data: z.unknown(),
+	created_at: z.iso.datetime(),
+});
+
+type IdempotencyRecord = z.infer<typeof IdempotencyRecordSchema>;
 
 async function digestKey(scope: string, key: string): Promise<string> {
 	// Hash so an arbitrary client key never produces an unsafe/oversized object key,
@@ -35,9 +38,22 @@ export class IdempotencyService {
 
 	/** The recorded `data` for a prior `(scope, key)`, or null if this is a first use. */
 	async lookup(scope: string, key: string): Promise<{ data: unknown } | null> {
-		const obj = await this.bucket.get(paths.idempotencyKey(await digestKey(scope, key)));
+		const objectKey = paths.idempotencyKey(await digestKey(scope, key));
+		const obj = await this.bucket.get(objectKey);
 		if (!obj) return null;
-		const record = (await obj.json()) as IdempotencyRecord;
+		// A corrupt record must not brick this key for the whole retention window:
+		// fail open (treat as first use) rather than 500 every replay until it prunes.
+		let record: IdempotencyRecord;
+		try {
+			record = await readStored(IdempotencyRecordSchema, obj, objectKey);
+		} catch (err) {
+			logOperationalError(
+				'stored_object_skipped',
+				{ operation: 'idempotency.lookup', object: objectKey },
+				err,
+			);
+			return null;
+		}
 		if (record.scope !== scope) return null;
 		return { data: record.data };
 	}

--- a/packages/core/src/services/catalog/IdempotencyService.ts
+++ b/packages/core/src/services/catalog/IdempotencyService.ts
@@ -60,6 +60,7 @@ export class IdempotencyService {
 
 	/** Record a first-use response. Best-effort: a lost create-if-absent race is ignored. */
 	async record(scope: string, key: string, data: unknown): Promise<void> {
+		const objectKey = paths.idempotencyKey(await digestKey(scope, key));
 		const record: IdempotencyRecord = {
 			schema_version: 1,
 			scope,
@@ -67,13 +68,27 @@ export class IdempotencyService {
 			created_at: new Date().toISOString(),
 		};
 		try {
-			await this.bucket.put(
-				paths.idempotencyKey(await digestKey(scope, key)),
-				JSON.stringify(record),
-				{ onlyIfNotExists: true },
-			);
+			await this.bucket.put(objectKey, JSON.stringify(record), { onlyIfNotExists: true });
 		} catch (err) {
 			if (!(err instanceof PreconditionFailedError)) throw err;
+			const existing = await this.bucket.get(objectKey);
+			if (!existing) return;
+			try {
+				await readStored(IdempotencyRecordSchema, existing, objectKey);
+			} catch (readErr) {
+				try {
+					await this.bucket.put(objectKey, JSON.stringify(record), {
+						onlyIfEtagMatches: existing.etag,
+					});
+					logOperationalError(
+						'corrupt_idempotency_record_replaced',
+						{ operation: 'idempotency.record', object: objectKey },
+						readErr,
+					);
+				} catch (replaceErr) {
+					if (!(replaceErr instanceof PreconditionFailedError)) throw replaceErr;
+				}
+			}
 		}
 	}
 

--- a/packages/core/src/services/catalog/IdempotencyService.ts
+++ b/packages/core/src/services/catalog/IdempotencyService.ts
@@ -71,23 +71,41 @@ export class IdempotencyService {
 			await this.bucket.put(objectKey, JSON.stringify(record), { onlyIfNotExists: true });
 		} catch (err) {
 			if (!(err instanceof PreconditionFailedError)) throw err;
-			const existing = await this.bucket.get(objectKey);
+			let existing;
+			try {
+				existing = await this.bucket.get(objectKey);
+			} catch (repairErr) {
+				logOperationalError(
+					'idempotency_record_repair_failed',
+					{ operation: 'idempotency.record', object: objectKey },
+					repairErr,
+				);
+				return;
+			}
 			if (!existing) return;
+			let corruption: unknown;
 			try {
 				await readStored(IdempotencyRecordSchema, existing, objectKey);
+				return;
 			} catch (readErr) {
-				try {
-					await this.bucket.put(objectKey, JSON.stringify(record), {
-						onlyIfEtagMatches: existing.etag,
-					});
-					logOperationalError(
-						'corrupt_idempotency_record_replaced',
-						{ operation: 'idempotency.record', object: objectKey },
-						readErr,
-					);
-				} catch (replaceErr) {
-					if (!(replaceErr instanceof PreconditionFailedError)) throw replaceErr;
-				}
+				corruption = readErr;
+			}
+			try {
+				await this.bucket.put(objectKey, JSON.stringify(record), {
+					onlyIfEtagMatches: existing.etag,
+				});
+				logOperationalError(
+					'corrupt_idempotency_record_replaced',
+					{ operation: 'idempotency.record', object: objectKey },
+					corruption,
+				);
+			} catch (replaceErr) {
+				if (replaceErr instanceof PreconditionFailedError) return;
+				logOperationalError(
+					'idempotency_record_repair_failed',
+					{ operation: 'idempotency.record', object: objectKey },
+					replaceErr,
+				);
 			}
 		}
 	}

--- a/packages/core/src/services/catalog/MaintenanceLock.test.ts
+++ b/packages/core/src/services/catalog/MaintenanceLock.test.ts
@@ -17,6 +17,7 @@ describe('MaintenanceLock', () => {
 
 	afterEach(() => {
 		clock.restore();
+		vi.restoreAllMocks();
 	});
 
 	it('acquires a free lease', async () => {
@@ -59,11 +60,15 @@ describe('MaintenanceLock', () => {
 	});
 
 	it('steals a lock whose stored record is malformed', async () => {
-		await bucket.put(paths.maintenanceLock, 'not-json');
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+		await bucket.put(paths.maintenanceLock, 'not-json-do-not-log');
 
 		expect(await lock.acquire('A', 1000)).toBe(true);
 		const stored = await bucket.get(paths.maintenanceLock);
 		expect((await stored!.json<{ holder: string }>()).holder).toBe('A');
+		const line = log.mock.calls[0]?.[0] as string;
+		expect(line).toContain('corrupt_maintenance_lock_ignored');
+		expect(line).not.toContain('not-json-do-not-log');
 	});
 
 	it('returns false when it loses the CAS on a contended steal', async () => {

--- a/packages/core/src/services/catalog/MaintenanceLock.ts
+++ b/packages/core/src/services/catalog/MaintenanceLock.ts
@@ -2,7 +2,9 @@ import { z } from 'zod';
 import type { Bucket } from '../../ports/bucket';
 import { Millis } from '../../duration';
 import { PreconditionFailedError } from '../../errors';
+import { logOperationalError } from '../../operationalLog';
 import { paths } from '../../paths';
+import { parseStored, StoredObjectError } from '../../schema';
 
 /**
  * Advisory lease for the single-writer maintenance sweep, built on the same
@@ -52,7 +54,7 @@ export class MaintenanceLock {
 			return this.tryCreate(body);
 		}
 
-		const current = this.parse(await existing.text());
+		const current = this.parse(await existing.text(), 'maintenance_lock.acquire');
 		const heldByOther = current && current.holder !== holder;
 		if (heldByOther && new Date(current.expires_at).getTime() > now) {
 			return false; // someone else holds it and it hasn't expired
@@ -76,9 +78,15 @@ export class MaintenanceLock {
 	async release(holder: string): Promise<void> {
 		const existing = await this.bucket.get(this.key);
 		if (!existing) return;
-		const current = this.parse(await existing.text());
+		const current = this.parse(await existing.text(), 'maintenance_lock.release');
 		if (!current || current.holder !== holder) return;
-		await this.bucket.delete(this.key).catch(() => {});
+		await this.bucket.delete(this.key).catch((err) => {
+			logOperationalError(
+				'maintenance_lock_release_failed',
+				{ operation: 'maintenance_lock.release', object: this.key },
+				err,
+			);
+		});
 	}
 
 	private async tryCreate(body: string): Promise<boolean> {
@@ -91,11 +99,19 @@ export class MaintenanceLock {
 		}
 	}
 
-	private parse(text: string): LockRecord | null {
+	private parse(text: string, operation: string): LockRecord | null {
 		try {
-			const result = LockRecordSchema.safeParse(JSON.parse(text));
-			return result.success ? result.data : null;
-		} catch {
+			return parseStored(LockRecordSchema, JSON.parse(text), this.key);
+		} catch (err) {
+			const safeError =
+				err instanceof SyntaxError
+					? new StoredObjectError(this.key, 'invalid_json', { causeName: err.name })
+					: err;
+			logOperationalError(
+				'corrupt_maintenance_lock_ignored',
+				{ operation, object: this.key },
+				safeError,
+			);
 			return null;
 		}
 	}

--- a/packages/core/src/services/catalog/MaintenanceService.ts
+++ b/packages/core/src/services/catalog/MaintenanceService.ts
@@ -3,7 +3,7 @@ import { Millis } from '../../duration';
 import { noopMetrics } from '../../ports/metrics';
 import type { Metrics } from '../../ports/metrics';
 import { paths } from '../../paths';
-import { CatalogSchema } from '../../schema';
+import { CatalogSchema, readStored } from '../../schema';
 import { listAllObjects } from './storage';
 
 // Every commit writes a new catalog snapshot; at ~20 writes/day that is
@@ -54,7 +54,7 @@ export class MaintenanceService {
 		const catalogObj = await this.bucket.get(paths.catalog);
 		if (!catalogObj) return 0; // uninitialized — nothing to prune
 
-		const catalog = CatalogSchema.parse(await catalogObj.json());
+		const catalog = await readStored(CatalogSchema, catalogObj, paths.catalog);
 		const protectedKeys = new Set<string>([paths.snapshot(catalog.current_snapshot_id)]);
 		if (catalog.previous_snapshot_id) {
 			protectedKeys.add(paths.snapshot(catalog.previous_snapshot_id));

--- a/packages/core/src/services/catalog/MigrationService.ts
+++ b/packages/core/src/services/catalog/MigrationService.ts
@@ -9,6 +9,7 @@
  */
 import { SYSTEM_ACTOR } from '../../ids';
 import type { Bucket } from '../../ports/bucket';
+import { logOperationalError } from '../../operationalLog';
 import { EventService } from './EventService';
 
 /** Per-object schema types that use the fan-out migration strategy. */
@@ -94,7 +95,11 @@ export class MigrationService {
 					}
 					data = parsed as Migratable;
 				} catch (err) {
-					console.warn(`runMigration: skipping unreadable object ${obj.key}: ${String(err)}`);
+					logOperationalError(
+						'stored_object_skipped',
+						{ operation: 'migration.scan', object: obj.key, target_type: targetType },
+						err,
+					);
 					result.skipped++;
 					continue;
 				}

--- a/packages/core/src/services/catalog/cas.ts
+++ b/packages/core/src/services/catalog/cas.ts
@@ -1,6 +1,8 @@
 import type { Bucket } from '../../ports/bucket';
 import { sleep } from '../../duration';
 import { ConflictError, NotFoundError, PreconditionFailedError } from '../../errors';
+import { logOperationalError } from '../../operationalLog';
+import { readStoredJson } from '../../schema';
 
 // Compare-and-swap helpers for the object store — one tested retry loop shared by
 // the catalog pointer and session records.
@@ -98,8 +100,13 @@ export async function acquireSingletonClaim(
 		}
 		let current: string | null | undefined;
 		try {
-			current = cfg.parseHolder(await existing.json());
-		} catch {
+			current = cfg.parseHolder(await readStoredJson(existing, cfg.key));
+		} catch (err) {
+			logOperationalError(
+				'corrupt_singleton_claim_replaced',
+				{ operation: 'singleton_claim.acquire', object: cfg.key },
+				err,
+			);
 			// Corrupt claim — stale by definition; replaced below.
 		}
 		if (current === holder) return { acquired: true, holder };
@@ -129,7 +136,7 @@ export async function releaseSingletonClaim(
 	try {
 		const existing = await cfg.bucket.get(cfg.key);
 		if (!existing) return;
-		if (cfg.parseHolder(await existing.json()) !== holder) return;
+		if (cfg.parseHolder(await readStoredJson(existing, cfg.key)) !== holder) return;
 		await cfg.bucket.put(cfg.key, cfg.serialize(null), { onlyIfEtagMatches: existing.etag });
 	} catch (err) {
 		// A losing CAS means someone re-acquired underneath us — exactly the claim
@@ -138,7 +145,13 @@ export async function releaseSingletonClaim(
 		// reconciliation pass survives it, but never silently.
 		if (err instanceof PreconditionFailedError) return;
 		if (cfg.onReleaseError) cfg.onReleaseError(err);
-		else console.warn(`releaseSingletonClaim: ${cfg.key}: ${String(err)}`);
+		else {
+			logOperationalError(
+				'singleton_claim_release_failed',
+				{ operation: 'singleton_claim.release', object: cfg.key },
+				err,
+			);
+		}
 	}
 }
 
@@ -157,7 +170,7 @@ export async function mutateObject<T>(
 	return withCasRetry(async () => {
 		const obj = await bucket.get(key);
 		if (!obj) throw options.notFound?.() ?? new NotFoundError(`Object ${key} not found`);
-		const current = parse(await obj.json());
+		const current = parse(await readStoredJson(obj, key));
 		const next = apply(current);
 		if (!next) return current;
 		await bucket.put(key, JSON.stringify(next), { onlyIfEtagMatches: obj.etag });

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -420,6 +420,21 @@ describe('NotebookService', () => {
 
 			expect(await notebooks.synced.verifyToken(projectId, meta.id, sync_token)).toBe(false);
 		});
+
+		it('surfaces token verification failures after a valid sidecar read', async () => {
+			const { meta, sync_token } = await create();
+			const digest = vi
+				.spyOn(crypto.subtle, 'digest')
+				.mockRejectedValueOnce(new Error('crypto unavailable'));
+
+			try {
+				await expect(notebooks.synced.verifyToken(projectId, meta.id, sync_token)).rejects.toThrow(
+					'crypto unavailable',
+				);
+			} finally {
+				digest.mockRestore();
+			}
+		});
 	});
 
 	describe('getNotebook', () => {
@@ -949,6 +964,31 @@ describe('NotebookService', () => {
 
 			const versions = await notebooks.listVersions(projectId, created.id);
 			expect(versions).toHaveLength(3);
+		});
+
+		it('skips a corrupt version record and logs without its bytes', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			await notebooks.updateNotebook(projectId, created.id, { code: 'v2' }, ACTOR);
+			const versions = await notebooks.listVersions(projectId, created.id);
+			const key = paths
+				.project(projectId)
+				.notebook(created.id)
+				.version(versions[0].version_id).meta;
+			await bucket.put(key, '{"secret":"do-not-log"');
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			try {
+				expect(await notebooks.listVersions(projectId, created.id)).toHaveLength(1);
+				const line = log.mock.calls[0]?.[0] as string;
+				expect(line).toContain('notebook.version_list');
+				expect(line).not.toContain('do-not-log');
+			} finally {
+				log.mockRestore();
+			}
 		});
 
 		it('getVersion returns specific version code', async () => {

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -9,11 +9,13 @@ import type { NotebookId, ProjectId, UserId } from '../../ids';
 import { noopMetrics } from '../../ports/metrics';
 import type { Metrics } from '../../ports/metrics';
 import { paths } from '../../paths';
+import { logOperationalError } from '../../operationalLog';
 import { compensableWrite, metricsObserver, saga } from '../../saga';
 import {
 	FsSnapshotSchema,
 	NotebookMetaSchema,
 	parseStored,
+	readStored,
 	SourceSchema,
 	toPublicNotebookEntry,
 	VersionSchema,
@@ -134,8 +136,8 @@ export class NotebookService {
 			throw new NotFoundError(`Notebook ${notebookId} not found`);
 		}
 
-		const meta = parseStored(NotebookMetaSchema, await metaObj.json(), nb.meta);
-		const source = parseStored(SourceSchema, await sourceObj.json(), nb.source);
+		const meta = await readStored(NotebookMetaSchema, metaObj, nb.meta);
+		const source = await readStored(SourceSchema, sourceObj, nb.source);
 		const readme = readmeObj ? await readmeObj.text() : null;
 
 		return { meta, readme, source };
@@ -618,7 +620,7 @@ export class NotebookService {
 					await mutateObject(
 						this.bucket,
 						ver.meta,
-						(raw) => VersionSchema.parse(raw),
+						(raw) => parseStored(VersionSchema, raw, ver.meta),
 						(current): Version => ({
 							...current,
 							...(htmlDescriptor ? { html_snapshot: htmlDescriptor } : {}),
@@ -701,7 +703,7 @@ export class NotebookService {
 			async (pfx) => {
 				const obj = await this.bucket.get(`${pfx}version.json`);
 				if (!obj) return; // listed-then-deleted race; skip rather than fail.
-				return VersionSchema.parse(await obj.json());
+				return readStored(VersionSchema, obj, `${pfx}version.json`);
 			},
 		);
 		return fetched.filter((v): v is Version => v !== undefined);
@@ -733,7 +735,7 @@ export class NotebookService {
 			throw new NotFoundError(`Version ${versionId} not found`);
 		}
 
-		const version = VersionSchema.parse(await metaObj.json());
+		const version = await readStored(VersionSchema, metaObj, ver.meta);
 		const code = await codeObj.text();
 
 		return { version, code };
@@ -813,8 +815,13 @@ export class NotebookService {
 			}
 		} catch (err) {
 			// Non-fatal: the save already committed. Log and move on.
-			console.error(
-				`pruneVersions failed for notebook ${notebookId} in project ${projectId}:`,
+			logOperationalError(
+				'notebook_version_prune_failed',
+				{
+					operation: 'notebook.version_prune',
+					project_id: projectId,
+					notebook_id: notebookId,
+				},
 				err,
 			);
 		}
@@ -831,8 +838,13 @@ export class NotebookService {
 		const obj = await this.bucket.get(nb.fsSnapshot);
 		if (!obj) return null;
 		try {
-			return FsSnapshotSchema.parse(await obj.json());
-		} catch {
+			return await readStored(FsSnapshotSchema, obj, nb.fsSnapshot);
+		} catch (err) {
+			logOperationalError(
+				'stored_object_skipped',
+				{ operation: 'notebook.fs_snapshot.read', object: nb.fsSnapshot },
+				err,
+			);
 			return null;
 		}
 	}

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -701,9 +701,19 @@ export class NotebookService {
 			result.delimitedPrefixes,
 			BUCKET_SCAN_CONCURRENCY,
 			async (pfx) => {
-				const obj = await this.bucket.get(`${pfx}version.json`);
+				const key = `${pfx}version.json`;
+				const obj = await this.bucket.get(key);
 				if (!obj) return; // listed-then-deleted race; skip rather than fail.
-				return readStored(VersionSchema, obj, `${pfx}version.json`);
+				try {
+					return await readStored(VersionSchema, obj, key);
+				} catch (err) {
+					logOperationalError(
+						'stored_object_skipped',
+						{ operation: 'notebook.version_list', object: key },
+						err,
+					);
+					return;
+				}
 			},
 		);
 		return fetched.filter((v): v is Version => v !== undefined);

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -13,7 +13,7 @@ import { noopMetrics } from '../../ports/metrics';
 import type { Metrics } from '../../ports/metrics';
 import { paths } from '../../paths';
 import { metricsObserver, saga } from '../../saga';
-import { parseStored, ProjectSchema, toPublicProjectEntry } from '../../schema';
+import { ProjectSchema, readStored, toPublicProjectEntry } from '../../schema';
 import type {
 	Project,
 	ProjectFederation,
@@ -98,7 +98,7 @@ export class ProjectService {
 		if (!obj) {
 			throw new NotFoundError(`Project ${id} not found`);
 		}
-		return parseStored(ProjectSchema, await obj.json(), paths.project(id).meta);
+		return readStored(ProjectSchema, obj, paths.project(id).meta);
 	}
 
 	async createProject(input: CreateProjectInput, actor: UserId): Promise<Project> {

--- a/packages/core/src/services/content/SyncedNotebookService.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.ts
@@ -183,9 +183,9 @@ export class SyncedNotebookService {
 		const nb = paths.project(projectId).notebook(notebookId);
 		const obj = await this.bucket.get(nb.integrationSyncToken);
 		if (!obj) return false;
+		let record;
 		try {
-			const record = await readStored(SyncTokenRecordSchema, obj, nb.integrationSyncToken);
-			return await verifySyncTokenRecord(record, token);
+			record = await readStored(SyncTokenRecordSchema, obj, nb.integrationSyncToken);
 		} catch (err) {
 			logOperationalError(
 				'stored_object_skipped',
@@ -194,6 +194,7 @@ export class SyncedNotebookService {
 			);
 			return false;
 		}
+		return verifySyncTokenRecord(record, token);
 	}
 
 	async sync(

--- a/packages/core/src/services/content/SyncedNotebookService.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.ts
@@ -20,9 +20,10 @@ import type {
 } from '../../integrations/syncedSource';
 import type { Metrics } from '../../ports/metrics';
 import { paths } from '../../paths';
+import { logOperationalError } from '../../operationalLog';
 import type { VersionPaths } from '../../paths';
 import { compensableWrite, metricsObserver, saga } from '../../saga';
-import { NotebookMetaSchema, SourceSchema } from '../../schema';
+import { NotebookMetaSchema, parseStored, readStored, SourceSchema } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject } from '../catalog/cas';
 import { buildNotebookEntry, buildNotebookMeta, buildVersion } from './notebookMeta';
@@ -139,7 +140,7 @@ export class SyncedNotebookService {
 		const source = await mutateObject(
 			this.bucket,
 			nb.source,
-			(raw) => assertSyncedSource(SourceSchema.parse(raw)),
+			(raw) => assertSyncedSource(parseStored(SourceSchema, raw, nb.source)),
 			(current) => {
 				const active = gitSourceConfig(current);
 				if (current.pending_config && gitSourceConfigsEqual(current.pending_config, desired)) {
@@ -159,7 +160,7 @@ export class SyncedNotebookService {
 		await mutateObject(
 			this.bucket,
 			nb.meta,
-			(raw) => NotebookMetaSchema.parse(raw),
+			(raw) => parseStored(NotebookMetaSchema, raw, nb.meta),
 			(current) => ({ ...current, updated_at: now }),
 		);
 		await this.catalog.updateNotebookEntry(
@@ -182,15 +183,17 @@ export class SyncedNotebookService {
 		const nb = paths.project(projectId).notebook(notebookId);
 		const obj = await this.bucket.get(nb.integrationSyncToken);
 		if (!obj) return false;
-		let rawRecord: unknown;
 		try {
-			rawRecord = await obj.json();
-		} catch {
+			const record = await readStored(SyncTokenRecordSchema, obj, nb.integrationSyncToken);
+			return await verifySyncTokenRecord(record, token);
+		} catch (err) {
+			logOperationalError(
+				'stored_object_skipped',
+				{ operation: 'sync_token.verify', object: nb.integrationSyncToken },
+				err,
+			);
 			return false;
 		}
-		const record = SyncTokenRecordSchema.safeParse(rawRecord);
-		if (!record.success) return false;
-		return verifySyncTokenRecord(record.data, token);
 	}
 
 	async sync(
@@ -246,7 +249,7 @@ export class SyncedNotebookService {
 				const advancedSource = await mutateObject(
 					this.bucket,
 					nb.source,
-					(raw) => SourceSchema.parse(raw),
+					(raw) => parseStored(SourceSchema, raw, nb.source),
 					(current) => {
 						const git = assertSyncedSource(current);
 						const currentPrepared = prepareSync(git, input);

--- a/packages/core/src/services/content/filesystemSnapshots.ts
+++ b/packages/core/src/services/content/filesystemSnapshots.ts
@@ -2,6 +2,7 @@ import type { NotebookId, ProjectId, SandboxId, UserId } from '../../ids';
 import { asFilesystemSnapshots } from '../../ports/sandbox';
 import type { ComputeResources, SandboxInstance, SandboxProvider } from '../../ports/sandbox';
 import type { FsSnapshot } from '../../schema';
+import { logOperationalError } from '../../operationalLog';
 import type { NotebookService } from './NotebookService';
 
 /**
@@ -85,7 +86,11 @@ export async function captureFilesystemSnapshot(
 			await fs.deleteSnapshot(previous.snapshot_id); // latest-wins GC
 		}
 	} catch (err) {
-		console.error(`fs snapshot capture failed for notebook ${notebookId}:`, err);
+		logOperationalError(
+			'filesystem_snapshot_capture_failed',
+			{ operation: 'filesystem_snapshot.capture', project_id: projectId, notebook_id: notebookId },
+			err,
+		);
 	}
 }
 
@@ -105,7 +110,15 @@ export async function reapFilesystemSnapshots(
 		try {
 			await fs.deleteSnapshot(snap.snapshot_id);
 			reaped++;
-		} catch {
+		} catch (err) {
+			logOperationalError(
+				'filesystem_snapshot_delete_failed',
+				{
+					operation: 'filesystem_snapshot.delete',
+					snapshot_id: snap.snapshot_id,
+				},
+				err,
+			);
 			// Best-effort: a later sweep retries if the snapshot survives.
 		}
 	}

--- a/packages/core/src/services/identity/IdentityService.test.ts
+++ b/packages/core/src/services/identity/IdentityService.test.ts
@@ -160,6 +160,23 @@ describe('IdentityService', () => {
 				vi.useRealTimers();
 			}
 		});
+
+		it('logs a failed shared stale-cache refresh once', async () => {
+			vi.useFakeTimers();
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+			try {
+				await identities.search('ada');
+				vi.advanceTimersByTime(31_000);
+				vi.spyOn(bucket, 'list').mockRejectedValue(new Error('directory unavailable'));
+
+				await Promise.all(Array.from({ length: 20 }, () => identities.search('ada')));
+				await vi.waitFor(() => expect(log).toHaveBeenCalledTimes(1));
+				expect(log.mock.calls[0]?.[0]).toContain('identity_directory_refresh_failed');
+			} finally {
+				log.mockRestore();
+				vi.useRealTimers();
+			}
+		});
 	});
 
 	describe('getByEmail', () => {

--- a/packages/core/src/services/identity/IdentityService.ts
+++ b/packages/core/src/services/identity/IdentityService.ts
@@ -5,7 +5,8 @@ import { foldCase, normalizeEmail } from '../../identityMatch';
 import type { UserId } from '../../ids';
 import type { AuthUser } from '../../ports/auth';
 import { paths } from '../../paths';
-import { IdentitySchema } from '../../schema';
+import { logOperationalError } from '../../operationalLog';
+import { IdentitySchema, readStored } from '../../schema';
 import type { Identity } from '../../schema';
 import { listAllKeys } from '../catalog/storage';
 
@@ -89,7 +90,7 @@ export class IdentityService {
 	async get(id: UserId): Promise<Identity | null> {
 		const obj = await this.bucket.get(paths.identity(id));
 		if (!obj) return null;
-		return IdentitySchema.parse(await obj.json());
+		return readStored(IdentitySchema, obj, paths.identity(id));
 	}
 
 	/**
@@ -116,7 +117,9 @@ export class IdentityService {
 			// Stale-while-revalidate: 30s staleness is already accepted, so don't
 			// make a keystroke-driven search pay the full rescan latency. A failed
 			// background refresh keeps serving the stale entries.
-			this.refreshing.catch(() => {});
+			this.refreshing.catch((err) => {
+				logOperationalError('identity_directory_refresh_failed', {}, err);
+			});
 			return this.directory.entries;
 		}
 		return this.refreshing;
@@ -129,8 +132,16 @@ export class IdentityService {
 			if (!obj) return null;
 			// Tolerate corrupt records (like getMany): one bad object must not take
 			// down search for the whole directory.
-			const parsed = IdentitySchema.safeParse(await obj.json());
-			return parsed.success ? parsed.data : null;
+			try {
+				return await readStored(IdentitySchema, obj, key);
+			} catch (err) {
+				logOperationalError(
+					'stored_object_skipped',
+					{ operation: 'identity.directory_scan', object: key },
+					err,
+				);
+				return null;
+			}
 		});
 		const entries = records.filter((r): r is Identity => r !== null);
 		this.directory = { at: Date.now(), entries };

--- a/packages/core/src/services/identity/IdentityService.ts
+++ b/packages/core/src/services/identity/IdentityService.ts
@@ -110,16 +110,20 @@ export class IdentityService {
 		}
 		// Single-flight: concurrent misses share one scan instead of each running
 		// their own list + N GETs.
-		this.refreshing ??= this.refresh().finally(() => {
-			this.refreshing = null;
-		});
+		if (!this.refreshing) {
+			this.refreshing = this.refresh().finally(() => {
+				this.refreshing = null;
+			});
+			if (this.directory) {
+				this.refreshing.catch((err) => {
+					logOperationalError('identity_directory_refresh_failed', {}, err);
+				});
+			}
+		}
 		if (this.directory) {
 			// Stale-while-revalidate: 30s staleness is already accepted, so don't
 			// make a keystroke-driven search pay the full rescan latency. A failed
 			// background refresh keeps serving the stale entries.
-			this.refreshing.catch((err) => {
-				logOperationalError('identity_directory_refresh_failed', {}, err);
-			});
 			return this.directory.entries;
 		}
 		return this.refreshing;

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -546,6 +546,28 @@ describe('ProjectIntegrationsStore', () => {
 		expect(await store.list(pid)).toEqual([]);
 	});
 
+	it('deletes a malformed head and logs without its bytes', async () => {
+		const store = makeStore(bucket);
+		const created = await store.create(
+			pid,
+			{ kind: 'echo', name: 'prod', config: { token: 't' } },
+			ACTOR,
+		);
+		const integrationPaths = paths.project(pid).integration(created.id);
+		await bucket.put(integrationPaths.head, '{"secret":"do-not-log"');
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		try {
+			await expect(store.delete(pid, created.id)).resolves.toBe(true);
+			expect(await bucket.list({ prefix: integrationPaths.base })).toMatchObject({ objects: [] });
+			const line = log.mock.calls[0]?.[0] as string;
+			expect(line).toContain('corrupt_integration_head_deleted');
+			expect(line).not.toContain('do-not-log');
+		} finally {
+			log.mockRestore();
+		}
+	});
+
 	it('resolveForSession renders enabled instances only; none → undefined', async () => {
 		const store = makeStore(bucket);
 		expect(await store.resolveForSession(pid, renderContext(createSessionId()))).toBeUndefined();

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -40,6 +40,8 @@ import {
 	IntegrationRecordSchema,
 	IntegrationVersionRecordSchema,
 	parseStored,
+	readStored,
+	readStoredJson,
 } from '../../schema';
 import type { IntegrationRecord, IntegrationVersionRecord } from '../../schema';
 import { listAllObjects } from '../catalog/storage';
@@ -520,7 +522,7 @@ class ScopedIntegrationsStore {
 		return withCasRetry(async () => {
 			const existing = await this.bucket.get(headPath);
 			if (!existing) return;
-			const raw = await existing.json();
+			const raw = await readStoredJson(existing, headPath);
 			// Already committed by an interrupted delete: resume its sweep (and its
 			// name release) rather than answer 412 on a token no live head can match.
 			if (isTombstoned(raw)) {
@@ -572,7 +574,7 @@ class ScopedIntegrationsStore {
 					const key = integrationPaths.version(version);
 					const body = await this.bucket.get(key);
 					if (!body) return null;
-					const record = parseStored(IntegrationVersionRecordSchema, await body.json(), key);
+					const record = await readStored(IntegrationVersionRecordSchema, body, key);
 					this.assertVersionIdentity(head, version, record, key);
 					return record;
 				},
@@ -679,8 +681,14 @@ class ScopedIntegrationsStore {
 		if (!probe) {
 			throw new ValidationError('Connection testing is not enabled on this deployment.');
 		}
-		const parsed = def.configSchema.parse(resolved);
-		return def.testConnection(parsed, probe);
+		// Never surface the Zod issues here — the resolved config is plaintext.
+		const parsed = def.configSchema.safeParse(resolved);
+		if (!parsed.success) {
+			throw new ValidationError(
+				`Stored config no longer matches kind "${def.kind}" — edit and re-save it.`,
+			);
+		}
+		return def.testConnection(parsed.data, probe);
 	}
 
 	/**
@@ -745,7 +753,7 @@ class ScopedIntegrationsStore {
 		const heads = await mapWithConcurrency(instanceDirs, BUCKET_SCAN_CONCURRENCY, async (dir) => {
 			const body = await this.bucket.get(`${dir}integration.json`);
 			if (!body) return null; // deleted between list and get — skip
-			const raw = await body.json();
+			const raw = await readStoredJson(body, `${dir}integration.json`);
 			if (isTombstoned(raw)) return null; // a committed delete, sweep pending
 			const head = parseStored(IntegrationRecordSchema, raw, `${dir}integration.json`);
 			const rawId = dir.slice(prefix.length, -1);
@@ -765,7 +773,7 @@ class ScopedIntegrationsStore {
 	private async getHead(scope: IntegrationScope, id: IntegrationId): Promise<IntegrationRecord> {
 		const body = await this.bucket.get(scope.integration(id).head);
 		if (!body) throw new NotFoundError(`Integration ${id} not found`);
-		return this.parseHead(scope, id, await body.json());
+		return this.parseHead(scope, id, await readStoredJson(body, scope.integration(id).head));
 	}
 
 	/** A tombstoned head is gone as far as every reader and writer is concerned. */
@@ -784,7 +792,7 @@ class ScopedIntegrationsStore {
 		const key = scope.integration(head.id).version(version);
 		const body = await this.bucket.get(key);
 		if (!body) throw new NotFoundError(`Integration ${head.id} version ${version} not found`);
-		const record = parseStored(IntegrationVersionRecordSchema, await body.json(), key);
+		const record = await readStored(IntegrationVersionRecordSchema, body, key);
 		// The record ENVELOPE version (distinct from the kind's schemaVersion):
 		// interpreting a newer envelope with these semantics could mis-handle
 		// fields it added. Older envelopes route through an upgrade seam here once

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -13,6 +13,7 @@ import type { IntegrationId, ProjectId, UserId } from '../../ids';
 import { createIntegrationId } from '../../ids';
 import { paths } from '../../paths';
 import type { IntegrationPaths } from '../../paths';
+import { logOperationalError } from '../../operationalLog';
 import type { Bucket } from '../../ports/bucket';
 import { noopMetrics } from '../../ports/metrics';
 import type { Metrics } from '../../ports/metrics';
@@ -42,6 +43,7 @@ import {
 	parseStored,
 	readStored,
 	readStoredJson,
+	StoredObjectError,
 } from '../../schema';
 import type { IntegrationRecord, IntegrationVersionRecord } from '../../schema';
 import { listAllObjects } from '../catalog/storage';
@@ -493,7 +495,12 @@ class ScopedIntegrationsStore {
 			if (err instanceof StaleHeadError) throw err.precondition;
 			// A head that cannot be parsed has no version to check and nothing to
 			// tombstone, but must still be removable — sweep its objects unguarded.
-			if (!(err instanceof ValidationError)) throw err;
+			if (!(err instanceof ValidationError || err instanceof StoredObjectError)) throw err;
+			logOperationalError(
+				'corrupt_integration_head_deleted',
+				{ operation: 'integration.delete', object: integrationPaths.head },
+				err,
+			);
 			existed = true;
 		}
 		const strays = (await listAllObjects(this.bucket, integrationPaths.base))

--- a/packages/core/src/services/integrations/registry.test.ts
+++ b/packages/core/src/services/integrations/registry.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { IntegrationRegistry } from './registry';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('IntegrationRegistry', () => {
+	it('disables an unrepresentable kind schema and logs without exception text', () => {
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const registry = new IntegrationRegistry();
+		registry.register({
+			kind: 'bad_schema',
+			title: 'Bad schema',
+			description: 'test',
+			category: 'other',
+			brand: { color: '#000000' },
+			schemaVersion: 1,
+			configSchema: z.object({ unsupported: z.date() }),
+			render: () => ({}),
+		});
+
+		expect(registry.list()).toEqual([]);
+		expect(log).toHaveBeenCalledOnce();
+		const line = log.mock.calls[0]?.[0] as string;
+		expect(JSON.parse(line)).toMatchObject({
+			level: 'error',
+			event: 'integration_kind_disabled',
+			integration_kind: 'bad_schema',
+		});
+		expect(line).not.toContain('Date cannot be represented');
+	});
+});

--- a/packages/core/src/services/integrations/registry.ts
+++ b/packages/core/src/services/integrations/registry.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { ValidationError } from '../../errors';
+import { logOperationalError } from '../../operationalLog';
 import type { KindDescriptor } from '../../ports/integrations';
 import type { IntegrationDefinition } from './sdk';
 import { secretPaths } from './secretFields';
@@ -21,7 +22,30 @@ export class IntegrationRegistry {
 		if (this.defs.has(def.kind)) {
 			throw new Error(`Duplicate integration kind "${def.kind}"`);
 		}
+		let inputSchema: Record<string, unknown>;
+		let storedSchema: Record<string, unknown>;
+		let paths: SecretPath[];
+		try {
+			inputSchema = decorateJsonSchema(
+				z.toJSONSchema(def.configSchema, { io: 'input' }) as Record<string, unknown>,
+			);
+			storedSchema = decorateJsonSchema(
+				z.toJSONSchema(def.configSchema, { io: 'output' }) as Record<string, unknown>,
+				true,
+			);
+			paths = secretPaths(inputSchema);
+		} catch (err) {
+			logOperationalError(
+				'integration_kind_disabled',
+				{ operation: 'integration.registry.register', integration_kind: def.kind },
+				err,
+			);
+			return;
+		}
 		this.defs.set(def.kind, def);
+		this.inputSchemas.set(def.kind, inputSchema);
+		this.storedSchemas.set(def.kind, storedSchema);
+		this.paths.set(def.kind, paths);
 	}
 
 	/** Resolves user-supplied kind names or throws a validation error. */
@@ -62,25 +86,14 @@ export class IntegrationRegistry {
 
 	/** Generates the strict authoring schema; defaulted fields remain optional. */
 	jsonSchema(kind: string): Record<string, unknown> {
-		const cached = this.inputSchemas.get(kind);
-		if (cached) return cached;
-		const schema = decorateJsonSchema(
-			z.toJSONSchema(this.get(kind).configSchema, { io: 'input' }) as Record<string, unknown>,
-		);
-		this.inputSchemas.set(kind, schema);
-		return schema;
+		this.get(kind);
+		return this.inputSchemas.get(kind)!;
 	}
 
 	/** Generates the persisted shape: defaults materialized and secrets sealed. */
 	storedJsonSchema(kind: string): Record<string, unknown> {
-		const cached = this.storedSchemas.get(kind);
-		if (cached) return cached;
-		const schema = decorateJsonSchema(
-			z.toJSONSchema(this.get(kind).configSchema, { io: 'output' }) as Record<string, unknown>,
-			true,
-		);
-		this.storedSchemas.set(kind, schema);
-		return schema;
+		this.get(kind);
+		return this.storedSchemas.get(kind)!;
 	}
 
 	secretPathsOf(kind: string): SecretPath[] {

--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -288,6 +288,10 @@ describe('ReconciliationService', () => {
 		const result = await reconciler.reconcile({ orphanGraceMs: 1_000 });
 
 		expect(result.orphansReaped).toBe(0);
+		const marker = await (await bucket.get(paths.reconcileOrphan(inflightId)))!.json<{
+			first_seen: number;
+		}>();
+		expect(marker.first_seen).toBeLessThanOrEqual(Date.now());
 		const line = log.mock.calls.find((call) =>
 			String(call[0]).includes('corrupt_orphan_marker_replaced'),
 		)?.[0] as string;

--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createNotebookId, createProjectId, createSandboxId, createVersionId } from '../../ids';
 import type { SandboxId } from '../../ids';
 import { paths } from '../../paths';
@@ -33,6 +33,10 @@ describe('ReconciliationService', () => {
 	const healthyId = createSandboxId();
 	const orphanId = createSandboxId();
 	const inflightId = createSandboxId();
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
 
 	beforeEach(() => {
 		bucket = new MemoryBucket();

--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -276,6 +276,21 @@ describe('ReconciliationService', () => {
 		expect(marker.first_seen).toBeLessThanOrEqual(Date.now());
 	});
 
+	it('Rule 3: replaces malformed marker JSON and logs without its bytes', async () => {
+		compute.active = [{ id: inflightId }];
+		await bucket.put(paths.reconcileOrphan(inflightId), '{"secret":"do-not-log"');
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const result = await reconciler.reconcile({ orphanGraceMs: 1_000 });
+
+		expect(result.orphansReaped).toBe(0);
+		const line = log.mock.calls.find((call) =>
+			String(call[0]).includes('corrupt_orphan_marker_replaced'),
+		)?.[0] as string;
+		expect(line).toContain('invalid_json');
+		expect(line).not.toContain('do-not-log');
+	});
+
 	it('Rule 1: force-destroys and still counts reclaimed when teardown throws', async () => {
 		const session = await createSession(terminalId);
 		await sessions.terminate(projectId, session.session_id);

--- a/packages/core/src/services/runtime/ReconciliationService.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.ts
@@ -1,8 +1,11 @@
+import { z } from 'zod';
 import type { Bucket } from '../../ports/bucket';
 import { Millis } from '../../duration';
 import type { NotebookId, SandboxId } from '../../ids';
+import { logOperationalError } from '../../operationalLog';
 import { paths } from '../../paths';
 import type { SandboxProvider } from '../../ports/sandbox';
+import { readStored } from '../../schema';
 import type { NotebookService } from '../content/NotebookService';
 import { SessionRetirer } from './SessionRetirer';
 import { RECLAIM_PROVISION_GRACE_MS } from './sessionLifecycle';
@@ -17,6 +20,8 @@ import type { SessionService } from './SessionService';
  * is a belt-and-suspenders guard against reaping an in-flight provision.
  */
 const DEFAULT_ORPHAN_GRACE_MS = Millis.minutes(15);
+
+const OrphanMarkerSchema = z.object({ first_seen: z.number() });
 
 export interface ReconcileResult {
 	/** True when the provider can't enumerate (no `listActive`) — nothing reconciled. */
@@ -199,15 +204,25 @@ export class ReconciliationService {
 		const existing = await this.bucket.get(key);
 		if (existing) {
 			try {
-				const { first_seen } = await existing.json<{ first_seen: number }>();
-				if (typeof first_seen === 'number' && Number.isFinite(first_seen) && first_seen <= now) {
-					return first_seen;
-				}
-			} catch {
-				// Corrupt marker — fall through and rewrite it below.
+				const { first_seen } = await readStored(OrphanMarkerSchema, existing, key);
+				// A future timestamp is clock skew across writers, not corruption —
+				// silently reset it to now (rewritten below) rather than logging an error.
+				if (first_seen <= now) return first_seen;
+			} catch (err) {
+				logOperationalError(
+					'corrupt_orphan_marker_replaced',
+					{ operation: 'reconciliation.orphan_marker.read', object: key },
+					err,
+				);
 			}
 		}
-		await this.bucket.put(key, JSON.stringify({ first_seen: now })).catch(() => {});
+		await this.bucket.put(key, JSON.stringify({ first_seen: now })).catch((err) => {
+			logOperationalError(
+				'orphan_marker_write_failed',
+				{ operation: 'reconciliation.orphan_marker.write', object: key },
+				err,
+			);
+		});
 		return now;
 	}
 

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -977,14 +977,13 @@ describe('SandboxProvisioner', () => {
 
 			// ...and the otherwise-masked commit failure is logged, not dropped.
 			expect(
-				errorSpy.mock.calls.some(
-					([msg, err]) =>
-						typeof msg === 'string' &&
-						msg.includes('commitSession failed') &&
-						err instanceof Error &&
-						err.message === 'commit boom',
-				),
+				errorSpy.mock.calls.some(([line]) => {
+					if (typeof line !== 'string') return false;
+					const event = JSON.parse(line) as Record<string, unknown>;
+					return event.event === 'session_commit_failed';
+				}),
 			).toBe(true);
+			expect(errorSpy.mock.calls.join('\n')).not.toContain('commit boom');
 			expect(calls.destroy).toBe(0);
 			errorSpy.mockRestore();
 		});

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -7,6 +7,7 @@ import type { NotebookId, ProjectId, SandboxId, UserId } from '../../ids';
 import { workspaceSourcePolicy } from '../../integrations/remoteWorkspace';
 import type { WorkspaceLoadMode } from '../../integrations/remoteWorkspace';
 import { paths } from '../../paths';
+import { logOperationalError } from '../../operationalLog';
 import type {
 	ComputeResources,
 	SandboxInstance,
@@ -541,7 +542,11 @@ export class SandboxProvisioner {
 		if (workspace.status === 'rejected') {
 			// A workspace failure would otherwise mask the commit failure — surface both.
 			if (commitError) {
-				console.error(`commitSession failed for notebook ${notebookId}:`, commitError);
+				logOperationalError(
+					'session_commit_failed',
+					{ operation: 'sandbox.commit_session', notebook_id: notebookId },
+					commitError,
+				);
 			}
 			throw workspace.reason;
 		}
@@ -601,7 +606,11 @@ export class SandboxProvisioner {
 			);
 		} catch (err) {
 			// Non-fatal: still destroy the sandbox so it does not linger and bill.
-			console.error(`captureSession failed during teardown for notebook ${notebookId}:`, err);
+			logOperationalError(
+				'session_capture_failed',
+				{ operation: 'sandbox.teardown.capture_session', notebook_id: notebookId },
+				err,
+			);
 		}
 		if (persisted) {
 			// Snapshot before destroy, once the session state above is final. Both are
@@ -614,8 +623,9 @@ export class SandboxProvisioner {
 					owner_user_id: actor,
 				});
 			} catch (err) {
-				console.error(
-					`captureFilesystemSnapshot failed during teardown for notebook ${notebookId}:`,
+				logOperationalError(
+					'filesystem_snapshot_capture_failed',
+					{ operation: 'sandbox.teardown.capture_snapshot', notebook_id: notebookId },
 					err,
 				);
 			}
@@ -623,7 +633,11 @@ export class SandboxProvisioner {
 		try {
 			await sandbox.destroy();
 		} catch (err) {
-			console.error(`sandbox.destroy failed during teardown for notebook ${notebookId}:`, err);
+			logOperationalError(
+				'sandbox_destroy_failed',
+				{ operation: 'sandbox.teardown.destroy', notebook_id: notebookId },
+				err,
+			);
 		}
 	}
 }

--- a/packages/core/src/services/runtime/SessionRetirer.ts
+++ b/packages/core/src/services/runtime/SessionRetirer.ts
@@ -2,6 +2,7 @@ import type { Bucket } from '../../ports/bucket';
 import type { SandboxProvider } from '../../ports/sandbox';
 import type { Session } from '../../schema';
 import { Millis } from '../../duration';
+import { logOperationalError } from '../../operationalLog';
 import { captureFilesystemSnapshot } from '../content/filesystemSnapshots';
 import type { NotebookService } from '../content/NotebookService';
 import { SandboxProvisioner } from './SandboxProvisioner';
@@ -287,8 +288,14 @@ export class SessionRetirer {
 				{ persistEdits },
 			);
 		} catch (err) {
-			console.error(
-				`captureSession failed during teardown for notebook ${session.notebook_id}:`,
+			logOperationalError(
+				'session_capture_failed',
+				{
+					operation: 'session_retire.capture_session',
+					project_id: session.project_id,
+					notebook_id: session.notebook_id,
+					session_id: session.session_id,
+				},
 				err,
 			);
 		}
@@ -310,8 +317,14 @@ export class SessionRetirer {
 			await sandbox.destroy();
 			return true;
 		} catch (err) {
-			console.error(
-				`sandbox.destroy failed during teardown for notebook ${session.notebook_id}:`,
+			logOperationalError(
+				'sandbox_destroy_failed',
+				{
+					operation: 'session_retire.destroy',
+					project_id: session.project_id,
+					notebook_id: session.notebook_id,
+					session_id: session.session_id,
+				},
 				err,
 			);
 			return false;

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -22,7 +22,14 @@ import type { SingletonClaimConfig } from '../catalog/cas';
 import { createSessionId } from '../../ids';
 import type { NotebookId, ProjectId, SandboxId, SessionId, UserId, VersionId } from '../../ids';
 import { paths } from '../../paths';
-import { AppClaimSchema, EditorClaimSchema, parseStored, SessionSchema } from '../../schema';
+import { logOperationalError } from '../../operationalLog';
+import {
+	AppClaimSchema,
+	EditorClaimSchema,
+	parseStored,
+	readStored,
+	SessionSchema,
+} from '../../schema';
 import type { EditorClaim, Session } from '../../schema';
 import {
 	ACTIVE_STATUSES,
@@ -106,7 +113,7 @@ export class SessionService {
 		return mutateObject(
 			this.bucket,
 			paths.session(projectId, id),
-			(raw) => SessionSchema.parse(raw),
+			(raw) => parseStored(SessionSchema, raw, paths.session(projectId, id)),
 			apply,
 			{
 				notFound: () => new NotFoundError(`Session ${id} not found`),
@@ -153,7 +160,7 @@ export class SessionService {
 			throw new NotFoundError(`Session ${id} not found`);
 		}
 
-		return parseStored(SessionSchema, await obj.json(), key);
+		return readStored(SessionSchema, obj, key);
 	}
 
 	/** Promote `starting` → `running` with the kernel URL. No-op if the session was
@@ -326,9 +333,13 @@ export class SessionService {
 			// (listing, reuse, reaper). Skip it (logged) so the good records survive.
 			let session: Session;
 			try {
-				session = SessionSchema.parse(await body.json());
+				session = await readStored(SessionSchema, body, obj.key);
 			} catch (err) {
-				console.warn(`scanPrefix: skipping unreadable session ${obj.key}: ${String(err)}`);
+				logOperationalError(
+					'stored_object_skipped',
+					{ operation: 'session.scan', object: obj.key },
+					err,
+				);
 				return SKIP;
 			}
 			return handle(session, obj, body.etag);
@@ -490,8 +501,17 @@ export class SessionService {
 		if (!obj) return undefined;
 		let holder: SessionId | null;
 		try {
-			holder = AppClaimSchema.parse(await obj.json()).session_id;
-		} catch {
+			holder = (await readStored(AppClaimSchema, obj, paths.appClaim(projectId, notebookId)))
+				.session_id;
+		} catch (err) {
+			logOperationalError(
+				'stored_object_skipped',
+				{
+					operation: 'session.app_claim.read',
+					object: paths.appClaim(projectId, notebookId),
+				},
+				err,
+			);
 			return undefined;
 		}
 		return holder ? candidates.find((s) => s.session_id === holder) : undefined;
@@ -579,14 +599,14 @@ export class SessionService {
 		const key = paths.editorClaim(projectId, notebookId);
 		const obj = await this.bucket.get(key);
 		if (!obj) return undefined;
-		const claim = parseStored(EditorClaimSchema, await obj.json(), key);
+		const claim = await readStored(EditorClaimSchema, obj, key);
 		if (
 			claim.transfer?.phase === 'requested' &&
 			Date.now() - Date.parse(claim.transfer.requested_at) >= TAKEOVER_REQUEST_TTL_MS
 		) {
 			await this.cancelRequestedTakeover(projectId, notebookId, claim.transfer.takeover_id);
 			const refreshed = await this.bucket.get(key);
-			return refreshed ? parseStored(EditorClaimSchema, await refreshed.json(), key) : undefined;
+			return refreshed ? readStored(EditorClaimSchema, refreshed, key) : undefined;
 		}
 		return claim;
 	}
@@ -644,7 +664,7 @@ export class SessionService {
 					await this.bucket.put(key, JSON.stringify(next), { onlyIfNotExists: true });
 					return { claimed: true, claim: next };
 				}
-				const current = parseStored(EditorClaimSchema, await obj.json(), key);
+				const current = await readStored(EditorClaimSchema, obj, key);
 				if (current.session_id === sessionId) return { claimed: true, claim: current };
 				if (current.transfer) {
 					if (current.transfer.phase !== 'ready' || current.transfer.requested_by !== requestedBy) {
@@ -725,7 +745,7 @@ export class SessionService {
 		try {
 			const obj = await this.bucket.get(key);
 			if (!obj) return;
-			const claim = EditorClaimSchema.parse(await obj.json());
+			const claim = await readStored(EditorClaimSchema, obj, key);
 			if (claim.session_id !== session.session_id || claim.transfer) return;
 			await this.bucket.put(
 				key,
@@ -752,7 +772,7 @@ export class SessionService {
 		return mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
-			(raw) => EditorClaimSchema.parse(raw),
+			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
 				if (claim.transfer?.takeover_id === input.takeoverId) {
 					if (
@@ -793,7 +813,7 @@ export class SessionService {
 		return mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
-			(raw) => EditorClaimSchema.parse(raw),
+			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
 				if (claim.transfer?.takeover_id !== takeoverId) throw new EditSessionChangedError();
 				return {
@@ -826,7 +846,7 @@ export class SessionService {
 		await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
-			(raw) => EditorClaimSchema.parse(raw),
+			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
 				acquired = false;
 				if (claim.transfer?.takeover_id !== takeoverId || claim.transfer.phase !== 'draining') {
@@ -867,7 +887,7 @@ export class SessionService {
 		await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
-			(raw) => EditorClaimSchema.parse(raw),
+			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
 				renewed = false;
 				if (claim.transfer?.takeover_id !== takeoverId || claim.transfer.phase !== 'draining') {
@@ -915,7 +935,7 @@ export class SessionService {
 		await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
-			(raw) => EditorClaimSchema.parse(raw),
+			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
 				advanced = false;
 				if (claim.transfer?.takeover_id !== takeoverId || claim.transfer.phase !== 'draining') {
@@ -964,7 +984,7 @@ export class SessionService {
 		await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
-			(raw) => EditorClaimSchema.parse(raw),
+			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
 				if (
 					claim.transfer?.takeover_id !== takeoverId ||
@@ -998,7 +1018,7 @@ export class SessionService {
 			await mutateObject(
 				this.bucket,
 				paths.editorClaim(projectId, notebookId),
-				(raw) => EditorClaimSchema.parse(raw),
+				(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 				(claim) => {
 					if (
 						claim.transfer?.takeover_id !== takeoverId ||
@@ -1018,8 +1038,16 @@ export class SessionService {
 					};
 				},
 			);
-		} catch {
+		} catch (err) {
 			this.metrics.increment('sessions.editor_claim.drain_lease_release_error');
+			logOperationalError(
+				'editor_claim_release_failed',
+				{
+					operation: 'session.takeover_drain_lease.release',
+					object: paths.editorClaim(projectId, notebookId),
+				},
+				err,
+			);
 		}
 	}
 
@@ -1032,7 +1060,7 @@ export class SessionService {
 		return mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
-			(raw) => EditorClaimSchema.parse(raw),
+			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
 				if (
 					claim.transfer?.takeover_id !== takeoverId ||
@@ -1060,12 +1088,21 @@ export class SessionService {
 		await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
-			(raw) => EditorClaimSchema.parse(raw),
+			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) =>
 				claim.transfer?.takeover_id === takeoverId && claim.transfer.phase === 'requested'
 					? { ...claim, transfer: undefined }
 					: null,
-		).catch(() => {});
+		).catch((err) => {
+			logOperationalError(
+				'editor_claim_cancel_failed',
+				{
+					operation: 'session.takeover.cancel',
+					object: paths.editorClaim(projectId, notebookId),
+				},
+				err,
+			);
+		});
 	}
 
 	/** The app-singleton lease over `_system/apps/{pid}/{nid}.json` (see AppClaimSchema). */
@@ -1075,11 +1112,19 @@ export class SessionService {
 			key: paths.appClaim(projectId, notebookId),
 			serialize: (holder) =>
 				JSON.stringify({ session_id: holder, claimed_at: new Date().toISOString() }),
-			parseHolder: (raw) => AppClaimSchema.parse(raw).session_id,
+			parseHolder: (raw) =>
+				parseStored(AppClaimSchema, raw, paths.appClaim(projectId, notebookId)).session_id,
 			isHolderLive: (holder) => this.holdsLiveApp(projectId, notebookId, holder as SessionId),
 			onReleaseError: (err) => {
 				this.metrics.increment('sessions.app_claim.release_error');
-				console.warn(`releaseApp: app claim for notebook ${notebookId}: ${String(err)}`);
+				logOperationalError(
+					'app_claim_release_failed',
+					{
+						operation: 'session.app_claim.release',
+						object: paths.appClaim(projectId, notebookId),
+					},
+					err,
+				);
 			},
 			retry: {
 				onConflict: () => this.metrics.increment('sessions.app_claim.conflict'),

--- a/packages/core/src/services/tokens/TokenService.test.ts
+++ b/packages/core/src/services/tokens/TokenService.test.ts
@@ -244,9 +244,15 @@ describe('TokenService', () => {
 				await bucket.delete(key);
 				return { id, email: 'owner@x.io', name: 'Owner', updated_at: '2026-07-24T00:00:00.000Z' };
 			});
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-			expect(await tokens.verify(token)).toBeTruthy(); // this call still passes...
-			expect(await bucket.get(key)).toBeNull(); // ...but the object stays deleted.
+			try {
+				expect(await tokens.verify(token)).toBeTruthy(); // this call still passes...
+				expect(await bucket.get(key)).toBeNull(); // ...but the object stays deleted.
+				expect(log).not.toHaveBeenCalled();
+			} finally {
+				log.mockRestore();
+			}
 		});
 
 		it('serves from the positive cache within the TTL, refreshes past it', async () => {

--- a/packages/core/src/services/tokens/TokenService.ts
+++ b/packages/core/src/services/tokens/TokenService.ts
@@ -1,7 +1,7 @@
 import type { Bucket, BucketObjectBody } from '../../ports/bucket';
 import { mapWithConcurrency } from '../../concurrency';
 import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
-import { NotFoundError, ResourceExhaustedError } from '../../errors';
+import { NotFoundError, PreconditionFailedError, ResourceExhaustedError } from '../../errors';
 import { createTokenId, TokenId } from '../../ids';
 import type { UserId } from '../../ids';
 import { timingSafeEqual } from '../../internal/hmac';
@@ -280,6 +280,7 @@ export class TokenService {
 			entry.record = updated;
 			entry.etag = written.etag;
 		} catch (err) {
+			if (err instanceof PreconditionFailedError) return;
 			logOperationalError(
 				'token_usage_touch_failed',
 				{ operation: 'token.touch', object: paths.token(entry.record.id) },

--- a/packages/core/src/services/tokens/TokenService.ts
+++ b/packages/core/src/services/tokens/TokenService.ts
@@ -8,7 +8,8 @@ import { timingSafeEqual } from '../../internal/hmac';
 import { toHex } from '../../internal/hex';
 import type { AuthUser } from '../../ports/auth';
 import { paths } from '../../paths';
-import { TokenSchema, toPublicToken } from '../../schema';
+import { logOperationalError } from '../../operationalLog';
+import { readStored, TokenSchema, toPublicToken } from '../../schema';
 import type { PublicToken, Token } from '../../schema';
 import { listAllKeys } from '../catalog/storage';
 import type { IdentityService } from '../identity/IdentityService';
@@ -74,15 +75,13 @@ export async function hashPatSecret(secret: string): Promise<string> {
  * a single corrupt record must never take down verify/list/revoke (it just reads
  * as an invalid credential). Returns null on any failure.
  */
-async function parseTokenBody(obj: BucketObjectBody): Promise<Token | null> {
-	let raw: unknown;
+async function parseTokenBody(obj: BucketObjectBody, key: string): Promise<Token | null> {
 	try {
-		raw = await obj.json();
-	} catch {
+		return await readStored(TokenSchema, obj, key);
+	} catch (err) {
+		logOperationalError('stored_object_skipped', { operation: 'token.read', object: key }, err);
 		return null;
 	}
-	const parsed = TokenSchema.safeParse(raw);
-	return parsed.success ? parsed.data : null;
 }
 
 /** Whether a token is still live at `nowMs` (a missing expiry never expires). */
@@ -174,7 +173,7 @@ export class TokenService {
 		const keys = await listAllKeys(this.bucket, paths.tokensPrefix);
 		const records = await mapWithConcurrency(keys, BUCKET_SCAN_CONCURRENCY, async (key) => {
 			const obj = await this.bucket.get(key);
-			return obj ? parseTokenBody(obj) : null;
+			return obj ? parseTokenBody(obj, key) : null;
 		});
 		return records
 			.filter((r): r is Token => r?.user_id === userId)
@@ -192,7 +191,7 @@ export class TokenService {
 		// A corrupt record can't prove ownership and already fails `verify`, so treat
 		// it as not-found rather than 500ing a security-relevant "make it stop
 		// working" call.
-		const record = obj ? await parseTokenBody(obj) : null;
+		const record = obj ? await parseTokenBody(obj, paths.token(tokenId)) : null;
 		if (!record || record.user_id !== userId) {
 			throw new NotFoundError(`Token ${tokenId} not found`);
 		}
@@ -244,7 +243,7 @@ export class TokenService {
 			this.cache.delete(tokenId);
 			return null;
 		}
-		const record = await parseTokenBody(obj);
+		const record = await parseTokenBody(obj, paths.token(tokenId));
 		if (!record) return null;
 
 		// Resolve `{email, name}` through the identity directory — every issuer has
@@ -280,7 +279,12 @@ export class TokenService {
 			// Keep the cache coherent so a same-process re-verify uses the new ETag.
 			entry.record = updated;
 			entry.etag = written.etag;
-		} catch {
+		} catch (err) {
+			logOperationalError(
+				'token_usage_touch_failed',
+				{ operation: 'token.touch', object: paths.token(entry.record.id) },
+				err,
+			);
 			// Usage bookkeeping only — swallow and keep serving the request.
 		}
 	}


### PR DESCRIPTION
## What

Makes corrupt/invalid stored objects fail **safe** and stops error logging from leaking stored bytes, credential material, or validator text.

- **`StoredObjectError` / `readStored` / `readStoredJson`** (`schema.ts`) — a labeled error carrying only the object key + `reason` + issue `path`/`code`, never the ZodError or the invalid value.
- **`logOperationalError`** (core) and **`bestEffort` / `errorMetadata`** (api) — value-free structured logging. `onError` sanitizes every 5xx to a generic `Internal server error` body while logging safe diagnostics.
- Swaps ad-hoc `.parse(await obj.json())` for `readStored` across catalog, content, identity, integrations, runtime, and token services (tolerant scans skip-and-log; single reads throw a sanitized labeled error).
- Registry **disables an unrepresentable integration kind** (logs) instead of throwing at use.

## Fail-open / consistency fixes

- `IdempotencyService.lookup` now treats a corrupt record as a cache miss (fail open) rather than 500ing every replay of that key for the 24h retention window.
- Test-connection path uses value-free `safeParse` + `ValidationError`, matching the deliberate `renderOne` pattern (no ZodError from decrypted plaintext config reaches logs).
- Reconciliation resets a future-dated orphan marker (benign writer clock skew) without logging it as corruption; real malformed JSON still logs.

## Verification

- `pnpm typecheck` clean; `pnpm check` clean (edited files).
- Core + API suites pass, including new tests for sanitized 500s, best-effort audit failures, corrupt-marker handling, and disabled kinds.