### PR TITLE
fix(web): footer version link + super-admin policy details

### DIFF
--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -82,10 +82,11 @@ export function useVersionQuery() {
 }
 
 /** Deployment capability flags (e.g. whether WIF is configured). */
-export function useCapabilitiesQuery() {
+export function useCapabilitiesQuery(enabled = true) {
 	return useQuery({
 		queryKey: systemKeys.capabilities(),
 		queryFn: () => apiData(apiClient.GET('/api/v1/capabilities')),
+		enabled,
 		...IMMUTABLE_QUERY,
 	});
 }

--- a/packages/web/src/components/Footer/Footer.test.tsx
+++ b/packages/web/src/components/Footer/Footer.test.tsx
@@ -92,6 +92,14 @@ describe('Footer', () => {
 		expect(link).toHaveAttribute('href', 'https://github.com/marimo-team/marimohub/commit/a1b2c3d');
 	});
 
+	it('renders git-describe versions as plain text — no such release tag exists', async () => {
+		const { user } = setup({ version: { ...VERSION, version: '0.2.0-5-gdeadbeef' } });
+		await openPopover(user);
+
+		expect(await screen.findByText('0.2.0-5-gdeadbeef')).toBeInTheDocument();
+		expect(screen.queryByRole('link', { name: /0\.2\.0/ })).not.toBeInTheDocument();
+	});
+
 	it('renders dev builds as plain text', async () => {
 		const { user } = setup({ version: { ...VERSION, version: 'dev' } });
 		await openPopover(user);

--- a/packages/web/src/components/Footer/Footer.test.tsx
+++ b/packages/web/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider } from '@/context/AuthContext';
+import { jsonOk, renderWithClient } from '@/test/render';
+import { Footer } from './Footer';
+
+const USER = { id: 'usr-123', email: 'ada@example.com' };
+
+const VERSION = {
+	version: '0.2.0',
+	image: 'ghcr.io/marimo-team/marimohub:0.2.0',
+	sandbox_image: null,
+	started_at: null,
+	replica: null,
+	node: null,
+	backends: { storage: 's3', compute: 'coreweave', auth: 'oidc' },
+};
+
+const CAPABILITIES = {
+	federation: { available: true },
+	integrations: { available: false },
+	viewer_mode: 'interactive',
+	viewer_session_modes: ['edit', 'run'],
+	editor_sandbox_sharing: 'shared',
+	default_role: null,
+	limits: {
+		max_concurrent_sessions_per_user: 5,
+		max_apps_per_project: null,
+		max_request_bytes: 1,
+		max_versions_per_notebook: 100,
+		default_page_size: 50,
+		max_page_size: 200,
+	},
+	sandbox_images: ['ghcr.io/marimo-team/marimo-sandbox:1.2.3'],
+	compute_profiles: [{ name: 'small', cpu: '1', memory: '2Gi' }],
+	compute_profile_override: 'editors',
+};
+
+function setup({
+	version = VERSION,
+	me = USER as Record<string, unknown>,
+}: { version?: typeof VERSION; me?: Record<string, unknown> } = {}) {
+	const capabilitiesFetch = vi.fn(() => jsonOk(CAPABILITIES));
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input);
+			if (url === '/api/v1/me') return jsonOk(me);
+			if (url === '/api/v1/version') return jsonOk(version);
+			if (url === '/api/v1/capabilities') return capabilitiesFetch();
+			throw new Error(`unexpected fetch: ${init?.method ?? 'GET'} ${url}`);
+		}),
+	);
+	const user = userEvent.setup();
+	renderWithClient(
+		<AuthProvider>
+			<Footer />
+		</AuthProvider>,
+		{ route: '/' },
+	);
+	return { user, capabilitiesFetch };
+}
+
+async function openPopover(user: ReturnType<typeof userEvent.setup>) {
+	await user.click(screen.getByRole('button', { name: 'Version info' }));
+	await waitFor(() => expect(screen.getByText('marimohub')).toBeInTheDocument());
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('Footer', () => {
+	it('links a release version to its GitHub release page', async () => {
+		const { user } = setup();
+		await openPopover(user);
+
+		const link = await screen.findByRole('link', { name: /0\.2\.0/ });
+		expect(link).toHaveAttribute(
+			'href',
+			'https://github.com/marimo-team/marimohub/releases/tag/v0.2.0',
+		);
+	});
+
+	it('links a git SHA version to its commit', async () => {
+		const { user } = setup({ version: { ...VERSION, version: 'a1b2c3d' } });
+		await openPopover(user);
+
+		const link = await screen.findByRole('link', { name: /a1b2c3d/ });
+		expect(link).toHaveAttribute('href', 'https://github.com/marimo-team/marimohub/commit/a1b2c3d');
+	});
+
+	it('renders dev builds as plain text', async () => {
+		const { user } = setup({ version: { ...VERSION, version: 'dev' } });
+		await openPopover(user);
+
+		expect(await screen.findByText('dev')).toBeInTheDocument();
+		expect(screen.queryByRole('link', { name: /dev/ })).not.toBeInTheDocument();
+	});
+
+	it('hides the policy section (and skips the fetch) for regular users', async () => {
+		const { user, capabilitiesFetch } = setup();
+		await openPopover(user);
+
+		expect(screen.queryByText('Policy')).not.toBeInTheDocument();
+		expect(capabilitiesFetch).not.toHaveBeenCalled();
+	});
+
+	it('shows deployment policy to super admins', async () => {
+		const { user } = setup({ me: { ...USER, is_super_admin: true } });
+		await openPopover(user);
+
+		expect(await screen.findByText('Policy')).toBeInTheDocument();
+		expect(screen.getByText('interactive')).toBeInTheDocument();
+		expect(screen.getByText('members only')).toBeInTheDocument();
+		// integrations unavailable → only federation listed
+		expect(screen.getByText('federation')).toBeInTheDocument();
+		expect(
+			screen.getByText(/5 sessions\/user · ∞ apps\/project · 100 versions/),
+		).toBeInTheDocument();
+		expect(screen.getByText('ghcr.io/marimo-team/marimo-sandbox:1.2.3')).toBeInTheDocument();
+		expect(screen.getByText('small (override: editors)')).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/components/Footer/Footer.tsx
+++ b/packages/web/src/components/Footer/Footer.tsx
@@ -11,10 +11,11 @@ const SOURCE_URL = 'https://github.com/marimo-team/marimohub';
 /**
  * MARIMOHUB_VERSION is either a release tag (`0.2.0`) or a git SHA (`a1b2c3d`);
  * only one of those has a release page, so pick the GitHub URL per shape. Any
- * other value (e.g. `dev`) has no page at all.
+ * other value (`dev`, git-describe suffixes like `0.2.0-5-gdeadbeef`) has no
+ * page at all.
  */
 function versionHref(version: string): string | null {
-	if (/^v?\d+\.\d+\.\d+/.test(version)) {
+	if (/^v?\d+\.\d+\.\d+$/.test(version)) {
 		return `${SOURCE_URL}/releases/tag/${version.startsWith('v') ? version : `v${version}`}`;
 	}
 	if (/^[0-9a-f]{7,40}$/i.test(version)) {

--- a/packages/web/src/components/Footer/Footer.tsx
+++ b/packages/web/src/components/Footer/Footer.tsx
@@ -1,11 +1,27 @@
 import type { ReactNode } from 'react';
 import { Info, ExternalLink } from 'lucide-react';
-import { useVersionQuery } from '@/api/hooks';
+import { useCapabilitiesQuery, useVersionQuery } from '@/api/hooks';
 import { Popover } from '@/components/ui';
+import { useAuth } from '@/context/AuthContext';
 import { formatRelative } from '@/lib/time';
 
-/** Source repository — the UI derives commit + issue links from it. */
+/** Source repository — the UI derives release/commit + issue links from it. */
 const SOURCE_URL = 'https://github.com/marimo-team/marimohub';
+
+/**
+ * MARIMOHUB_VERSION is either a release tag (`0.2.0`) or a git SHA (`a1b2c3d`);
+ * only one of those has a release page, so pick the GitHub URL per shape. Any
+ * other value (e.g. `dev`) has no page at all.
+ */
+function versionHref(version: string): string | null {
+	if (/^v?\d+\.\d+\.\d+/.test(version)) {
+		return `${SOURCE_URL}/releases/tag/${version.startsWith('v') ? version : `v${version}`}`;
+	}
+	if (/^[0-9a-f]{7,40}$/i.test(version)) {
+		return `${SOURCE_URL}/commit/${version}`;
+	}
+	return null;
+}
 
 function InfoRow({ label, value }: { label: string; value: ReactNode }) {
 	return (
@@ -28,17 +44,21 @@ function Timestamp({ iso }: { iso: string }) {
 /**
  * Slim bottom bar with a single info affordance: clicking it opens a popover with
  * the deployment's version, image, start time, replica, runtime, and active
- * backends (from `GET /api/v1/version`). The bar renders even while the query is in
- * flight or has failed — the popover just shows what's known — so it never blocks
- * or shifts the layout.
+ * backends (from `GET /api/v1/version`). Super admins additionally see the
+ * deployment policy (from `GET /api/v1/capabilities`). The bar renders even while
+ * the queries are in flight or have failed — the popover just shows what's known —
+ * so it never blocks or shifts the layout.
  */
 export function Footer() {
 	const { data: v } = useVersionQuery();
+	const { user } = useAuth();
+	const isSuperAdmin = user?.is_super_admin ?? false;
+	const { data: caps } = useCapabilitiesQuery(isSuperAdmin);
 
-	const isRealVersion = v ? v.version !== 'dev' : false;
-	const versionValue = isRealVersion ? (
+	const href = v ? versionHref(v.version) : null;
+	const versionValue = href ? (
 		<a
-			href={`${SOURCE_URL}/commit/${v!.version}`}
+			href={href}
 			target="_blank"
 			rel="noreferrer"
 			className="inline-flex items-center gap-1 text-foreground underline-offset-4 hover:underline"
@@ -83,6 +103,51 @@ export function Footer() {
 							/>
 						)}
 					</dl>
+					{isSuperAdmin && caps && (
+						<div className="border-t pt-2">
+							<div className="mb-1 font-medium text-foreground">Policy</div>
+							<dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+								<InfoRow label="Viewer mode" value={caps.viewer_mode} />
+								<InfoRow label="Sandbox sharing" value={caps.editor_sandbox_sharing} />
+								<InfoRow label="Default role" value={caps.default_role ?? 'members only'} />
+								<InfoRow
+									label="Features"
+									value={
+										[
+											caps.federation.available && 'federation',
+											caps.integrations.available && 'integrations',
+										]
+											.filter(Boolean)
+											.join(' · ') || 'none'
+									}
+								/>
+								<InfoRow
+									label="Limits"
+									value={
+										<span className="tabular-nums">
+											{caps.limits.max_concurrent_sessions_per_user ?? '∞'} sessions/user ·{' '}
+											{caps.limits.max_apps_per_project ?? '∞'} apps/project ·{' '}
+											{caps.limits.max_versions_per_notebook} versions/notebook
+										</span>
+									}
+								/>
+								{caps.sandbox_images.length > 0 && (
+									<InfoRow label="Images" value={caps.sandbox_images.join(', ')} />
+								)}
+								{caps.compute_profiles.length > 0 && (
+									<InfoRow
+										label="Profiles"
+										value={
+											caps.compute_profiles.map((p) => p.name).join(' · ') +
+											(caps.compute_profile_override === 'none'
+												? ''
+												: ` (override: ${caps.compute_profile_override})`)
+										}
+									/>
+								)}
+							</dl>
+						</div>
+					)}
 					<div className="flex gap-3 border-t pt-2 text-muted-foreground">
 						<a
 							href={SOURCE_URL}


### PR DESCRIPTION
- Link release versions (e.g. \`0.2.0\`) in the footer info popover to the GitHub release page instead of the dead \`/commit/0.2.0\` URL; git SHAs still link to their commit, \`dev\` stays plain text.
- For super admins, show a **Policy** section in the popover (from \`GET /api/v1/capabilities\`): viewer mode, sandbox sharing, default role, features, limits, sandbox images, compute profiles. Capabilities are only fetched when the viewer is a super admin.

Added \`Footer.test.tsx\` covering the link shapes and admin gating.