### PR TITLE
fix(server): revalidate SPA shell, immutably cache fingerprinted assets

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,7 +7,6 @@
  * state lives in object storage + compute — so this scales horizontally.
  */
 import { serve } from '@hono/node-server';
-import { serveStatic } from '@hono/node-server/serve-static';
 import { secureHeaders } from 'hono/secure-headers';
 import type { ApiDeps } from '@marimo-hub/api';
 import { createApi } from '@marimo-hub/api';
@@ -15,6 +14,7 @@ import { createFromEnv, isConfigError } from '@marimo-hub/config';
 import { startMaintenance, startSessionLifecycle } from './cron';
 import { logEvent } from './log';
 import { WideEventMetrics } from './metrics';
+import { serveStaticWithCache } from './staticCache';
 import { attachSandboxProxyUpgrade } from './sandboxProxyWs';
 
 // Process-level safety net. A rejected promise with no catch handler — e.g. a
@@ -104,8 +104,8 @@ app.use('*', secureHeaders());
 // so they take precedence; everything else falls through to static assets, with
 // a single-page-app fallback to index.html.
 const staticRoot = process.env.MARIMOHUB_STATIC_ROOT ?? './public';
-app.use('/*', serveStatic({ root: staticRoot }));
-app.get('*', serveStatic({ path: `${staticRoot}/index.html` }));
+app.use('/*', serveStaticWithCache({ root: staticRoot }));
+app.get('*', serveStaticWithCache({ path: `${staticRoot}/index.html` }));
 
 // Maintenance + session-lifecycle loops — run on a single replica (the
 // marimohub-maintenance Deployment). The bucket-CAS leases inside are

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,7 +14,7 @@ import { createFromEnv, isConfigError } from '@marimo-hub/config';
 import { startMaintenance, startSessionLifecycle } from './cron';
 import { logEvent } from './log';
 import { WideEventMetrics } from './metrics';
-import { serveStaticWithCache } from './staticCache';
+import { serveSpaFallback, serveStaticWithCache } from './staticCache';
 import { attachSandboxProxyUpgrade } from './sandboxProxyWs';
 
 // Process-level safety net. A rejected promise with no catch handler — e.g. a
@@ -105,7 +105,7 @@ app.use('*', secureHeaders());
 // a single-page-app fallback to index.html.
 const staticRoot = process.env.MARIMOHUB_STATIC_ROOT ?? './public';
 app.use('/*', serveStaticWithCache({ root: staticRoot }));
-app.get('*', serveStaticWithCache({ path: `${staticRoot}/index.html` }));
+app.get('*', serveSpaFallback(staticRoot));
 
 // Maintenance + session-lifecycle loops — run on a single replica (the
 // marimohub-maintenance Deployment). The bucket-CAS leases inside are

--- a/apps/server/src/staticCache.test.ts
+++ b/apps/server/src/staticCache.test.ts
@@ -7,6 +7,7 @@ import {
 	cacheControlForStaticPath,
 	IMMUTABLE_ASSET_CACHE_CONTROL,
 	REVALIDATE_STATIC_CACHE_CONTROL,
+	serveSpaFallback,
 	serveStaticWithCache,
 } from './staticCache';
 
@@ -50,7 +51,7 @@ describe('cacheControlForStaticPath', () => {
 
 		const app = new Hono();
 		app.use('/*', serveStaticWithCache({ root }));
-		app.get('*', serveStaticWithCache({ path: join(root, 'index.html') }));
+		app.get('*', serveSpaFallback(root));
 
 		expect((await app.request('/')).headers.get('Cache-Control')).toBe(
 			REVALIDATE_STATIC_CACHE_CONTROL,
@@ -62,8 +63,14 @@ describe('cacheControlForStaticPath', () => {
 			IMMUTABLE_ASSET_CACHE_CONTROL,
 		);
 
-		const missingAssetApp = new Hono();
-		missingAssetApp.use('/*', serveStaticWithCache({ root }));
-		expect((await missingAssetApp.request('/missing.js')).status).toBe(404);
+		const missingAsset = await app.request('/assets/missing.js');
+		expect(missingAsset.status).toBe(404);
+		expect(missingAsset.headers.get('Cache-Control')).not.toBe(IMMUTABLE_ASSET_CACHE_CONTROL);
+
+		const invalidRange = await app.request('/assets/index-C8a1b2.js', {
+			headers: { Range: 'bytes=999-' },
+		});
+		expect(invalidRange.status).toBe(416);
+		expect(invalidRange.headers.get('Cache-Control')).toBe(REVALIDATE_STATIC_CACHE_CONTROL);
 	});
 });

--- a/apps/server/src/staticCache.test.ts
+++ b/apps/server/src/staticCache.test.ts
@@ -1,0 +1,69 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Hono } from 'hono';
+import {
+	cacheControlForStaticPath,
+	IMMUTABLE_ASSET_CACHE_CONTROL,
+	REVALIDATE_STATIC_CACHE_CONTROL,
+	serveStaticWithCache,
+} from './staticCache';
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+	for (const root of temporaryRoots.splice(0)) rmSync(root, { force: true, recursive: true });
+});
+
+describe('cacheControlForStaticPath', () => {
+	it('revalidates the HTML shell', () => {
+		expect(cacheControlForStaticPath('/app/public/index.html')).toBe(
+			REVALIDATE_STATIC_CACHE_CONTROL,
+		);
+		expect(cacheControlForStaticPath('/app/public/projects/acme')).toBe(
+			REVALIDATE_STATIC_CACHE_CONTROL,
+		);
+	});
+
+	it('revalidates stable public files', () => {
+		expect(cacheControlForStaticPath('/app/public/favicon.svg')).toBe(
+			REVALIDATE_STATIC_CACHE_CONTROL,
+		);
+	});
+
+	it('caches fingerprinted assets for the URL lifetime', () => {
+		expect(cacheControlForStaticPath('/app/public/assets/index-C8a1b2.js')).toBe(
+			IMMUTABLE_ASSET_CACHE_CONTROL,
+		);
+		expect(cacheControlForStaticPath('C:\\app\\public\\assets\\index-C8a1b2.css')).toBe(
+			IMMUTABLE_ASSET_CACHE_CONTROL,
+		);
+	});
+
+	it('applies the policy to static responses and SPA fallbacks', async () => {
+		const root = mkdtempSync(join(tmpdir(), 'marimohub-static-'));
+		temporaryRoots.push(root);
+		mkdirSync(join(root, 'assets'));
+		writeFileSync(join(root, 'index.html'), '<!doctype html>');
+		writeFileSync(join(root, 'assets', 'index-C8a1b2.js'), 'console.log(1);');
+
+		const app = new Hono();
+		app.use('/*', serveStaticWithCache({ root }));
+		app.get('*', serveStaticWithCache({ path: join(root, 'index.html') }));
+
+		expect((await app.request('/')).headers.get('Cache-Control')).toBe(
+			REVALIDATE_STATIC_CACHE_CONTROL,
+		);
+		expect((await app.request('/projects/acme')).headers.get('Cache-Control')).toBe(
+			REVALIDATE_STATIC_CACHE_CONTROL,
+		);
+		expect((await app.request('/assets/index-C8a1b2.js')).headers.get('Cache-Control')).toBe(
+			IMMUTABLE_ASSET_CACHE_CONTROL,
+		);
+
+		const missingAssetApp = new Hono();
+		missingAssetApp.use('/*', serveStaticWithCache({ root }));
+		expect((await missingAssetApp.request('/missing.js')).status).toBe(404);
+	});
+});

--- a/apps/server/src/staticCache.ts
+++ b/apps/server/src/staticCache.ts
@@ -5,6 +5,10 @@ import type { MiddlewareHandler } from 'hono';
 export const REVALIDATE_STATIC_CACHE_CONTROL = 'public, max-age=0, must-revalidate';
 export const IMMUTABLE_ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutable';
 
+function isAssetPath(requestPath: string): boolean {
+	return requestPath === '/assets' || requestPath.startsWith('/assets/');
+}
+
 /**
  * Return the cache policy for a file served by the SPA.
  *
@@ -25,8 +29,23 @@ export function serveStaticWithCache(options: ServeStaticOptions): MiddlewareHan
 		const response = await handler(context, next);
 		if (response instanceof Response) {
 			const requestPath = options.path ?? context.req.path;
-			response.headers.set('Cache-Control', cacheControlForStaticPath(requestPath));
+			const isCacheableResponse =
+				(response.status >= 200 && response.status < 300) || response.status === 304;
+			response.headers.set(
+				'Cache-Control',
+				isCacheableResponse
+					? cacheControlForStaticPath(requestPath)
+					: REVALIDATE_STATIC_CACHE_CONTROL,
+			);
 		}
 		return response;
+	};
+}
+
+export function serveSpaFallback(staticRoot: string): MiddlewareHandler {
+	const handler = serveStaticWithCache({ path: `${staticRoot}/index.html` });
+	return async (context, next) => {
+		if (isAssetPath(context.req.path)) return next();
+		return handler(context, next);
 	};
 }

--- a/apps/server/src/staticCache.ts
+++ b/apps/server/src/staticCache.ts
@@ -1,0 +1,32 @@
+import { serveStatic } from '@hono/node-server/serve-static';
+import type { ServeStaticOptions } from '@hono/node-server/serve-static';
+import type { MiddlewareHandler } from 'hono';
+
+export const REVALIDATE_STATIC_CACHE_CONTROL = 'public, max-age=0, must-revalidate';
+export const IMMUTABLE_ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+/**
+ * Return the cache policy for a file served by the SPA.
+ *
+ * Vite fingerprints files under `assets/`, so those files can be retained for
+ * the lifetime of the URL. The HTML shell and other stable URLs must revalidate
+ * after a deploy so they cannot keep pointing at an older asset manifest.
+ */
+export function cacheControlForStaticPath(filePath: string): string {
+	const normalizedPath = filePath.replaceAll('\\', '/');
+	return normalizedPath.includes('/assets/') && !normalizedPath.endsWith('/index.html')
+		? IMMUTABLE_ASSET_CACHE_CONTROL
+		: REVALIDATE_STATIC_CACHE_CONTROL;
+}
+
+export function serveStaticWithCache(options: ServeStaticOptions): MiddlewareHandler {
+	const handler = serveStatic(options);
+	return async (context, next) => {
+		const response = await handler(context, next);
+		if (response instanceof Response) {
+			const requestPath = options.path ?? context.req.path;
+			response.headers.set('Cache-Control', cacheControlForStaticPath(requestPath));
+		}
+		return response;
+	};
+}


### PR DESCRIPTION
## Problem

`apps/server` served static assets with no explicit `Cache-Control`. After a deploy, browsers could keep serving a stale `index.html` that references an old, now-deleted asset manifest — producing broken pages until a hard refresh.

## Fix

Wrap `serveStatic` (`serveStaticWithCache`) to attach an explicit policy per path:

- **HTML shell + other stable URLs** (`favicon.svg`, SPA fallback routes) → `public, max-age=0, must-revalidate` so they always re-check after a deploy.
- **Vite-fingerprinted files under `assets/`** → `public, max-age=31536000, immutable`, safe to keep for the URL's lifetime since the hash changes on every build.

## Tests

`staticCache.test.ts` covers the policy function (HTML, stable public files, fingerprinted assets, Windows-style paths) and end-to-end that the header is applied to static responses, the SPA fallback, and that missing assets still 404. All server tests pass.