### PR TITLE
fix(web): make the base-image picker readable

### DIFF
--- a/packages/web/src/components/Notebook/ChangeBaseImageDialog.tsx
+++ b/packages/web/src/components/Notebook/ChangeBaseImageDialog.tsx
@@ -1,7 +1,7 @@
 import { toast } from 'sonner';
 import { FormDialog, useAppForm, useSeedOnOpen } from '@/components/form';
 import { useNotebookQuery, useUpdateNotebook } from '@/api/hooks';
-import { baseImageOptions, DEFAULT_BASE_IMAGE, useSandboxImages } from './baseImage';
+import { baseImageOptions, DEFAULT_BASE_IMAGE, imageLabel, useSandboxImages } from './baseImage';
 
 interface ChangeBaseImageDialogProps {
 	isOpen: boolean;
@@ -36,7 +36,7 @@ export function ChangeBaseImageDialog({
 				toast.success(
 					choice === DEFAULT_BASE_IMAGE
 						? 'Base image reset to default'
-						: `Base image set to "${choice}"`,
+						: `Base image set to "${imageLabel(choice)}"`,
 				);
 				onClose();
 			} catch (err) {
@@ -59,6 +59,7 @@ export function ChangeBaseImageDialog({
 			title="Change Base Image"
 			submitLabel="Save"
 			pendingLabel="Saving..."
+			width="lg"
 		>
 			<p className="text-xs text-muted-foreground">
 				The image "{notebook.title}" runs on. Takes effect the next time a session starts.

--- a/packages/web/src/components/Notebook/baseImage.test.tsx
+++ b/packages/web/src/components/Notebook/baseImage.test.tsx
@@ -2,11 +2,67 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { waitFor } from '@testing-library/react';
 import { systemKeys } from '@/api/queryKeys';
 import { jsonError, jsonOk, renderHookWithClient } from '@/test/render';
-import { DEFAULT_BASE_IMAGE, baseImageOptions, useSandboxImages } from './baseImage';
+import {
+	DEFAULT_BASE_IMAGE,
+	baseImageOptions,
+	imageLabel,
+	parseImageRef,
+	useSandboxImages,
+} from './baseImage';
 
 afterEach(() => {
 	vi.unstubAllGlobals();
 	vi.restoreAllMocks();
+});
+
+describe('parseImageRef', () => {
+	it('splits a tagged reference', () => {
+		expect(parseImageRef('ghcr.io/marimo-team/marimo-sandbox:py3.13-marimo0.23.16')).toEqual({
+			repository: 'ghcr.io/marimo-team/marimo-sandbox',
+			tag: 'py3.13-marimo0.23.16',
+			digest: undefined,
+		});
+	});
+
+	it('splits a digest pin', () => {
+		expect(parseImageRef('ghcr.io/marimo-team/marimo-sandbox@sha256:abc123')).toEqual({
+			repository: 'ghcr.io/marimo-team/marimo-sandbox',
+			tag: undefined,
+			digest: 'sha256:abc123',
+		});
+	});
+
+	it('does not mistake a registry port for a tag', () => {
+		expect(parseImageRef('localhost:5000/img')).toEqual({
+			repository: 'localhost:5000/img',
+			tag: undefined,
+			digest: undefined,
+		});
+	});
+});
+
+describe('imageLabel', () => {
+	it('prettifies the published marimo tag convention', () => {
+		expect(imageLabel('ghcr.io/marimo-team/marimo-sandbox:py3.13-marimo0.23.16')).toBe(
+			'marimo 0.23.16 · Python 3.13',
+		);
+	});
+
+	it('falls back to the bare tag for any other convention', () => {
+		expect(imageLabel('ghcr.io/acme/kernel:cuda12')).toBe('cuda12');
+	});
+
+	it('names the image and abbreviates the hash for a digest pin', () => {
+		expect(
+			imageLabel(
+				'ghcr.io/marimo-team/marimo-sandbox@sha256:574845a49db05398e1ebfb06182affe0fcfd6d9e',
+			),
+		).toBe('marimo-sandbox@574845a49db0');
+	});
+
+	it('uses the bare name when there is no tag or digest', () => {
+		expect(imageLabel('ghcr.io/acme/kernel')).toBe('kernel');
+	});
 });
 
 describe('baseImageOptions', () => {
@@ -16,11 +72,25 @@ describe('baseImageOptions', () => {
 		]);
 	});
 
-	it('describes Default with the first image and lists every image in order', () => {
+	it('names the default image and shows the full reference under each option', () => {
+		const latest = 'ghcr.io/marimo-team/marimo-sandbox:py3.13-marimo0.23.16';
+		const previous = 'ghcr.io/marimo-team/marimo-sandbox:py3.13-marimo0.23.11';
+		expect(baseImageOptions([latest, previous])).toEqual([
+			{
+				value: DEFAULT_BASE_IMAGE,
+				label: 'Default (marimo 0.23.16 · Python 3.13)',
+				description: latest,
+			},
+			{ value: latest, label: 'marimo 0.23.16 · Python 3.13', description: latest },
+			{ value: previous, label: 'marimo 0.23.11 · Python 3.13', description: previous },
+		]);
+	});
+
+	it('omits a description that would merely repeat the label', () => {
 		expect(baseImageOptions(['a', 'b'])).toEqual([
-			{ value: DEFAULT_BASE_IMAGE, label: 'Default', description: 'a' },
-			{ value: 'a', label: 'a' },
-			{ value: 'b', label: 'b' },
+			{ value: DEFAULT_BASE_IMAGE, label: 'Default (a)', description: 'a' },
+			{ value: 'a', label: 'a', description: undefined },
+			{ value: 'b', label: 'b', description: undefined },
 		]);
 	});
 });

--- a/packages/web/src/components/Notebook/baseImage.ts
+++ b/packages/web/src/components/Notebook/baseImage.ts
@@ -10,9 +10,66 @@ export function useSandboxImages(): string[] {
 	return data?.sandbox_images ?? [];
 }
 
+/**
+ * The tag convention our published kernel images use — `py3.13-marimo0.23.16`.
+ * Matching it is best-effort prettification, never a requirement: any other tag
+ * (or a digest pin) falls through to the generic handling in {@link imageLabel}.
+ */
+const MARIMO_TAG = /^py(\d+(?:\.\d+)*)-marimo(.+)$/;
+
+interface ImageRef {
+	/** Everything before the tag/digest, e.g. `ghcr.io/marimo-team/marimo-sandbox`. */
+	repository: string;
+	tag?: string;
+	digest?: string;
+}
+
+/**
+ * Split an image reference into repository + tag/digest. The tag separator is the
+ * last `:` AFTER the last `/`, so a registry port (`localhost:5000/img`) is not
+ * mistaken for one.
+ */
+export function parseImageRef(ref: string): ImageRef {
+	const [namePart, digest] = ref.split('@', 2);
+	const lastSlash = namePart.lastIndexOf('/');
+	const lastColon = namePart.lastIndexOf(':');
+	const hasTag = lastColon > lastSlash;
+	return {
+		repository: hasTag ? namePart.slice(0, lastColon) : namePart,
+		tag: hasTag ? namePart.slice(lastColon + 1) : undefined,
+		digest,
+	};
+}
+
+/**
+ * A short, human-readable name for an image — the part that distinguishes it from
+ * the deployment's other images, since those usually share a repository. The full
+ * reference stays visible as the option's description.
+ */
+export function imageLabel(ref: string): string {
+	const { repository, tag, digest } = parseImageRef(ref);
+	const marimo = tag?.match(MARIMO_TAG);
+	if (marimo) return `marimo ${marimo[2]} · Python ${marimo[1]}`;
+	if (tag) return tag;
+	// Digest pins have nothing readable, so name the image and abbreviate the hash.
+	const name = repository.slice(repository.lastIndexOf('/') + 1);
+	if (digest) return `${name}@${digest.replace(/^sha256:/, '').slice(0, 12)}`;
+	return name;
+}
+
 export function baseImageOptions(images: string[]): RadioGroupFieldOption[] {
+	const describe = (image: string) => {
+		const label = imageLabel(image);
+		// Suppress a description that would just repeat the label (unparseable refs).
+		return { value: image, label, description: label === image ? undefined : image };
+	};
+	const fallback = images[0];
 	return [
-		{ value: DEFAULT_BASE_IMAGE, label: 'Default', description: images[0] },
-		...images.map((image) => ({ value: image, label: image })),
+		{
+			value: DEFAULT_BASE_IMAGE,
+			label: fallback ? `Default (${imageLabel(fallback)})` : 'Default',
+			description: fallback,
+		},
+		...images.map(describe),
 	];
 }

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -745,6 +745,7 @@ export function Project() {
 				title="Create New Notebook"
 				submitLabel="Create"
 				pendingLabel="Creating..."
+				width="lg"
 			>
 				<createNotebookForm.AppField name="name">
 					{(f) => <f.TextField label="Notebook Name" placeholder="my_analysis" autoFocus />}


### PR DESCRIPTION
The base-image picker labelled each option with the raw image reference, so every row rendered as a truncated `ghcr.io/marimo-team/marimo-sandbox:py3.13-ma...` — nothing distinguished the options.

## Changes

- **`imageLabel` / `parseImageRef`** (`baseImage.ts`) — label options the way the compute picker already does: short name, detail underneath. Prettifies our published `py{X}-marimo{Y}` tags, falls back to the bare tag for any other convention, and abbreviates a digest pin to `marimo-sandbox@574845a49db0`. The full reference stays visible as the description.
- **Width** — `Create New Notebook` and `Change Base Image` go `sm` → `lg` (384px → 512px) via the existing `width` prop, so the reference no longer truncates.
- **Toast** — `ChangeBaseImageDialog` was interpolating the raw ref into its success message.

The prettification is best-effort and degrades gracefully; operators set arbitrary refs, so nothing requires the marimo tag convention. `parseImageRef` takes the last `:` *after* the last `/`, so `localhost:5000/img` isn't misread as a tag.
