### PR TITLE
chore(lint): add production-hardening rules

### DIFF
--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -339,12 +339,14 @@ function toSessionError(err: unknown): { code: string; message: string } {
 class AppClaimLostError extends Error {
 	constructor(readonly holder: SessionId) {
 		super('app claim lost');
+		this.name = 'AppClaimLostError';
 	}
 }
 
 class EditorClaimLostError extends Error {
 	constructor(readonly holder: SessionId) {
 		super('editor claim lost');
+		this.name = 'EditorClaimLostError';
 	}
 }
 

--- a/packages/compute-cloudflare/src/index.ts
+++ b/packages/compute-cloudflare/src/index.ts
@@ -54,7 +54,9 @@ async function waitForTunnelReady(url: string): Promise<void> {
 			// DNS not resolvable yet / connection refused — keep polling until the cap.
 		}
 		if (Date.now() >= deadline) return;
-		await new Promise((resolve) => setTimeout(resolve, TUNNEL_READY_INTERVAL_MS));
+		await new Promise((resolve) => {
+			setTimeout(resolve, TUNNEL_READY_INTERVAL_MS);
+		});
 	}
 }
 

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -11,7 +11,9 @@
 // Private duplicate of core's `duration.ts` sleep: this package is
 // intentionally zero-dep (no `core` import), so it keeps its own copy.
 function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
 }
 
 /**

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -171,7 +171,9 @@ async function runProcess(process: ModalProcessLike): Promise<ExecResult> {
 }
 
 function delay(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
 }
 
 let processSequence = 0;

--- a/packages/config/src/computeProfiles.ts
+++ b/packages/config/src/computeProfiles.ts
@@ -31,6 +31,7 @@ export class ComputeProfileConfigError extends ConfigError {
 			remediation: 'Use name:cpu=<cores>;mem=<Mi|Gi|Ti>, with lowercase names and unique keys.',
 			docs: 'docs/configuration.md#compute',
 		});
+		this.name = 'ComputeProfileConfigError';
 	}
 }
 

--- a/packages/core/src/duration.ts
+++ b/packages/core/src/duration.ts
@@ -36,5 +36,7 @@ export const Seconds = {
 };
 
 export function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -8,6 +8,12 @@ export abstract class DomainError extends Error {
 	abstract readonly code: string;
 	/** HTTP status this error maps to. */
 	abstract readonly status: number;
+	constructor(message?: string) {
+		super(message);
+		// Default; concrete subclasses override with their own name. Guarantees a
+		// non-`Error` name even if a subclass forgets to set one.
+		this.name = 'DomainError';
+	}
 }
 
 export class BadRequestError extends DomainError {

--- a/packages/core/src/services/catalog/cas.test.ts
+++ b/packages/core/src/services/catalog/cas.test.ts
@@ -27,11 +27,16 @@ describe('withCasRetry', () => {
 	it('throws ConflictError once retries are exhausted', async () => {
 		const onExhausted = vi.fn();
 		await expect(
-			withCasRetry(async () => Promise.reject(new PreconditionFailedError('race')), {
-				retries: 3,
-				backoffMs: () => 0,
-				onExhausted,
-			}),
+			withCasRetry(
+				async () => {
+					throw new PreconditionFailedError('race');
+				},
+				{
+					retries: 3,
+					backoffMs: () => 0,
+					onExhausted,
+				},
+			),
 		).rejects.toBeInstanceOf(ConflictError);
 		expect(onExhausted).toHaveBeenCalledTimes(1);
 	});

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -1101,7 +1101,7 @@ describe('ProjectIntegrationsStore', () => {
 							// The rename is committed and readable here: whatever a concurrent
 							// reader sees now, it can echo back as an If-Match token.
 							exposed = await (await bucket.get(key))?.json<{ name: string; updated_at: string }>();
-							return Promise.reject(new Error('final head commit failed'));
+							throw new Error('final head commit failed');
 						}
 					}
 					return bucket.put(key, value, options);

--- a/packages/core/src/services/integrations/kinds/pyspark.ts
+++ b/packages/core/src/services/integrations/kinds/pyspark.ts
@@ -108,7 +108,7 @@ export const pyspark = defineIntegration({
 				throw new ValidationError(`Spark Connect parameter "${name}" has a typed field.`);
 			}
 		}
-		const secretNames = config.secret_spark_config.map(({ name }) => name);
+		const secretNames = new Set(config.secret_spark_config.map(({ name }) => name));
 		for (const key of Object.keys(config.spark_config)) {
 			if (key.trim() === '') throw new ValidationError('Spark configuration keys cannot be empty.');
 			if (SENSITIVE_CONFIG_REGEX.test(key)) {
@@ -116,7 +116,7 @@ export const pyspark = defineIntegration({
 					`Spark configuration "${key}" looks credential-bearing; use secret Spark config.`,
 				);
 			}
-			if (secretNames.includes(key)) {
+			if (secretNames.has(key)) {
 				throw new ValidationError(`Spark configuration "${key}" is configured twice.`);
 			}
 		}

--- a/packages/core/src/services/runtime/sandboxFiles.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.ts
@@ -39,7 +39,9 @@ async function withRetry<T>(op: () => Promise<T>, attempts = SANDBOX_WRITE_ATTEM
 			return await op();
 		} catch (err) {
 			if (attempt >= attempts) throw err;
-			await new Promise((resolve) => setTimeout(resolve, 100 * attempt));
+			await new Promise((resolve) => {
+				setTimeout(resolve, 100 * attempt);
+			});
 		}
 	}
 }

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -434,10 +434,10 @@ describe('ProjectIntegrationsPanel — list view', () => {
 		setup({}, { kinds: [postgresKind, customEnvKind], entries });
 
 		expect(await screen.findAllByTestId('integration-row')).toHaveLength(30);
-		await user.type(
-			screen.getByRole('searchbox', { name: 'Search configured integrations' }),
-			'connection-29',
-		);
+		// Paste rather than `type`: filtering is synchronous, so per-keystroke typing
+		// just re-renders all 30 rows 13 times and can blow the test timeout in CI.
+		await user.click(screen.getByRole('searchbox', { name: 'Search configured integrations' }));
+		await user.paste('connection-29');
 
 		expect(screen.getAllByTestId('integration-row')).toHaveLength(1);
 		expect(screen.getByText('connection-29')).toBeInTheDocument();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
 			'eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
 			'react/react-in-jsx-scope': 'off',
 
-			// --- consistency + bug-catchers (added) ---
+			// --- consistency + bug-catchers ---
 			'eslint/eqeqeq': ['error', 'always', { null: 'ignore' }],
 			'eslint/prefer-const': 'error',
 			'eslint/prefer-template': 'error',
@@ -85,10 +85,10 @@ export default defineConfig({
 			// as callbacks), so it adds noise without catching real `this` loss.
 			'typescript/unbound-method': 'off',
 
-			// --- additional consistency + cleanup (batch 2) ---
-			// NB: `prefer-nullish-coalescing` was evaluated and rejected — our `||`
-			// fallbacks are intentional (empty-string/0 should fall through to the
-			// default), so `??` would change behavior. Don't re-add it.
+			// --- consistency + cleanup ---
+			// `prefer-nullish-coalescing` is intentionally off: our `||` fallbacks on
+			// empty-string/0 should fall through to the default, so `??` would change
+			// behavior.
 			'typescript/prefer-optional-chain': 'error',
 			'typescript/no-unnecessary-type-assertion': 'error',
 			// Force object literals to be validated by annotation, not branded past the
@@ -114,7 +114,7 @@ export default defineConfig({
 			'react/jsx-no-useless-fragment': 'error',
 			'react/no-array-index-key': 'error',
 
-			// --- autofixable style cleanups (batch 3) ---
+			// --- autofixable style cleanups ---
 			'react/self-closing-comp': 'error',
 			'react/jsx-boolean-value': 'error',
 			'react/jsx-curly-brace-presence': ['error', { props: 'never', children: 'never' }],
@@ -130,10 +130,50 @@ export default defineConfig({
 			'unicorn/prefer-array-flat': 'error',
 			'unicorn/prefer-logical-operator-over-ternary': 'error',
 			'unicorn/prefer-modern-math-apis': 'error',
-			// NB: `text-encoding-identifier-case` was evaluated and rejected — it
-			// rewrites `'utf-8'` to `'utf8'`, but `SandboxInstance.readFile` passes the
+			// `text-encoding-identifier-case` is intentionally off: it rewrites
+			// `'utf-8'` to `'utf8'`, but `SandboxInstance.readFile` passes the
 			// vendor-reported encoding straight through and the Cloudflare sandbox SDK
-			// emits `'utf-8'`, so normalizing it breaks that boundary type. Don't re-add it.
+			// emits `'utf-8'`, so normalizing it breaks that boundary type.
+
+			// --- production hardening ---
+			// Injection sinks: no code-from-string, no `javascript:` URLs.
+			'eslint/no-eval': 'error',
+			'eslint/no-implied-eval': 'error',
+			'eslint/no-new-func': 'error',
+			'eslint/no-script-url': 'error',
+
+			// `custom-error-definition` requires each error subclass to set `this.name`
+			// to its own class name — load-bearing because `isConfigError`/domain
+			// dispatch match on `err.name` across module-dup boundaries (see
+			// packages/config/src/errors.ts). The rest extend the existing
+			// `only-throw-error` guarantee to type-guards and rejected promises.
+			'unicorn/error-message': 'error',
+			'unicorn/custom-error-definition': 'error',
+			'unicorn/prefer-type-error': 'error',
+			'unicorn/no-thenable': 'error',
+			'unicorn/no-useless-promise-resolve-reject': 'error',
+			'typescript/prefer-promise-reject-errors': 'error',
+
+			// A value returned from a `new Promise(executor)` is discarded, and a
+			// returned promise's rejection is swallowed. Force a statement body.
+			'eslint/no-promise-executor-return': 'error',
+			// Reassigning a parameter mutates the caller's object and hides data flow.
+			'eslint/no-param-reassign': 'error',
+			'eslint/no-return-assign': 'error',
+			// `parseInt(x)` without a radix parses `'0x…'`/legacy-octal surprisingly.
+			'eslint/radix': 'error',
+			'unicorn/prefer-set-has': 'error',
+
+			'typescript/no-unnecessary-template-expression': 'error',
+			'typescript/no-meaningless-void-operator': 'error',
+			'typescript/no-redundant-type-constituents': 'error',
+
+			// Deferred — valuable, but each needs a case-by-case migration rather
+			// than a blanket flip: `no-non-null-assertion` (many `!` sites are safe
+			// after a `.has()`/regex guard), `no-unnecessary-condition` (trips on
+			// defensive checks at trust boundaries), `no-confusing-void-expression`
+			// (mostly `() => setState()` arrows). `no-await-in-loop` stays off: our
+			// loops are intentionally sequential (CAS retries, ordered writes).
 
 			// --- react hooks correctness (packages/web) ---
 			'react-hooks/rules-of-hooks': 'error',
@@ -188,6 +228,12 @@ export default defineConfig({
 					'typescript/no-misused-promises': 'off',
 					// Test doubles assert minimal object literals to SDK types on purpose.
 					'typescript/consistent-type-assertions': 'off',
+					// Redirect-validation tests use `javascript:` URLs as the malicious
+					// input they assert is rejected.
+					'eslint/no-script-url': 'off',
+					// Inline `new Promise((r) => setTimeout(r, ms))` sleeps are fine in
+					// tests; the swallowed-rejection footgun the rule guards doesn't apply.
+					'eslint/no-promise-executor-return': 'off',
 				},
 			},
 			{


### PR DESCRIPTION
Adds a curated set of oxlint rules for production robustness, evaluated empirically (kept clean/low-fix rules, deferred large migrations).

**Adopted**
- Injection sinks: `no-eval`, `no-implied-eval`, `no-new-func`, `no-script-url`
- Error discipline: `custom-error-definition` (subclasses must set `this.name` — load-bearing for `err.name`-based `isConfigError`/domain dispatch across module-dup boundaries), `error-message`, `prefer-type-error`, `no-thenable`, `no-useless-promise-resolve-reject`, `prefer-promise-reject-errors`
- Robustness: `no-promise-executor-return`, `no-param-reassign`, `no-return-assign`, `radix`, `prefer-set-has`
- Type-safety: `no-unnecessary-template-expression`, `no-meaningless-void-operator`, `no-redundant-type-constituents`

Small code fixes to land clean: set `this.name` on 3 error classes + abstract `DomainError`; wrap 5 `setTimeout` sleeps in statement bodies; `.includes()` → `Set` in a hot path; 2 autofixed test throws.

**Deferred** (documented inline): `no-non-null-assertion`, `no-unnecessary-condition`, `no-confusing-void-expression` need case-by-case migration; `no-await-in-loop` stays off (loops are intentionally sequential).

No blanket `throw new Error` ban — plain-`Error` throws are legit invariant asserts; user-facing errors already flow through `DomainError`.

`vp lint`, `pnpm typecheck`, and touched-package tests pass.