### PR TITLE
feat(api): super-admin audit logs

### DIFF
--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -484,7 +484,7 @@ Every event carries a `schema_version` field so the log stays parseable as the e
 }
 ```
 
-**Event types (emitted today):** every catalog mutation is appended by `CatalogService` after its winning CAS commit (best-effort: a failed append never fails the mutation, it bumps the `events.append_failed` metric). The `event` field is the operation name: `project.create` · `project.update` · `project.members` · `project.delete` · `project.gc` · `notebook.create` · `notebook.update` · `notebook.delete` · `notebook.gc` · `notebook.synced.create` · `notebook.synced.sync`. Context fields (`project_id`, `notebook_id`, …) ride along per operation. Read one day via the admin-only `GET /api/v1/projects/{pid}/events?date=`.
+**Event types (emitted today):** every catalog mutation is appended by `CatalogService` after its winning CAS commit (best-effort: a failed append never fails the mutation, it bumps the `events.append_failed` metric). The `event` field is the operation name: `project.create` · `project.update` · `project.members` · `project.delete` · `project.gc` · `notebook.create` · `notebook.update` · `notebook.delete` · `notebook.gc` · `notebook.synced.create` · `notebook.synced.sync`. Context fields (`project_id`, `notebook_id`, …) ride along per operation. Project admins read one day with `GET /api/v1/projects/{pid}/events?date=`. Super admins read a paginated deployment stream with `GET /api/v1/events`. Each deployment query covers at most 30 UTC days.
 
 **Planned, not yet emitted:** session lifecycle (`session.create` · `session.terminate` · `session.expired`), `notebook.run`, `notebook.snapshot` (snapshot capture on teardown, §8), and `migration.run`.
 
@@ -1017,6 +1017,7 @@ Routes are defined with `@hono/zod-openapi`: each declares typed request and res
 - **Auth** — current user and personal access token management
 - **Users** — identity resolution and directory search
 - **Projects** — project, member, and audit-event management
+- **Audit** — the super-admin deployment audit stream
 - **Notebooks** — local and Git-synced notebooks, content, versions, restore,
   duplicate, HTML snapshots, and sync-token rotation
 - **Sessions** — list, create, inspect, heartbeat, stop, editor ownership, and

--- a/docs/api.md
+++ b/docs/api.md
@@ -26,8 +26,8 @@ or a [personal access token](/api-tokens) sent as `Authorization: Bearer …`
 (for CI, scripts, and the CLI).
 Project reads require effective `viewer` access through ownership, membership,
 or `MARIMOHUB_DEFAULT_ROLE`; `none` hides non-member projects. Writes are
-role-gated, and the audit log requires project `admin` (see
-[Security → Authorization](/security#authorization-roles)).
+role-gated. A project audit log requires project `admin`. The deployment audit
+log requires a super admin (see [Security → Authorization](/security#authorization-roles)).
 Editor ownership, temporary session creation, and takeover are documented in
 [Editor sessions](/editor-sessions).
 
@@ -59,6 +59,10 @@ Resource groups:
   effective role). Admins can read the audit log one UTC day at a time
   (`GET /projects/{pid}/events?date=YYYY-MM-DD`, defaults to today) — every
   project/notebook mutation is recorded as an event.
+- **Audit** — super admins can read deployment events with `GET /events`. The
+  endpoint returns newest events first. It supports exact filters for event type,
+  actor ID, and project ID. The default range is the last 30 UTC days. A custom
+  inclusive range cannot contain more than 30 days.
 - **Notebooks** — create and manage local or Git-synced notebooks, read code,
   manage versions, and rotate notebook sync tokens.
 - **Sessions** — list, create, inspect, heartbeat, and stop kernel sessions.
@@ -74,7 +78,7 @@ Resource groups:
 ## Pagination
 
 The project, notebook, notebook-version, project-session, integration-instance,
-and integration-version list endpoints return this page shape:
+integration-version, and deployment-audit list endpoints return this page shape:
 
 ```jsonc
 {
@@ -93,8 +97,8 @@ get the next page. Items are ordered newest-first. A `next_cursor` value of
 `null` marks the final page. The cursor is opaque.
 
 Some small or naturally bounded collections still return arrays. These include
-project members, API tokens, integration kinds, audit events, and user search
-results. The OpenAPI response schema is authoritative for each route.
+project members, API tokens, integration kinds, project daily audit events, and
+user search results. The OpenAPI response schema is authoritative for each route.
 `GET /api/v1/capabilities` reports the default and maximum page sizes and other
 server limits.
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -169,6 +169,10 @@ It is the one grant that overrides the per-project role model. Only super admins
 can manage [organization-wide integrations](./integrations.md#organization-wide-integrations).
 Project roles never grant this access.
 
+The web application gives super admins a deployment audit-log page. The page
+uses `GET /api/v1/events`. This endpoint returns at most 30 UTC days per query.
+Project admins retain access to each project's daily audit log.
+
 An entry containing `@` matches the caller's login email, case-insensitively;
 any other entry matches the user id (the IdP `sub`) exactly. The two namespaces
 do not overlap — an email entry never elevates a caller whose _id_ happens to

--- a/internal/schemas/allowed-breaking/bucket.md
+++ b/internal/schemas/allowed-breaking/bucket.md
@@ -10,3 +10,10 @@ required fields — allowlist one only with a migration or upgrade seam in place
 
 GET /projects/{pid}/secrets/{name}.json `api path removed without deprecation`
 PUT /projects/{pid}/secrets/{name}.json `api path removed without deprecation`
+
+Event objects written by `EventService` already contain `id`; making it required
+records the existing write contract and needs no stored-data migration.
+
+```text
+PUT /_system/events/{date}/{id}.json `added the new required request property `id``
+```

--- a/internal/schemas/bucket.yml
+++ b/internal/schemas/bucket.yml
@@ -1566,6 +1566,9 @@ components:
     Event:
       type: object
       properties:
+        id:
+          type: string
+          minLength: 1
         schema_version:
           type: integer
           exclusiveMinimum: 0
@@ -1579,6 +1582,7 @@ components:
         actor:
           type: string
       required:
+        - id
         - schema_version
         - ts
         - event

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -18,6 +18,8 @@ tags:
     description: Project secret management
   - name: Users
     description: User identity resolution
+  - name: Audit
+    description: Deployment and project audit events
   - name: System
     description: Deployment metadata
 security:
@@ -394,6 +396,47 @@ components:
             - true
       required:
         - success
+    AuditLogPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditLogEntry'
+        next_cursor:
+          type:
+            - string
+            - 'null'
+      required:
+        - items
+        - next_cursor
+    AuditLogEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        schema_version:
+          type: integer
+          exclusiveMinimum: 0
+        ts:
+          type: string
+          format: date-time
+          example: 2025-03-05T14:00:00Z
+        event:
+          type: string
+          example: project.update
+        actor:
+          type: string
+        metadata:
+          type: object
+          additionalProperties: {}
+      required:
+        - id
+        - schema_version
+        - ts
+        - event
+        - actor
+        - metadata
     AuditEvent:
       type: object
       properties:
@@ -2091,6 +2134,118 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '409':
           description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/events:
+    get:
+      tags:
+        - Audit
+      summary: List deployment audit events
+      description: Deployment-wide audit trail, newest first. Super-admin only. Date
+        ranges are inclusive and limited to 30 UTC days.
+      parameters:
+        - schema:
+            type: integer
+            exclusiveMinimum: 0
+            example: 100
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: string
+            example: WyIyMDI1LTAzLTA1VDE0OjAwOjAwWiIsIm5iLTEiXQ
+          required: false
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+            example: 2026-07-01
+            description: UTC calendar date
+          required: false
+          description: UTC calendar date
+          name: from
+          in: query
+        - schema:
+            type: string
+            pattern: ^\d{4}-\d{2}-\d{2}$
+            example: 2026-07-01
+            description: UTC calendar date
+          required: false
+          description: UTC calendar date
+          name: to
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+          required: false
+          name: event
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+          required: false
+          name: actor
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+          required: false
+          name: project_id
+          in: query
+      responses:
+        '200':
+          description: Deployment audit events, newest first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/AuditLogPage'
+                required:
+                  - success
+                  - data
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Insufficient role
           content:
             application/json:
               schema:

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -41,6 +41,7 @@ const OPENAPI_DOC = {
 		{ name: 'Integrations', description: 'Project and organization integrations' },
 		{ name: 'Secrets', description: 'Project secret management' },
 		{ name: 'Users', description: 'User identity resolution' },
+		{ name: 'Audit', description: 'Deployment and project audit events' },
 		{ name: 'System', description: 'Deployment metadata' },
 	],
 	// Every documented `/api/v1/*` route sits behind the authN guard, satisfiable

--- a/packages/api/src/routes/events.test.ts
+++ b/packages/api/src/routes/events.test.ts
@@ -211,6 +211,7 @@ describe('Event routes', () => {
 		const pid = await createProject();
 
 		await expectError(await request('GET', `/projects/${pid}/events?date=yesterday`), 422);
+		await expectError(await request('GET', `/projects/${pid}/events?date=2025-02-30`), 422);
 		expect(await expectOk(await request('GET', `/projects/${pid}/events?date=2001-01-01`))).toEqual(
 			[],
 		);

--- a/packages/api/src/routes/events.test.ts
+++ b/packages/api/src/routes/events.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import { composeAuthenticators } from '@marimo-hub/core';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
 import { ACTOR, uid } from '@marimo-hub/core/testing';
 import { createApi } from '../createApi';
@@ -26,6 +27,125 @@ describe('Event routes', () => {
 		);
 		return data.id;
 	}
+
+	function superAdminApi() {
+		return createTestApi({
+			bucket,
+			userId: ACTOR,
+			deps: { policy: { superAdmins: [ACTOR] } },
+		});
+	}
+
+	it('lists deployment events for super admins, newest first with opaque metadata', async () => {
+		const { request: adminRequest, deps } = superAdminApi();
+		await deps.services.events.append({
+			event: 'token.create',
+			actor: ACTOR,
+			token_id: 'token-1',
+			payload: { nested: ['value'] },
+		});
+		await deps.services.events.append({
+			event: 'project.update',
+			actor: ACTOR,
+			project_id: 'proj-one',
+		});
+
+		const page = await expectOk<{
+			items: Record<string, any>[];
+			next_cursor: string | null;
+		}>(await adminRequest('GET', '/events?limit=10'));
+		expect(page.next_cursor).toBeNull();
+		expect(page.items.map((event) => event.event)).toEqual(['project.update', 'token.create']);
+		expect(page.items[1]).toMatchObject({
+			id: expect.any(String),
+			schema_version: 1,
+			actor: ACTOR,
+			metadata: { token_id: 'token-1', payload: { nested: ['value'] } },
+		});
+		expect(page.items[1].metadata.id).toBeUndefined();
+	});
+
+	it('paginates and combines exact deployment-event filters', async () => {
+		const { request: adminRequest, deps } = superAdminApi();
+		await deps.services.events.append({
+			event: 'notebook.update',
+			actor: ACTOR,
+			project_id: 'proj-one',
+		});
+		await deps.services.events.append({
+			event: 'notebook.update',
+			actor: uid('someone-else'),
+			project_id: 'proj-one',
+		});
+		await deps.services.events.append({
+			event: 'notebook.create',
+			actor: ACTOR,
+			project_id: 'proj-one',
+		});
+		await deps.services.events.append({
+			event: 'notebook.update',
+			actor: ACTOR,
+			project_id: 'proj-two',
+		});
+
+		const filtered = await expectOk<{ items: any[]; next_cursor: string | null }>(
+			await adminRequest(
+				'GET',
+				`/events?event=notebook.update&actor=${ACTOR}&project_id=proj-one&limit=1`,
+			),
+		);
+		expect(filtered.items).toHaveLength(1);
+		expect(filtered.items[0].metadata.project_id).toBe('proj-one');
+		expect(filtered.next_cursor).toBeNull();
+
+		const first = await expectOk<{ items: any[]; next_cursor: string | null }>(
+			await adminRequest('GET', '/events?limit=2'),
+		);
+		expect(first.items).toHaveLength(2);
+		expect(first.next_cursor).toBeTruthy();
+		const second = await expectOk<{ items: any[]; next_cursor: string | null }>(
+			await adminRequest('GET', `/events?limit=2&cursor=${encodeURIComponent(first.next_cursor!)}`),
+		);
+		expect(second.items).toHaveLength(2);
+		expect(new Set([...first.items, ...second.items].map((event) => event.id)).size).toBe(4);
+	});
+
+	it('requires deployment super-admin access for the global stream', async () => {
+		await expectError(await request('GET', '/events'), 403, 'FORBIDDEN');
+
+		const app = createApi(makeTestDeps(bucket));
+		await expectError(await app.request('/api/v1/events'), 401, 'UNAUTHORIZED');
+	});
+
+	it('accepts a PAT issued by a super admin', async () => {
+		const session = superAdminApi();
+		await session.request('GET', '/me');
+		const { token } = await expectOk<{ token: string }>(
+			await session.request('POST', '/me/tokens', { name: 'audit-reader' }),
+			201,
+		);
+		const app = createApi({
+			...session.deps,
+			authenticator: composeAuthenticators(session.deps.services.tokens, {
+				authenticate: async () => null,
+			}),
+		});
+		const page = await expectOk<{ items: any[] }>(
+			await app.request('/api/v1/events', {
+				headers: { authorization: `Bearer ${token}` },
+			}),
+		);
+		expect(page.items.some((event) => event.event === 'token.create')).toBe(true);
+	});
+
+	it('validates the global date range and cursor', async () => {
+		const { request: adminRequest } = superAdminApi();
+		await expectError(await adminRequest('GET', '/events?from=2026-01-01'), 422);
+		await expectError(await adminRequest('GET', '/events?from=2026-02-01&to=2026-01-01'), 422);
+		await expectError(await adminRequest('GET', '/events?from=2026-01-01&to=2026-01-31'), 422);
+		await expectError(await adminRequest('GET', '/events?from=2026-02-30&to=2026-03-01'), 422);
+		await expectError(await adminRequest('GET', '/events?cursor=not-base64'), 400, 'BAD_REQUEST');
+	});
 
 	it('returns the project’s events for today, in append order', async () => {
 		const pid = await createProject();

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -1,13 +1,94 @@
 import { createRoute, z } from '@hono/zod-openapi';
+import { ValidationError } from '@marimo-hub/core';
+import type { Event } from '@marimo-hub/core';
 import {
 	assertProjectRole,
+	assertSuperAdmin,
 	AuditEventResponseSchema,
+	AuditLogEntryResponseSchema,
 	commonErrors,
 	createApp,
 	errorResponses,
 	jsonContent,
 	ProjectIdParam,
 } from '../shared';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, pageSchema, PaginationQuery } from '../pagination';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_EVENT_RANGE_DAYS = 30;
+const DateQuery = z
+	.string()
+	.regex(/^\d{4}-\d{2}-\d{2}$/)
+	.openapi({ example: '2026-07-01', description: 'UTC calendar date' });
+
+const GlobalEventQuery = PaginationQuery.extend({
+	from: DateQuery.optional(),
+	to: DateQuery.optional(),
+	event: z.string().min(1).optional(),
+	actor: z.string().min(1).optional(),
+	project_id: z.string().min(1).optional(),
+});
+
+function parseDate(value: string): number {
+	const parsed = Date.parse(`${value}T00:00:00.000Z`);
+	if (!Number.isFinite(parsed) || new Date(parsed).toISOString().slice(0, 10) !== value) {
+		throw new ValidationError(`Invalid UTC date: ${value}`);
+	}
+	return parsed;
+}
+
+function eventRange(
+	from: string | undefined,
+	to: string | undefined,
+): { from: string; to: string } {
+	if ((from === undefined) !== (to === undefined)) {
+		throw new ValidationError('from and to must be supplied together');
+	}
+	if (from === undefined || to === undefined) {
+		const end = new Date();
+		const endDate = end.toISOString().slice(0, 10);
+		return {
+			from: new Date(Date.parse(`${endDate}T00:00:00.000Z`) - 29 * DAY_MS)
+				.toISOString()
+				.slice(0, 10),
+			to: endDate,
+		};
+	}
+	const fromTime = parseDate(from);
+	const toTime = parseDate(to);
+	if (fromTime > toTime) throw new ValidationError('from must not be after to');
+	if ((toTime - fromTime) / DAY_MS + 1 > MAX_EVENT_RANGE_DAYS) {
+		throw new ValidationError(`Audit event ranges cannot exceed ${MAX_EVENT_RANGE_DAYS} days`);
+	}
+	return { from, to };
+}
+
+function auditLogEntry(event: Event) {
+	const { id, schema_version, ts, event: type, actor, ...metadata } = event;
+	return { id, schema_version, ts, event: type, actor, metadata };
+}
+
+const listGlobalEvents = createRoute({
+	method: 'get',
+	path: '/events',
+	tags: ['Audit'],
+	summary: 'List deployment audit events',
+	description:
+		'Deployment-wide audit trail, newest first. Super-admin only. Date ranges are inclusive ' +
+		'and limited to 30 UTC days.',
+	request: { query: GlobalEventQuery },
+	responses: {
+		200: jsonContent(
+			z.object({
+				success: z.literal(true),
+				data: pageSchema(AuditLogEntryResponseSchema, 'AuditLogPage'),
+			}),
+			'Deployment audit events, newest first',
+		),
+		...commonErrors(),
+		...errorResponses(400, 403),
+	},
+});
 
 const listEvents = createRoute({
 	method: 'get',
@@ -38,6 +119,29 @@ const listEvents = createRoute({
 });
 
 const app = createApp();
+
+app.openapi(listGlobalEvents, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	assertSuperAdmin(user, deps.policy);
+	const query = c.req.valid('query');
+	const range = eventRange(query.from, query.to);
+	const page = await deps.services.events.listEvents({
+		...range,
+		limit: Math.min(query.limit ?? DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE),
+		cursor: query.cursor,
+		event: query.event,
+		actor: query.actor,
+		projectId: query.project_id,
+	});
+	return c.json(
+		{
+			success: true,
+			data: { items: page.items.map(auditLogEntry), next_cursor: page.nextCursor },
+		},
+		200,
+	);
+});
 
 app.openapi(listEvents, async (c) => {
 	const deps = c.get('deps');

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -1,5 +1,11 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { ValidationError } from '@marimo-hub/core';
+import {
+	MAX_EVENT_RANGE_DAYS,
+	Millis,
+	parseUtcDate,
+	UTC_DATE_PATTERN,
+	ValidationError,
+} from '@marimo-hub/core';
 import type { Event } from '@marimo-hub/core';
 import {
 	assertProjectRole,
@@ -14,11 +20,11 @@ import {
 } from '../shared';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, pageSchema, PaginationQuery } from '../pagination';
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-const MAX_EVENT_RANGE_DAYS = 30;
+const DAY_MS = Millis.days(1);
 const DateQuery = z
 	.string()
-	.regex(/^\d{4}-\d{2}-\d{2}$/)
+	.regex(UTC_DATE_PATTERN)
+	.refine((value) => parseUtcDate(value) !== null, { message: 'Invalid UTC date' })
 	.openapi({ example: '2026-07-01', description: 'UTC calendar date' });
 
 const GlobalEventQuery = PaginationQuery.extend({
@@ -28,14 +34,6 @@ const GlobalEventQuery = PaginationQuery.extend({
 	actor: z.string().min(1).optional(),
 	project_id: z.string().min(1).optional(),
 });
-
-function parseDate(value: string): number {
-	const parsed = Date.parse(`${value}T00:00:00.000Z`);
-	if (!Number.isFinite(parsed) || new Date(parsed).toISOString().slice(0, 10) !== value) {
-		throw new ValidationError(`Invalid UTC date: ${value}`);
-	}
-	return parsed;
-}
 
 function eventRange(
 	from: string | undefined,
@@ -48,14 +46,16 @@ function eventRange(
 		const end = new Date();
 		const endDate = end.toISOString().slice(0, 10);
 		return {
-			from: new Date(Date.parse(`${endDate}T00:00:00.000Z`) - 29 * DAY_MS)
+			from: new Date(Date.parse(`${endDate}T00:00:00.000Z`) - (MAX_EVENT_RANGE_DAYS - 1) * DAY_MS)
 				.toISOString()
 				.slice(0, 10),
 			to: endDate,
 		};
 	}
-	const fromTime = parseDate(from);
-	const toTime = parseDate(to);
+	const fromTime = parseUtcDate(from);
+	const toTime = parseUtcDate(to);
+	if (fromTime === null) throw new ValidationError(`Invalid UTC date: ${from}`);
+	if (toTime === null) throw new ValidationError(`Invalid UTC date: ${to}`);
 	if (fromTime > toTime) throw new ValidationError('from must not be after to');
 	if ((toTime - fromTime) / DAY_MS + 1 > MAX_EVENT_RANGE_DAYS) {
 		throw new ValidationError(`Audit event ranges cannot exceed ${MAX_EVENT_RANGE_DAYS} days`);
@@ -101,11 +101,10 @@ const listEvents = createRoute({
 	request: {
 		params: ProjectIdParam,
 		query: z.object({
-			date: z
-				.string()
-				.regex(/^\d{4}-\d{2}-\d{2}$/)
-				.optional()
-				.openapi({ example: '2026-07-01', description: 'UTC day (defaults to today)' }),
+			date: DateQuery.optional().openapi({
+				example: '2026-07-01',
+				description: 'UTC day (defaults to today)',
+			}),
 		}),
 	},
 	responses: {

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -524,6 +524,17 @@ export const AuditEventResponseSchema = z
 	})
 	.openapi('AuditEvent');
 
+export const AuditLogEntryResponseSchema = z
+	.object({
+		id: z.string(),
+		schema_version: z.number().int().positive(),
+		ts: dt(),
+		event: z.string().openapi({ example: 'project.update' }),
+		actor: z.string(),
+		metadata: z.record(z.string(), z.unknown()),
+	})
+	.openapi('AuditLogEntry');
+
 export const ProjectFederationResponseSchema = z
 	.object({
 		enabled: z.boolean(),

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -41,6 +41,8 @@ export type ResolvedUser = components['schemas']['User'];
 export type ApiToken = components['schemas']['ApiToken'];
 /** The create response: metadata plus the one-time plaintext `token`. */
 export type ApiTokenCreated = components['schemas']['ApiTokenCreated'];
+export type AuditLogEntry = components['schemas']['AuditLogEntry'];
+export type AuditLogPage = components['schemas']['AuditLogPage'];
 
 export interface ApiError {
 	code: string;

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -936,6 +936,106 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/events': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * List deployment audit events
+		 * @description Deployment-wide audit trail, newest first. Super-admin only. Date ranges are inclusive and limited to 30 UTC days.
+		 */
+		get: {
+			parameters: {
+				query?: {
+					limit?: number;
+					cursor?: string;
+					/** @description UTC calendar date */
+					from?: string;
+					/** @description UTC calendar date */
+					to?: string;
+					event?: string;
+					actor?: string;
+					project_id?: string;
+				};
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Deployment audit events, newest first */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['AuditLogPage'];
+						};
+					};
+				};
+				/** @description Bad request */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Insufficient role */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/projects/{pid}/events': {
 		parameters: {
 			query?: never;
@@ -5069,6 +5169,25 @@ export interface components {
 		SuccessResponse: {
 			/** @enum {boolean} */
 			success: true;
+		};
+		AuditLogPage: {
+			items: components['schemas']['AuditLogEntry'][];
+			next_cursor: string | null;
+		};
+		AuditLogEntry: {
+			id: string;
+			schema_version: number;
+			/**
+			 * Format: date-time
+			 * @example 2025-03-05T14:00:00Z
+			 */
+			ts: string;
+			/** @example project.update */
+			event: string;
+			actor: string;
+			metadata: {
+				[key: string]: unknown;
+			};
 		};
 		AuditEvent: {
 			/**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from './errors';
 export * from './paths';
 export * from './authz';
 export * from './identityMatch';
+export * from './utcDate';
 
 // Port interfaces (also available at the '@marimo-hub/core/ports' subpath)
 export * from './ports';

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -186,6 +186,7 @@ describe('SnapshotSchema (looseObject rolling-deploy invariant)', () => {
 describe('EventSchema', () => {
 	it('preserves unknown fields (loose, append-only event records)', () => {
 		const parsed = EventSchema.parse({
+			id: '01HXYZ9ABCDEFGHJKMNPQRSTVW',
 			schema_version: 1,
 			ts: NOW,
 			event: 'session.started',
@@ -197,8 +198,13 @@ describe('EventSchema', () => {
 
 	it('rejects a bad timestamp', () => {
 		expect(
-			EventSchema.safeParse({ schema_version: 1, ts: 'not-a-date', event: 'x', actor: ACTOR })
-				.success,
+			EventSchema.safeParse({
+				id: '01HXYZ9ABCDEFGHJKMNPQRSTVW',
+				schema_version: 1,
+				ts: 'not-a-date',
+				event: 'x',
+				actor: ACTOR,
+			}).success,
 		).toBe(false);
 	});
 });

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -775,6 +775,7 @@ export function toPublicToken(token: Token): PublicToken {
 // --- Event ---
 
 export const EventSchema = z.looseObject({
+	id: z.string().min(1),
 	schema_version: SchemaVersionSchema,
 	ts: z.iso.datetime(),
 	event: z.string(),

--- a/packages/core/src/services/catalog/EventService.test.ts
+++ b/packages/core/src/services/catalog/EventService.test.ts
@@ -113,6 +113,114 @@ describe('EventService', () => {
 		});
 	});
 
+	describe('listEvents', () => {
+		it('returns newest events first across days and pages without gaps', async () => {
+			vi.setSystemTime(new Date('2025-03-04T12:00:00.000Z'));
+			await events.append({ event: 'day-1', actor: uid('a') });
+			vi.setSystemTime(new Date('2025-03-05T12:00:00.000Z'));
+			await events.append({ event: 'day-2-first', actor: uid('a') });
+			await events.append({ event: 'day-2-second', actor: uid('b') });
+
+			const first = await events.listEvents({
+				from: '2025-03-04',
+				to: '2025-03-05',
+				limit: 2,
+			});
+			expect(first.items.map((event) => event.event)).toEqual(['day-2-second', 'day-2-first']);
+			expect(first.nextCursor).toBeTruthy();
+
+			const second = await events.listEvents({
+				from: '2025-03-04',
+				to: '2025-03-05',
+				limit: 2,
+				cursor: first.nextCursor ?? undefined,
+			});
+			expect(second.items.map((event) => event.event)).toEqual(['day-1']);
+			expect(second.nextCursor).toBeNull();
+		});
+
+		it('does not repeat a newer event appended between pages', async () => {
+			await events.append({ event: 'first', actor: uid('a') });
+			await events.append({ event: 'second', actor: uid('a') });
+			const first = await events.listEvents({
+				from: '2025-03-05',
+				to: '2025-03-05',
+				limit: 1,
+			});
+
+			await events.append({ event: 'newest', actor: uid('a') });
+			const second = await events.listEvents({
+				from: '2025-03-05',
+				to: '2025-03-05',
+				limit: 1,
+				cursor: first.nextCursor ?? undefined,
+			});
+			expect(first.items.map((event) => event.event)).toEqual(['second']);
+			expect(second.items.map((event) => event.event)).toEqual(['first']);
+		});
+
+		it('combines exact event, actor, and project filters', async () => {
+			await events.append({
+				event: 'notebook.update',
+				actor: uid('ada'),
+				project_id: 'proj-one',
+				payload: { nested: ['kept'] },
+			});
+			await events.append({
+				event: 'notebook.update',
+				actor: uid('grace'),
+				project_id: 'proj-one',
+			});
+			await events.append({
+				event: 'notebook.create',
+				actor: uid('ada'),
+				project_id: 'proj-one',
+			});
+
+			const page = await events.listEvents({
+				from: '2025-03-05',
+				to: '2025-03-05',
+				limit: 10,
+				event: 'notebook.update',
+				actor: 'ada',
+				projectId: 'proj-one',
+			});
+			expect(page.items).toHaveLength(1);
+			expect(page.items[0].payload).toEqual({ nested: ['kept'] });
+		});
+
+		it('rejects malformed and out-of-range cursors', async () => {
+			await expect(
+				events.listEvents({
+					from: '2025-03-05',
+					to: '2025-03-05',
+					limit: 10,
+					cursor: 'not-base64',
+				}),
+			).rejects.toThrow('Invalid event pagination cursor');
+
+			const invalidDate = btoa(JSON.stringify(['2025-02-30', 'event-id']));
+			await expect(
+				events.listEvents({
+					from: '2025-02-01',
+					to: '2025-03-02',
+					limit: 10,
+					cursor: invalidDate,
+				}),
+			).rejects.toThrow('Invalid event pagination cursor');
+
+			const outside = btoa(JSON.stringify(['2025-03-04', 'event-id']));
+			await expect(
+				events.listEvents({
+					from: '2025-03-05',
+					to: '2025-03-05',
+					limit: 10,
+					cursor: outside,
+				}),
+			).rejects.toThrow('outside the requested date range');
+		});
+	});
+
 	describe('daily rollover', () => {
 		it('writes to separate files for different days', async () => {
 			vi.setSystemTime(new Date('2025-03-05T23:59:00.000Z'));

--- a/packages/core/src/services/catalog/EventService.test.ts
+++ b/packages/core/src/services/catalog/EventService.test.ts
@@ -219,6 +219,19 @@ describe('EventService', () => {
 				}),
 			).rejects.toThrow('outside the requested date range');
 		});
+
+		it.each([
+			[{ from: 'invalid', to: '2025-03-05' }, 'Invalid UTC date: invalid'],
+			[{ from: '2025-03-05', to: '2025-02-30' }, 'Invalid UTC date: 2025-02-30'],
+			[{ from: '2025-03-06', to: '2025-03-05' }, 'Event range start must not be after its end'],
+			[{ from: '2025-02-01', to: '2025-03-03' }, 'Event ranges cannot exceed 30 days'],
+		])('rejects an invalid event range with a bad request: %o', async (range, message) => {
+			await expect(events.listEvents({ ...range, limit: 10 })).rejects.toMatchObject({
+				code: 'BAD_REQUEST',
+				status: 400,
+				message,
+			});
+		});
 	});
 
 	describe('daily rollover', () => {

--- a/packages/core/src/services/catalog/EventService.ts
+++ b/packages/core/src/services/catalog/EventService.ts
@@ -1,12 +1,78 @@
 import type { Bucket } from '../../ports/bucket';
 import { mapWithConcurrency } from '../../concurrency';
 import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
+import { BadRequestError } from '../../errors';
 import { createEventId } from '../../ids';
 import type { UserId } from '../../ids';
 import { paths } from '../../paths';
 import { logOperationalError } from '../../operationalLog';
 import { EventSchema, readStored } from '../../schema';
 import type { Event } from '../../schema';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function isUtcDate(value: string): boolean {
+	if (!DATE_RE.test(value)) return false;
+	const parsed = Date.parse(`${value}T00:00:00.000Z`);
+	return Number.isFinite(parsed) && new Date(parsed).toISOString().slice(0, 10) === value;
+}
+
+export interface EventListOptions {
+	from: string;
+	to: string;
+	limit: number;
+	cursor?: string;
+	event?: string;
+	actor?: string;
+	projectId?: string;
+}
+
+export interface EventPage {
+	items: Event[];
+	nextCursor: string | null;
+}
+
+interface EventCursor {
+	date: string;
+	id: string;
+}
+
+function encodeCursor(cursor: EventCursor): string {
+	return btoa(JSON.stringify([cursor.date, cursor.id]));
+}
+
+function decodeCursor(value: string | undefined): EventCursor | null {
+	if (!value) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(atob(value));
+	} catch {
+		throw new BadRequestError('Invalid event pagination cursor');
+	}
+	if (
+		!Array.isArray(parsed) ||
+		parsed.length !== 2 ||
+		typeof parsed[0] !== 'string' ||
+		!isUtcDate(parsed[0]) ||
+		typeof parsed[1] !== 'string' ||
+		parsed[1].length === 0
+	) {
+		throw new BadRequestError('Invalid event pagination cursor');
+	}
+	return { date: parsed[0], id: parsed[1] };
+}
+
+function previousDate(date: string): string {
+	return new Date(Date.parse(`${date}T00:00:00.000Z`) - DAY_MS).toISOString().slice(0, 10);
+}
+
+function matches(event: Event, options: EventListOptions): boolean {
+	if (options.event !== undefined && event.event !== options.event) return false;
+	if (options.actor !== undefined && event.actor !== options.actor) return false;
+	if (options.projectId !== undefined && event.project_id !== options.projectId) return false;
+	return true;
+}
 
 export class EventService {
 	constructor(private bucket: Bucket) {}
@@ -48,7 +114,9 @@ export class EventService {
 					// One corrupt/legacy event object must not make the whole day's audit
 					// log unreadable — skip it (logged) rather than throwing.
 					try {
-						return await readStored(EventSchema, body, obj.key);
+						const event = await readStored(EventSchema, body, obj.key);
+						const filename = obj.key.slice(prefix.length);
+						return { ...event, id: filename.replace(/\.json$/, '') };
 					} catch (err) {
 						logOperationalError(
 							'stored_object_skipped',
@@ -66,5 +134,40 @@ export class EventService {
 		} while (cursor);
 
 		return events;
+	}
+
+	async listEvents(options: EventListOptions): Promise<EventPage> {
+		if (!Number.isInteger(options.limit) || options.limit <= 0) {
+			throw new BadRequestError('Event page limit must be a positive integer');
+		}
+		const cursor = decodeCursor(options.cursor);
+		if (cursor && (cursor.date < options.from || cursor.date > options.to)) {
+			throw new BadRequestError('Event pagination cursor is outside the requested date range');
+		}
+
+		const found: { event: Event; date: string }[] = [];
+		let date = cursor?.date ?? options.to;
+
+		while (date >= options.from && found.length <= options.limit) {
+			const events = await this.getEvents(date);
+			for (let index = events.length - 1; index >= 0; index--) {
+				const event = events[index];
+				if (cursor?.date === date && event.id >= cursor.id) continue;
+				if (!matches(event, options)) continue;
+				found.push({ event, date });
+				if (found.length > options.limit) break;
+			}
+			date = previousDate(date);
+		}
+
+		const page = found.slice(0, options.limit);
+		const last = page[page.length - 1];
+		return {
+			items: page.map(({ event }) => event),
+			nextCursor:
+				found.length > options.limit && last
+					? encodeCursor({ date: last.date, id: last.event.id })
+					: null,
+		};
 	}
 }

--- a/packages/core/src/services/catalog/EventService.ts
+++ b/packages/core/src/services/catalog/EventService.ts
@@ -1,6 +1,7 @@
 import type { Bucket } from '../../ports/bucket';
 import { mapWithConcurrency } from '../../concurrency';
 import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
+import { Millis } from '../../duration';
 import { BadRequestError } from '../../errors';
 import { createEventId } from '../../ids';
 import type { UserId } from '../../ids';
@@ -8,15 +9,10 @@ import { paths } from '../../paths';
 import { logOperationalError } from '../../operationalLog';
 import { EventSchema, readStored } from '../../schema';
 import type { Event } from '../../schema';
+import { parseUtcDate } from '../../utcDate';
 
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-function isUtcDate(value: string): boolean {
-	if (!DATE_RE.test(value)) return false;
-	const parsed = Date.parse(`${value}T00:00:00.000Z`);
-	return Number.isFinite(parsed) && new Date(parsed).toISOString().slice(0, 10) === value;
-}
+export const MAX_EVENT_RANGE_DAYS = 30;
+const DAY_MS = Millis.days(1);
 
 export interface EventListOptions {
 	from: string;
@@ -54,7 +50,7 @@ function decodeCursor(value: string | undefined): EventCursor | null {
 		!Array.isArray(parsed) ||
 		parsed.length !== 2 ||
 		typeof parsed[0] !== 'string' ||
-		!isUtcDate(parsed[0]) ||
+		parseUtcDate(parsed[0]) === null ||
 		typeof parsed[1] !== 'string' ||
 		parsed[1].length === 0
 	) {
@@ -65,6 +61,17 @@ function decodeCursor(value: string | undefined): EventCursor | null {
 
 function previousDate(date: string): string {
 	return new Date(Date.parse(`${date}T00:00:00.000Z`) - DAY_MS).toISOString().slice(0, 10);
+}
+
+function assertValidEventRange(from: string, to: string): void {
+	const fromTime = parseUtcDate(from);
+	if (fromTime === null) throw new BadRequestError(`Invalid UTC date: ${from}`);
+	const toTime = parseUtcDate(to);
+	if (toTime === null) throw new BadRequestError(`Invalid UTC date: ${to}`);
+	if (fromTime > toTime) throw new BadRequestError('Event range start must not be after its end');
+	if ((toTime - fromTime) / DAY_MS + 1 > MAX_EVENT_RANGE_DAYS) {
+		throw new BadRequestError(`Event ranges cannot exceed ${MAX_EVENT_RANGE_DAYS} days`);
+	}
 }
 
 function matches(event: Event, options: EventListOptions): boolean {
@@ -140,6 +147,7 @@ export class EventService {
 		if (!Number.isInteger(options.limit) || options.limit <= 0) {
 			throw new BadRequestError('Event page limit must be a positive integer');
 		}
+		assertValidEventRange(options.from, options.to);
 		const cursor = decodeCursor(options.cursor);
 		if (cursor && (cursor.date < options.from || cursor.date > options.to)) {
 			throw new BadRequestError('Event pagination cursor is outside the requested date range');

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -14,7 +14,7 @@ import { SessionService } from './runtime/SessionService';
 import { TokenService } from './tokens/TokenService';
 
 export { CatalogService } from './catalog/CatalogService';
-export { EventService } from './catalog/EventService';
+export { EventService, MAX_EVENT_RANGE_DAYS } from './catalog/EventService';
 export { IdempotencyService } from './catalog/IdempotencyService';
 export { SyncedNotebookService } from './content/SyncedNotebookService';
 export { IdentityService } from './identity/IdentityService';

--- a/packages/core/src/utcDate.test.ts
+++ b/packages/core/src/utcDate.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { parseUtcDate } from './utcDate';
+
+describe('parseUtcDate', () => {
+	it('parses real ISO calendar dates at UTC midnight', () => {
+		expect(parseUtcDate('2024-02-29')).toBe(Date.parse('2024-02-29T00:00:00.000Z'));
+	});
+
+	it.each(['2025-02-29', '2025-02-30', '2025-13-01', '2025-1-01', 'not-a-date'])(
+		'rejects %s',
+		(value) => {
+			expect(parseUtcDate(value)).toBeNull();
+		},
+	);
+});

--- a/packages/core/src/utcDate.ts
+++ b/packages/core/src/utcDate.ts
@@ -1,0 +1,9 @@
+export const UTC_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parseUtcDate(value: string): number | null {
+	if (!UTC_DATE_PATTERN.test(value)) return null;
+	const parsed = Date.parse(`${value}T00:00:00.000Z`);
+	return Number.isFinite(parsed) && new Date(parsed).toISOString().slice(0, 10) === value
+		? parsed
+		: null;
+}

--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -34,7 +34,7 @@ describe('App routes', () => {
 		);
 		window.history.replaceState({}, '', '/admin/audit-logs');
 
-		renderWithClient(<App />);
+		renderWithClient(<App />, { toaster: false });
 
 		expect(await screen.findByRole('heading', { name: 'Projects' })).toBeInTheDocument();
 		expect(window.location.pathname).toBe('/');

--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { installMatchMedia, jsonOk, renderWithClient } from '@/test/render';
+import App from './App';
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+	window.history.replaceState({}, '', '/');
+	localStorage.clear();
+});
+
+describe('App routes', () => {
+	it('redirects a non-super-admin away from the audit log page', async () => {
+		installMatchMedia(false);
+		const requests: string[] = [];
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				requests.push(url);
+				if (url === '/api/v1/me') {
+					return jsonOk({
+						id: 'user-one',
+						email: 'user@example.com',
+						logout_url: null,
+						is_super_admin: false,
+					});
+				}
+				if (url === '/api/v1/projects') return jsonOk({ items: [], next_cursor: null });
+				if (url === '/api/v1/version') return jsonOk({ version: 'test', backends: {} });
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		window.history.replaceState({}, '', '/admin/audit-logs');
+
+		renderWithClient(<App />);
+
+		expect(await screen.findByRole('heading', { name: 'Projects' })).toBeInTheDocument();
+		expect(window.location.pathname).toBe('/');
+		expect(requests.some((url) => url.startsWith('/api/v1/events?'))).toBe(false);
+	});
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { ThemeProvider } from '@/context/ThemeContext';
 import { AuthProvider, useAuth } from '@/context/AuthContext';
@@ -11,6 +11,8 @@ import { SignIn } from '@/components/SignIn/SignIn';
 import { ErrorBoundary, Button } from '@/components/ui';
 import { Toaster } from '@/components/ui/sonner';
 import { ApiRequestError } from '@/api/client';
+
+const AuditLogPage = lazy(() => import('@/components/AuditLog/AuditLogPage'));
 
 function AuthGate({ children }: { children: React.ReactNode }) {
 	const { isPending, error, user, signIn, refetchUser } = useAuth();
@@ -75,6 +77,11 @@ function PageFallback() {
 	);
 }
 
+function SuperAdminAuditLogs() {
+	const { user } = useAuth();
+	return user?.is_super_admin ? <AuditLogPage /> : <Navigate to="/" replace />;
+}
+
 function StandardLayout() {
 	return (
 		<div className="flex min-h-dvh flex-col">
@@ -85,6 +92,7 @@ function StandardLayout() {
 						<Routes>
 							<Route path="/" element={<ProjectList />} />
 							<Route path="/projects/:pid" element={<Project />} />
+							<Route path="/admin/audit-logs" element={<SuperAdminAuditLogs />} />
 							<Route path="*" element={<Navigate to="/" replace />} />
 						</Routes>
 					</Suspense>

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -1,4 +1,10 @@
-import { useQuery, useSuspenseQuery, useMutation, keepPreviousData } from '@tanstack/react-query';
+import {
+	useInfiniteQuery,
+	useQuery,
+	useSuspenseQuery,
+	useMutation,
+	keepPreviousData,
+} from '@tanstack/react-query';
 import { apiClient, apiData, apiDataWithResponse } from './client';
 import { useApiMutation } from './mutation';
 import { isApiErrorCode, isNotFoundError, notebookPath } from './request';
@@ -10,6 +16,7 @@ import {
 	sessionKeys,
 	systemKeys,
 	integrationKeys,
+	auditKeys,
 } from './queryKeys';
 import type {
 	IntegrationEntry,
@@ -28,6 +35,38 @@ const SESSIONS_POLL_INTERVAL_MS = 5_000;
  * the dependent UI just renders nothing rather than spamming the endpoint.
  */
 const IMMUTABLE_QUERY = { staleTime: Number.POSITIVE_INFINITY, retry: false } as const;
+
+export interface AuditLogFilters {
+	from: string;
+	to: string;
+	event: string;
+	actor: string;
+	projectId: string;
+}
+
+export function useAuditLogsQuery(filters: AuditLogFilters) {
+	return useInfiniteQuery({
+		queryKey: auditKeys.list(filters),
+		initialPageParam: null as string | null,
+		queryFn: ({ pageParam }) =>
+			apiData(
+				apiClient.GET('/api/v1/events', {
+					params: {
+						query: {
+							from: filters.from,
+							to: filters.to,
+							limit: 50,
+							...(pageParam ? { cursor: pageParam } : {}),
+							...(filters.event ? { event: filters.event } : {}),
+							...(filters.actor ? { actor: filters.actor } : {}),
+							...(filters.projectId ? { project_id: filters.projectId } : {}),
+						},
+					},
+				}),
+			),
+		getNextPageParam: (lastPage) => lastPage.next_cursor,
+	});
+}
 
 // Auth
 export function useUserQuery() {

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -18,6 +18,7 @@ import {
 	integrationKeys,
 	auditKeys,
 } from './queryKeys';
+import type { AuditLogFilters } from './queryKeys';
 import type {
 	IntegrationEntry,
 	NotebookDetail,
@@ -36,13 +37,7 @@ const SESSIONS_POLL_INTERVAL_MS = 5_000;
  */
 const IMMUTABLE_QUERY = { staleTime: Number.POSITIVE_INFINITY, retry: false } as const;
 
-export interface AuditLogFilters {
-	from: string;
-	to: string;
-	event: string;
-	actor: string;
-	projectId: string;
-}
+export type { AuditLogFilters } from './queryKeys';
 
 export function useAuditLogsQuery(filters: AuditLogFilters) {
 	return useInfiniteQuery({

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -47,7 +47,7 @@ export const systemKeys = {
 	capabilities: () => [...systemKeys.all, 'capabilities'] as const,
 };
 
-export interface AuditLogKeyFilters {
+export interface AuditLogFilters {
 	from: string;
 	to: string;
 	event: string;
@@ -57,7 +57,7 @@ export interface AuditLogKeyFilters {
 
 export const auditKeys = {
 	all: ['audit-events'] as const,
-	list: (filters: AuditLogKeyFilters) => [...auditKeys.all, 'list', filters] as const,
+	list: (filters: AuditLogFilters) => [...auditKeys.all, 'list', filters] as const,
 };
 
 export const sessionKeys = {

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -47,6 +47,19 @@ export const systemKeys = {
 	capabilities: () => [...systemKeys.all, 'capabilities'] as const,
 };
 
+export interface AuditLogKeyFilters {
+	from: string;
+	to: string;
+	event: string;
+	actor: string;
+	projectId: string;
+}
+
+export const auditKeys = {
+	all: ['audit-events'] as const,
+	list: (filters: AuditLogKeyFilters) => [...auditKeys.all, 'list', filters] as const,
+};
+
 export const sessionKeys = {
 	all: ['sessions'] as const,
 	detail: (sid: string) => [...sessionKeys.all, 'detail', sid] as const,

--- a/packages/web/src/components/AuditLog/AuditLogPage.test.tsx
+++ b/packages/web/src/components/AuditLog/AuditLogPage.test.tsx
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { jsonError, jsonOk, renderWithClient } from '@/test/render';
+import type { AuditLogEntry } from '@/types';
+import AuditLogPage from './AuditLogPage';
+
+const PROJECT_EVENT: AuditLogEntry = {
+	id: 'event-2',
+	schema_version: 1,
+	ts: '2026-08-03T17:00:00.000Z',
+	event: 'project.update',
+	actor: 'user-ada',
+	metadata: { project_id: 'proj-one', payload: { field: 'description' } },
+};
+
+const TOKEN_EVENT: AuditLogEntry = {
+	id: 'event-1',
+	schema_version: 1,
+	ts: '2026-08-03T16:00:00.000Z',
+	event: 'token.create',
+	actor: 'system',
+	metadata: { token_id: 'token-one' },
+};
+
+function usersResponse(url: string): Response | null {
+	if (!url.startsWith('/api/v1/users?')) return null;
+	return jsonOk({
+		'user-ada': { id: 'user-ada', email: 'ada@example.com', name: 'Ada Lovelace' },
+	});
+}
+
+function setup(fetchImpl: (url: string) => Promise<Response>) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			return fetchImpl(url);
+		}),
+	);
+	const user = userEvent.setup();
+	const clipboard = vi.fn(() => Promise.resolve());
+	Object.defineProperty(navigator, 'clipboard', {
+		value: { writeText: clipboard },
+		configurable: true,
+	});
+	renderWithClient(<AuditLogPage />);
+	return { user, clipboard };
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+	Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+describe('AuditLogPage', () => {
+	it('renders the event list, resolves actors, selects rows, and copies structured JSON', async () => {
+		const { user, clipboard } = setup(async (url) => {
+			const users = usersResponse(url);
+			if (users) return users;
+			if (url.startsWith('/api/v1/events?')) {
+				return jsonOk({ items: [PROJECT_EVENT, TOKEN_EVENT], next_cursor: null });
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+
+		expect(await screen.findByRole('button', { name: /project\.update/ })).toBeInTheDocument();
+		await waitFor(() => expect(screen.getAllByText('Ada Lovelace').length).toBeGreaterThan(0));
+		expect(screen.getAllByText('system').length).toBeGreaterThan(0);
+		expect(screen.getAllByText('proj-one').length).toBeGreaterThan(0);
+		await user.click(screen.getByText('Object(1)'));
+		expect(screen.getByText('field')).toBeInTheDocument();
+		expect(screen.getByText('description')).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: /token\.create/ }));
+		expect(screen.getByText('token_id')).toBeInTheDocument();
+		expect(screen.getByText('token-one')).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: 'Copy event JSON' }));
+		await waitFor(() => expect(clipboard).toHaveBeenCalledTimes(1));
+		expect(JSON.parse(clipboard.mock.calls[0][0])).toMatchObject({
+			id: 'event-1',
+			metadata: { token_id: 'token-one' },
+		});
+	});
+
+	it('applies exact filters and follows the next-page cursor', async () => {
+		const eventUrls: string[] = [];
+		const { user } = setup(async (url) => {
+			const users = usersResponse(url);
+			if (users) return users;
+			if (url.startsWith('/api/v1/events?')) {
+				eventUrls.push(url);
+				const parsed = new URL(url, 'http://localhost');
+				return parsed.searchParams.has('cursor')
+					? jsonOk({ items: [TOKEN_EVENT], next_cursor: null })
+					: jsonOk({ items: [PROJECT_EVENT], next_cursor: 'page-two' });
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+
+		await screen.findByRole('button', { name: /project\.update/ });
+		await user.type(screen.getByLabelText('Event type'), 'project.update');
+		await user.type(screen.getByLabelText('Actor ID'), 'user-ada');
+		await user.type(screen.getByLabelText('Project ID'), 'proj-one');
+		await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+		await waitFor(() => expect(eventUrls).toHaveLength(2));
+		const filtered = new URL(eventUrls[1], 'http://localhost');
+		expect(filtered.searchParams.get('event')).toBe('project.update');
+		expect(filtered.searchParams.get('actor')).toBe('user-ada');
+		expect(filtered.searchParams.get('project_id')).toBe('proj-one');
+		expect(filtered.searchParams.get('limit')).toBe('50');
+
+		await user.click(screen.getByRole('button', { name: 'Load more' }));
+		await waitFor(() => expect(eventUrls).toHaveLength(3));
+		expect(new URL(eventUrls[2], 'http://localhost').searchParams.get('cursor')).toBe('page-two');
+		expect(await screen.findByRole('button', { name: /token\.create/ })).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: 'Clear' }));
+		expect(screen.getByLabelText('Event type')).toHaveValue('');
+		expect(screen.getByLabelText('Actor ID')).toHaveValue('');
+		expect(screen.getByLabelText('Project ID')).toHaveValue('');
+	});
+
+	it('shows an empty state and rejects ranges longer than 30 days before fetching', async () => {
+		const eventUrls: string[] = [];
+		const { user } = setup(async (url) => {
+			if (url.startsWith('/api/v1/events?')) {
+				eventUrls.push(url);
+				return jsonOk({ items: [], next_cursor: null });
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+
+		expect(await screen.findByText('No audit events found')).toBeInTheDocument();
+		await user.clear(screen.getByLabelText('From (UTC)'));
+		await user.type(screen.getByLabelText('From (UTC)'), '2026-01-01');
+		await user.clear(screen.getByLabelText('To (UTC)'));
+		await user.type(screen.getByLabelText('To (UTC)'), '2026-01-31');
+		expect(screen.getByText('Date ranges can include at most 30 days.')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Apply' })).toBeDisabled();
+		expect(eventUrls).toHaveLength(1);
+	});
+
+	it('shows API failures with a retry action', async () => {
+		setup(async (url) => {
+			if (url.startsWith('/api/v1/events?')) return jsonError('INTERNAL_ERROR', 'Storage failed');
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+
+		expect(await screen.findByText('Unable to load audit events')).toBeInTheDocument();
+		expect(screen.getByText('Storage failed')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/components/AuditLog/AuditLogPage.tsx
+++ b/packages/web/src/components/AuditLog/AuditLogPage.tsx
@@ -68,23 +68,21 @@ function PrimitiveValue({ value }: { value: string | number | boolean | null }) 
 
 function MetadataValue({ value, depth = 0 }: { value: unknown; depth?: number }) {
 	if (Array.isArray(value)) {
-		const items = value.map((item, index) => ({
-			item,
-			index,
-			key: `${index}:${JSON.stringify(item)}`,
-		}));
 		return (
 			<details open={depth === 0} className="group">
 				<summary className="cursor-pointer select-none text-muted-foreground">
 					Array({value.length})
 				</summary>
 				<div className="mt-1 border-l pl-3">
-					{items.map(({ item, index, key }) => (
-						<div key={key} className="grid grid-cols-[auto_minmax(0,1fr)] gap-2 py-0.5">
-							<span className="text-muted-foreground">{index}</span>
-							<MetadataValue value={item} depth={depth + 1} />
-						</div>
-					))}
+					{value.map((item, index) => {
+						return (
+							// oxlint-disable-next-line react/no-array-index-key -- Stored event metadata is immutable.
+							<div key={index} className="grid grid-cols-[auto_minmax(0,1fr)] gap-2 py-0.5">
+								<span className="text-muted-foreground">{index}</span>
+								<MetadataValue value={item} depth={depth + 1} />
+							</div>
+						);
+					})}
 				</div>
 			</details>
 		);

--- a/packages/web/src/components/AuditLog/AuditLogPage.tsx
+++ b/packages/web/src/components/AuditLog/AuditLogPage.tsx
@@ -1,0 +1,414 @@
+import { useState } from 'react';
+import type { SubmitEvent } from 'react';
+import { Check, Copy, FilterX, RefreshCw, ScrollText } from 'lucide-react';
+import { Button, EmptyState, Skeleton, TextField, UserLabel } from '@/components/ui';
+import { useAuditLogsQuery, useUsersQuery } from '@/api/hooks';
+import type { AuditLogFilters } from '@/api/hooks';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { cn } from '@/lib/utils';
+import type { AuditLogEntry, ResolvedUser } from '@/types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_RANGE_DAYS = 30;
+
+function defaultFilters(): AuditLogFilters {
+	const to = new Date().toISOString().slice(0, 10);
+	const from = new Date(Date.parse(`${to}T00:00:00.000Z`) - 29 * DAY_MS).toISOString().slice(0, 10);
+	return { from, to, event: '', actor: '', projectId: '' };
+}
+
+function rangeError(filters: AuditLogFilters): string | null {
+	if (!filters.from || !filters.to) return 'Choose both a start and end date.';
+	const from = Date.parse(`${filters.from}T00:00:00.000Z`);
+	const to = Date.parse(`${filters.to}T00:00:00.000Z`);
+	if (!Number.isFinite(from) || !Number.isFinite(to)) return 'Choose valid UTC dates.';
+	if (from > to) return 'The start date must not be after the end date.';
+	if ((to - from) / DAY_MS + 1 > MAX_RANGE_DAYS) return 'Date ranges can include at most 30 days.';
+	return null;
+}
+
+function normalized(filters: AuditLogFilters): AuditLogFilters {
+	return {
+		from: filters.from,
+		to: filters.to,
+		event: filters.event.trim(),
+		actor: filters.actor.trim(),
+		projectId: filters.projectId.trim(),
+	};
+}
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+	year: 'numeric',
+	month: 'short',
+	day: 'numeric',
+	hour: 'numeric',
+	minute: '2-digit',
+	second: '2-digit',
+});
+
+function formatTimestamp(value: string): string {
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? value : dateTimeFormatter.format(date);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function PrimitiveValue({ value }: { value: string | number | boolean | null }) {
+	if (value === null) return <span className="text-muted-foreground">null</span>;
+	if (typeof value === 'boolean') {
+		return <span className="text-amber-700 dark:text-amber-300">{String(value)}</span>;
+	}
+	if (typeof value === 'number') {
+		return <span className="text-violet-700 dark:text-violet-300">{value}</span>;
+	}
+	return <span className="break-all text-primary">{value || '""'}</span>;
+}
+
+function MetadataValue({ value, depth = 0 }: { value: unknown; depth?: number }) {
+	if (Array.isArray(value)) {
+		const items = value.map((item, index) => ({
+			item,
+			index,
+			key: `${index}:${JSON.stringify(item)}`,
+		}));
+		return (
+			<details open={depth === 0} className="group">
+				<summary className="cursor-pointer select-none text-muted-foreground">
+					Array({value.length})
+				</summary>
+				<div className="mt-1 border-l pl-3">
+					{items.map(({ item, index, key }) => (
+						<div key={key} className="grid grid-cols-[auto_minmax(0,1fr)] gap-2 py-0.5">
+							<span className="text-muted-foreground">{index}</span>
+							<MetadataValue value={item} depth={depth + 1} />
+						</div>
+					))}
+				</div>
+			</details>
+		);
+	}
+	if (isRecord(value)) {
+		const entries = Object.entries(value);
+		return (
+			<details open={depth === 0} className="group">
+				<summary className="cursor-pointer select-none text-muted-foreground">
+					Object({entries.length})
+				</summary>
+				<div className="mt-1 border-l pl-3">
+					{entries.map(([key, item]) => (
+						<div
+							key={key}
+							className="grid grid-cols-[minmax(6rem,auto)_minmax(0,1fr)] gap-2 py-0.5"
+						>
+							<span className="break-all text-muted-foreground">{key}</span>
+							<MetadataValue value={item} depth={depth + 1} />
+						</div>
+					))}
+				</div>
+			</details>
+		);
+	}
+	if (
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean' ||
+		value === null
+	) {
+		return <PrimitiveValue value={value} />;
+	}
+	return <span className="break-all text-muted-foreground">Unsupported metadata value</span>;
+}
+
+function ActorLabel({
+	id,
+	users,
+	loading,
+}: {
+	id: string;
+	users: Record<string, ResolvedUser>;
+	loading: boolean;
+}) {
+	return <UserLabel user={users[id]} fallbackId={id} loading={loading} />;
+}
+
+function EventList({
+	events,
+	selectedId,
+	onSelect,
+	users,
+	usersLoading,
+}: {
+	events: AuditLogEntry[];
+	selectedId: string | undefined;
+	onSelect: (id: string) => void;
+	users: Record<string, ResolvedUser>;
+	usersLoading: boolean;
+}) {
+	return (
+		<div className="min-w-[700px]">
+			<div className="grid grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,1fr)_auto] gap-3 border-b bg-muted/60 px-4 py-2 text-xs font-medium text-muted-foreground">
+				<span>Event</span>
+				<span>Actor</span>
+				<span>Project</span>
+				<span>Timestamp</span>
+			</div>
+			{events.map((event) => (
+				<button
+					key={event.id}
+					type="button"
+					aria-pressed={selectedId === event.id}
+					onClick={() => onSelect(event.id)}
+					className={cn(
+						'grid w-full grid-cols-[minmax(0,1.5fr)_minmax(0,1fr)_minmax(0,1fr)_auto] gap-3 border-b px-4 py-3 text-left text-xs outline-none transition-colors last:border-b-0 hover:bg-accent/60 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring',
+						selectedId === event.id ? 'bg-primary/8' : 'bg-card',
+					)}
+				>
+					<span className="truncate font-mono text-[12px] font-medium text-primary">
+						{event.event}
+					</span>
+					<ActorLabel id={event.actor} users={users} loading={usersLoading} />
+					<span className="truncate font-mono text-muted-foreground">
+						{typeof event.metadata.project_id === 'string' ? event.metadata.project_id : '—'}
+					</span>
+					<time dateTime={event.ts} className="whitespace-nowrap text-muted-foreground">
+						{formatTimestamp(event.ts)}
+					</time>
+				</button>
+			))}
+		</div>
+	);
+}
+
+function EventDetails({
+	event,
+	users,
+	usersLoading,
+}: {
+	event: AuditLogEntry;
+	users: Record<string, ResolvedUser>;
+	usersLoading: boolean;
+}) {
+	const { copied, copy } = useCopyToClipboard();
+	return (
+		<aside className="flex min-h-0 flex-col overflow-hidden rounded-xl border bg-card shadow-xs">
+			<div className="flex items-center justify-between border-b px-4 py-3">
+				<h2 className="text-sm font-semibold">Event details</h2>
+				<Button
+					variant="ghost"
+					size="sm"
+					aria-label="Copy event JSON"
+					onPress={() => void copy(JSON.stringify(event, null, 2))}
+				>
+					{copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+					{copied ? 'Copied' : 'Copy JSON'}
+				</Button>
+			</div>
+			<div className="min-h-0 flex-1 overflow-y-auto p-4">
+				<dl className="overflow-hidden rounded-lg border text-xs">
+					{[
+						['Event', event.event],
+						['Event ID', event.id],
+						['Timestamp', formatTimestamp(event.ts)],
+						['Schema version', String(event.schema_version)],
+					].map(([label, value]) => (
+						<div
+							key={label}
+							className="grid grid-cols-[7rem_minmax(0,1fr)] border-b last:border-b-0"
+						>
+							<dt className="bg-muted/50 px-3 py-2 text-muted-foreground">{label}</dt>
+							<dd className="break-all px-3 py-2 font-mono">{value}</dd>
+						</div>
+					))}
+					<div className="grid grid-cols-[7rem_minmax(0,1fr)] border-t">
+						<dt className="bg-muted/50 px-3 py-2 text-muted-foreground">Actor</dt>
+						<dd className="flex min-w-0 flex-col px-3 py-2">
+							<ActorLabel id={event.actor} users={users} loading={usersLoading} />
+							<span className="break-all font-mono text-[11px] text-muted-foreground">
+								{event.actor}
+							</span>
+						</dd>
+					</div>
+				</dl>
+
+				<div className="mt-5">
+					<h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+						Metadata
+					</h3>
+					<div className="rounded-lg border bg-muted/25 p-3 font-mono text-xs leading-5">
+						{Object.keys(event.metadata).length > 0 ? (
+							<MetadataValue value={event.metadata} />
+						) : (
+							<span className="text-muted-foreground">No metadata</span>
+						)}
+					</div>
+				</div>
+			</div>
+		</aside>
+	);
+}
+
+function LoadingRows() {
+	return (
+		<div className="flex flex-col gap-3 p-4" aria-label="Loading audit events">
+			{Array.from({ length: 6 }, (_, index) => (
+				<div key={index} className="flex items-center justify-between gap-4">
+					<Skeleton className="h-4 w-40" />
+					<Skeleton className="h-4 w-24" />
+					<Skeleton className="h-4 w-32" />
+				</div>
+			))}
+		</div>
+	);
+}
+
+export default function AuditLogPage() {
+	const initial = defaultFilters();
+	const [draft, setDraft] = useState<AuditLogFilters>(initial);
+	const [filters, setFilters] = useState<AuditLogFilters>(initial);
+	const [selectedId, setSelectedId] = useState<string>();
+	const validationError = rangeError(draft);
+	const query = useAuditLogsQuery(filters);
+	const events = query.data?.pages.flatMap((page) => page.items) ?? [];
+	const selected = events.find((event) => event.id === selectedId) ?? events[0];
+	const usersQuery = useUsersQuery(events.map((event) => event.actor));
+	const users = usersQuery.data ?? {};
+
+	const apply = (formEvent: SubmitEvent<HTMLFormElement>) => {
+		formEvent.preventDefault();
+		if (validationError) return;
+		setSelectedId(undefined);
+		setFilters(normalized(draft));
+	};
+
+	const clear = () => {
+		const defaults = defaultFilters();
+		setDraft(defaults);
+		setFilters(defaults);
+		setSelectedId(undefined);
+	};
+
+	return (
+		<div className="flex min-h-0 flex-1 flex-col overflow-hidden p-6 max-md:overflow-y-auto max-md:p-3">
+			<div className="mb-4 flex shrink-0 items-start justify-between gap-4 max-md:flex-col">
+				<div>
+					<h1 className="text-xl font-semibold">Audit logs</h1>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Deployment-wide audit events for the selected UTC date range.
+					</p>
+				</div>
+				<Button variant="default" size="sm" onPress={() => void query.refetch()}>
+					<RefreshCw className={cn('size-3.5', query.isRefetching ? 'animate-spin' : '')} />
+					Refresh
+				</Button>
+			</div>
+
+			<form
+				onSubmit={apply}
+				className="mb-4 flex shrink-0 flex-wrap items-end gap-3 rounded-xl border bg-card p-3 shadow-xs"
+			>
+				<TextField
+					type="date"
+					label="From (UTC)"
+					value={draft.from}
+					onChange={(from) => setDraft((current) => ({ ...current, from }))}
+					className="w-40"
+				/>
+				<TextField
+					type="date"
+					label="To (UTC)"
+					value={draft.to}
+					onChange={(to) => setDraft((current) => ({ ...current, to }))}
+					className="w-40"
+				/>
+				<TextField
+					label="Event type"
+					placeholder="project.update"
+					value={draft.event}
+					onChange={(event) => setDraft((current) => ({ ...current, event }))}
+					className="min-w-44 flex-1"
+				/>
+				<TextField
+					label="Actor ID"
+					placeholder="user_…"
+					value={draft.actor}
+					onChange={(actor) => setDraft((current) => ({ ...current, actor }))}
+					className="min-w-44 flex-1"
+				/>
+				<TextField
+					label="Project ID"
+					placeholder="proj-…"
+					value={draft.projectId}
+					onChange={(projectId) => setDraft((current) => ({ ...current, projectId }))}
+					className="min-w-44 flex-1"
+				/>
+				<div className="flex gap-2">
+					<Button type="submit" variant="primary" size="md" isDisabled={Boolean(validationError)}>
+						Apply
+					</Button>
+					<Button type="button" variant="ghost" size="md" onPress={clear}>
+						<FilterX className="size-3.5" />
+						Clear
+					</Button>
+				</div>
+				{validationError ? (
+					<p className="w-full text-xs text-destructive">{validationError}</p>
+				) : null}
+			</form>
+
+			<div className="grid min-h-0 flex-1 grid-cols-[minmax(0,1.7fr)_minmax(22rem,0.8fr)] gap-4 max-lg:grid-cols-1 max-lg:overflow-y-auto">
+				<section className="flex min-h-0 flex-col overflow-hidden rounded-xl border bg-card shadow-xs">
+					<div className="min-h-0 flex-1 overflow-auto">
+						{query.isPending ? (
+							<LoadingRows />
+						) : query.isError ? (
+							<div className="flex h-full min-h-64 flex-col items-center justify-center gap-3 p-8 text-center">
+								<p className="text-sm font-medium">Unable to load audit events</p>
+								<p className="text-xs text-muted-foreground">{query.error.message}</p>
+								<Button size="sm" onPress={() => void query.refetch()}>
+									Retry
+								</Button>
+							</div>
+						) : events.length === 0 ? (
+							<div className="p-4">
+								<EmptyState
+									icon={<ScrollText />}
+									message="No audit events found"
+									description="Try a different date range or clear the filters."
+								/>
+							</div>
+						) : (
+							<EventList
+								events={events}
+								selectedId={selected?.id}
+								onSelect={setSelectedId}
+								users={users}
+								usersLoading={usersQuery.isPending}
+							/>
+						)}
+					</div>
+					{query.hasNextPage ? (
+						<div className="flex shrink-0 justify-center border-t p-3">
+							<Button
+								size="sm"
+								isDisabled={query.isFetchingNextPage}
+								onPress={() => void query.fetchNextPage()}
+							>
+								{query.isFetchingNextPage ? 'Loading…' : 'Load more'}
+							</Button>
+						</div>
+					) : null}
+				</section>
+
+				{selected ? (
+					<EventDetails event={selected} users={users} usersLoading={usersQuery.isPending} />
+				) : (
+					<aside className="flex min-h-64 items-center justify-center rounded-xl border border-dashed bg-card/50 p-8 text-sm text-muted-foreground">
+						Select an event to inspect its metadata.
+					</aside>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/Header/Header.test.tsx
+++ b/packages/web/src/components/Header/Header.test.tsx
@@ -1,12 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router-dom';
 import { AuthProvider } from '@/context/AuthContext';
 import { ThemeProvider } from '@/context/ThemeContext';
 import { installMatchMedia, jsonOk, renderWithClient } from '@/test/render';
 import { Header } from './Header';
 
 const USER = { id: 'usr-123', email: 'ada@example.com' };
+
+function LocationProbe() {
+	return <output data-testid="location">{useLocation().pathname}</output>;
+}
 
 /**
  * `userEvent.setup()` installs its own `navigator.clipboard`, so the app's must
@@ -54,7 +59,10 @@ function setup(
 	renderWithClient(
 		<ThemeProvider>
 			<AuthProvider>
-				<Header />
+				<>
+					<Header />
+					<LocationProbe />
+				</>
 			</AuthProvider>
 		</ThemeProvider>,
 		{ route: '/' },
@@ -129,6 +137,14 @@ describe('Header', () => {
 		const { user } = setup();
 		await openUserMenu(user);
 		expect(screen.queryByRole('menuitem', { name: /Org integrations/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole('menuitem', { name: /Audit logs/ })).not.toBeInTheDocument();
+	});
+
+	it('navigates super admins to the audit log page', async () => {
+		const { user } = setup(undefined, { ...USER, is_super_admin: true });
+		await openUserMenu(user);
+		await user.click(screen.getByRole('menuitem', { name: /Audit logs/ }));
+		expect(screen.getByTestId('location')).toHaveTextContent('/admin/audit-logs');
 	});
 
 	it('opens the org integrations dialog for a super admin and lists the org entries', async () => {

--- a/packages/web/src/components/Header/Header.tsx
+++ b/packages/web/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { MenuTrigger, Button, Popover, Menu, MenuItem, Separator } from 'react-aria-components';
-import { ChevronDown, Copy, KeyRound, Moon, Puzzle, Sun } from 'lucide-react';
+import { ChevronDown, Copy, KeyRound, Moon, Puzzle, ScrollText, Sun } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/context/ThemeContext';
@@ -11,6 +11,7 @@ import { ApiTokensDialog } from '@/components/Account/ApiTokensDialog';
 import { OrgIntegrationsDialog } from '@/components/Project/ProjectIntegrationsDialog';
 
 export function Header() {
+	const navigate = useNavigate();
 	const { user, signOut } = useAuth();
 	const { theme, toggleTheme } = useTheme();
 	const tokensDialog = useDisclosure();
@@ -59,6 +60,7 @@ export function Header() {
 										void copy(user.id).then((ok) => ok && toast.success('User id copied'));
 									} else if (key === 'api-tokens') tokensDialog.open();
 									else if (key === 'org-integrations') orgIntegrationsDialog.open();
+									else if (key === 'audit-logs') void navigate('/admin/audit-logs');
 								}}
 							>
 								<MenuItem
@@ -93,6 +95,15 @@ export function Header() {
 									>
 										<Puzzle className="size-3.5" />
 										Org integrations
+									</MenuItem>
+								)}
+								{user.is_super_admin && (
+									<MenuItem
+										id="audit-logs"
+										className="flex cursor-pointer items-center gap-2 px-3 py-2 text-[13px] outline-none transition-colors focus:bg-muted max-md:min-h-11"
+									>
+										<ScrollText className="size-3.5" />
+										Audit logs
 									</MenuItem>
 								)}
 								<Separator className="h-px bg-border" />

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -26,6 +26,8 @@ import type {
 	ResolvedUser as ClientResolvedUser,
 	ApiToken as ClientApiToken,
 	ApiTokenCreated as ClientApiTokenCreated,
+	AuditLogEntry as ClientAuditLogEntry,
+	AuditLogPage as ClientAuditLogPage,
 	ApiResponse as ClientApiResponse,
 	ApiError as ClientApiError,
 } from '@marimo-hub/client';
@@ -68,6 +70,8 @@ export type ResolvedUser = ClientResolvedUser;
 export type ApiToken = ClientApiToken;
 /** The token-create response: metadata plus the one-time plaintext `token`. */
 export type ApiTokenCreated = ClientApiTokenCreated;
+export type AuditLogEntry = ClientAuditLogEntry;
+export type AuditLogPage = ClientAuditLogPage;
 export type ApiResponse<T> = ClientApiResponse<T>;
 export type ApiError = ClientApiError;
 export type User = ClientUser;


### PR DESCRIPTION
- Add an audit-log event feed for super admins.
- `EventService` records and lists catalog events; exposed via a new `events` API route (client + OpenAPI/bucket schemas regenerated).
- Web UI surfaces the feed via a new `AuditLog` page linked from the Header.
