### PR TITLE
chore(lint): add perf, correctness, and type-aware rules

### DIFF
--- a/apps/docs/.vitepress/theme/components/PageActions.vue
+++ b/apps/docs/.vitepress/theme/components/PageActions.vue
@@ -69,7 +69,7 @@ function openIn(base: string): void {
 }
 
 function menuItems(): HTMLButtonElement[] {
-	return [...menu.value?.querySelectorAll('button') ?? []];
+	return [...(menu.value?.querySelectorAll('button') ?? [])];
 }
 
 async function toggleMenu(): Promise<void> {

--- a/apps/docs/.vitepress/theme/components/PageActions.vue
+++ b/apps/docs/.vitepress/theme/components/PageActions.vue
@@ -43,7 +43,7 @@ async function copyText(text: string): Promise<void> {
 	textarea.value = text;
 	textarea.style.position = 'fixed';
 	textarea.style.opacity = '0';
-	document.body.appendChild(textarea);
+	document.body.append(textarea);
 	textarea.select();
 	document.execCommand('copy');
 	textarea.remove();
@@ -69,7 +69,7 @@ function openIn(base: string): void {
 }
 
 function menuItems(): HTMLButtonElement[] {
-	return Array.from(menu.value?.querySelectorAll('button') ?? []);
+	return [...menu.value?.querySelectorAll('button') ?? []];
 }
 
 async function toggleMenu(): Promise<void> {

--- a/apps/docs/.vitepress/wizard/highlight.ts
+++ b/apps/docs/.vitepress/wizard/highlight.ts
@@ -21,7 +21,7 @@ function highlightEnv(line: string): string {
 	let value = after;
 	let comment = '';
 	const ci = after.indexOf('  #');
-	if (ci >= 0) {
+	if (ci !== -1) {
 		value = after.slice(0, ci);
 		comment = after.slice(ci);
 	}

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -638,7 +638,7 @@ describe('OIDC authenticate (cookie session)', () => {
 		// 'A'/'B' can decode to identical bytes and leave the signature valid — a
 		// flaky check. The first char carries all 6 bits, so this is deterministic.)
 		const [header, payload, sig] = token.split('.');
-		const mangledSig = (sig[0] === 'A' ? 'B' : 'A') + sig.slice(1);
+		const mangledSig = (sig.startsWith('A') ? 'B' : 'A') + sig.slice(1);
 		const mangled = `${header}.${payload}.${mangledSig}`;
 		expect(await auth.authenticate(requestWithCookie(mangled))).toBeNull();
 	});

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -318,7 +318,7 @@ describe('createK8sClient', () => {
 		const res = await client.exec('pod-1', ['sh', '-lc', 'cat'], bytes);
 		expect(objectMode).toBe(false);
 		expect(everyChunkWasRawBytes).toBe(true);
-		expect(Array.from(Buffer.concat(received))).toEqual([0xff, 0x00, 0x80, 0x7f]);
+		expect([...Buffer.concat(received)]).toEqual([0xff, 0x00, 0x80, 0x7f]);
 		expect(res.exitCode).toBe(0);
 	});
 

--- a/packages/core/src/internal/base64url.test.ts
+++ b/packages/core/src/internal/base64url.test.ts
@@ -8,7 +8,7 @@ describe('base64url', () => {
 			const encoded = toBase64Url(bytes);
 			// padding-free + URL-safe alphabet only
 			expect(encoded).not.toMatch(/[+/=]/);
-			expect(Array.from(fromBase64Url(encoded))).toEqual(Array.from(bytes));
+			expect([...fromBase64Url(encoded)]).toEqual([...bytes]);
 		}
 	});
 

--- a/packages/core/src/services/runtime/sandboxFiles.test.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.test.ts
@@ -80,7 +80,7 @@ describe('restoreWorkspace', () => {
 
 		await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT);
 
-		expect(Array.from(fs.get('data/x.parquet')!)).toEqual(Array.from(blob));
+		expect([...fs.get('data/x.parquet')!]).toEqual([...blob]);
 	});
 
 	it('sends payloads over the file channel, never inlining them into an exec argv (ARG_MAX-safe)', async () => {
@@ -94,7 +94,7 @@ describe('restoreWorkspace', () => {
 
 		await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT);
 
-		expect(Array.from(fs.get('data/big.bin')!)).toEqual(Array.from(blob));
+		expect([...fs.get('data/big.bin')!]).toEqual([...blob]);
 		// The only exec is the mkdir: no command carries the payload, and nothing is
 		// base64-armored through a shell (nor left behind as a temp file).
 		expect(calls.exec.every((c) => c.startsWith('mkdir -p ') && c.length < 4096)).toBe(true);
@@ -247,7 +247,7 @@ describe('captureWorkspace', () => {
 		await captureWorkspace(instance, bucket, projectId, notebookId, MOUNT, 'workspace');
 
 		const stored = await (await bucket.get(nb.workspaceFile('data/x.parquet')))!.bytes();
-		expect(Array.from(stored)).toEqual(Array.from(blob));
+		expect([...stored]).toEqual([...blob]);
 	});
 
 	it('mirror-deletes stale workspace keys not present in the sandbox (never the source files)', async () => {

--- a/packages/core/src/testing/bucketContract.ts
+++ b/packages/core/src/testing/bucketContract.ts
@@ -41,7 +41,7 @@ export function bucketContract(name: string, makeBucket: () => Bucket | Promise<
 			const got = await bucket.get('bin/blob');
 			expect(got).not.toBeNull();
 			const bytes = await got!.bytes();
-			expect(Array.from(bytes)).toEqual(Array.from(data));
+			expect([...bytes]).toEqual([...data]);
 			expect(got!.size).toBe(data.length);
 		});
 
@@ -50,7 +50,7 @@ export function bucketContract(name: string, makeBucket: () => Bucket | Promise<
 			const got = await bucket.get('bin/text');
 			expect(await got!.text()).toBe('héllo');
 			// bytes() yields the UTF-8 encoding of the same string.
-			expect(Array.from(await got!.bytes())).toEqual(Array.from(new TextEncoder().encode('héllo')));
+			expect([...await got!.bytes()]).toEqual([...new TextEncoder().encode('héllo')]);
 		});
 
 		it('get and head of a missing key return null', async () => {

--- a/packages/core/src/testing/bucketContract.ts
+++ b/packages/core/src/testing/bucketContract.ts
@@ -50,7 +50,7 @@ export function bucketContract(name: string, makeBucket: () => Bucket | Promise<
 			const got = await bucket.get('bin/text');
 			expect(await got!.text()).toBe('héllo');
 			// bytes() yields the UTF-8 encoding of the same string.
-			expect([...await got!.bytes()]).toEqual([...new TextEncoder().encode('héllo')]);
+			expect([...(await got!.bytes())]).toEqual([...new TextEncoder().encode('héllo')]);
 		});
 
 		it('get and head of a missing key return null', async () => {

--- a/packages/storage-gcs/src/index.test.ts
+++ b/packages/storage-gcs/src/index.test.ts
@@ -87,7 +87,7 @@ function makeFakeGcsFetch(): typeof fetch {
 		const q = url.searchParams;
 		const isUpload = url.pathname.startsWith('/upload/');
 		const oIndex = url.pathname.indexOf('/o/');
-		const key = oIndex >= 0 ? decodeURIComponent(url.pathname.slice(oIndex + 3)) : undefined;
+		const key = oIndex !== -1 ? decodeURIComponent(url.pathname.slice(oIndex + 3)) : undefined;
 		const json = (body: unknown, status = 200, headers: Record<string, string> = {}) =>
 			new Response(JSON.stringify(body), {
 				status,
@@ -135,7 +135,7 @@ function makeFakeGcsFetch(): typeof fetch {
 		}
 
 		// List: GET /storage/v1/b/BUCKET/o?prefix=&delimiter=
-		if (method === 'GET' && oIndex < 0 && url.pathname.endsWith('/o')) {
+		if (method === 'GET' && oIndex === -1 && url.pathname.endsWith('/o')) {
 			const prefix = q.get('prefix') ?? '';
 			const items = [...store.entries()]
 				.filter(([k]) => k.startsWith(prefix))

--- a/packages/web/src/lib/download.ts
+++ b/packages/web/src/lib/download.ts
@@ -7,7 +7,7 @@ export function triggerDownload(filename: string, blob: Blob): void {
 	const anchor = document.createElement('a');
 	anchor.href = url;
 	anchor.download = filename;
-	document.body.appendChild(anchor);
+	document.body.append(anchor);
 	anchor.click();
 	anchor.remove();
 	URL.revokeObjectURL(url);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -106,7 +106,6 @@ export default defineConfig({
 			'unicorn/prefer-number-properties': 'error',
 			'unicorn/no-lonely-if': 'error',
 			'unicorn/prefer-array-some': 'error',
-			'unicorn/prefer-includes': 'error',
 			'unicorn/prefer-string-slice': 'error',
 			'unicorn/prefer-date-now': 'error',
 			'unicorn/explicit-length-check': 'error',
@@ -125,7 +124,6 @@ export default defineConfig({
 			// breaks calls to params typed `T | undefined` (not optional) and erases
 			// deliberate test intent (`fn(undefined)`), so only clean returns/defaults.
 			'unicorn/no-useless-undefined': ['error', { checkArguments: false }],
-			'unicorn/prefer-string-starts-ends-with': 'error',
 			'unicorn/prefer-regexp-test': 'error',
 			'unicorn/prefer-array-flat': 'error',
 			'unicorn/prefer-logical-operator-over-ternary': 'error',
@@ -200,7 +198,6 @@ export default defineConfig({
 			'unicorn/no-useless-spread': 'error',
 			'unicorn/prefer-set-size': 'error',
 			'unicorn/prefer-array-index-of': 'error',
-			'unicorn/prefer-array-find': 'error',
 			'unicorn/prefer-blob-reading-methods': 'error',
 			'unicorn/prefer-modern-dom-apis': 'error',
 			'unicorn/prefer-dom-node-append': 'error',
@@ -208,6 +205,13 @@ export default defineConfig({
 			'unicorn/prefer-keyboard-event-key': 'error',
 
 			// --- type-aware ---
+			// These three supersede the AST-only unicorn `prefer-includes` /
+			// `prefer-string-starts-ends-with` / `prefer-array-find`: they catch the
+			// same patterns plus `s[0] === x`, `charAt`, `slice`, `indexOf === 0`.
+			// `prefer-includes`/`prefer-array-find` are off by omission; the
+			// starts/ends one is on via the default correctness category, so disable
+			// it explicitly to avoid duplicate diagnostics on the same code.
+			'unicorn/prefer-string-starts-ends-with': 'off',
 			'typescript/prefer-includes': 'error',
 			'typescript/prefer-string-starts-ends-with': 'error',
 			'typescript/prefer-find': 'error',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -218,21 +218,23 @@ export default defineConfig({
 			'typescript/prefer-as-const': 'error',
 			'typescript/no-unnecessary-type-constraint': 'error',
 
-			// Rejected: `react-perf/jsx-no-new-*` (inline handlers/objects/JSX as
-			// props are idiomatic and only cost when the child is memoized — 100+
-			// noisy, non-autofixable hits); `unicorn/no-negated-condition` (stylistic
-			// if/else swaps); `unicorn/consistent-function-scoping` (debatable, and
-			// noisy in tests); `typescript/no-unnecessary-type-arguments` (churn for
-			// no current benefit); `eslint/no-template-curly-in-string` (our `${…}`
-			// literals are deliberate bash param-expansions in shell bootstrap
-			// scripts); `unicorn/no-array-for-each` (its autofix isn't type-aware and
-			// would break `Headers`/`Map`/`Set` `.forEach`). `unicorn/prefer-at`
-			// (`.at()` returns `T | undefined`, breaking typed-array bitwise code that
-			// index access types as `T`); `typescript/non-nullable-type-assertion-style`
-			// (would push `as` casts toward `!`, at odds with the deferred
-			// `no-non-null-assertion`); `unicorn/prefer-string-raw` (rewrites one
-			// segment of a `+`-built shell string to a tagged template, tripping
-			// `prefer-template`).
+			// Rejected — don't re-add:
+			// - `react-perf/jsx-no-new-*`: inline handlers/objects/JSX as props are
+			//   idiomatic and only cost when the child is memoized (100+ noisy,
+			//   non-autofixable hits).
+			// - `unicorn/prefer-at`: `.at()` returns `T | undefined`, breaking
+			//   typed-array bitwise code that index access types as `T`.
+			// - `typescript/non-nullable-type-assertion-style`: pushes `as` casts
+			//   toward `!`, at odds with the deferred `no-non-null-assertion`.
+			// - `unicorn/prefer-string-raw`: rewrites one segment of a `+`-built shell
+			//   string to a tagged template, tripping `prefer-template`.
+			// - `unicorn/no-array-for-each`: autofix isn't type-aware, would break
+			//   `Headers`/`Map`/`Set` `.forEach`.
+			// - `eslint/no-template-curly-in-string`: our `${…}` literals are
+			//   deliberate bash param-expansions in shell bootstrap scripts.
+			// - `unicorn/no-negated-condition`: stylistic if/else swaps.
+			// - `unicorn/consistent-function-scoping`: debatable, and noisy in tests.
+			// - `typescript/no-unnecessary-type-arguments`: churn for no current benefit.
 
 			// --- react hooks correctness (packages/web) ---
 			'react-hooks/rules-of-hooks': 'error',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -175,6 +175,65 @@ export default defineConfig({
 			// (mostly `() => setState()` arrows). `no-await-in-loop` stays off: our
 			// loops are intentionally sequential (CAS retries, ordered writes).
 
+			// --- correctness + foot-guns ---
+			'eslint/no-self-compare': 'error',
+			'eslint/no-unmodified-loop-condition': 'error',
+			'eslint/no-constructor-return': 'error',
+			'eslint/default-case-last': 'error',
+			'eslint/no-useless-concat': 'error',
+			'eslint/prefer-object-spread': 'error',
+			'eslint/symbol-description': 'error',
+			'typescript/no-array-delete': 'error',
+			'typescript/no-for-in-array': 'error',
+			'typescript/no-confusing-non-null-assertion': 'error',
+			'typescript/no-unnecessary-parameter-property-assignment': 'error',
+			'unicorn/no-negation-in-equality-check': 'error',
+			'unicorn/no-useless-fallback-in-spread': 'error',
+			'unicorn/no-array-method-this-argument': 'error',
+			'unicorn/require-array-join-separator': 'error',
+			'unicorn/consistent-existence-index-check': 'error',
+			// Passing one item / an already-awaited value to `Promise.all`/`race`/etc.
+			// is almost always a mistake — the concurrency wrapper does nothing.
+			'unicorn/no-single-promise-in-promise-methods': 'error',
+			'unicorn/no-await-in-promise-methods': 'error',
+
+			// --- perf / modern APIs ---
+			'unicorn/prefer-spread': 'error',
+			'unicorn/no-useless-spread': 'error',
+			'unicorn/prefer-set-size': 'error',
+			'unicorn/prefer-array-index-of': 'error',
+			'unicorn/prefer-array-find': 'error',
+			'unicorn/prefer-blob-reading-methods': 'error',
+			'unicorn/prefer-modern-dom-apis': 'error',
+			'unicorn/prefer-dom-node-append': 'error',
+			'unicorn/prefer-dom-node-remove': 'error',
+			'unicorn/prefer-keyboard-event-key': 'error',
+
+			// --- type-aware ---
+			'typescript/prefer-includes': 'error',
+			'typescript/prefer-string-starts-ends-with': 'error',
+			'typescript/prefer-find': 'error',
+			'typescript/prefer-reduce-type-parameter': 'error',
+			'typescript/prefer-return-this-type': 'error',
+			'typescript/prefer-as-const': 'error',
+			'typescript/no-unnecessary-type-constraint': 'error',
+
+			// Rejected: `react-perf/jsx-no-new-*` (inline handlers/objects/JSX as
+			// props are idiomatic and only cost when the child is memoized — 100+
+			// noisy, non-autofixable hits); `unicorn/no-negated-condition` (stylistic
+			// if/else swaps); `unicorn/consistent-function-scoping` (debatable, and
+			// noisy in tests); `typescript/no-unnecessary-type-arguments` (churn for
+			// no current benefit); `eslint/no-template-curly-in-string` (our `${…}`
+			// literals are deliberate bash param-expansions in shell bootstrap
+			// scripts); `unicorn/no-array-for-each` (its autofix isn't type-aware and
+			// would break `Headers`/`Map`/`Set` `.forEach`). `unicorn/prefer-at`
+			// (`.at()` returns `T | undefined`, breaking typed-array bitwise code that
+			// index access types as `T`); `typescript/non-nullable-type-assertion-style`
+			// (would push `as` casts toward `!`, at odds with the deferred
+			// `no-non-null-assertion`); `unicorn/prefer-string-raw` (rewrites one
+			// segment of a `+`-built shell string to a tagged template, tripping
+			// `prefer-template`).
+
 			// --- react hooks correctness (packages/web) ---
 			'react-hooks/rules-of-hooks': 'error',
 			'react-hooks/exhaustive-deps': 'warn',
@@ -234,6 +293,11 @@ export default defineConfig({
 					// Inline `new Promise((r) => setTimeout(r, ms))` sleeps are fine in
 					// tests; the swallowed-rejection footgun the rule guards doesn't apply.
 					'eslint/no-promise-executor-return': 'off',
+					// Tests concatenate distinct fixture fragments (one literal per file's
+					// content) for readability, and spread a `Buffer` into a plain array to
+					// compare bytes — both trip these rules for no real gain.
+					'eslint/no-useless-concat': 'off',
+					'unicorn/no-useless-spread': 'off',
 				},
 			},
 			{

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -192,8 +192,6 @@ export default defineConfig({
 			'unicorn/no-array-method-this-argument': 'error',
 			'unicorn/require-array-join-separator': 'error',
 			'unicorn/consistent-existence-index-check': 'error',
-			// Passing one item / an already-awaited value to `Promise.all`/`race`/etc.
-			// is almost always a mistake — the concurrency wrapper does nothing.
 			'unicorn/no-single-promise-in-promise-methods': 'error',
 			'unicorn/no-await-in-promise-methods': 'error',
 
@@ -295,9 +293,8 @@ export default defineConfig({
 					// Inline `new Promise((r) => setTimeout(r, ms))` sleeps are fine in
 					// tests; the swallowed-rejection footgun the rule guards doesn't apply.
 					'eslint/no-promise-executor-return': 'off',
-					// Tests concatenate distinct fixture fragments (one literal per file's
-					// content) for readability, and spread a `Buffer` into a plain array to
-					// compare bytes — both trip these rules for no real gain.
+					// Tests concatenate fixture fragments and spread a `Buffer` into an
+					// array to compare bytes — both are deliberate.
 					'eslint/no-useless-concat': 'off',
 					'unicorn/no-useless-spread': 'off',
 				},


### PR DESCRIPTION
Follow-up to #79. A second curated batch of oxlint rules, chosen to be autofixable or need very few manual fixes (perf, correctness, type-aware, foot-guns). Probed empirically, kept only clean/safe rules; all code changes here are autofixes.

**Correctness / foot-guns**
`no-self-compare`, `no-unmodified-loop-condition`, `no-constructor-return`, `default-case-last`, `no-useless-concat`, `prefer-object-spread`, `symbol-description`, `no-array-delete`, `no-for-in-array`, `no-confusing-non-null-assertion`, `no-unnecessary-parameter-property-assignment`, `no-negation-in-equality-check`, `no-useless-fallback-in-spread`, `no-array-method-this-argument`, `require-array-join-separator`, `consistent-existence-index-check`, `no-single-promise-in-promise-methods`, `no-await-in-promise-methods`

**Perf / modern APIs**
`prefer-spread`, `no-useless-spread`, `prefer-set-size`, `prefer-array-index-of`, `prefer-array-find`, `prefer-blob-reading-methods`, `prefer-modern-dom-apis`, `prefer-dom-node-append`, `prefer-dom-node-remove`, `prefer-keyboard-event-key`

**Type-aware**
`prefer-includes`, `prefer-string-starts-ends-with`, `prefer-find`, `prefer-reduce-type-parameter`, `prefer-return-this-type`, `prefer-as-const`, `no-unnecessary-type-constraint`

All violations were autofixed (spread/`indexOf`/`startsWith`/`append` rewrites, all semantically equivalent). Two test-only false positives are exempted with reasons (fixture-fragment concatenation; `Buffer`→array spread for byte comparison).

**Rejected/dropped, documented inline** — notably `prefer-at` (`.at()` returns `T | undefined`, breaking typed-array bitwise code), `non-nullable-type-assertion-style` (pushes `as`→`!`, at odds with the deferred `no-non-null-assertion`), `prefer-string-raw` (rewrote one segment of a `+`-built shell string to a tagged template, tripping `prefer-template`), the `react-perf/jsx-no-new-*` family (idiomatic inline props, 100+ noisy hits), `no-negated-condition`, `consistent-function-scoping`, `no-unnecessary-type-arguments`, `no-template-curly-in-string` (deliberate bash `${…}`), `no-array-for-each` (autofix unsafe on `Headers`/`Map` `.forEach`).

`vp lint`, `pnpm typecheck`, and touched-package tests pass.