### PR TITLE
feat(web): sandbox-free snapshot page for notebook outputs

### DIFF
--- a/packages/api/src/routes/notebooks.test.ts
+++ b/packages/api/src/routes/notebooks.test.ts
@@ -870,6 +870,8 @@ describe('Notebook routes', () => {
 		// User-generated HTML: must be forced into an opaque origin, never sniffed.
 		expect(res.headers.get('Content-Security-Policy')).toBe('sandbox allow-scripts');
 		expect(res.headers.get('X-Content-Type-Options')).toBe('nosniff');
+		// Never disk-cached: a shared machine must not replay private outputs after logout.
+		expect(res.headers.get('Cache-Control')).toBe('private, no-store');
 		expect(res.headers.get('X-Marimohub-Version-Id')).toBe(committed!.versionId);
 		expect(res.headers.get('X-Marimohub-Captured-At')).toBeTruthy();
 		expect(await res.text()).toBe('<html><body>outputs</body></html>');

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Footer } from '@/components/Footer/Footer';
 import { ProjectList } from '@/components/ProjectList/ProjectList';
 import { Project } from '@/components/Project/Project';
 import { NotebookPage } from '@/components/NotebookPage/NotebookPage';
+import { SnapshotPage } from '@/components/NotebookPage/SnapshotPage';
 import { SignIn } from '@/components/SignIn/SignIn';
 import { ErrorBoundary, Button } from '@/components/ui';
 import { Toaster } from '@/components/ui/sonner';
@@ -115,6 +116,8 @@ function AppContent() {
 							path="/projects/:pid/notebooks/:nid/app"
 							element={<NotebookPage variant="app" />}
 						/>
+						{/* The last HTML snapshot, sandbox-free (no session is ever started). */}
+						<Route path="/projects/:pid/notebooks/:nid/snapshot" element={<SnapshotPage />} />
 						<Route path="*" element={<StandardLayout />} />
 					</Routes>
 				</Suspense>

--- a/packages/web/src/components/AuditLog/AuditLogPage.test.tsx
+++ b/packages/web/src/components/AuditLog/AuditLogPage.test.tsx
@@ -39,7 +39,7 @@ function setup(fetchImpl: (url: string) => Promise<Response>) {
 		}),
 	);
 	const user = userEvent.setup();
-	const clipboard = vi.fn(() => Promise.resolve());
+	const clipboard = vi.fn((_text: string) => Promise.resolve());
 	Object.defineProperty(navigator, 'clipboard', {
 		value: { writeText: clipboard },
 		configurable: true,

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from '@/lib/utils';
 import {
 	Button,
+	Chip,
 	ConfirmDialog,
 	IconButton,
 	IconLink,
@@ -341,10 +342,10 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 				<div className="h-5 w-px bg-border" />
 				<span className="truncate text-[13px] font-medium">{title}</span>
 				{isApp && (
-					<span className="flex shrink-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-[11px] font-medium text-primary">
+					<Chip>
 						<AppWindow className="size-3" />
 						App
-					</span>
+					</Chip>
 				)}
 				{!isApp && !isViewer && (
 					<IconButton

--- a/packages/web/src/components/NotebookPage/SnapshotPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/SnapshotPage.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+import { SnapshotPage } from './SnapshotPage';
+import { jsonError, jsonOk, renderWithClient } from '@/test/render';
+
+const PID = 'proj-x';
+const NID = 'nb-1';
+
+/** Route every request the page makes; `html: null` models "never ran" (404). */
+function makeFetch(opts: { html: string | null }) {
+	const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(input);
+		const method = init?.method ?? 'GET';
+		if (url.endsWith(`/notebooks/${NID}/html`)) {
+			if (opts.html == null) return jsonError('NO_HTML_SNAPSHOT', 'none', 404);
+			return new Response(opts.html, {
+				headers: {
+					'content-type': 'text/html',
+					'X-Marimohub-Captured-At': '2025-03-05T14:00:00Z',
+				},
+			});
+		}
+		if (url.endsWith(`/notebooks/${NID}`)) {
+			return jsonOk({
+				meta: { id: NID, title: 'Forecast', author: 'me' },
+				source: { type: 'local', current_version_id: 'ver-head' },
+			});
+		}
+		throw new Error(`unexpected fetch: ${method} ${url}`);
+	});
+	vi.stubGlobal('fetch', impl);
+	return impl;
+}
+
+const onlyReads = (impl: ReturnType<typeof makeFetch>) =>
+	impl.mock.calls.every(([, init]) => (init?.method ?? 'GET') === 'GET');
+
+function renderPage() {
+	return renderWithClient(
+		<Routes>
+			<Route path="/projects/:pid/notebooks/:nid/snapshot" element={<SnapshotPage />} />
+		</Routes>,
+		{ route: `/projects/${PID}/notebooks/${NID}/snapshot` },
+	);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('SnapshotPage', () => {
+	it('renders the snapshot in an opaque-origin iframe and never starts a session', async () => {
+		const impl = makeFetch({ html: '<html><body>outputs</body></html>' });
+		const { container } = renderPage();
+
+		await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull());
+		const iframe = container.querySelector('iframe')!;
+		expect(iframe.getAttribute('srcdoc')).toContain('outputs');
+		// Opaque origin: no allow-same-origin, unlike the live-kernel iframe.
+		expect(iframe.getAttribute('sandbox')).toBe('allow-scripts');
+		expect(screen.getByText(/captured when the last editing session ended/)).toBeInTheDocument();
+		// Compute-free by design: reads only, no session create.
+		expect(onlyReads(impl)).toBe(true);
+	});
+
+	it('shows the empty state when no snapshot has been captured', async () => {
+		const impl = makeFetch({ html: null });
+		const { container } = renderPage();
+
+		await waitFor(() => expect(screen.getByText('No outputs yet')).toBeInTheDocument());
+		expect(container.querySelector('iframe')).toBeNull();
+		expect(onlyReads(impl)).toBe(true);
+	});
+
+	it('shows the header with the notebook title and a back link to the project', async () => {
+		makeFetch({ html: '<html><body>x</body></html>' });
+		renderPage();
+
+		expect(await screen.findByText('Forecast')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Back to project' })).toHaveAttribute(
+			'href',
+			`/projects/${PID}`,
+		);
+	});
+});

--- a/packages/web/src/components/NotebookPage/SnapshotPage.tsx
+++ b/packages/web/src/components/NotebookPage/SnapshotPage.tsx
@@ -1,0 +1,42 @@
+import { useLocation, useParams } from 'react-router-dom';
+import { ArrowLeft, Camera } from 'lucide-react';
+import { Chip, IconLink } from '@/components/ui';
+import { useNotebookQuery } from '@/api/hooks';
+import { StaticNotebookView } from '@/components/NotebookPage/StaticNotebookView';
+
+/**
+ * Full-screen view of a notebook's last HTML snapshot ("View static outputs").
+ * Compute-free: no session is ever started; the snapshot renders in
+ * StaticNotebookView's opaque-origin iframe.
+ */
+export function SnapshotPage() {
+	const { pid, nid } = useParams<{ pid: string; nid: string }>();
+	const location = useLocation();
+	const fallbackTitle = (location.state as { title?: string } | null)?.title ?? nid ?? 'Notebook';
+	const { data: notebook } = useNotebookQuery(pid!, nid!);
+	// Prefer the canonical title once detail loads, so a rename reflects immediately.
+	const title = notebook?.meta.title ?? fallbackTitle;
+
+	return (
+		<div className="flex h-dvh flex-col">
+			<title>{`${title} · marimohub`}</title>
+			<header className="flex h-10 min-h-10 items-center gap-2 border-b bg-background px-3 max-md:h-11 max-md:min-h-11">
+				<IconLink
+					to={`/projects/${pid}`}
+					label="Back to project"
+					variant="bordered"
+					className="max-md:size-11"
+				>
+					<ArrowLeft className="size-4" />
+				</IconLink>
+				<div className="h-5 w-px bg-border" />
+				<span className="truncate text-[13px] font-medium">{title}</span>
+				<Chip>
+					<Camera className="size-3" />
+					Snapshot
+				</Chip>
+			</header>
+			<StaticNotebookView projectId={pid!} notebookId={nid!} title={title} variant="standalone" />
+		</div>
+	);
+}

--- a/packages/web/src/components/NotebookPage/StaticNotebookView.tsx
+++ b/packages/web/src/components/NotebookPage/StaticNotebookView.tsx
@@ -7,17 +7,25 @@ interface StaticNotebookViewProps {
 	projectId: string;
 	notebookId: string;
 	title: string;
+	/** Banner copy: the role-gated viewer fallback vs the standalone SnapshotPage. */
+	variant?: 'viewer' | 'standalone';
 }
 
 /**
- * What a viewer sees opening a notebook when their viewer mode grants no edit
- * kernel (MARIMOHUB_VIEWER_MODE=static or applications): the notebook's last
- * captured HTML snapshot (from a past editor session's teardown), or an empty
- * state when none exists yet. The snapshot is user-generated HTML, so it renders
- * in an iframe WITHOUT `allow-same-origin` — an opaque origin, unlike the
- * live-kernel iframe (the server's CSP `sandbox` header is the second layer).
+ * The notebook's last captured HTML snapshot (from a past editor session's
+ * teardown), or an empty state when none exists yet. Shown to viewers whose
+ * mode grants no edit kernel (MARIMOHUB_VIEWER_MODE=static or applications)
+ * and on the standalone SnapshotPage. The snapshot is user-generated HTML, so
+ * it renders in an iframe WITHOUT `allow-same-origin` — an opaque origin,
+ * unlike the live-kernel iframe (the server's CSP `sandbox` header is the
+ * second layer).
  */
-export function StaticNotebookView({ projectId, notebookId, title }: StaticNotebookViewProps) {
+export function StaticNotebookView({
+	projectId,
+	notebookId,
+	title,
+	variant = 'viewer',
+}: StaticNotebookViewProps) {
 	const { data, isPending, isError } = useNotebookHtmlQuery(projectId, notebookId);
 
 	if (isPending) {
@@ -42,16 +50,23 @@ export function StaticNotebookView({ projectId, notebookId, title }: StaticNoteb
 		);
 	}
 
+	const capturedFrom = data?.capturedAt ? ` from ${formatRelative(data.capturedAt)}` : '';
+	const banner = data
+		? variant === 'viewer'
+			? `Static snapshot of outputs${capturedFrom} — sessions are disabled for viewers.`
+			: `Static snapshot of outputs${capturedFrom} — captured when the last editing session ended.`
+		: variant === 'viewer'
+			? "You're a viewer on this project — sessions are disabled."
+			: null;
+
 	return (
 		<>
-			<div className="flex items-center gap-1.5 border-b bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground">
-				<Camera className="size-3.5 shrink-0" />
-				<span>
-					{data
-						? `Static snapshot of outputs${data.capturedAt ? ` from ${formatRelative(data.capturedAt)}` : ''} — sessions are disabled for viewers.`
-						: "You're a viewer on this project — sessions are disabled."}
-				</span>
-			</div>
+			{banner && (
+				<div className="flex items-center gap-1.5 border-b bg-muted/50 px-3 py-1.5 text-xs text-muted-foreground">
+					<Camera className="size-3.5 shrink-0" />
+					<span>{banner}</span>
+				</div>
+			)}
 			{data ? (
 				<div className="flex-1 overflow-hidden">
 					<iframe

--- a/packages/web/src/components/Project/Project.test.tsx
+++ b/packages/web/src/components/Project/Project.test.tsx
@@ -134,6 +134,7 @@ async function renderProject() {
 	renderWithClient(
 		<Routes>
 			<Route path="/projects/:pid" element={<Project />} />
+			<Route path="/projects/:pid/notebooks/:nid/snapshot" element={<div>snapshot page</div>} />
 			<Route path="/" element={<div>home</div>} />
 		</Routes>,
 		{ route: `/projects/${PID}`, suspenseFallback: <div>loading</div> },
@@ -355,11 +356,23 @@ describe('Project — Notebook Actions', () => {
 			'Rename',
 			'Duplicate',
 			'Run as app',
+			'View static outputs',
 			'Version history',
 			'Download notebook file',
 			'Download workspace',
 			'Delete',
 		]);
+	});
+
+	it('"View static outputs" opens the sandbox-free snapshot page', async () => {
+		const user = userEvent.setup();
+		const calls = makeFetch();
+		await renderProject();
+
+		await chooseNotebookAction(user, 'View static outputs');
+		expect(await screen.findByText('snapshot page')).toBeInTheDocument();
+		// A navigation, not compute: no session create fired.
+		expect(calls.some((c) => c.method === 'POST' && c.url.endsWith('/sessions'))).toBe(false);
 	});
 
 	it('deletes a notebook only after confirmation', async () => {

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import {
 	AppWindow,
 	ArrowLeft,
+	Camera,
 	ChevronDown,
 	Container,
 	Copy,
@@ -30,6 +31,7 @@ import {
 } from 'lucide-react';
 import {
 	Button,
+	Chip,
 	DropdownMenu,
 	IconButton,
 	IconLink,
@@ -471,6 +473,7 @@ export function Project() {
 							},
 						]
 					: []),
+				{ id: 'view-snapshot', label: 'View static outputs', icon: <Camera className="size-4" /> },
 				{ id: 'history', label: 'Version history', icon: <History className="size-4" /> },
 			],
 			[
@@ -659,7 +662,11 @@ export function Project() {
 												else if (key === 'stop-app') {
 													const app = sessionByNotebook.get(nb.id)?.app;
 													if (app) appModal.open({ action: 'stop', notebook: nb, session: app });
-												} else if (key === 'change-image') baseImageModal.open(nb);
+												} else if (key === 'view-snapshot')
+													void navigate(`/projects/${pid}/notebooks/${nb.id}/snapshot`, {
+														state: { title: nb.title },
+													});
+												else if (key === 'change-image') baseImageModal.open(nb);
 												else if (key === 'change-compute') computeProfileModal.open(nb);
 												else if (key === 'history') historyModal.open(nb);
 												else if (key === 'sync-settings')
@@ -680,12 +687,9 @@ export function Project() {
 									)}
 									<span className="truncate text-sm font-medium">{nb.title}</span>
 									{badges.map((badge) => (
-										<span
-											key={badge}
-											className="shrink-0 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-[11px] font-medium text-primary max-md:hidden"
-										>
+										<Chip key={badge} className="max-md:hidden">
 											{badge}
-										</span>
+										</Chip>
 									))}
 								</div>
 								<div className="flex shrink-0 items-center gap-3">

--- a/packages/web/src/components/ui/Chip.tsx
+++ b/packages/web/src/components/ui/Chip.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+/** Small rounded-pill label, e.g. the "App"/"Snapshot" page badges. */
+export function Chip({ className, children }: { className?: string; children: ReactNode }) {
+	return (
+		<span
+			className={cn(
+				'flex shrink-0 items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-2 py-0.5 text-[11px] font-medium text-primary',
+				className,
+			)}
+		>
+			{children}
+		</span>
+	);
+}

--- a/packages/web/src/components/ui/index.ts
+++ b/packages/web/src/components/ui/index.ts
@@ -4,6 +4,8 @@ export type { BrandProps } from './Brand';
 export { Button } from './Button';
 export type { ButtonProps } from './Button';
 
+export { Chip } from './Chip';
+
 export { IconButton } from './IconButton';
 export type { IconButtonProps } from './IconButton';
 


### PR DESCRIPTION
Adds `/projects/:pid/notebooks/:nid/snapshot` and a **View static outputs** notebook action: view the last captured HTML snapshot without starting a sandbox.

- The snapshot renders in the existing opaque-origin iframe (`srcdoc` + `sandbox="allow-scripts"`, no `allow-same-origin`); the server's `CSP: sandbox` header remains the second layer.
- Tests pin the containment invariants: iframe sandbox attribute on both render paths, no session create ever fired, and the API route's CSP/nosniff/`private, no-store` headers.
- Extracts a `Chip` ui primitive for the pill badges duplicated across NotebookPage, Project, and the new page.
- Fixes an untyped clipboard mock in `AuditLogPage.test.tsx` that broke web typecheck.