### PR TITLE
feat(api,web): per-version output snapshots, staleness note, HTML download

### DIFF
--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -3527,6 +3527,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/notebooks/{nid}/versions/{vid}/html:
+    get:
+      tags:
+        - Notebooks
+      summary: One version's HTML snapshot of the notebook's outputs
+      description: Serves the HTML snapshot captured for this specific version, raw.
+        404 with code `NO_HTML_SNAPSHOT` when the version captured none.
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+        - schema:
+            type: string
+            pattern: ^nb-[0-9a-z]{16}$
+            example: nb-3w8h2k9qm4xz7rp3
+          required: true
+          name: nid
+          in: path
+        - schema:
+            type: string
+            pattern: ^ver_[0-9A-Z]{26}$
+            example: ver_01HXYZ33333RSTUVWXYZAB
+          required: true
+          name: vid
+          in: path
+      responses:
+        '200':
+          description: The HTML snapshot, served sandboxed (CSP forces an opaque origin)
+          content:
+            text/html:
+              schema:
+                type: string
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/projects/{pid}/notebooks/{nid}/versions/{vid}/restore:
     post:
       tags:

--- a/packages/api/src/routes/notebooks.test.ts
+++ b/packages/api/src/routes/notebooks.test.ts
@@ -877,6 +877,54 @@ describe('Notebook routes', () => {
 		expect(await res.text()).toBe('<html><body>outputs</body></html>');
 	});
 
+	it('GET /{nid}/versions/{vid}/html serves that version’s snapshot with the same containment headers', async () => {
+		const created = await expectOk<any>(
+			await request('POST', nb(''), { title: 'NB', description: 'D', code: 'v1' }),
+			201,
+		);
+		const services = createServices(bucket);
+		const first = await services.notebooks.commitSession(
+			projectId,
+			created.id,
+			{ code: 'v2', html: '<html>first</html>' },
+			ACTOR,
+		);
+		await services.notebooks.commitSession(
+			projectId,
+			created.id,
+			{ code: 'v3', html: '<html>second</html>' },
+			ACTOR,
+		);
+
+		// The pinned version, not the latest.
+		const res = await request('GET', nb(`/${created.id}/versions/${first!.versionId}/html`));
+		expect(res.status).toBe(200);
+		expect(res.headers.get('Content-Security-Policy')).toBe('sandbox allow-scripts');
+		expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+		expect(res.headers.get('X-Marimohub-Version-Id')).toBe(first!.versionId);
+		expect(await res.text()).toBe('<html>first</html>');
+	});
+
+	it('GET /{nid}/versions/{vid}/html 404s: NO_HTML_SNAPSHOT for a snapshot-less version, NOT_FOUND for an unknown one', async () => {
+		const created = await expectOk<any>(
+			await request('POST', nb(''), { title: 'NB', description: 'D', code: 'v1' }),
+			201,
+		);
+		// The initial save captured no HTML.
+		const versions = await expectOk<any>(await request('GET', nb(`/${created.id}/versions`)));
+		const vid = versions.items[0].version_id;
+		await expectError(
+			await request('GET', nb(`/${created.id}/versions/${vid}/html`)),
+			404,
+			'NO_HTML_SNAPSHOT',
+		);
+		await expectError(
+			await request('GET', nb(`/${created.id}/versions/${createVersionId()}/html`)),
+			404,
+			'NOT_FOUND',
+		);
+	});
+
 	it('GET /{nid}/html is visibility-gated: 404 for a non-member, 200 for a default-role viewer', async () => {
 		const created = await expectOk<any>(
 			await request('POST', nb(''), { title: 'NB', description: 'D', code: 'v1' }),

--- a/packages/api/src/routes/notebooks.ts
+++ b/packages/api/src/routes/notebooks.ts
@@ -392,6 +392,25 @@ const getNotebookHtml = createRoute({
 	},
 });
 
+const getVersionHtml = createRoute({
+	method: 'get',
+	path: '/projects/{pid}/notebooks/{nid}/versions/{vid}/html',
+	tags: ['Notebooks'],
+	summary: "One version's HTML snapshot of the notebook's outputs",
+	description:
+		'Serves the HTML snapshot captured for this specific version, raw. ' +
+		'404 with code `NO_HTML_SNAPSHOT` when the version captured none.',
+	request: { params: VersionIdParam },
+	responses: {
+		200: {
+			content: { 'text/html': { schema: z.string() } },
+			description: 'The HTML snapshot, served sandboxed (CSP forces an opaque origin)',
+		},
+		...commonErrors(),
+		...errorResponses(404),
+	},
+});
+
 const restoreVersion = createRoute({
 	method: 'post',
 	path: '/projects/{pid}/notebooks/{nid}/versions/{vid}/restore',
@@ -604,6 +623,29 @@ app.openapi(getVersion, async (c) => {
 	return c.json({ success: true, data: { version: toPublicVersion(version), code } }, 200);
 });
 
+/**
+ * Serve an HTML snapshot. The snapshot is user-generated HTML (marimo's export
+ * embeds scripts) and must never execute same-origin with the app. CSP
+ * `sandbox` forces an opaque origin even when the URL is opened directly,
+ * independent of the client's own <iframe sandbox> — two independent
+ * containment layers. Authenticated content is never disk-cached (a shared
+ * machine must not serve a private notebook's outputs after logout).
+ */
+function serveHtmlSnapshot(
+	c: Context<HonoEnv>,
+	snapshot: { versionId: string; capturedAt: string; html: string } | null,
+) {
+	if (!snapshot) {
+		return fail(c, 'NO_HTML_SNAPSHOT', 'No HTML snapshot has been captured yet', 404);
+	}
+	c.header('Content-Security-Policy', 'sandbox allow-scripts');
+	c.header('X-Content-Type-Options', 'nosniff');
+	c.header('Cache-Control', 'private, no-store');
+	c.header('X-Marimohub-Version-Id', snapshot.versionId);
+	c.header('X-Marimohub-Captured-At', snapshot.capturedAt);
+	return c.html(snapshot.html, 200);
+}
+
 app.openapi(getNotebookHtml, async (c) => {
 	const deps = c.get('deps');
 	const { notebooks, projects } = deps.services;
@@ -617,21 +659,17 @@ app.openapi(getNotebookHtml, async (c) => {
 		notebooks.getNotebook(pid, nid),
 		notebooks.getLatestHtmlSnapshot(pid, nid),
 	]);
-	if (!snapshot) {
-		return fail(c, 'NO_HTML_SNAPSHOT', 'No HTML snapshot has been captured yet', 404);
-	}
-	// The snapshot is user-generated HTML (marimo's export embeds scripts) and must
-	// never execute same-origin with the app. CSP `sandbox` forces an opaque origin
-	// even when the URL is opened directly, independent of the client's own
-	// <iframe sandbox> — two independent containment layers.
-	c.header('Content-Security-Policy', 'sandbox allow-scripts');
-	c.header('X-Content-Type-Options', 'nosniff');
-	// Authenticated, user-generated content: never disk-cached (a shared machine
-	// must not serve a private notebook's outputs after logout).
-	c.header('Cache-Control', 'private, no-store');
-	c.header('X-Marimohub-Version-Id', snapshot.versionId);
-	c.header('X-Marimohub-Captured-At', snapshot.capturedAt);
-	return c.html(snapshot.html, 200);
+	return serveHtmlSnapshot(c, snapshot);
+});
+
+app.openapi(getVersionHtml, async (c) => {
+	const deps = c.get('deps');
+	const { notebooks, projects } = deps.services;
+	const user = c.get('user');
+	const { pid, nid, vid } = c.req.valid('param');
+	await assertProjectVisible(projects, pid, user, deps.policy);
+	const snapshot = await notebooks.getVersionHtmlSnapshot(pid, nid, vid);
+	return serveHtmlSnapshot(c, snapshot);
 });
 
 app.openapi(restoreVersion, async (c) => {

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -2297,6 +2297,87 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/projects/{pid}/notebooks/{nid}/versions/{vid}/html': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * One version's HTML snapshot of the notebook's outputs
+		 * @description Serves the HTML snapshot captured for this specific version, raw. 404 with code `NO_HTML_SNAPSHOT` when the version captured none.
+		 */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					pid: string;
+					nid: string;
+					vid: string;
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description The HTML snapshot, served sandboxed (CSP forces an opaque origin) */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'text/html': string;
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/projects/{pid}/notebooks/{nid}/versions/{vid}/restore': {
 		parameters: {
 			query?: never;

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -1,3 +1,4 @@
+import { all } from 'better-all';
 import type { Bucket } from '../../ports/bucket';
 import { mapWithConcurrency } from '../../concurrency';
 import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
@@ -719,19 +720,24 @@ export class NotebookService {
 		return fetched.filter((v): v is Version => v !== undefined);
 	}
 
+	/**
+	 * A malformed id is a client mistake, not a server fault: map the bare parse
+	 * Error to a domain 404 so the API renders a 4xx instead of a raw 500.
+	 */
+	private parseVersionId(versionId: string): VersionId {
+		try {
+			return VersionId.parse(versionId);
+		} catch {
+			throw new NotFoundError(`Version ${versionId} not found`);
+		}
+	}
+
 	async getVersion(
 		projectId: ProjectId,
 		notebookId: NotebookId,
 		versionId: string,
 	): Promise<{ version: Version; code: string }> {
-		// A malformed id is a client mistake, not a server fault: map the bare parse
-		// Error to a domain 404 so the API renders a 4xx instead of a raw 500.
-		let vid: VersionId;
-		try {
-			vid = VersionId.parse(versionId);
-		} catch {
-			throw new NotFoundError(`Version ${versionId} not found`);
-		}
+		const vid = this.parseVersionId(versionId);
 		const { source } = await this.getNotebook(projectId, notebookId);
 		const ver = paths.project(projectId).notebook(notebookId).version(vid);
 		const entryNotebook = remoteWorkspaceEntry(source);
@@ -749,6 +755,38 @@ export class NotebookService {
 		const code = await codeObj.text();
 
 		return { version, code };
+	}
+
+	/**
+	 * One version's HTML snapshot. NotFoundError when the version itself is
+	 * unknown; null when the version exists but captured no snapshot (or the
+	 * object was pruned).
+	 */
+	async getVersionHtmlSnapshot(
+		projectId: ProjectId,
+		notebookId: NotebookId,
+		versionId: string,
+	): Promise<{ versionId: string; capturedAt: string; html: string } | null> {
+		const vid = this.parseVersionId(versionId);
+		const ver = paths.project(projectId).notebook(notebookId).version(vid);
+		// Both object paths are deterministic, so the reads overlap; a
+		// snapshot-less version wastes one harmless html read.
+		const { version, htmlObj } = await all({
+			version: async () => {
+				const metaObj = await this.bucket.get(ver.meta);
+				if (!metaObj) {
+					throw new NotFoundError(`Version ${versionId} not found`);
+				}
+				return readStored(VersionSchema, metaObj, ver.meta);
+			},
+			htmlObj: async () => this.bucket.get(ver.html),
+		});
+		if (!version.html_snapshot || !htmlObj) return null;
+		return {
+			versionId: vid,
+			capturedAt: version.html_snapshot.captured_at,
+			html: await htmlObj.text(),
+		};
 	}
 
 	/**

--- a/packages/web/src/api/hooks.test.tsx
+++ b/packages/web/src/api/hooks.test.tsx
@@ -227,7 +227,7 @@ describe('useNotebookHtmlQuery', () => {
 		expect(result.current.error?.message).toBe('Failed to load notebook outputs (HTTP 500)');
 	});
 
-	it('returns the html and the captured-at header', async () => {
+	it('returns the html and the captured-at and version headers', async () => {
 		stubFetch(
 			async () =>
 				new Response('<h1>out</h1>', {
@@ -235,6 +235,7 @@ describe('useNotebookHtmlQuery', () => {
 					headers: {
 						'content-type': 'text/html',
 						'X-Marimohub-Captured-At': '2025-03-05T14:00:00Z',
+						'X-Marimohub-Version-Id': 'ver-1',
 					},
 				}),
 		);
@@ -247,6 +248,7 @@ describe('useNotebookHtmlQuery', () => {
 		expect(result.current.data).toEqual({
 			html: '<h1>out</h1>',
 			capturedAt: '2025-03-05T14:00:00Z',
+			versionId: 'ver-1',
 		});
 	});
 

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -792,35 +792,68 @@ export function useNotebookVersionQuery(
 	});
 }
 
-/** The latest captured HTML output snapshot, or null when no version has one yet. */
+/** A captured HTML output snapshot, or null when none exists (yet). */
 export interface NotebookHtmlSnapshot {
 	html: string;
 	/** When the snapshot was captured (`X-Marimohub-Captured-At`), for the banner. */
 	capturedAt: string | null;
+	/** The version it was captured for (`X-Marimohub-Version-Id`), for staleness. */
+	versionId: string | null;
 }
 
-/** Fetch the latest HTML snapshot; `NO_HTML_SNAPSHOT` is an empty state. */
-export function useNotebookHtmlQuery(projectId: string, notebookId: string) {
+function htmlSnapshotPath(projectId: string, notebookId: string, versionId?: string): string {
+	const base = notebookPath(projectId, notebookId);
+	return versionId ? `${base}/versions/${versionId}/html` : `${base}/html`;
+}
+
+async function fetchHtmlSnapshot(
+	projectId: string,
+	notebookId: string,
+	versionId?: string,
+): Promise<NotebookHtmlSnapshot | null> {
+	const res = await fetch(htmlSnapshotPath(projectId, notebookId, versionId));
+	if (res.status === 404) {
+		// Only "exists but never ran" is the empty state; a deleted/hidden
+		// notebook (code NOT_FOUND) must surface as an error, not "no outputs".
+		const body = (await res.json().catch(() => null)) as {
+			error?: { code?: string };
+		} | null;
+		if (body?.error?.code === 'NO_HTML_SNAPSHOT') return null;
+		throw new Error('Notebook not found');
+	}
+	if (!res.ok) throw new Error(`Failed to load notebook outputs (HTTP ${res.status})`);
+	return {
+		html: await res.text(),
+		capturedAt: res.headers.get('X-Marimohub-Captured-At'),
+		versionId: res.headers.get('X-Marimohub-Version-Id'),
+	};
+}
+
+/**
+ * Fetch the latest HTML snapshot (or a specific version's when `versionId` is
+ * set); `NO_HTML_SNAPSHOT` is an empty state.
+ */
+export function useNotebookHtmlQuery(projectId: string, notebookId: string, versionId?: string) {
 	return useQuery({
-		queryKey: notebookKeys.html(projectId, notebookId),
-		queryFn: async (): Promise<NotebookHtmlSnapshot | null> => {
-			const res = await fetch(`${notebookPath(projectId, notebookId)}/html`);
-			if (res.status === 404) {
-				// Only "exists but never ran" is the empty state; a deleted/hidden
-				// notebook (code NOT_FOUND) must surface as an error, not "no outputs".
-				const body = (await res.json().catch(() => null)) as {
-					error?: { code?: string };
-				} | null;
-				if (body?.error?.code === 'NO_HTML_SNAPSHOT') return null;
-				throw new Error('Notebook not found');
-			}
-			if (!res.ok) throw new Error(`Failed to load notebook outputs (HTTP ${res.status})`);
-			return {
-				html: await res.text(),
-				capturedAt: res.headers.get('X-Marimohub-Captured-At'),
-			};
-		},
+		queryKey: notebookKeys.html(projectId, notebookId, versionId),
+		queryFn: () => fetchHtmlSnapshot(projectId, notebookId, versionId),
 		staleTime: 5 * 60 * 1000,
+	});
+}
+
+/** Download the latest outputs snapshot as a standalone .html file. */
+export function useDownloadOutputsHtml(projectId: string) {
+	return useMutation({
+		mutationFn: async ({ notebookId, title }: { notebookId: string; title: string }) => {
+			const snapshot = await fetchHtmlSnapshot(projectId, notebookId);
+			if (!snapshot) {
+				throw new Error('No outputs have been captured yet — run the notebook first');
+			}
+			triggerDownload(
+				`${sanitizeFilename(title)}.html`,
+				new Blob([snapshot.html], { type: 'text/html' }),
+			);
+		},
 	});
 }
 

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -37,8 +37,8 @@ export const notebookKeys = {
 		[...notebookKeys.all, 'versions', { projectId, notebookId }] as const,
 	version: (projectId: string, notebookId: string, versionId: string) =>
 		[...notebookKeys.all, 'version', { projectId, notebookId, versionId }] as const,
-	html: (projectId: string, notebookId: string) =>
-		[...notebookKeys.all, 'html', { projectId, notebookId }] as const,
+	html: (projectId: string, notebookId: string, versionId?: string) =>
+		[...notebookKeys.all, 'html', { projectId, notebookId, versionId: versionId ?? null }] as const,
 };
 
 export const systemKeys = {

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { VersionHistoryDialog } from './VersionHistoryDialog';
 import type { NotebookEntry, NotebookVersion } from '@/types';
@@ -119,10 +120,12 @@ function renderDialog({
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	const onClose = vi.fn();
 	const wrapper = ({ children }: { children: ReactNode }) => (
-		<QueryClientProvider client={client}>
-			{children}
-			<Toaster />
-		</QueryClientProvider>
+		<MemoryRouter>
+			<QueryClientProvider client={client}>
+				{children}
+				<Toaster />
+			</QueryClientProvider>
+		</MemoryRouter>
 	);
 	render(
 		<VersionHistoryDialog
@@ -193,6 +196,26 @@ describe('VersionHistoryDialog', () => {
 		expect(stamped).toHaveAttribute('href', 'https://github.com/org/repo/commit/deadbeefcafe0123');
 		const legacy = screen.getByRole('link', { name: 'abc123d' });
 		expect(legacy).toHaveAttribute('href', 'https://github.com/org/repo/commit/abc123def456');
+	});
+
+	it('links versions with a captured snapshot to the outputs page', async () => {
+		makeFetch({
+			versions: [
+				{
+					...version('v2', '2026-07-01T10:00:00Z', 'ran and saved'),
+					html_snapshot: { captured_at: '2026-07-01T10:00:00Z', size_bytes: 100 },
+				},
+				version('v1', '2026-06-30T10:00:00Z', 'never ran'),
+			],
+		});
+		renderDialog();
+
+		const rows = await screen.findAllByTestId('version-row');
+		expect(within(rows[0]).getByRole('link', { name: 'View outputs' })).toHaveAttribute(
+			'href',
+			`/projects/${PID}/notebooks/${NID}/snapshot?version=v2`,
+		);
+		expect(within(rows[1]).queryByRole('link', { name: 'View outputs' })).toBeNull();
 	});
 
 	it('shows no commit links for a local notebook', async () => {

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
@@ -1,12 +1,13 @@
 import { lazy, Suspense, useState } from 'react';
 import { toast } from 'sonner';
-import { MoveRight } from 'lucide-react';
+import { Camera, MoveRight } from 'lucide-react';
 import {
 	Button,
 	ConfirmDialog,
 	DialogModal,
 	displayName,
 	EmptyState,
+	IconLink,
 	Skeleton,
 	UserLabel,
 } from '@/components/ui';
@@ -80,6 +81,8 @@ interface VersionListItemProps {
 	showRestore: boolean;
 	/** GitHub link for the synced commit this version mirrors, when known. */
 	commitLink?: { href: string; label: string };
+	/** SnapshotPage link for this version's captured outputs, when it has any. */
+	outputsLink?: { to: string; state: { title: string } };
 	onSelect: () => void;
 	onRestore: () => void;
 }
@@ -93,6 +96,7 @@ function VersionListItem({
 	usersLoading,
 	showRestore,
 	commitLink,
+	outputsLink,
 	onSelect,
 	onRestore,
 }: VersionListItemProps) {
@@ -135,6 +139,18 @@ function VersionListItem({
 				>
 					{commitLink.label}
 				</a>
+			)}
+			{outputsLink && (
+				<IconLink
+					to={outputsLink.to}
+					state={outputsLink.state}
+					label="View outputs"
+					tooltip="View outputs"
+					size="sm"
+					className="shrink-0"
+				>
+					<Camera className="size-3.5" />
+				</IconLink>
 			)}
 			{showRestore && (
 				<Button variant="ghost" size="sm" onPress={onRestore} className="shrink-0">
@@ -180,6 +196,13 @@ export function VersionHistoryDialog({
 			? { href: githubCommitUrl(coords.repo, commit), label: shortCommit(commit) }
 			: undefined;
 	};
+	const outputsLinkFor = (v: NotebookVersion) =>
+		v.html_snapshot
+			? {
+					to: `/projects/${projectId}/notebooks/${notebook.id}/snapshot?version=${v.version_id}`,
+					state: { title: notebook.title },
+				}
+			: undefined;
 
 	const effectiveCompare =
 		compareId && ids.has(compareId) ? compareId : (versions[0]?.version_id ?? null);
@@ -287,6 +310,7 @@ export function VersionHistoryDialog({
 										usersLoading={usersLoading}
 										showRestore={restorable && i !== 0}
 										commitLink={commitLinkFor(v)}
+										outputsLink={outputsLinkFor(v)}
 										onSelect={() => {
 											setBaseId(v.version_id);
 											setCompareId(null);

--- a/packages/web/src/components/NotebookPage/SnapshotPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/SnapshotPage.test.tsx
@@ -8,16 +8,17 @@ const PID = 'proj-x';
 const NID = 'nb-1';
 
 /** Route every request the page makes; `html: null` models "never ran" (404). */
-function makeFetch(opts: { html: string | null }) {
+function makeFetch(opts: { html: string | null; snapshotVersion?: string }) {
 	const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = String(input);
 		const method = init?.method ?? 'GET';
-		if (url.endsWith(`/notebooks/${NID}/html`)) {
+		if (url.includes(`/notebooks/${NID}/`) && url.endsWith('/html')) {
 			if (opts.html == null) return jsonError('NO_HTML_SNAPSHOT', 'none', 404);
 			return new Response(opts.html, {
 				headers: {
 					'content-type': 'text/html',
 					'X-Marimohub-Captured-At': '2025-03-05T14:00:00Z',
+					'X-Marimohub-Version-Id': opts.snapshotVersion ?? 'ver-head',
 				},
 			});
 		}
@@ -36,12 +37,12 @@ function makeFetch(opts: { html: string | null }) {
 const onlyReads = (impl: ReturnType<typeof makeFetch>) =>
 	impl.mock.calls.every(([, init]) => (init?.method ?? 'GET') === 'GET');
 
-function renderPage() {
+function renderPage(search = '') {
 	return renderWithClient(
 		<Routes>
 			<Route path="/projects/:pid/notebooks/:nid/snapshot" element={<SnapshotPage />} />
 		</Routes>,
-		{ route: `/projects/${PID}/notebooks/${NID}/snapshot` },
+		{ route: `/projects/${PID}/notebooks/${NID}/snapshot${search}` },
 	);
 }
 
@@ -62,6 +63,31 @@ describe('SnapshotPage', () => {
 		expect(screen.getByText(/captured when the last editing session ended/)).toBeInTheDocument();
 		// Compute-free by design: reads only, no session create.
 		expect(onlyReads(impl)).toBe(true);
+	});
+
+	it('?version= pins to that version’s snapshot and notes it trails the head', async () => {
+		const impl = makeFetch({
+			html: '<html><body>old outputs</body></html>',
+			snapshotVersion: 'ver-old',
+		});
+		const { container } = renderPage('?version=ver-old');
+
+		await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull());
+		expect(
+			impl.mock.calls.some(([url]) =>
+				String(url).endsWith(`/notebooks/${NID}/versions/ver-old/html`),
+			),
+		).toBe(true);
+		expect(screen.getByText(/the notebook has changed since these outputs/)).toBeInTheDocument();
+	});
+
+	it('notes staleness when the latest snapshot trails the notebook head', async () => {
+		makeFetch({ html: '<html><body>x</body></html>', snapshotVersion: 'ver-old' });
+		renderPage();
+
+		expect(
+			await screen.findByText(/the notebook has changed since these outputs/),
+		).toBeInTheDocument();
 	});
 
 	it('shows the empty state when no snapshot has been captured', async () => {

--- a/packages/web/src/components/NotebookPage/SnapshotPage.tsx
+++ b/packages/web/src/components/NotebookPage/SnapshotPage.tsx
@@ -1,17 +1,20 @@
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, Camera } from 'lucide-react';
 import { Chip, IconLink } from '@/components/ui';
 import { useNotebookQuery } from '@/api/hooks';
 import { StaticNotebookView } from '@/components/NotebookPage/StaticNotebookView';
 
 /**
- * Full-screen view of a notebook's last HTML snapshot ("View static outputs").
+ * Full-screen view of a notebook's HTML snapshot ("View static outputs"): the
+ * latest by default, or one version's via `?version=` (from Version history).
  * Compute-free: no session is ever started; the snapshot renders in
  * StaticNotebookView's opaque-origin iframe.
  */
 export function SnapshotPage() {
 	const { pid, nid } = useParams<{ pid: string; nid: string }>();
 	const location = useLocation();
+	const [searchParams] = useSearchParams();
+	const versionId = searchParams.get('version') ?? undefined;
 	const fallbackTitle = (location.state as { title?: string } | null)?.title ?? nid ?? 'Notebook';
 	const { data: notebook } = useNotebookQuery(pid!, nid!);
 	// Prefer the canonical title once detail loads, so a rename reflects immediately.
@@ -36,7 +39,14 @@ export function SnapshotPage() {
 					Snapshot
 				</Chip>
 			</header>
-			<StaticNotebookView projectId={pid!} notebookId={nid!} title={title} variant="standalone" />
+			<StaticNotebookView
+				projectId={pid!}
+				notebookId={nid!}
+				title={title}
+				variant="standalone"
+				versionId={versionId}
+				headVersionId={notebook?.source.current_version_id ?? undefined}
+			/>
 		</div>
 	);
 }

--- a/packages/web/src/components/NotebookPage/StaticNotebookView.tsx
+++ b/packages/web/src/components/NotebookPage/StaticNotebookView.tsx
@@ -9,6 +9,10 @@ interface StaticNotebookViewProps {
 	title: string;
 	/** Banner copy: the role-gated viewer fallback vs the standalone SnapshotPage. */
 	variant?: 'viewer' | 'standalone';
+	/** Pin to one version's snapshot instead of the newest available. */
+	versionId?: string;
+	/** The notebook's current head; when the snapshot trails it, the banner says so. */
+	headVersionId?: string;
 }
 
 /**
@@ -25,8 +29,10 @@ export function StaticNotebookView({
 	notebookId,
 	title,
 	variant = 'viewer',
+	versionId,
+	headVersionId,
 }: StaticNotebookViewProps) {
-	const { data, isPending, isError } = useNotebookHtmlQuery(projectId, notebookId);
+	const { data, isPending, isError } = useNotebookHtmlQuery(projectId, notebookId, versionId);
 
 	if (isPending) {
 		return (
@@ -51,10 +57,13 @@ export function StaticNotebookView({
 	}
 
 	const capturedFrom = data?.capturedAt ? ` from ${formatRelative(data.capturedAt)}` : '';
+	const stale = !!data?.versionId && !!headVersionId && data.versionId !== headVersionId;
 	const banner = data
 		? variant === 'viewer'
 			? `Static snapshot of outputs${capturedFrom} — sessions are disabled for viewers.`
-			: `Static snapshot of outputs${capturedFrom} — captured when the last editing session ended.`
+			: stale
+				? `Static snapshot of outputs${capturedFrom} — the notebook has changed since these outputs were captured.`
+				: `Static snapshot of outputs${capturedFrom} — captured when the last editing session ended.`
 		: variant === 'viewer'
 			? "You're a viewer on this project — sessions are disabled."
 			: null;

--- a/packages/web/src/components/Project/Project.test.tsx
+++ b/packages/web/src/components/Project/Project.test.tsx
@@ -116,6 +116,11 @@ function makeFetch(
 			return jsonOk({ code: 'print("download")' });
 		if (method === 'GET' && url.endsWith(`/projects/${PID}/notebooks/nb-1/workspace.zip`))
 			return new Response(new Blob(['zip']), { status: 200 });
+		if (method === 'GET' && url.endsWith(`/projects/${PID}/notebooks/nb-1/html`))
+			return new Response('<html>outputs</html>', {
+				status: 200,
+				headers: { 'content-type': 'text/html' },
+			});
 
 		if (url.includes(`/projects/${PID}/notebooks`))
 			return jsonOk({ items: notebooks, next_cursor: null });
@@ -359,6 +364,7 @@ describe('Project — Notebook Actions', () => {
 			'View static outputs',
 			'Version history',
 			'Download notebook file',
+			'Download outputs (HTML)',
 			'Download workspace',
 			'Delete',
 		]);
@@ -625,6 +631,22 @@ describe('Project — Notebook Actions', () => {
 		);
 		expect(createObjectURL).toHaveBeenCalledOnce();
 		expect(revokeObjectURL).toHaveBeenCalledWith('blob:download');
+	});
+
+	it('downloads the outputs snapshot as HTML', async () => {
+		const user = userEvent.setup();
+		const calls = makeFetch();
+		const { createObjectURL } = installDownloadMocks();
+		await renderProject();
+
+		await chooseNotebookAction(user, 'Download outputs (HTML)');
+
+		await waitFor(() =>
+			expect(calls.some((c) => c.method === 'GET' && c.url.endsWith('/notebooks/nb-1/html'))).toBe(
+				true,
+			),
+		);
+		expect(createObjectURL).toHaveBeenCalledOnce();
 	});
 
 	it('downloads the notebook workspace archive', async () => {

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -12,6 +12,7 @@ import {
 	Copy,
 	Cpu,
 	Download,
+	FileDown,
 	FileText,
 	FolderArchive,
 	GitBranch,
@@ -60,6 +61,7 @@ import {
 	useDuplicateNotebook,
 	useDeleteNotebook,
 	useDownloadNotebookFile,
+	useDownloadOutputsHtml,
 	useDownloadWorkspace,
 	useProjectQuery,
 	useUpdateProject,
@@ -163,6 +165,7 @@ export function Project() {
 	const duplicateNotebook = useDuplicateNotebook(pid!);
 	const deleteNotebook = useDeleteNotebook(pid!);
 	const downloadNotebookFile = useDownloadNotebookFile(pid!);
+	const downloadOutputsHtml = useDownloadOutputsHtml(pid!);
 	const downloadWorkspace = useDownloadWorkspace(pid!);
 	const updateProject = useUpdateProject();
 	const deleteProject = useDeleteProject();
@@ -336,6 +339,10 @@ export function Project() {
 		downloadNotebookFile.mutate({ notebookId: nb.id, title: nb.title }, { onError: toastError });
 	};
 
+	const handleDownloadOutputs = (nb: NotebookEntry) => {
+		downloadOutputsHtml.mutate({ notebookId: nb.id, title: nb.title }, { onError: toastError });
+	};
+
 	const handleDownloadWorkspace = (nb: NotebookEntry) => {
 		toast.promise(downloadWorkspace.mutateAsync({ notebookId: nb.id, title: nb.title }), {
 			loading: `Preparing workspace for "${nb.title}"...`,
@@ -481,6 +488,11 @@ export function Project() {
 					id: 'download-file',
 					label: 'Download notebook file',
 					icon: <Download className="size-4" />,
+				},
+				{
+					id: 'download-outputs',
+					label: 'Download outputs (HTML)',
+					icon: <FileDown className="size-4" />,
 				},
 				{
 					id: 'download-workspace',
@@ -672,6 +684,7 @@ export function Project() {
 												else if (key === 'sync-settings')
 													syncSettings.open({ notebookId: nb.id, title: nb.title });
 												else if (key === 'download-file') handleDownloadFile(nb);
+												else if (key === 'download-outputs') handleDownloadOutputs(nb);
 												else if (key === 'download-workspace') handleDownloadWorkspace(nb);
 												else if (key === 'delete') deleteModal.open(nb);
 											}}


### PR DESCRIPTION
Follow-ups to #84:

- **Per-version snapshots**: `GET .../versions/{vid}/html` serves a specific version's captured outputs with the same containment headers (CSP `sandbox`, nosniff, `private, no-store`) via a shared helper. Version history rows with outputs link to the snapshot page (`?version=`).
- **Staleness note**: the snapshot page banner reads the `X-Marimohub-Version-Id` header and notes when the outputs trail the notebook head.
- **Download outputs (HTML)**: new notebook action in the download group; errors clearly when nothing has been captured yet.
- Drive-by: version meta + html bucket reads overlap via `better-all`; openapi/client specs regenerated.

Tests: API 465, core 1359, web 535 pass; `pnpm check` + typechecks clean.