### PR TITLE
feat(server): OTLP + Prometheus metrics export and richer OTEL resources

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,14 +16,18 @@
 		"@marimo-hub/config": "workspace:*",
 		"@marimo-hub/core": "workspace:*",
 		"@opentelemetry/api": "catalog:",
+		"@opentelemetry/exporter-metrics-otlp-http": "catalog:",
+		"@opentelemetry/exporter-prometheus": "catalog:",
 		"@opentelemetry/exporter-trace-otlp-http": "catalog:",
 		"@opentelemetry/resources": "catalog:",
+		"@opentelemetry/sdk-metrics": "catalog:",
 		"@opentelemetry/sdk-trace-base": "catalog:",
 		"@opentelemetry/sdk-trace-node": "catalog:",
 		"hono": "catalog:"
 	},
 	"devDependencies": {
 		"@marimo-hub/tsconfig": "workspace:*",
+		"@opentelemetry/core": "catalog:",
 		"@types/node": "catalog:",
 		"typescript": "catalog:",
 		"vite-plus": "catalog:",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -52,8 +52,8 @@ process.on('uncaughtException', (err) => {
 // surfaces at the next flush).
 const metrics = new WideEventMetrics();
 
-// Tracing (standard OTEL_* env vars); the global provider must register before
-// requests are served.
+// Tracing + metrics (standard OTEL_* env vars); the global providers must
+// register before requests are served.
 const otel = startOtel();
 
 // Config errors are deterministic — a restart can't fix them — so print a readable
@@ -61,7 +61,7 @@ const otel = startOtel();
 // non-fatal preflight below instead, so they never crashloop a replica.)
 let deps: ApiDeps;
 try {
-	deps = createFromEnv(process.env, metrics, { tracing: otel !== null });
+	deps = createFromEnv(process.env, metrics, { tracing: otel?.tracing ?? false });
 } catch (err) {
 	if (isConfigError(err)) {
 		console.error(`\n${err.format()}\n`);
@@ -69,7 +69,8 @@ try {
 	}
 	throw err;
 }
-if (otel) deps.tracingMiddleware = httpInstrumentationMiddleware();
+// Installed for metrics-only mode too: RED metrics still record, spans don't.
+if (otel) deps.tracingMiddleware = httpInstrumentationMiddleware({ disableTracing: !otel.tracing });
 const app = createApi(deps);
 
 // Boot preflight: probe downstream deps (storage conditional-writes, OIDC
@@ -131,10 +132,10 @@ const server = serve({ fetch: app.fetch, port }, (info) => {
 // kernel (the HTTP side is handled inside `app.fetch`). A no-op otherwise.
 attachSandboxProxyUpgrade(server, deps);
 
-// Drain on shutdown: let in-flight requests finish and flush buffered spans,
-// bounded so long-lived sockets (WS kernel proxies) can't hold the pod past
-// its termination grace window. Registered only when tracing is enabled so the
-// default signal semantics are unchanged otherwise.
+// Drain on shutdown: let in-flight requests finish and flush buffered spans and
+// metrics, bounded so long-lived sockets (WS kernel proxies) can't hold the pod
+// past its termination grace window. Registered only when telemetry is enabled
+// so the default signal semantics are unchanged otherwise.
 if (otel) {
 	const drain = () => {
 		const closed = new Promise<void>((resolve) => {

--- a/apps/server/src/otel.test.ts
+++ b/apps/server/src/otel.test.ts
@@ -1,4 +1,14 @@
 import { httpInstrumentationMiddleware } from '@hono/otel';
+import { metrics as metricsApi } from '@opentelemetry/api';
+import { ExportResultCode } from '@opentelemetry/core';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
+import {
+	AggregationTemporality,
+	InMemoryMetricExporter,
+	MeterProvider,
+	PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
 import {
 	BasicTracerProvider,
 	InMemorySpanExporter,
@@ -8,26 +18,26 @@ import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { Hono } from 'hono';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { isOtelEnabled, startOtel } from './otel';
+import { isTracingEnabled, metricsExporter, startOtel } from './otel';
 
-describe('isOtelEnabled', () => {
+describe('isTracingEnabled', () => {
 	it('is off without an OTLP endpoint', () => {
-		expect(isOtelEnabled({})).toBe(false);
+		expect(isTracingEnabled({})).toBe(false);
 	});
 
 	it('is on when OTEL_EXPORTER_OTLP_ENDPOINT is set', () => {
-		expect(isOtelEnabled({ OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318' })).toBe(true);
+		expect(isTracingEnabled({ OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318' })).toBe(true);
 	});
 
 	it('is on with only the traces-specific endpoint', () => {
 		expect(
-			isOtelEnabled({ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: 'http://localhost:4318/v1/traces' }),
+			isTracingEnabled({ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: 'http://localhost:4318/v1/traces' }),
 		).toBe(true);
 	});
 
 	it('honors OTEL_SDK_DISABLED', () => {
 		expect(
-			isOtelEnabled({
+			isTracingEnabled({
 				OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
 				OTEL_SDK_DISABLED: 'true',
 			}),
@@ -36,7 +46,7 @@ describe('isOtelEnabled', () => {
 
 	it('honors OTEL_TRACES_EXPORTER=none', () => {
 		expect(
-			isOtelEnabled({
+			isTracingEnabled({
 				OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
 				OTEL_TRACES_EXPORTER: 'none',
 			}),
@@ -45,7 +55,7 @@ describe('isOtelEnabled', () => {
 
 	it('disables tracing for unimplemented exporters instead of exporting over OTLP', () => {
 		expect(
-			isOtelEnabled({
+			isTracingEnabled({
 				OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
 				OTEL_TRACES_EXPORTER: 'console',
 			}),
@@ -53,15 +63,61 @@ describe('isOtelEnabled', () => {
 	});
 });
 
+describe('metricsExporter', () => {
+	it('is off without an OTLP endpoint (otlp is the default exporter)', () => {
+		expect(metricsExporter({})).toBeNull();
+	});
+
+	it('selects otlp when the shared OTLP endpoint is set', () => {
+		expect(metricsExporter({ OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318' })).toBe('otlp');
+	});
+
+	it('selects otlp with only the metrics-specific endpoint', () => {
+		expect(
+			metricsExporter({ OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: 'http://localhost:4318/v1/metrics' }),
+		).toBe('otlp');
+	});
+
+	it('selects prometheus without needing any endpoint', () => {
+		expect(metricsExporter({ OTEL_METRICS_EXPORTER: 'prometheus' })).toBe('prometheus');
+	});
+
+	it('honors OTEL_METRICS_EXPORTER=none', () => {
+		expect(
+			metricsExporter({
+				OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+				OTEL_METRICS_EXPORTER: 'none',
+			}),
+		).toBeNull();
+	});
+
+	it('honors OTEL_SDK_DISABLED', () => {
+		expect(
+			metricsExporter({ OTEL_METRICS_EXPORTER: 'prometheus', OTEL_SDK_DISABLED: 'true' }),
+		).toBeNull();
+	});
+
+	it('disables metrics for unimplemented exporters', () => {
+		expect(
+			metricsExporter({
+				OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+				OTEL_METRICS_EXPORTER: 'console',
+			}),
+		).toBeNull();
+	});
+});
+
 describe('startOtel', () => {
 	afterEach(() => {
 		vi.unstubAllEnvs();
 		vi.restoreAllMocks();
+		metricsApi.disable();
 	});
 
 	it('returns null and registers nothing when disabled', () => {
 		vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', '');
 		vi.stubEnv('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', '');
+		vi.stubEnv('OTEL_EXPORTER_OTLP_METRICS_ENDPOINT', '');
 		const register = vi.spyOn(NodeTracerProvider.prototype, 'register');
 		expect(startOtel()).toBeNull();
 		expect(register).not.toHaveBeenCalled();
@@ -70,25 +126,78 @@ describe('startOtel', () => {
 	it('registers a provider with the env-configured service name when enabled', async () => {
 		vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318');
 		vi.stubEnv('OTEL_SERVICE_NAME', 'marimohub-test');
+		vi.stubEnv('OTEL_METRICS_EXPORTER', 'none');
 		// Stubbed so the test never mutates the process-wide tracer provider.
 		const register = vi
 			.spyOn(NodeTracerProvider.prototype, 'register')
 			.mockImplementation(() => {});
 		const handle = startOtel();
 		expect(handle).not.toBeNull();
+		expect(handle?.tracing).toBe(true);
 		expect(register).toHaveBeenCalledOnce();
 		const provider = register.mock.instances[0] as NodeTracerProvider;
 		// Never ended — an ended span would enter the batch exporter and make
 		// shutdown() block on flushing to the (nonexistent) endpoint.
 		const span = provider.getTracer('test').startSpan('probe');
-		expect((span as unknown as ReadableSpan).resource.attributes['service.name']).toBe(
-			'marimohub-test',
-		);
+		const resource = (span as unknown as ReadableSpan).resource;
+		await resource.waitForAsyncAttributes?.();
+		expect(resource.attributes['service.name']).toBe('marimohub-test');
+		expect(resource.attributes['process.pid']).toBe(process.pid);
+		expect(resource.attributes['host.name']).toBeDefined();
+		expect(resource.attributes['service.instance.id']).toBeDefined();
+		await handle?.shutdown();
+	});
+
+	it('lets OTEL_RESOURCE_ATTRIBUTES override detected resource attributes', async () => {
+		vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318');
+		vi.stubEnv('OTEL_RESOURCE_ATTRIBUTES', 'service.instance.id=pod-7');
+		vi.stubEnv('OTEL_METRICS_EXPORTER', 'none');
+		const register = vi
+			.spyOn(NodeTracerProvider.prototype, 'register')
+			.mockImplementation(() => {});
+		const handle = startOtel();
+		const provider = register.mock.instances[0] as NodeTracerProvider;
+		const span = provider.getTracer('test').startSpan('probe');
+		const resource = (span as unknown as ReadableSpan).resource;
+		await resource.waitForAsyncAttributes?.();
+		expect(resource.attributes['service.instance.id']).toBe('pod-7');
+		await handle?.shutdown();
+	});
+
+	it('clamps the export timeout when OTEL_METRIC_EXPORT_INTERVAL is shorter', async () => {
+		vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4318');
+		vi.stubEnv('OTEL_TRACES_EXPORTER', 'none');
+		vi.stubEnv('OTEL_METRIC_EXPORT_INTERVAL', '1000');
+		// Intercepted so shutdown's final flush never hits the network.
+		vi.spyOn(OTLPMetricExporter.prototype, 'export').mockImplementation((_metrics, callback) => {
+			callback({ code: ExportResultCode.SUCCESS });
+		});
+		const handle = startOtel();
+		expect(handle).not.toBeNull();
+		await handle?.shutdown();
+	});
+
+	it('starts metrics-only in prometheus mode, without a tracer provider', async () => {
+		vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', '');
+		vi.stubEnv('OTEL_EXPORTER_OTLP_TRACES_ENDPOINT', '');
+		vi.stubEnv('OTEL_METRICS_EXPORTER', 'prometheus');
+		// Stubbed so the test never binds the scrape port.
+		const startServer = vi
+			.spyOn(PrometheusExporter.prototype, 'startServer')
+			.mockResolvedValue(undefined);
+		const register = vi.spyOn(NodeTracerProvider.prototype, 'register');
+		const setGlobal = vi.spyOn(metricsApi, 'setGlobalMeterProvider');
+		const handle = startOtel();
+		expect(handle).not.toBeNull();
+		expect(handle?.tracing).toBe(false);
+		expect(register).not.toHaveBeenCalled();
+		expect(startServer).toHaveBeenCalledOnce();
+		expect(setGlobal).toHaveBeenCalledOnce();
 		await handle?.shutdown();
 	});
 });
 
-describe('tracing middleware', () => {
+describe('instrumentation middleware', () => {
 	it('emits a span per request with route name and status', async () => {
 		const exporter = new InMemorySpanExporter();
 		const provider = new BasicTracerProvider({
@@ -105,5 +214,30 @@ describe('tracing middleware', () => {
 		expect(spans).toHaveLength(1);
 		expect(spans[0]?.name).toBe('GET /api/health');
 		expect(spans[0]?.attributes['http.response.status_code']).toBe(200);
+	});
+
+	it('records request-duration metrics even with tracing disabled', async () => {
+		const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+		const meterProvider = new MeterProvider({
+			readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 60_000 })],
+		});
+		const app = new Hono();
+		app.use('*', httpInstrumentationMiddleware({ meterProvider, disableTracing: true }));
+		app.get('/api/health', (c) => c.json({ ok: true }));
+
+		const res = await app.request('/api/health');
+		expect(res.status).toBe(200);
+
+		await meterProvider.forceFlush();
+		const recorded = exporter
+			.getMetrics()
+			.flatMap((rm) => rm.scopeMetrics)
+			.flatMap((sm) => sm.metrics);
+		const duration = recorded.find((m) => m.descriptor.name === 'http.server.request.duration');
+		expect(duration).toBeDefined();
+		const point = duration?.dataPoints[0];
+		expect(point?.attributes['http.route']).toBe('/api/health');
+		expect(point?.attributes['http.response.status_code']).toBe(200);
+		await meterProvider.shutdown();
 	});
 });

--- a/apps/server/src/otel.ts
+++ b/apps/server/src/otel.ts
@@ -1,22 +1,37 @@
 /**
- * OpenTelemetry tracing, driven entirely by standard OTEL_* env vars: enabled
- * iff an OTLP endpoint is set; sampling and exporter endpoint/headers come from
- * the SDK's own env handling, the resource from `envDetector`. Manual setup
- * only — auto-instrumentation patches modules via require/import hooks, which
- * cannot work in the single-file bundle (no node_modules at runtime).
+ * OpenTelemetry tracing + metrics, driven entirely by standard OTEL_* env vars:
+ * each pillar is enabled iff its exporter has somewhere to send data. Sampling
+ * and exporter endpoint/headers come from the SDK's own env handling; the
+ * resource from env/host/process detectors. Manual setup only —
+ * auto-instrumentation patches modules via require/import hooks, which cannot
+ * work in the single-file bundle (no node_modules at runtime).
  */
+import { metrics as metricsApi } from '@opentelemetry/api';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { defaultResource, detectResources, envDetector } from '@opentelemetry/resources';
+import {
+	defaultResource,
+	detectResources,
+	envDetector,
+	hostDetector,
+	processDetector,
+	serviceInstanceIdDetector,
+} from '@opentelemetry/resources';
+import type { IMetricReader } from '@opentelemetry/sdk-metrics';
+import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { logEvent } from './log';
 
 export interface OtelHandle {
-	/** Flush buffered spans and stop exporting. */
+	/** True when the request middleware should create SERVER spans. */
+	tracing: boolean;
+	/** Flush buffered telemetry and stop exporting. */
 	shutdown(): Promise<void>;
 }
 
-export function isOtelEnabled(env: Record<string, string | undefined> = process.env): boolean {
+export function isTracingEnabled(env: Record<string, string | undefined> = process.env): boolean {
 	if (env.OTEL_SDK_DISABLED === 'true') return false;
 	// Only the OTLP exporter (the spec default) is implemented. Any other
 	// OTEL_TRACES_EXPORTER selection disables tracing rather than silently
@@ -26,24 +41,94 @@ export function isOtelEnabled(env: Record<string, string | undefined> = process.
 }
 
 /**
- * Reads process.env only — the exporter and resource detectors do their own
+ * The exporter OTEL_METRICS_EXPORTER selects, or null when metrics are off.
+ * `otlp` (the spec default) also needs an OTLP endpoint; `prometheus` is
+ * pull-based and needs none. Unimplemented selections disable metrics.
+ */
+export function metricsExporter(
+	env: Record<string, string | undefined> = process.env,
+): 'otlp' | 'prometheus' | null {
+	if (env.OTEL_SDK_DISABLED === 'true') return null;
+	const exporter = env.OTEL_METRICS_EXPORTER ?? 'otlp';
+	if (exporter === 'prometheus') return 'prometheus';
+	if (exporter !== 'otlp') return null;
+	return env.OTEL_EXPORTER_OTLP_ENDPOINT || env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ? 'otlp' : null;
+}
+
+function envMillis(name: string, fallback: number): number {
+	const value = Number(process.env[name]);
+	return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function otlpMetricReader(): PeriodicExportingMetricReader {
+	// Only the full sdk-node reads these env vars. The reader rejects a timeout
+	// longer than the interval, so clamp rather than crash boot.
+	const interval = envMillis('OTEL_METRIC_EXPORT_INTERVAL', 60_000);
+	return new PeriodicExportingMetricReader({
+		exporter: new OTLPMetricExporter(),
+		exportIntervalMillis: interval,
+		exportTimeoutMillis: Math.min(envMillis('OTEL_METRIC_EXPORT_TIMEOUT', 30_000), interval),
+	});
+}
+
+/**
+ * Reads process.env only — the exporters and resource detectors do their own
  * env reading, so an injectable env here would be misleading.
  */
 export function startOtel(): OtelHandle | null {
-	if (!isOtelEnabled()) return null;
-	const provider = new NodeTracerProvider({
-		// defaultResource() ignores OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES;
-		// only envDetector reads them, so merge it in explicitly.
-		resource: defaultResource().merge(detectResources({ detectors: [envDetector] })),
-		spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter())],
-	});
-	// Global tracer provider + AsyncLocalStorage context + W3C propagation.
-	provider.register();
+	const tracing = isTracingEnabled();
+	const metricsKind = metricsExporter();
+	if (!tracing && !metricsKind) return null;
+
+	// Only envDetector reads OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES
+	// (defaultResource() ignores them). Later detectors win on merge, so it goes
+	// last: operator-set attributes override detected ones like the random-UUID
+	// service.instance.id.
+	const resource = defaultResource().merge(
+		detectResources({
+			detectors: [hostDetector, processDetector, serviceInstanceIdDetector, envDetector],
+		}),
+	);
+
+	const shutdowns: (() => Promise<void>)[] = [];
+
+	if (tracing) {
+		const provider = new NodeTracerProvider({
+			resource,
+			spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter())],
+		});
+		// Global tracer provider + AsyncLocalStorage context + W3C propagation.
+		provider.register();
+		shutdowns.push(() => provider.shutdown());
+	}
+
+	if (metricsKind) {
+		const reader: IMetricReader =
+			metricsKind === 'prometheus'
+				? // Serves /metrics itself; reads OTEL_EXPORTER_PROMETHEUS_HOST/PORT
+					// (default: all interfaces, :9464).
+					new PrometheusExporter()
+				: otlpMetricReader();
+		const meterProvider = new MeterProvider({ resource, readers: [reader] });
+		// Lights up the RED metrics the @hono/otel middleware records.
+		metricsApi.setGlobalMeterProvider(meterProvider);
+		shutdowns.push(() => meterProvider.shutdown());
+	}
+
 	logEvent({
 		level: 'info',
 		event: 'otel_started',
+		tracing,
+		metrics: metricsKind ?? 'off',
 		endpoint:
-			process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ?? process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+			process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ??
+			process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ??
+			process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
 	});
-	return { shutdown: () => provider.shutdown() };
+	return {
+		tracing,
+		shutdown: async () => {
+			await Promise.allSettled(shutdowns.map((fn) => fn()));
+		},
+	};
 }

--- a/charts/marimohub/README.md
+++ b/charts/marimohub/README.md
@@ -54,6 +54,8 @@ Updater](https://argocd-image-updater.readthedocs.io/) or
 | `secrets.data` | `{}` | Or let the chart create the Secret (dev) |
 | `ingress.enabled` / `.className` / `.host` | `true` / `""` / `hub.example.com` | |
 | `ingress.tls.*` | enabled, `marimohub-tls` | |
+| `metrics.enabled` / `.port` | `false` / `9464` | Prometheus scrape mode; port exposed on the Service, never the ingress |
+| `metrics.serviceMonitor.*` | disabled, `30s`, `{}` labels | Prometheus Operator ServiceMonitor |
 | `resources` | 100m/256Mi → 500m/512Mi | API container |
 | `nodeSelector` / `tolerations` / `affinity` | empty | Set per cluster |
 

--- a/charts/marimohub/templates/_helpers.tpl
+++ b/charts/marimohub/templates/_helpers.tpl
@@ -110,10 +110,16 @@ spec:
       imagePullPolicy: {{ $v.image.pullPolicy }}
       securityContext:
         {{- toYaml $v.containerSecurityContext | nindent 8 }}
-      {{- if not .maintenance }}
+      {{- if or (not .maintenance) $v.metrics.enabled }}
       ports:
+        {{- if not .maintenance }}
         - name: http
           containerPort: {{ $v.containerPort }}
+        {{- end }}
+        {{- if $v.metrics.enabled }}
+        - name: metrics
+          containerPort: {{ $v.metrics.port }}
+        {{- end }}
       {{- end }}
       envFrom:
         {{- if or $v.config $v.compute.profiles (ne $v.compute.profileOverride "none") }}
@@ -130,6 +136,12 @@ spec:
         # explicit env overrides any value coming from the ConfigMap/Secret.
         - name: MARIMOHUB_RUN_MAINTENANCE
           value: {{ if .maintenance }}"true"{{ else }}"false"{{ end }}
+        {{- if $v.metrics.enabled }}
+        - name: OTEL_METRICS_EXPORTER
+          value: prometheus
+        - name: OTEL_EXPORTER_PROMETHEUS_PORT
+          value: {{ $v.metrics.port | quote }}
+        {{- end }}
         {{- with $v.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/marimohub/templates/_helpers.tpl
+++ b/charts/marimohub/templates/_helpers.tpl
@@ -110,12 +110,10 @@ spec:
       imagePullPolicy: {{ $v.image.pullPolicy }}
       securityContext:
         {{- toYaml $v.containerSecurityContext | nindent 8 }}
-      {{- if or (not .maintenance) $v.metrics.enabled }}
+      {{- if not .maintenance }}
       ports:
-        {{- if not .maintenance }}
         - name: http
           containerPort: {{ $v.containerPort }}
-        {{- end }}
         {{- if $v.metrics.enabled }}
         - name: metrics
           containerPort: {{ $v.metrics.port }}
@@ -136,7 +134,10 @@ spec:
         # explicit env overrides any value coming from the ConfigMap/Secret.
         - name: MARIMOHUB_RUN_MAINTENANCE
           value: {{ if .maintenance }}"true"{{ else }}"false"{{ end }}
-        {{- if $v.metrics.enabled }}
+        {{- /* API pods only: the Service/ServiceMonitor never scrape the
+        maintenance pod, so a listener there would just be an unscraped open
+        port. */}}
+        {{- if and $v.metrics.enabled (not .maintenance) }}
         - name: OTEL_METRICS_EXPORTER
           value: prometheus
         - name: OTEL_EXPORTER_PROMETHEUS_PORT

--- a/charts/marimohub/templates/service.yaml
+++ b/charts/marimohub/templates/service.yaml
@@ -14,3 +14,9 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: {{ .Values.containerPort }}
       protocol: TCP
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}

--- a/charts/marimohub/templates/servicemonitor.yaml
+++ b/charts/marimohub/templates/servicemonitor.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "marimohub.fullname" . }}
+  labels:
+    {{- include "marimohub.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "marimohub.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+{{- end }}

--- a/charts/marimohub/values.yaml
+++ b/charts/marimohub/values.yaml
@@ -74,8 +74,8 @@ service:
   port: 80
 
 # Prometheus scraping of the server's OpenTelemetry metrics: injects
-# OTEL_METRICS_EXPORTER=prometheus into the pods and exposes the port on the
-# Service (not the ingress). For OTLP push instead, leave this off and set
+# OTEL_METRICS_EXPORTER=prometheus into the API pods and exposes the port on
+# the Service (not the ingress). For OTLP push instead, leave this off and set
 # OTEL_* vars via config/extraEnv.
 metrics:
   enabled: false

--- a/charts/marimohub/values.yaml
+++ b/charts/marimohub/values.yaml
@@ -73,6 +73,19 @@ service:
   type: ClusterIP
   port: 80
 
+# Prometheus scraping of the server's OpenTelemetry metrics: injects
+# OTEL_METRICS_EXPORTER=prometheus into the pods and exposes the port on the
+# Service (not the ingress). For OTLP push instead, leave this off and set
+# OTEL_* vars via config/extraEnv.
+metrics:
+  enabled: false
+  port: 9464
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    # Labels for the operator's serviceMonitorSelector (e.g. release: kube-prometheus-stack).
+    labels: {}
+
 ingress:
   enabled: true
   className: ''

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -129,6 +129,33 @@ The middleware traces every request, including static assets; use
 `OTEL_TRACES_SAMPLER=parentbased_traceidratio` with a ratio in
 `OTEL_TRACES_SAMPLER_ARG` to reduce span volume.
 
+Spans and metrics share one resource: `service.name` and
+`OTEL_RESOURCE_ATTRIBUTES` from env, plus detected host and process attributes
+and a random `service.instance.id` (override it per pod via
+`OTEL_RESOURCE_ATTRIBUTES`, e.g. from the Kubernetes Downward API).
+
+### Metrics (OpenTelemetry)
+
+The server records RED metrics per request: the `http.server.request.duration`
+histogram (labelled by route, method, and status code) and the
+`http.server.active_requests` gauge. `OTEL_METRICS_EXPORTER` selects the mode:
+
+- **`otlp`** (default): push over OTLP/HTTP whenever
+  `OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`) is
+  set, so pointing the server at a collector exports traces _and_ metrics.
+  `OTEL_METRIC_EXPORT_INTERVAL` / `OTEL_METRIC_EXPORT_TIMEOUT` (milliseconds,
+  default 60000/30000) set the cadence; `OTEL_METRICS_EXPORTER=none` keeps
+  traces without metrics.
+- **`prometheus`**: serve a scrape endpoint on `:9464/metrics`
+  (`OTEL_EXPORTER_PROMETHEUS_HOST` / `OTEL_EXPORTER_PROMETHEUS_PORT`), no OTLP
+  endpoint needed. Keep the port off the public ingress. The Helm chart wires
+  this up: `metrics.enabled=true` exposes it on the Service,
+  `metrics.serviceMonitor.enabled=true` adds a Prometheus Operator
+  ServiceMonitor.
+
+Any other `OTEL_METRICS_EXPORTER` value disables metrics;
+`OTEL_SDK_DISABLED=true` turns everything off.
+
 ## Cost control
 
 Compute backends differ in cost model — pick per [Compute](/compute):

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -232,9 +232,9 @@ export interface ApiDeps {
 	 */
 	authRoutes?: Hono;
 	/**
-	 * Optional request-tracing middleware (e.g. @hono/otel), registered ahead of
-	 * every route — including the sandbox-proxy short-circuits. Absent (Workers,
-	 * tests): no overhead.
+	 * Optional request-instrumentation middleware (e.g. @hono/otel: SERVER spans
+	 * and/or RED metrics), registered ahead of every route — including the
+	 * sandbox-proxy short-circuits. Absent (Workers, tests): no overhead.
 	 */
 	tracingMiddleware?: MiddlewareHandler;
 	/** How the notebook sandbox is mounted, exposed, and persisted. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,10 +39,22 @@ catalogs:
     '@opentelemetry/api':
       specifier: ^1.9.0
       version: 1.9.1
+    '@opentelemetry/core':
+      specifier: ^2.9.0
+      version: 2.9.0
+    '@opentelemetry/exporter-metrics-otlp-http':
+      specifier: ^0.220.0
+      version: 0.220.0
+    '@opentelemetry/exporter-prometheus':
+      specifier: ^0.220.0
+      version: 0.220.0
     '@opentelemetry/exporter-trace-otlp-http':
       specifier: ^0.220.0
       version: 0.220.0
     '@opentelemetry/resources':
+      specifier: ^2.9.0
+      version: 2.9.0
+    '@opentelemetry/sdk-metrics':
       specifier: ^2.9.0
       version: 2.9.0
     '@opentelemetry/sdk-trace-base':
@@ -261,10 +273,19 @@ importers:
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http':
+        specifier: 'catalog:'
+        version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus':
+        specifier: 'catalog:'
+        version: 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: 'catalog:'
         version: 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':
+        specifier: 'catalog:'
+        version: 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics':
         specifier: 'catalog:'
         version: 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
@@ -280,6 +301,9 @@ importers:
       '@marimo-hub/tsconfig':
         specifier: workspace:*
         version: link:../../packages/ts-config
+      '@opentelemetry/core':
+        specifier: 'catalog:'
+        version: 2.9.0(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.3
@@ -1925,6 +1949,18 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.220.0':
+    resolution: {integrity: sha512-Yqt3RBw/bRVncaE9qIIhk4WfjbAQqXuP9FgAaU+IKPndnLEp/cUqZlSC324+bpmduRz7DoTjig8Ub0PeILWXUA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.220.0':
+    resolution: {integrity: sha512-JZD5DL/NBpVd2BHefvYosm3G40UZ/KzExLv5tc0eZe0CtrsHHtcOk3YPUxR2EINmUeBf8+w5UReTV8fFPn95lA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
 
   '@opentelemetry/exporter-trace-otlp-http@0.220.0':
     resolution: {integrity: sha512-/+ExB3lRkf+erv4PnoywyL7RHKITidxtUpUTS55k7OQ0dB42S7gEF1gry7swb9MSm1hYLUhJg4QQh9W8SpwwqA==}
@@ -6223,6 +6259,23 @@ snapshots:
   '@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
 
   '@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,8 +17,12 @@ catalog:
   '@hono/otel': ^1.1.2
   '@hono/zod-openapi': ^1.2.2
   '@opentelemetry/api': ^1.9.0
+  '@opentelemetry/core': ^2.9.0
+  '@opentelemetry/exporter-metrics-otlp-http': ^0.220.0
+  '@opentelemetry/exporter-prometheus': ^0.220.0
   '@opentelemetry/exporter-trace-otlp-http': ^0.220.0
   '@opentelemetry/resources': ^2.9.0
+  '@opentelemetry/sdk-metrics': ^2.9.0
   '@opentelemetry/sdk-trace-base': ^2.9.0
   '@opentelemetry/sdk-trace-node': ^2.9.0
   '@tailwindcss/vite': ^4.3.0


### PR DESCRIPTION
Follow-up to #83. Standard `OTEL_*` env vars only; no new `MARIMOHUB_*` config.

- **OTLP metrics push** (`OTEL_METRICS_EXPORTER=otlp`, the spec default): whenever an OTLP endpoint is set, a `MeterProvider` + periodic reader exports the RED metrics `@hono/otel` already records — `http.server.request.duration` (route/method/status) and `http.server.active_requests`. Honors `OTEL_METRIC_EXPORT_INTERVAL/_TIMEOUT`, clamping the timeout to the interval (the SDK reader otherwise throws and crashes boot).
- **Prometheus scrape mode** (`OTEL_METRICS_EXPORTER=prometheus`): `/metrics` on :9464, no OTLP endpoint needed; works metrics-only (middleware installed with `disableTracing`). Helm: `metrics.enabled` exposes the port on the Service (never the ingress), `metrics.serviceMonitor.enabled` adds a Prometheus Operator ServiceMonitor.
- **Richer resources**: host/process/serviceInstanceId detectors on the shared trace+metric resource; `envDetector` last so `OTEL_RESOURCE_ATTRIBUTES` (e.g. Downward-API pod identity) overrides detected values.

## Verification

- `pnpm check` / `typecheck` / `test` green (server suite → 43 tests: metrics gate matrix, middleware metric recording, resource assertions, clamp regression)
- Booted the built bundle: no OTEL env → clean, zero telemetry; prometheus mode → scraped the histogram off :9464; OTLP mode → stub collector received `POST /v1/traces` + `/v1/metrics` at the configured interval
- `helm lint`/`template` pass; default chart render is unchanged