### PR TITLE
Post-merge review fixes for per-version snapshots (#85)

### DIFF
--- a/packages/api/src/routes/notebooks.test.ts
+++ b/packages/api/src/routes/notebooks.test.ts
@@ -925,6 +925,31 @@ describe('Notebook routes', () => {
 		);
 	});
 
+	it('GET /{nid}/versions/{vid}/html is visibility-gated like the latest-snapshot route', async () => {
+		const created = await expectOk<any>(
+			await request('POST', nb(''), { title: 'NB', description: 'D', code: 'v1' }),
+			201,
+		);
+		const committed = await createServices(bucket).notebooks.commitSession(
+			projectId,
+			created.id,
+			{ code: 'v2', html: '<html>x</html>' },
+			ACTOR,
+		);
+		const path = nb(`/${created.id}/versions/${committed!.versionId}/html`);
+
+		// Under MARIMOHUB_DEFAULT_ROLE=none a non-member cannot even see the project.
+		const stranger = createTestApi({ bucket, userId: uid('user_z') }).request;
+		await expectError(await stranger('GET', path), 404, 'NOT_FOUND');
+
+		const viewer = createTestApi({
+			bucket,
+			userId: uid('user_v'),
+			deps: { policy: { defaultRole: 'viewer' } },
+		}).request;
+		expect((await viewer('GET', path)).status).toBe(200);
+	});
+
 	it('GET /{nid}/html is visibility-gated: 404 for a non-member, 200 for a default-role viewer', async () => {
 		const created = await expectOk<any>(
 			await request('POST', nb(''), { title: 'NB', description: 'D', code: 'v1' }),

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -1093,6 +1093,80 @@ describe('NotebookService', () => {
 		});
 	});
 
+	describe('getVersionHtmlSnapshot', () => {
+		it('returns the pinned version’s snapshot, not the latest', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const first = await notebooks.commitSession(
+				projectId,
+				created.id,
+				{ code: 'v2', html: '<html>first</html>' },
+				ACTOR,
+			);
+			await notebooks.commitSession(
+				projectId,
+				created.id,
+				{ code: 'v3', html: '<html>second</html>' },
+				ACTOR,
+			);
+
+			const snapshot = await notebooks.getVersionHtmlSnapshot(
+				projectId,
+				created.id,
+				first!.versionId,
+			);
+			expect(snapshot).toEqual({
+				versionId: first!.versionId,
+				capturedAt: expect.any(String),
+				html: '<html>first</html>',
+			});
+		});
+
+		it('returns null for a version without a snapshot, and when the html object was pruned', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			// The initial save captured no HTML.
+			const { source } = await notebooks.getNotebook(projectId, created.id);
+			expect(
+				await notebooks.getVersionHtmlSnapshot(projectId, created.id, source.current_version_id!),
+			).toBeNull();
+
+			// Descriptor present but the html object itself is gone (pruned).
+			const committed = await notebooks.commitSession(
+				projectId,
+				created.id,
+				{ code: 'v2', html: '<html>x</html>' },
+				ACTOR,
+			);
+			const ver = paths.project(projectId).notebook(created.id).version(committed!.versionId);
+			await bucket.delete(ver.html);
+			expect(
+				await notebooks.getVersionHtmlSnapshot(projectId, created.id, committed!.versionId),
+			).toBeNull();
+		});
+
+		it('rejects with NotFoundError for unknown and malformed version ids', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+
+			await expect(
+				notebooks.getVersionHtmlSnapshot(projectId, created.id, createVersionId()),
+			).rejects.toThrow(NotFoundError);
+			await expect(
+				notebooks.getVersionHtmlSnapshot(projectId, created.id, 'not-a-version-id'),
+			).rejects.toThrow(NotFoundError);
+		});
+	});
+
 	describe('commitSession', () => {
 		it('cuts a new version from changed code and updates the live notebook + source', async () => {
 			const created = await notebooks.createNotebook(

--- a/packages/web/src/api/hooks.test.tsx
+++ b/packages/web/src/api/hooks.test.tsx
@@ -216,6 +216,20 @@ describe('useNotebookHtmlQuery', () => {
 		expect(result.current.error?.message).toBe('Notebook not found');
 	});
 
+	it('names the version, not the notebook, when a pinned snapshot 404s', async () => {
+		const fetchMock = stubFetch(async () => jsonError('NOT_FOUND', 'gone', 404));
+
+		const { result } = renderHookWithClient(() => useNotebookHtmlQuery(PID, NID, 'ver-old'), {
+			toaster: false,
+		});
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+		expect(result.current.error?.message).toBe('Version not found');
+		expect(urlsOf(fetchMock)[0]).toBe(
+			`/api/v1/projects/${PID}/notebooks/${NID}/versions/ver-old/html`,
+		);
+	});
+
 	it('throws with the status on a server error', async () => {
 		stubFetch(async () => new Response('nope', { status: 500 }));
 

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -819,7 +819,7 @@ async function fetchHtmlSnapshot(
 			error?: { code?: string };
 		} | null;
 		if (body?.error?.code === 'NO_HTML_SNAPSHOT') return null;
-		throw new Error('Notebook not found');
+		throw new Error(versionId ? 'Version not found' : 'Notebook not found');
 	}
 	if (!res.ok) throw new Error(`Failed to load notebook outputs (HTTP ${res.status})`);
 	return {
@@ -837,7 +837,8 @@ export function useNotebookHtmlQuery(projectId: string, notebookId: string, vers
 	return useQuery({
 		queryKey: notebookKeys.html(projectId, notebookId, versionId),
 		queryFn: () => fetchHtmlSnapshot(projectId, notebookId, versionId),
-		staleTime: 5 * 60 * 1000,
+		// A pinned version's snapshot is immutable; only the latest alias can change.
+		staleTime: versionId ? Infinity : 5 * 60 * 1000,
 	});
 }
 

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -838,6 +838,9 @@ export function useNotebookHtmlQuery(projectId: string, notebookId: string, vers
 		queryKey: notebookKeys.html(projectId, notebookId, versionId),
 		queryFn: () => fetchHtmlSnapshot(projectId, notebookId, versionId),
 		// A pinned version's snapshot is immutable; only the latest alias can change.
+		// It can be pruned server-side, but keeping the cached copy then is deliberate:
+		// a refetch would yank rendered outputs into the empty state mid-view, and the
+		// in-memory cache expires with the session anyway.
 		staleTime: versionId ? Infinity : 5 * 60 * 1000,
 	});
 }

--- a/packages/web/src/components/NotebookPage/SnapshotPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/SnapshotPage.test.tsx
@@ -99,6 +99,16 @@ describe('SnapshotPage', () => {
 		expect(onlyReads(impl)).toBe(true);
 	});
 
+	it('shows a version-specific empty state when a pinned snapshot is gone', async () => {
+		makeFetch({ html: null });
+		renderPage('?version=ver-old');
+
+		await waitFor(() =>
+			expect(screen.getByText('No outputs for this version')).toBeInTheDocument(),
+		);
+		expect(screen.getByText(/or they have since been cleaned up/)).toBeInTheDocument();
+	});
+
 	it('shows the header with the notebook title and a back link to the project', async () => {
 		makeFetch({ html: '<html><body>x</body></html>' });
 		renderPage();

--- a/packages/web/src/components/NotebookPage/StaticNotebookView.tsx
+++ b/packages/web/src/components/NotebookPage/StaticNotebookView.tsx
@@ -87,9 +87,13 @@ export function StaticNotebookView({
 				</div>
 			) : (
 				<div className="flex flex-1 flex-col items-center justify-center gap-2 p-6 text-center">
-					<p className="text-sm font-medium">No outputs yet</p>
+					<p className="text-sm font-medium">
+						{versionId ? 'No outputs for this version' : 'No outputs yet'}
+					</p>
 					<p className="max-w-md text-sm text-muted-foreground">
-						An editor needs to run this notebook before its outputs can be viewed.
+						{versionId
+							? 'This version captured no outputs, or they have since been cleaned up.'
+							: 'An editor needs to run this notebook before its outputs can be viewed.'}
 					</p>
 				</div>
 			)}


### PR DESCRIPTION
Follow-ups from reviewing #85 after merge:

- **Tests**: visibility gating on `GET …/versions/{vid}/html` (mirrors the latest-snapshot route); core coverage for `getVersionHtmlSnapshot`, including the descriptor-present-but-object-pruned branch.
- **Web**: pinned 404s say "Version not found" (not "Notebook not found"); version-aware empty state when a pinned snapshot is gone; `staleTime: Infinity` for immutable pinned snapshots.

Tests: core 80, API 59, web 74 pass; `pnpm check` + typechecks clean.