### PR TITLE
feat(server,core): bridge Metrics port to OTEL and correlate logs with traces

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,7 +14,7 @@ import { createApi } from '@marimo-hub/api';
 import { createFromEnv, isConfigError } from '@marimo-hub/config';
 import { startMaintenance, startSessionLifecycle } from './cron';
 import { logEvent } from './log';
-import { WideEventMetrics } from './metrics';
+import { fanoutMetrics, OtelMetrics, WideEventMetrics } from './metrics';
 import { startOtel } from './otel';
 import { serveSpaFallback, serveStaticWithCache } from './staticCache';
 import { attachSandboxProxyUpgrade } from './sandboxProxyWs';
@@ -50,11 +50,15 @@ process.on('uncaughtException', (err) => {
 // Telemetry sink: services emit CAS/reaper/snapshot signals here; the maintenance
 // loop flushes them as one wide event per cycle (and request-path CAS contention
 // surfaces at the next flush).
-const metrics = new WideEventMetrics();
+const wideEvents = new WideEventMetrics();
 
 // Tracing + metrics (standard OTEL_* env vars); the global providers must
 // register before requests are served.
 const otel = startOtel();
+
+// Fan domain metrics out to OTEL when its metrics pillar is on; the maintenance
+// loop below still flushes `wideEvents` directly.
+const metrics = otel?.metrics ? fanoutMetrics(wideEvents, new OtelMetrics()) : wideEvents;
 
 // Config errors are deterministic — a restart can't fix them — so print a readable
 // remediation block to stderr and exit. (Transient backend problems go through the
@@ -119,7 +123,7 @@ app.get('*', serveSpaFallback(staticRoot));
 // marimohub-maintenance Deployment). The bucket-CAS leases inside are
 // defense-in-depth guards.
 if (process.env.MARIMOHUB_RUN_MAINTENANCE === 'true') {
-	startMaintenance(deps, metrics);
+	startMaintenance(deps, wideEvents);
 	startSessionLifecycle(deps);
 }
 

--- a/apps/server/src/log.ts
+++ b/apps/server/src/log.ts
@@ -1,9 +1,11 @@
 /**
- * Minimal, dependency-free structured logger (Node control plane). Mirrors the
- * helper in `@marimo-hub/api` rather than importing it: `logEvent` is an internal
- * util that isn't part of the api package's public barrel, so duplicating the
- * ~5 lines keeps the api/server boundary clean and avoids widening that surface.
+ * Minimal structured logger (Node control plane). Mirrors the helper in
+ * `@marimo-hub/api` rather than importing it: `logEvent` is an internal util
+ * that isn't part of the api package's public barrel, so duplicating the ~5
+ * lines keeps the api/server boundary clean and avoids widening that surface.
  */
+import { traceContext } from '@marimo-hub/core';
+
 export function logEvent(fields: Record<string, unknown>): void {
-	console.log(JSON.stringify({ ts: new Date().toISOString(), ...fields }));
+	console.log(JSON.stringify({ ts: new Date().toISOString(), ...traceContext(), ...fields }));
 }

--- a/apps/server/src/metrics.test.ts
+++ b/apps/server/src/metrics.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { WideEventMetrics } from './metrics';
+import {
+	AggregationTemporality,
+	InMemoryMetricExporter,
+	MeterProvider,
+	PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import type { MetricData } from '@opentelemetry/sdk-metrics';
+import { describe, expect, it, vi } from 'vitest';
+import type { Metrics } from '@marimo-hub/core';
+import { fanoutMetrics, OtelMetrics, WideEventMetrics } from './metrics';
 
 describe('WideEventMetrics', () => {
 	it('accumulates repeated increments', () => {
@@ -21,5 +29,69 @@ describe('WideEventMetrics', () => {
 		metrics.increment('a');
 		metrics.gauge('b', 1);
 		expect(metrics.collect()).toEqual({ 'counter.a': 1, 'gauge.b': 1 });
+	});
+});
+
+async function collect(
+	provider: MeterProvider,
+	exporter: InMemoryMetricExporter,
+): Promise<Map<string, MetricData>> {
+	await provider.forceFlush();
+	const metrics = exporter
+		.getMetrics()
+		.flatMap((rm) => rm.scopeMetrics)
+		.flatMap((sm) => sm.metrics);
+	return new Map(metrics.map((m) => [m.descriptor.name, m]));
+}
+
+describe('OtelMetrics', () => {
+	function setup() {
+		const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+		const provider = new MeterProvider({
+			readers: [new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 60_000 })],
+		});
+		return { exporter, provider, metrics: new OtelMetrics(provider) };
+	}
+
+	it('accumulates counters per name with tags', async () => {
+		const { exporter, provider, metrics } = setup();
+		metrics.increment('catalog.cas.conflict');
+		metrics.increment('catalog.cas.conflict', 2);
+		metrics.increment('sessions.reaped', 3, { reason: 'expired' });
+
+		const byName = await collect(provider, exporter);
+		expect(byName.get('catalog.cas.conflict')?.dataPoints[0]?.value).toBe(3);
+		const reaped = byName.get('sessions.reaped')?.dataPoints[0];
+		expect(reaped?.value).toBe(3);
+		expect(reaped?.attributes).toEqual({ reason: 'expired' });
+		await provider.shutdown();
+	});
+
+	it('records the latest gauge value', async () => {
+		const { exporter, provider, metrics } = setup();
+		metrics.gauge('sessions.live', 5);
+		metrics.gauge('sessions.live', 2);
+
+		const byName = await collect(provider, exporter);
+		expect(byName.get('sessions.live')?.dataPoints[0]?.value).toBe(2);
+		await provider.shutdown();
+	});
+});
+
+describe('fanoutMetrics', () => {
+	it('forwards every call to all targets', () => {
+		const target: Metrics = { increment: vi.fn(), gauge: vi.fn() };
+		const wide = new WideEventMetrics();
+		const fan = fanoutMetrics(target, wide);
+
+		fan.increment('catalog.cas.conflict', 2, { source: 'test' });
+		fan.gauge('sessions.live', 7);
+
+		expect(target.increment).toHaveBeenCalledWith('catalog.cas.conflict', 2, { source: 'test' });
+		expect(target.gauge).toHaveBeenCalledWith('sessions.live', 7, undefined);
+		expect(wide.collect()).toEqual({
+			'counter.catalog.cas.conflict': 2,
+			'gauge.sessions.live': 7,
+		});
 	});
 });

--- a/apps/server/src/metrics.ts
+++ b/apps/server/src/metrics.ts
@@ -1,4 +1,6 @@
-import type { Metrics } from '@marimo-hub/core';
+import type { Counter, Gauge, MeterProvider } from '@opentelemetry/api';
+import { metrics as metricsApi } from '@opentelemetry/api';
+import type { Metrics, MetricTags } from '@marimo-hub/core';
 
 /**
  * A `Metrics` implementation that accumulates counters and latest gauge values
@@ -30,4 +32,50 @@ export class WideEventMetrics implements Metrics {
 		for (const [k, v] of this.gauges) out[`gauge.${k}`] = v;
 		return out;
 	}
+}
+
+/**
+ * Bridges the `Metrics` port to OpenTelemetry instruments, so the domain
+ * signals export alongside the HTTP RED metrics. Construct only after
+ * `startOtel()`: unlike traces, the metrics API has no late-registration proxy,
+ * so a meter resolved before the provider registers stays a no-op forever.
+ */
+export class OtelMetrics implements Metrics {
+	private readonly meter;
+	private readonly counters = new Map<string, Counter>();
+	private readonly gauges = new Map<string, Gauge>();
+
+	constructor(provider: MeterProvider = metricsApi.getMeterProvider()) {
+		this.meter = provider.getMeter('@marimo-hub/server');
+	}
+
+	increment(name: string, value = 1, tags?: MetricTags): void {
+		let counter = this.counters.get(name);
+		if (!counter) {
+			counter = this.meter.createCounter(name);
+			this.counters.set(name, counter);
+		}
+		counter.add(value, tags);
+	}
+
+	gauge(name: string, value: number, tags?: MetricTags): void {
+		let gauge = this.gauges.get(name);
+		if (!gauge) {
+			gauge = this.meter.createGauge(name);
+			this.gauges.set(name, gauge);
+		}
+		gauge.record(value, tags);
+	}
+}
+
+/** Emit every signal to all targets (e.g. wide-event flush + OTEL export). */
+export function fanoutMetrics(...targets: Metrics[]): Metrics {
+	return {
+		increment(name, value, tags) {
+			for (const t of targets) t.increment(name, value, tags);
+		},
+		gauge(name, value, tags) {
+			for (const t of targets) t.gauge(name, value, tags);
+		},
+	};
 }

--- a/apps/server/src/otel.test.ts
+++ b/apps/server/src/otel.test.ts
@@ -134,6 +134,7 @@ describe('startOtel', () => {
 		const handle = startOtel();
 		expect(handle).not.toBeNull();
 		expect(handle?.tracing).toBe(true);
+		expect(handle?.metrics).toBe(false);
 		expect(register).toHaveBeenCalledOnce();
 		const provider = register.mock.instances[0] as NodeTracerProvider;
 		// Never ended — an ended span would enter the batch exporter and make
@@ -190,6 +191,7 @@ describe('startOtel', () => {
 		const handle = startOtel();
 		expect(handle).not.toBeNull();
 		expect(handle?.tracing).toBe(false);
+		expect(handle?.metrics).toBe(true);
 		expect(register).not.toHaveBeenCalled();
 		expect(startServer).toHaveBeenCalledOnce();
 		expect(setGlobal).toHaveBeenCalledOnce();

--- a/apps/server/src/otel.ts
+++ b/apps/server/src/otel.ts
@@ -27,6 +27,8 @@ import { logEvent } from './log';
 export interface OtelHandle {
 	/** True when the request middleware should create SERVER spans. */
 	tracing: boolean;
+	/** True when a global MeterProvider is registered and exporting. */
+	metrics: boolean;
 	/** Flush buffered telemetry and stop exporting. */
 	shutdown(): Promise<void>;
 }
@@ -127,6 +129,7 @@ export function startOtel(): OtelHandle | null {
 	});
 	return {
 		tracing,
+		metrics: metricsKind !== null,
 		shutdown: async () => {
 			await Promise.allSettled(shutdowns.map((fn) => fn()));
 		},

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -134,11 +134,19 @@ Spans and metrics share one resource: `service.name` and
 and a random `service.instance.id` (override it per pod via
 `OTEL_RESOURCE_ATTRIBUTES`, e.g. from the Kubernetes Downward API).
 
+While tracing is enabled, every log line emitted inside a traced request also
+carries `trace_id` / `span_id`, so your log pipeline can pivot from a line
+straight to its trace.
+
 ### Metrics (OpenTelemetry)
 
-The server records RED metrics per request: the `http.server.request.duration`
+The server records RED metrics per request — the `http.server.request.duration`
 histogram (labelled by route, method, and status code) and the
-`http.server.active_requests` gauge. `OTEL_METRICS_EXPORTER` selects the mode:
+`http.server.active_requests` gauge — plus domain signals: catalog CAS
+contention (`catalog.cas.*`), session and reaper activity (`sessions.*`), and
+snapshot growth (`snapshots.*`, `maintenance.*`), which also still flush as one
+wide-event log line per maintenance cycle. `OTEL_METRICS_EXPORTER` selects the
+mode:
 
 - **`otlp`** (default): push over OTLP/HTTP whenever
   `OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`) is

--- a/packages/api/src/log.ts
+++ b/packages/api/src/log.ts
@@ -1,10 +1,13 @@
 /**
- * Minimal, dependency-free structured logger. Emits one JSON object per event so
- * lines are machine-parseable in log aggregators (no pino/winston — keeps the
- * Cloudflare Workers build dependency-free).
+ * Minimal structured logger. Emits one JSON object per event so lines are
+ * machine-parseable in log aggregators (no pino/winston — keeps the Cloudflare
+ * Workers build dependency-free; `traceContext` is the pure OTEL facade, so
+ * that still holds).
  */
+import { traceContext } from '@marimo-hub/core';
+
 export function logEvent(fields: Record<string, unknown>): void {
-	console.log(JSON.stringify({ ts: new Date().toISOString(), ...fields }));
+	console.log(JSON.stringify({ ts: new Date().toISOString(), ...traceContext(), ...fields }));
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
 	},
 	"devDependencies": {
 		"@marimo-hub/tsconfig": "workspace:*",
+		"@opentelemetry/context-async-hooks": "catalog:",
 		"@opentelemetry/sdk-trace-base": "catalog:",
 		"@types/node": "catalog:",
 		"typescript": "catalog:",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,9 @@ export type {
 	WorkspaceSourcePolicy,
 } from './integrations/remoteWorkspace';
 
+// Trace↔log correlation (the `traced` span wrapper stays internal to createServices)
+export { traceContext } from './tracing';
+
 // Saga orchestrator (multi-step compensating operations)
 export * from './saga';
 

--- a/packages/core/src/tracing.test.ts
+++ b/packages/core/src/tracing.test.ts
@@ -1,4 +1,5 @@
-import { trace } from '@opentelemetry/api';
+import { context, trace } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
 	BasicTracerProvider,
 	InMemorySpanExporter,
@@ -8,16 +9,21 @@ import { afterAll, afterEach, describe, expect, it } from 'vitest';
 import type { UserId } from './ids';
 import { createServices } from './services';
 import { MemoryBucket } from './testing/MemoryBucket';
-import { traced } from './tracing';
+import { traceContext, traced } from './tracing';
 
 const exporter = new InMemorySpanExporter();
 const provider = new BasicTracerProvider({
 	spanProcessors: [new SimpleSpanProcessor(exporter)],
 });
 trace.setGlobalTracerProvider(provider);
+// traceContext() reads the ACTIVE span, which needs real context propagation.
+context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
 
 afterEach(() => exporter.reset());
-afterAll(() => trace.disable());
+afterAll(() => {
+	trace.disable();
+	context.disable();
+});
 
 class Fake {
 	calls = 0;
@@ -113,5 +119,21 @@ describe('createServices tracing option', () => {
 		const services = createServices(new MemoryBucket());
 		await services.identities.get('user-1' as UserId);
 		expect(exporter.getFinishedSpans()).toHaveLength(0);
+	});
+});
+
+describe('traceContext', () => {
+	it('is undefined outside any span', () => {
+		expect(traceContext()).toBeUndefined();
+	});
+
+	it('returns the active span ids', () => {
+		provider.getTracer('test').startActiveSpan('op', (span) => {
+			expect(traceContext()).toEqual({
+				trace_id: span.spanContext().traceId,
+				span_id: span.spanContext().spanId,
+			});
+			span.end();
+		});
 	});
 });

--- a/packages/core/src/tracing.ts
+++ b/packages/core/src/tracing.ts
@@ -8,7 +8,17 @@
  * notebook content). Extractors must emit identifiers and storage keys only.
  */
 import type { Attributes } from '@opentelemetry/api';
-import { SpanStatusCode, trace } from '@opentelemetry/api';
+import { isSpanContextValid, SpanStatusCode, trace } from '@opentelemetry/api';
+
+/**
+ * The active span's ids as log fields, or undefined when no span is recording
+ * (Workers, tracing off) — lets a log line join its trace in the aggregator.
+ */
+export function traceContext(): { trace_id: string; span_id: string } | undefined {
+	const ctx = trace.getActiveSpan()?.spanContext();
+	if (!ctx || !isSpanContextValid(ctx)) return undefined;
+	return { trace_id: ctx.traceId, span_id: ctx.spanId };
+}
 
 export type AttrExtractors<T> = {
 	[K in keyof T]?: T[K] extends (...args: infer A) => unknown ? (...args: A) => Attributes : never;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ catalogs:
     '@opentelemetry/api':
       specifier: ^1.9.0
       version: 1.9.1
+    '@opentelemetry/context-async-hooks':
+      specifier: ^2.9.0
+      version: 2.9.0
     '@opentelemetry/core':
       specifier: ^2.9.0
       version: 2.9.0
@@ -845,6 +848,9 @@ importers:
       '@marimo-hub/tsconfig':
         specifier: workspace:*
         version: link:../ts-config
+      '@opentelemetry/context-async-hooks':
+        specifier: 'catalog:'
+        version: 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base':
         specifier: 'catalog:'
         version: 2.9.0(@opentelemetry/api@1.9.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalog:
   '@hono/otel': ^1.1.2
   '@hono/zod-openapi': ^1.2.2
   '@opentelemetry/api': ^1.9.0
+  '@opentelemetry/context-async-hooks': ^2.9.0
   '@opentelemetry/core': ^2.9.0
   '@opentelemetry/exporter-metrics-otlp-http': ^0.220.0
   '@opentelemetry/exporter-prometheus': ^0.220.0


### PR DESCRIPTION
Follow-up to #86 — the last two items from the o11y list.

- **Metrics-port bridge**: `OtelMetrics implements Metrics` + `fanoutMetrics` in `apps/server/src/metrics.ts` — domain signals (`catalog.cas.*`, `sessions.*`, `snapshots.*`, `maintenance.*`) export as OTEL counters/gauges whenever the metrics pillar is on. The wide-event flush is unchanged (the maintenance loop keeps its `WideEventMetrics`); zero changes to `packages/core` services. Gotcha encoded in the code: the OTEL metrics global has no late-registration proxy, so the bridge constructs only after `startOtel()` (new `OtelHandle.metrics` flag).
- **Trace↔log correlation**: `traceContext()` in core's `tracing.ts` returns `{trace_id, span_id}` from the active span (undefined when none — Workers and tracing-off stay no-ops); both `logEvent` helpers spread it into every line. No new deps for `packages/api`.
