### PR TITLE
feat(auth): expand OIDC claims with group policies and email verification

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
@@ -1,10 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`setup snippets > renders auth/oidc with all four enterprise provider sub-sections 1`] = `
-"<p>App-native OpenID Connect — the production backend. marimohub discovers the
-provider's endpoints automatically from the issuer's
-<code>/.well-known/openid-configuration</code>, so you only supply an issuer, client
-credentials, and a redirect URI.</p>
+"<p>App-native OpenID Connect is the production backend. marimohub discovers the
+provider endpoints from <code>/.well-known/openid-configuration</code>. You supply the
+issuer, client credentials, and redirect URI.</p>
 <pre><code class="language-bash">MARIMOHUB_AUTH_BACKEND=oidc
 MARIMOHUB_AUTH_OIDC_ISSUER=https://accounts.example.com
 MARIMOHUB_AUTH_OIDC_CLIENT_ID=…
@@ -14,20 +13,57 @@ MARIMOHUB_AUTH_SESSION_SECRET=…            # signs the session cookie (HS256, 
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com  # REQUIRED allowlist (verified email); \`*\` allows all
 # MARIMOHUB_AUTH_OIDC_AUDIENCE=…           # optional: expected ID-token audience (the client id is enforced anyway)
 # MARIMOHUB_AUTH_OIDC_PROMPT=consent       # optional: override the default (select_account) OAuth prompt
+# MARIMOHUB_AUTH_OIDC_SCOPES=&quot;openid email profile groups&quot; # add only provider-required scopes
 </code></pre>
 <p>The <strong>redirect URI</strong> is always <code>https://&lt;your-host&gt;/api/auth/callback</code>. Register
-it with your provider exactly as you set it here, or login fails with a
-<code>redirect_uri_mismatch</code> error. <code>ALLOWED_EMAIL_DOMAINS</code> is <strong>required</strong> —
-marimohub fails closed rather than admitting every account the IdP
-authenticates; list your domains or set <code>*</code> to allow all.</p>
+this exact value with your provider. A different value causes a
+<code>redirect_uri_mismatch</code> error. <code>ALLOWED_EMAIL_DOMAINS</code> is <strong>required</strong>. Set one
+or more domains, or set <code>*</code> to allow all.</p>
+<p>If the provider publishes UserInfo, marimohub uses it for profile claims.
+UserInfo must have the same <code>sub</code> as the validated ID token. Email verification
+is required by default. If a trusted issuer omits <code>email_verified</code>, use
+<code>MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION=trusted-issuer</code>. Any present value other
+than boolean <code>true</code> is invalid.</p>
+<p>The signed session JWT has a 3,800-byte limit. If necessary, marimohub omits the
+profile picture first and the display name second. Required identity and
+authorization claims are never omitted. Login fails if they exceed the limit.</p>
+<p>The issuer, callback, discovered authorization, and discovered logout endpoints
+must use HTTPS and cannot contain embedded credentials.</p>
+<h3>Groups and roles</h3>
+<p>Group authorization is optional and uses exact provider group IDs. Set a JSON
+Pointer to the provider array. Then set at least one group policy:</p>
+<pre><code class="language-bash">MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM=/groups
+MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS=hub-users
+MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS=hub-platform-admins
+MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS=hub-viewers
+MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS=hub-editors
+MARIMOHUB_AUTH_OIDC_DEFAULT_ADMIN_GROUPS=hub-project-admins
+</code></pre>
+<p>Nested claims use JSON Pointer syntax, such as <code>/realm_access/roles</code>.
+<code>ALLOWED_GROUPS</code> controls login. The other lists map groups to internal
+entitlements. The session cookie stores mapped entitlements, not raw groups.</p>
+<p>Group sessions last at most one hour by default. This limit bounds the delay
+after an IdP removes a user from a group. Kernels inherit the session JWT expiry
+as a fixed authorization deadline. Active editors cannot extend it. At expiry,
+the lifecycle destroys the kernel and the proxy closes WebSockets. This teardown
+skips the final capture so that the kernel stops promptly. Periodic snapshots
+limit potential data loss.</p>
+<p>Missing, malformed, or oversized group data cannot satisfy the login policy.
+marimohub accepts at most 200 group IDs. It does not resolve group-overage
+references from the provider. Configure the IdP to emit only the groups that
+marimohub needs.
+Group-derived roles apply only to the browser session. They do not transfer to
+personal access tokens.</p>
+<p>The user ID is the OIDC <code>sub</code> within the configured issuer. The same <code>sub</code> from
+another issuer can identify a different person. Therefore, an issuer URL change
+is an identity migration. Reconcile stored owners and members before the change.</p>
 <p>Generate a session secret with <code>openssl rand -base64 32</code>.</p>
 <h3>Google</h3>
 <ol>
 <li>In the <a href="https://console.cloud.google.com/apis/credentials">Google Cloud Console</a>,
 open <strong>APIs &amp; Services → Credentials</strong>.</li>
 <li><strong>Create Credentials → OAuth client ID</strong>, application type <strong>Web application</strong>.</li>
-<li>Under <strong>Authorized redirect URIs</strong>, add <code>https://hub.example.com/api/auth/callback</code>
-(and <code>http://localhost:3000/api/auth/callback</code> for local testing).</li>
+<li>Under <strong>Authorized redirect URIs</strong>, add <code>https://hub.example.com/api/auth/callback</code>.</li>
 <li>Copy the <strong>Client ID</strong> and <strong>Client secret</strong>.</li>
 </ol>
 <pre><code class="language-bash">MARIMOHUB_AUTH_OIDC_ISSUER=https://accounts.google.com
@@ -35,10 +71,9 @@ MARIMOHUB_AUTH_OIDC_CLIENT_ID=…apps.googleusercontent.com
 MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=…
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com   # a single domain is also sent to Google as the \`hd\` hint
 </code></pre>
-<p>marimohub defaults the OAuth <code>prompt</code> to <code>select_account</code>, so a returning user
-always gets the Google account chooser instead of being silently logged in with
-their last account. Override it via <code>MARIMOHUB_AUTH_OIDC_PROMPT</code> (e.g. <code>consent</code>
-to also re-show the consent screen).</p>
+<p>The default OAuth <code>prompt</code> is <code>select_account</code>, which displays the Google
+account chooser. Set <code>MARIMOHUB_AUTH_OIDC_PROMPT=consent</code> to display the consent
+screen again.</p>
 <p>See <a href="https://developers.google.com/identity/openid-connect/openid-connect">Google's OpenID Connect docs</a>.</p>
 <h3>Microsoft Entra ID</h3>
 <ol>

--- a/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
@@ -11,7 +11,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=…
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_SESSION_SECRET=…            # signs the session cookie (HS256, ≥32 bytes)
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com  # REQUIRED allowlist (verified email); \`*\` allows all
-# MARIMOHUB_AUTH_OIDC_AUDIENCE=…           # optional: expected ID-token audience (the client id is enforced anyway)
+# MARIMOHUB_AUTH_OIDC_AUDIENCE=…           # deprecated and ignored; aud must contain the client ID
 # MARIMOHUB_AUTH_OIDC_PROMPT=consent       # optional: override the default (select_account) OAuth prompt
 # MARIMOHUB_AUTH_OIDC_SCOPES=&quot;openid email profile groups&quot; # add only provider-required scopes
 </code></pre>
@@ -23,7 +23,8 @@ or more domains, or set <code>*</code> to allow all.</p>
 UserInfo must have the same <code>sub</code> as the validated ID token. Email verification
 is required by default. If a trusted issuer omits <code>email_verified</code>, use
 <code>MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION=trusted-issuer</code>. Any present value other
-than boolean <code>true</code> is invalid.</p>
+than boolean <code>true</code> is invalid. A domain allowlist always requires boolean
+<code>true</code>, even under <code>trusted-issuer</code>.</p>
 <p>The signed session JWT has a 3,800-byte limit. If necessary, marimohub omits the
 profile picture first and the display name second. Required identity and
 authorization claims are never omitted. Login fails if they exceed the limit.</p>
@@ -44,10 +45,11 @@ MARIMOHUB_AUTH_OIDC_DEFAULT_ADMIN_GROUPS=hub-project-admins
 entitlements. The session cookie stores mapped entitlements, not raw groups.</p>
 <p>Group sessions last at most one hour by default. This limit bounds the delay
 after an IdP removes a user from a group. Kernels inherit the session JWT expiry
-as a fixed authorization deadline. Active editors cannot extend it. At expiry,
-the lifecycle destroys the kernel and the proxy closes WebSockets. This teardown
-skips the final capture so that the kernel stops promptly. Periodic snapshots
-limit potential data loss.</p>
+as a fixed authorization deadline. Active editors cannot extend it. Session
+reuse keeps the earliest caller credential deadline. At expiry, the lifecycle
+destroys the kernel and the proxy closes WebSockets. This teardown skips the
+final capture so that the kernel stops promptly. Periodic snapshots limit
+potential data loss.</p>
 <p>Missing, malformed, or oversized group data cannot satisfy the login policy.
 marimohub accepts at most 200 group IDs. It does not resolve group-overage
 references from the provider. Configure the IdP to emit only the groups that

--- a/apps/server/src/sandboxProxyWs.test.ts
+++ b/apps/server/src/sandboxProxyWs.test.ts
@@ -335,6 +335,39 @@ describe('attachSandboxProxyUpgrade', () => {
 			}
 		});
 
+		it('destroys a stalled upstream request when the client disconnects', async () => {
+			let upstreamRequestStarted = false;
+			let upstreamRequestClosed = false;
+			const stalled = createServer((req) => {
+				upstreamRequestStarted = true;
+				req.on('close', () => {
+					upstreamRequestClosed = true;
+				});
+			});
+			await new Promise<void>((resolve) => stalled.listen(0, '127.0.0.1', resolve));
+			const stalledOrigin = `http://127.0.0.1:${(stalled.address() as AddressInfo).port}`;
+
+			try {
+				const { deps, token } = await runningProxySession(
+					stalledOrigin,
+					new Date(Date.now() + 60_000).toISOString(),
+				);
+				const server = fakeUpgradeServer();
+				attachSandboxProxyUpgrade(server, deps);
+				const socket = new PassThrough();
+
+				server.listeners[0](fakeIncomingMessage(`/proxy/${token}/`), socket, Buffer.alloc(0));
+				await vi.waitFor(() => expect(upstreamRequestStarted).toBe(true));
+
+				socket.destroy();
+
+				await vi.waitFor(() => expect(upstreamRequestClosed).toBe(true));
+			} finally {
+				stalled.closeAllConnections();
+				await new Promise<void>((resolve) => stalled.close(() => resolve()));
+			}
+		});
+
 		it('closes an established kernel WebSocket at the authorization deadline', async () => {
 			const upgrader = createServer();
 			let upstreamSocket: Duplex | undefined;

--- a/apps/server/src/sandboxProxyWs.test.ts
+++ b/apps/server/src/sandboxProxyWs.test.ts
@@ -30,6 +30,37 @@ function authAs(userId: UserId | null): Authenticator {
 	};
 }
 
+async function runningProxySession(origin: string, authorizationExpiresAt: string) {
+	const bucket = await createInitializedBucket();
+	const services = createServices(bucket);
+	const project = await services.projects.createProject({ name: 'Owned', description: 'd' }, ACTOR);
+	const pid = project.id as ProjectId;
+	const notebook = await services.notebooks.createNotebook(
+		pid,
+		{ title: 'NB', description: 'd', code: 'import marimo as mo' },
+		ACTOR,
+	);
+	const session = await services.sessions.createSession({
+		notebook_id: notebook.id,
+		project_id: pid,
+		user_id: ACTOR,
+		authorization_expires_at: authorizationExpiresAt,
+	});
+	await services.sessions.setRunning(pid, session.session_id, '/proxy/x/', false, origin);
+	const token = await signProxyToken(pid, session.session_id, SECRET);
+	const deps = makeTestDeps(bucket, {
+		authenticator: authAs(ACTOR),
+		sandbox: {
+			bucket: { name: 'test', endpoint: '' },
+			hostname: 'localhost',
+			workdir: '/workspace',
+			persistWorkspace: 'source',
+			exposure: new ProxyExposure(SECRET),
+		},
+	});
+	return { deps, token };
+}
+
 /** Collect bytes written to a client socket, in flowing mode. */
 function collect(socket: PassThrough): { text(): string } {
 	const chunks: Buffer[] = [];
@@ -89,6 +120,42 @@ describe('attachSandboxProxyUpgrade', () => {
 		expect(out.text()).toMatch(/^HTTP\/1\.1 403/);
 	});
 
+	it('rejects when authorization expires between request validation and the upstream dial', async () => {
+		const now = Date.now();
+		const deadline = now + 1000;
+		const { deps, token } = await runningProxySession(
+			'http://127.0.0.1:1',
+			new Date(deadline).toISOString(),
+		);
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValueOnce(now).mockReturnValue(deadline);
+		const server = fakeUpgradeServer();
+		attachSandboxProxyUpgrade(server, deps);
+		const socket = new PassThrough();
+		const out = collect(socket);
+
+		server.listeners[0](fakeIncomingMessage(`/proxy/${token}/`), socket, Buffer.alloc(0));
+
+		await vi.waitFor(() => expect(socket.destroyed).toBe(true));
+		expect(out.text()).toMatch(/^HTTP\/1\.1 410/);
+		nowSpy.mockRestore();
+	});
+
+	it('returns 502 when the upstream dial fails before authorization expires', async () => {
+		const { deps, token } = await runningProxySession(
+			'http://127.0.0.1:1',
+			new Date(Date.now() + 60_000).toISOString(),
+		);
+		const server = fakeUpgradeServer();
+		attachSandboxProxyUpgrade(server, deps);
+		const socket = new PassThrough();
+		const out = collect(socket);
+
+		server.listeners[0](fakeIncomingMessage(`/proxy/${token}/`), socket, Buffer.alloc(0));
+
+		await vi.waitFor(() => expect(socket.destroyed).toBe(true));
+		expect(out.text()).toMatch(/^HTTP\/1\.1 502/);
+	});
+
 	describe('upstream relay', () => {
 		let upstream: ReturnType<typeof createServer>;
 		let upstreamOrigin: string;
@@ -123,6 +190,7 @@ describe('attachSandboxProxyUpgrade', () => {
 				notebook_id: notebook.id,
 				project_id: pid,
 				user_id: ACTOR,
+				authorization_expires_at: new Date(Date.now() + 60_000).toISOString(),
 			});
 			await services.sessions.setRunning(
 				pid,
@@ -173,8 +241,12 @@ describe('attachSandboxProxyUpgrade', () => {
 			const upgrader = createServer();
 			// An upgraded socket detaches from the server, so keep it to close by hand.
 			let upstreamSocket: Duplex | undefined;
+			let receivedClientHead = '';
 			upgrader.on('upgrade', (_req, socket) => {
 				upstreamSocket = socket;
+				socket.on('data', (chunk) => {
+					receivedClientHead += chunk.toString();
+				});
 				socket.write(
 					'HTTP/1.1 101 Switching Protocols\r\n' +
 						'Upgrade: websocket\r\n' +
@@ -230,10 +302,103 @@ describe('attachSandboxProxyUpgrade', () => {
 				const req = fakeIncomingMessage(`/proxy/${token}/`);
 				req.headers.connection = 'Upgrade';
 				req.headers.upgrade = 'websocket';
-				server.listeners[0](req, socket, Buffer.alloc(0));
+				server.listeners[0](req, socket, Buffer.from('client-head'));
 
 				await vi.waitFor(() => expect(out.text()).toMatch(/^HTTP\/1\.1 101/));
 				expect(out.text().toLowerCase()).not.toContain('set-cookie');
+				await vi.waitFor(() => expect(receivedClientHead).toBe('client-head'));
+			} finally {
+				upstreamSocket?.destroy();
+				await new Promise<void>((resolve) => upgrader.close(() => resolve()));
+			}
+		});
+
+		it('closes an upgrade that is still waiting on the kernel at the deadline', async () => {
+			const stalled = createServer(() => {});
+			await new Promise<void>((resolve) => stalled.listen(0, '127.0.0.1', resolve));
+			const stalledOrigin = `http://127.0.0.1:${(stalled.address() as AddressInfo).port}`;
+
+			try {
+				const { deps, token } = await runningProxySession(
+					stalledOrigin,
+					new Date(Date.now() + 250).toISOString(),
+				);
+				const server = fakeUpgradeServer();
+				attachSandboxProxyUpgrade(server, deps);
+				const socket = new PassThrough();
+
+				server.listeners[0](fakeIncomingMessage(`/proxy/${token}/`), socket, Buffer.alloc(0));
+
+				await vi.waitFor(() => expect(socket.destroyed).toBe(true), { timeout: 2000 });
+			} finally {
+				await new Promise<void>((resolve) => stalled.close(() => resolve()));
+			}
+		});
+
+		it('closes an established kernel WebSocket at the authorization deadline', async () => {
+			const upgrader = createServer();
+			let upstreamSocket: Duplex | undefined;
+			upgrader.on('upgrade', (_req, socket) => {
+				upstreamSocket = socket;
+				socket.write(
+					'HTTP/1.1 101 Switching Protocols\r\n' +
+						'Upgrade: websocket\r\n' +
+						'Connection: Upgrade\r\n\r\n',
+				);
+			});
+			await new Promise<void>((resolve) => upgrader.listen(0, '127.0.0.1', resolve));
+			const upgraderOrigin = `http://127.0.0.1:${(upgrader.address() as AddressInfo).port}`;
+
+			try {
+				const bucket = await createInitializedBucket();
+				const services = createServices(bucket);
+				const project = await services.projects.createProject(
+					{ name: 'Owned', description: 'd' },
+					ACTOR,
+				);
+				const pid = project.id as ProjectId;
+				const notebook = await services.notebooks.createNotebook(
+					pid,
+					{ title: 'NB', description: 'd', code: 'import marimo as mo' },
+					ACTOR,
+				);
+				const session = await services.sessions.createSession({
+					notebook_id: notebook.id,
+					project_id: pid,
+					user_id: ACTOR,
+					authorization_expires_at: new Date(Date.now() + 1500).toISOString(),
+				});
+				await services.sessions.setRunning(
+					pid,
+					session.session_id,
+					'/proxy/x/',
+					false,
+					upgraderOrigin,
+				);
+				const token = await signProxyToken(pid, session.session_id, SECRET);
+				const deps = makeTestDeps(bucket, {
+					authenticator: authAs(ACTOR),
+					sandbox: {
+						bucket: { name: 'test', endpoint: '' },
+						hostname: 'localhost',
+						workdir: '/workspace',
+						persistWorkspace: 'source',
+						exposure: new ProxyExposure(SECRET),
+					},
+				});
+				const server = fakeUpgradeServer();
+				attachSandboxProxyUpgrade(server, deps);
+
+				const socket = new PassThrough();
+				const out = collect(socket);
+				const req = fakeIncomingMessage(`/proxy/${token}/`);
+				req.headers.connection = 'Upgrade';
+				req.headers.upgrade = 'websocket';
+				server.listeners[0](req, socket, Buffer.alloc(0));
+
+				await vi.waitFor(() => expect(out.text()).toMatch(/^HTTP\/1\.1 101/));
+				expect(socket.destroyed).toBe(false);
+				await vi.waitFor(() => expect(socket.destroyed).toBe(true), { timeout: 4000 });
 			} finally {
 				upstreamSocket?.destroy();
 				await new Promise<void>((resolve) => upgrader.close(() => resolve()));

--- a/apps/server/src/sandboxProxyWs.ts
+++ b/apps/server/src/sandboxProxyWs.ts
@@ -57,6 +57,14 @@ export function attachSandboxProxyUpgrade(server: UpgradeServer, deps: ApiDeps):
 					rejectUpgrade(clientSocket, decision.status, decision.code);
 					return;
 				}
+				const remainingAuthorizationMs =
+					decision.authorizationDeadline === undefined
+						? undefined
+						: decision.authorizationDeadline - Date.now();
+				if (remainingAuthorizationMs !== undefined && remainingAuthorizationMs <= 0) {
+					rejectUpgrade(clientSocket, 410, 'GONE');
+					return;
+				}
 
 				const target = new URL(decision.targetUrl);
 				const lib = target.protocol === 'https:' ? https : http;
@@ -80,14 +88,34 @@ export function attachSandboxProxyUpgrade(server: UpgradeServer, deps: ApiDeps):
 					method: 'GET',
 					headers,
 				});
+				let kernelSocket: Duplex | undefined;
+				let authorizationExpired = false;
+				let authorizationTimer: ReturnType<typeof setTimeout> | undefined;
+				const clearAuthorizationTimer = () => {
+					if (authorizationTimer) clearTimeout(authorizationTimer);
+					authorizationTimer = undefined;
+				};
+				if (remainingAuthorizationMs !== undefined) {
+					authorizationTimer = setTimeout(() => {
+						authorizationExpired = true;
+						authorizationTimer = undefined;
+						proxyReq.destroy();
+						kernelSocket?.destroy();
+						clientSocket.destroy();
+					}, remainingAuthorizationMs);
+					authorizationTimer.unref();
+					clientSocket.on('close', clearAuthorizationTimer);
+				}
 
 				// Kernel answered without upgrading (e.g. 4xx) — relay the status, close.
 				proxyReq.on('response', (proxyRes) => {
+					clearAuthorizationTimer();
 					rejectUpgrade(clientSocket, proxyRes.statusCode ?? 502, proxyRes.statusMessage ?? '');
 					proxyRes.destroy();
 				});
 
-				proxyReq.on('upgrade', (proxyRes, kernelSocket, kernelHead) => {
+				proxyReq.on('upgrade', (proxyRes, connectedKernelSocket, kernelHead) => {
+					kernelSocket = connectedKernelSocket;
 					const statusLine = `HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage}`;
 					const headerLines: string[] = [statusLine];
 					for (const [key, value] of Object.entries(proxyRes.headers)) {
@@ -98,20 +126,23 @@ export function attachSandboxProxyUpgrade(server: UpgradeServer, deps: ApiDeps):
 					}
 					clientSocket.write(`${headerLines.join('\r\n')}\r\n\r\n`);
 					if (kernelHead?.length) clientSocket.write(kernelHead);
-					if (head?.length) kernelSocket.write(head);
+					if (head?.length) connectedKernelSocket.write(head);
 
 					const teardown = () => {
-						kernelSocket.destroy();
+						clearAuthorizationTimer();
+						connectedKernelSocket.destroy();
 						clientSocket.destroy();
 					};
-					kernelSocket.on('error', teardown);
-					kernelSocket.on('close', teardown);
+					connectedKernelSocket.on('error', teardown);
+					connectedKernelSocket.on('close', teardown);
 					clientSocket.on('close', teardown);
-					kernelSocket.pipe(clientSocket);
-					clientSocket.pipe(kernelSocket);
+					connectedKernelSocket.pipe(clientSocket);
+					clientSocket.pipe(connectedKernelSocket);
 				});
 
 				proxyReq.on('error', (err) => {
+					clearAuthorizationTimer();
+					if (authorizationExpired) return;
 					logEvent({
 						level: 'warn',
 						event: 'sandbox_proxy_ws_upstream_error',

--- a/apps/server/src/sandboxProxyWs.ts
+++ b/apps/server/src/sandboxProxyWs.ts
@@ -90,11 +90,19 @@ export function attachSandboxProxyUpgrade(server: UpgradeServer, deps: ApiDeps):
 				});
 				let kernelSocket: Duplex | undefined;
 				let authorizationExpired = false;
+				let clientClosed = false;
 				let authorizationTimer: ReturnType<typeof setTimeout> | undefined;
 				const clearAuthorizationTimer = () => {
 					if (authorizationTimer) clearTimeout(authorizationTimer);
 					authorizationTimer = undefined;
 				};
+				const handleClientClose = () => {
+					clientClosed = true;
+					clearAuthorizationTimer();
+					if (!kernelSocket) proxyReq.destroy();
+				};
+				clientSocket.on('close', handleClientClose);
+				if (clientSocket.destroyed) handleClientClose();
 				if (remainingAuthorizationMs !== undefined) {
 					authorizationTimer = setTimeout(() => {
 						authorizationExpired = true;
@@ -104,7 +112,6 @@ export function attachSandboxProxyUpgrade(server: UpgradeServer, deps: ApiDeps):
 						clientSocket.destroy();
 					}, remainingAuthorizationMs);
 					authorizationTimer.unref();
-					clientSocket.on('close', clearAuthorizationTimer);
 				}
 
 				// Kernel answered without upgrading (e.g. 4xx) — relay the status, close.
@@ -142,7 +149,7 @@ export function attachSandboxProxyUpgrade(server: UpgradeServer, deps: ApiDeps):
 
 				proxyReq.on('error', (err) => {
 					clearAuthorizationTimer();
-					if (authorizationExpired) return;
+					if (authorizationExpired || clientClosed) return;
 					logEvent({
 						level: 'warn',
 						event: 'sandbox_proxy_ws_upstream_error',

--- a/development_docs/architecture.md
+++ b/development_docs/architecture.md
@@ -397,14 +397,14 @@ saves and stops the session at the earlier deadline; Modal is only the fallback.
 
 ### Authentication — `MARIMOHUB_AUTH_*`
 
-| Variable                                | Purpose                                          |
-| --------------------------------------- | ------------------------------------------------ |
-| `MARIMOHUB_AUTH_BACKEND`                | `oidc` \| `cloudflare-access` \| `dev`           |
-| `MARIMOHUB_AUTH_OIDC_ISSUER`            | OIDC issuer URL                                  |
-| `MARIMOHUB_AUTH_OIDC_CLIENT_ID`         | OAuth client ID                                  |
-| `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET`     | OAuth client secret (secret)                     |
-| `MARIMOHUB_AUTH_OIDC_AUDIENCE`          | Expected token audience                          |
-| `MARIMOHUB_AUTH_DEV_USER_ID` / `_EMAIL` | Fixed identity for the `dev` bypass (local only) |
+| Variable                                | Purpose                                              |
+| --------------------------------------- | ---------------------------------------------------- |
+| `MARIMOHUB_AUTH_BACKEND`                | `oidc` \| `cloudflare-access` \| `dev`               |
+| `MARIMOHUB_AUTH_OIDC_ISSUER`            | OIDC issuer URL                                      |
+| `MARIMOHUB_AUTH_OIDC_CLIENT_ID`         | OAuth client ID                                      |
+| `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET`     | OAuth client secret (secret)                         |
+| `MARIMOHUB_AUTH_OIDC_AUDIENCE`          | Deprecated and ignored; `aud` must contain client ID |
+| `MARIMOHUB_AUTH_DEV_USER_ID` / `_EMAIL` | Fixed identity for the `dev` bypass (local only)     |
 
 > Authorization needs no env vars: roles are data in the notebook storage
 > ([§3.4](#34-authorization-authz)).

--- a/development_docs/auth.md
+++ b/development_docs/auth.md
@@ -34,33 +34,54 @@ property.
 
 ## OIDC (`MARIMOHUB_AUTH_BACKEND=oidc`)
 
-The adapter discovers the provider at `<issuer>/.well-known/openid-configuration`,
-runs Authorization Code + PKCE, verifies the ID token (JWKS signature + `iss` /
-`aud` / `nonce` / expiry), and mints the `mh_session` cookie. Protocol mechanics
-use [`oauth4webapi`](https://github.com/panva/oauth4webapi); cookie signing uses
+The adapter discovers the provider at `<issuer>/.well-known/openid-configuration`.
+It runs Authorization Code + PKCE and verifies the ID token signature, `iss`,
+`aud`, `nonce`, and expiry. UserInfo must have the same `sub` as the ID token.
+The adapter then mints the `mh_session` cookie. Protocol code uses
+[`oauth4webapi`](https://github.com/panva/oauth4webapi). Cookie signing uses
 [`jose`](https://github.com/panva/jose).
 
-| Variable                            | Req | Description                                                  |
-| ----------------------------------- | --- | ------------------------------------------------------------ |
-| `MARIMOHUB_AUTH_OIDC_ISSUER`        | ✓   | e.g. `https://accounts.google.com`.                          |
-| `MARIMOHUB_AUTH_OIDC_CLIENT_ID`     | ✓   | OAuth client ID.                                             |
-| `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET` | ✓   | OAuth client secret (sent via `client_secret_post`).         |
-| `MARIMOHUB_AUTH_OIDC_REDIRECT_URI`  | ✓   | **Must be** `<your-origin>/api/auth/callback`.               |
-| `MARIMOHUB_AUTH_SESSION_SECRET`     | ✓   | HS256 cookie-signing key; use ≥32 random bytes.              |
-| `MARIMOHUB_AUTH_OIDC_AUDIENCE`      |     | Unused — `aud` must contain the client ID (enforced anyway). |
+| Variable                                 | Req | Description                                                    |
+| ---------------------------------------- | --- | -------------------------------------------------------------- |
+| `MARIMOHUB_AUTH_OIDC_ISSUER`             | ✓   | For example, `https://accounts.google.com`.                    |
+| `MARIMOHUB_AUTH_OIDC_CLIENT_ID`          | ✓   | OAuth client ID.                                               |
+| `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET`      | ✓   | OAuth client secret (sent via `client_secret_post`).           |
+| `MARIMOHUB_AUTH_OIDC_REDIRECT_URI`       | ✓   | **Must be** `<your-origin>/api/auth/callback`.                 |
+| `MARIMOHUB_AUTH_SESSION_SECRET`          | ✓   | HS256 cookie-signing key with ≥32 random bytes.                |
+| `MARIMOHUB_AUTH_OIDC_AUDIENCE`           |     | Unused — `aud` must contain the client ID (enforced anyway).   |
+| `MARIMOHUB_AUTH_OIDC_SCOPES`             |     | Defaults to `openid email profile`. Keep `openid` and `email`. |
+| `MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION` |     | `required` (default) or explicit `trusted-issuer`.             |
+| `MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM`       |     | JSON Pointer for opt-in group policy and entitlement mapping.  |
 
-**Routes** (public, mounted before the authN guard): `GET /api/auth/login`
-starts the flow; `/api/auth/callback` exchanges the code and sets `mh_session`;
-`/api/auth/logout` clears it and redirects to the provider end-session endpoint.
+**Routes** are public and mount before the authentication guard.
+`GET /api/auth/login` starts the flow. `/api/auth/callback` exchanges the code
+and sets `mh_session`. `/api/auth/logout` clears the cookie and redirects to the
+provider logout endpoint.
 
 **Redirect URI** is always `<origin>/api/auth/callback` and must match what you
-register byte-for-byte. Providers require HTTPS (except `localhost`), as does
-`oauth4webapi`.
+register byte-for-byte. The issuer, redirect URI, and discovered authorization
+and logout endpoints must use HTTPS and cannot contain credentials.
 
-**Cookies**: `mh_session` (HS256 JWT — `sub`=id, `email` claim; httpOnly,
-Secure, SameSite=Lax; 8h default) and the short-lived `mh_oidc_txn` (PKCE
-verifier + state + nonce during the round-trip). Rotating
-`MARIMOHUB_AUTH_SESSION_SECRET` invalidates all sessions.
+**Cookies**: `mh_session` is an issuer-, audience-, and type-bound HS256 JWT.
+It is HttpOnly, Secure, and SameSite=Lax. Its default lifetime is 8 hours, or
+at most 1 hour with group policy. The short-lived `mh_oidc_txn` stores the PKCE
+verifier, state, and nonce. Rotating `MARIMOHUB_AUTH_SESSION_SECRET` invalidates
+all sessions.
+
+The session JWT cannot exceed 3,800 bytes. If necessary, the signer omits
+`picture_url` first and `name` second. It never omits required identity or
+authorization claims. Login fails if those claims exceed the limit.
+
+Each deployment supports one issuer. Stored user IDs use that issuer's `sub`.
+An issuer change is an identity migration. Reconcile stored owners and members
+before the change.
+
+The session stores mapped entitlements, not raw groups. Group-derived roles do
+not transfer to personal access tokens. Group-authorized kernels use the session
+JWT expiry as a fixed authorization deadline. Active editors cannot extend it.
+At expiry, the lifecycle destroys the kernel and the proxy closes WebSockets.
+This teardown skips the final capture so that the kernel stops promptly.
+Periodic snapshots limit potential data loss.
 
 > The session cookie is `Secure` (HTTPS only). For local `http://localhost`
 > work, use the [`dev`](#dev-marimohub_auth_backenddev) backend, not `oidc`.

--- a/development_docs/auth.md
+++ b/development_docs/auth.md
@@ -48,7 +48,7 @@ The adapter then mints the `mh_session` cookie. Protocol code uses
 | `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET`      | ✓   | OAuth client secret (sent via `client_secret_post`).           |
 | `MARIMOHUB_AUTH_OIDC_REDIRECT_URI`       | ✓   | **Must be** `<your-origin>/api/auth/callback`.                 |
 | `MARIMOHUB_AUTH_SESSION_SECRET`          | ✓   | HS256 cookie-signing key with ≥32 random bytes.                |
-| `MARIMOHUB_AUTH_OIDC_AUDIENCE`           |     | Unused — `aud` must contain the client ID (enforced anyway).   |
+| `MARIMOHUB_AUTH_OIDC_AUDIENCE`           |     | Deprecated and ignored; `aud` must contain the client ID.      |
 | `MARIMOHUB_AUTH_OIDC_SCOPES`             |     | Defaults to `openid email profile`. Keep `openid` and `email`. |
 | `MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION` |     | `required` (default) or explicit `trusted-issuer`.             |
 | `MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM`       |     | JSON Pointer for opt-in group policy and entitlement mapping.  |
@@ -61,6 +61,9 @@ provider logout endpoint.
 **Redirect URI** is always `<origin>/api/auth/callback` and must match what you
 register byte-for-byte. The issuer, redirect URI, and discovered authorization
 and logout endpoints must use HTTPS and cannot contain credentials.
+
+`trusted-issuer` applies only when all email domains are allowed. A domain
+allowlist always requires `email_verified: true`.
 
 **Cookies**: `mh_session` is an issuer-, audience-, and type-bound HS256 JWT.
 It is HttpOnly, Secure, and SameSite=Lax. Its default lifetime is 8 hours, or
@@ -79,6 +82,7 @@ before the change.
 The session stores mapped entitlements, not raw groups. Group-derived roles do
 not transfer to personal access tokens. Group-authorized kernels use the session
 JWT expiry as a fixed authorization deadline. Active editors cannot extend it.
+Session reuse keeps the earliest credential deadline presented by any caller.
 At expiry, the lifecycle destroys the kernel and the proxy closes WebSockets.
 This teardown skips the final capture so that the kernel stops promptly.
 Periodic snapshots limit potential data loss.

--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -165,7 +165,7 @@ selected version and cannot write changes back.
 | `_system/sessions/{pid}/{sid}.json`                            | JSON     | Live session record, partitioned by project so a project-scoped read lists only `_system/sessions/{pid}/`. Created on notebook open, updated by heartbeat, and retired by an explicit stop or lifecycle deadline. Closing a browser tab does not immediately delete it.                                                                                                                                                                                                                                |
 | `_system/apps/{pid}/{nid}.json`                                | JSON     | Per-notebook app-singleton claim: names the app session that owns the notebook's shared app sandbox. Written create-if-absent by the create saga, replaced via ETag CAS when stale, CAS'd to a free marker (`session_id: null`) on teardown. All writes go through `SessionService.claimApp`/`releaseApp`. See §4.8.1.                                                                                                                                                                                 |
 | `_system/editors/{pid}/{nid}.json`                             | JSON     | Per-notebook persistent-editor claim. Records the shared/exclusive mode, names the only session allowed to save, and records idempotent takeover phases. All writes go through `SessionService`. See §4.8.2.                                                                                                                                                                                                                                                                                           |
-| `_system/identities/{user-id}.json`                            | JSON     | User display identity (`{ id, email, name }`). Upserted on each authenticated request; mutable, last-writer-wins. Resolves opaque `author`/`user_id` ids to a person.                                                                                                                                                                                                                                                                                                                                  |
+| `_system/identities/{user-id}.json`                            | JSON     | User display identity (`{ id, email, name, picture_url? }`). Updated on each authenticated request with last-writer-wins. Resolves opaque `author`/`user_id` IDs to a person.                                                                                                                                                                                                                                                                                                                          |
 | `_system/tokens/{token-id}.json`                               | JSON     | Personal access token record (`{ id, user_id, name, hash, … }`) keyed by the ULID embedded in the presented `mhub_pat_` bearer, so verification is a single GET. Stores only the SHA-256 of the secret. Mutable, last-writer-wins (coarse `last_used_at` refresh); revocation deletes the object. See §4.11.                                                                                                                                                                                           |
 | `_system/events/{YYYY-MM-DD}/{event-id}.json`                  | JSON     | Structured event log. One immutable object per event, keyed by a monotonic ULID under a per-day prefix. Primary audit trail.                                                                                                                                                                                                                                                                                                                                                                           |
 | `_system/idempotency/{digest}.json`                            | JSON     | Recorded `POST`-create response for an `Idempotency-Key`, keyed by `sha256(user:route\nkey)`. Replayed on retry; pruned after 24h. See [`idempotency.md`](./idempotency.md).                                                                                                                                                                                                                                                                                                                           |
@@ -367,6 +367,7 @@ Records are partitioned by project (`_system/sessions/{pid}/{sid}.json`) so the 
 	"status": "running",
 	"started_at": "2025-03-05T14:30:00Z",
 	"last_heartbeat": "2025-03-05T14:35:00Z",
+	"authorization_expires_at": "2025-03-05T15:30:00Z",
 	"runtime": {
 		"python_version": "3.11",
 		"marimo_version": "0.9.0"
@@ -387,6 +388,8 @@ When a session goes `failed`, `markFailed` may persist an optional sanitized `er
 **Valid `status` values:** `starting` · `running` · `terminating` · `terminated` · `failed` · `expired`
 
 `sandbox_id` / `sandbox_url` link the record to the live kernel runtime (a separate container/compute service); `compute_profile` records the configured profile name used at launch and is absent when profiles are unset; `used_fallback` records whether a fallback runtime was used. The optional field is forward-compatible with existing records and requires no migration.
+
+`authorization_expires_at` exists only for sessions authorized by an OIDC group policy. It copies the signed browser session's JWT `exp` value. The lifecycle never extends this deadline. At expiry, it destroys direct subdomain kernels. HTTP proxy requests fail closed, and the Node proxy closes established WebSockets. This teardown skips the final capture so that the kernel stops promptly. Periodic snapshots limit potential data loss. The session API does not return this internal field.
 
 **Session lifecycle:**
 
@@ -498,11 +501,12 @@ The identity directory maps a stable user id — the auth `sub`, which is what e
 	"id": "user_abc123",
 	"email": "ada@example.com",
 	"name": "Ada Lovelace",
+	"picture_url": "https://idp.example.com/avatar/ada",
 	"updated_at": "2025-03-05T14:30:00Z"
 }
 ```
 
-`name` falls back to the email local-part when the identity provider supplies no display name (`AuthUser.name` is optional — the OIDC `name` claim from the `profile` scope, or the Access `name` claim, when present).
+If the identity provider supplies no display name, `name` uses the email local-part. `AuthUser.name` is optional. OIDC reads the `name` claim from the `profile` scope. Access reads its `name` claim. The optional `picture_url` must be an HTTPS URL from the identity provider.
 
 **Why this shape — store the id, refresh the directory.** The foreign keys throughout the store (`author`, `session.user_id`, `snapshot.actor`, `project.owner`/`members`) keep storing the **stable id only**, never a name/email copy. A copy denormalized at write time would go stale when a user later changes their display name or email; instead the directory is **refreshed on every authenticated request**, so resolution always reflects the latest known identity. Reads resolve ids → identities in one batch lookup (`GET /api/v1/users?ids=…`, §13) rather than touching the snapshot.
 
@@ -974,7 +978,11 @@ A request that fails authentication receives `401 UNAUTHORIZED`. The verified us
 `project.json`, resolves the caller's effective role, and rejects an
 insufficient role with `403 FORBIDDEN`.
 
-**Super admins.** `MARIMOHUB_SUPER_ADMINS` lists operators who resolve to `admin` on **every** project, overriding both membership and `MARIMOHUB_DEFAULT_ROLE`. It is the single deployment-wide exception to the per-project model: a super admin sees and lists all projects (even under `none`), reads/writes every notebook and secret, controls any session, and reads the audit trail. An entry containing `@` matches the login email (case-insensitive); any other entry matches the user id (`sub`) exactly — the id and email namespaces do not overlap (`isSuperAdmin`, `packages/core/src/authz.ts`). The elevation flows through the same `effectiveRole` the role matrix uses, so no enforcement path is special-cased; the two invariants that still bind everyone hold for super admins too — a project `owner` cannot be demoted/removed, and a soft-deleted project stays `404`. A PAT minted by a super admin inherits the power.
+**Super admins.** `MARIMOHUB_SUPER_ADMINS` grants `admin` on every project. This status overrides membership and `MARIMOHUB_DEFAULT_ROLE`. A super admin can list all projects, including deployments configured with `none`. The operator can also manage notebooks, secrets, sessions, and the audit trail.
+
+An entry that contains `@` matches the login email without case sensitivity. Other entries match the user ID (`sub`) exactly. The ID and email namespaces do not overlap. See `isSuperAdmin` in `packages/core/src/authz.ts`.
+
+All routes use the same `effectiveRole` calculation. Project owners still cannot be demoted or removed. Soft-deleted projects still return `404`. Static super-admin status applies to PATs. OIDC group-derived status applies only to the browser session and does not transfer to PATs.
 
 Read-side isolation under `none` keeps the read model intact (§7.1). Filtering `GET /projects` would otherwise cost a membership check per project, so each catalog snapshot project entry carries a denormalized **`member_ids`** array (owner + members), refreshed in the same CAS as every membership edit. The list filters in-memory over data already fetched — still 2 GETs. Single-project reads (`GET /projects/{id}`, notebook & session reads) load `project.json` and check `viewer` only when `defaultRole` is `none`; with a default role set they short-circuit with no extra load.
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -103,10 +103,9 @@ an invite row and an id row — adding a member is rejected (409) when any of
 their known identifiers is already on the roster, so removing a member always
 revokes their access.
 
-Because the login email is an authorization credential here, the OIDC adapter
-refuses to mint a session when the provider declares the email unverified
-(`email_verified: false`) — otherwise an attacker self-registering the
-invitee's address at a lax IdP could inherit the invite.
+The login email grants access, so OIDC requires `email_verified: true` by
+default. `trusted-issuer` permits an enterprise issuer to omit the claim. Any
+present value other than boolean `true` is rejected.
 
 Invite emails are PII of people who never signed in: the members list and
 project detail show them only to project admins (and to the invitee themself).

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -105,7 +105,8 @@ revokes their access.
 
 The login email grants access, so OIDC requires `email_verified: true` by
 default. `trusted-issuer` permits an enterprise issuer to omit the claim. Any
-present value other than boolean `true` is rejected.
+present value other than boolean `true` is rejected. A domain allowlist always
+requires boolean `true`, even under `trusted-issuer`.
 
 Invite emails are PII of people who never signed in: the members list and
 project detail show them only to project admins (and to the invitee themself).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,7 +277,7 @@ App-native OpenID Connect (the production backend).
 | `MARIMOHUB_AUTH_OIDC_CLIENT_ID` | OAuth2 client id. | Yes | — | — |
 | `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET` 🔒 | OAuth2 client secret. | Yes | — | — |
 | `MARIMOHUB_AUTH_OIDC_REDIRECT_URI` | Absolute callback URL. | Yes | — | `https://hub.example.com/api/auth/callback` |
-| `MARIMOHUB_AUTH_OIDC_AUDIENCE` | Optional ID-token audience. oauth4webapi always enforces the client ID. | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_AUDIENCE` | Deprecated and ignored. The ID-token `aud` claim must contain the configured client ID. | — | — | — |
 | `MARIMOHUB_AUTH_OIDC_PROMPT` | OAuth `prompt` value. `select_account` displays the account chooser. Use `consent` to display consent again. Space-separated combinations are valid. | — | `select_account` | `consent` |
 | `MARIMOHUB_AUTH_OIDC_SCOPES` | Space-separated scopes. Must include `openid` and `email`. Add only scopes that the provider requires for group claims. `offline_access` is invalid because marimohub stores no refresh tokens. | — | `openid email profile` | — |
 | `MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION` | Requires boolean `email_verified=true` by default. If a trusted issuer omits the claim, use `trusted-issuer`. Other present values are invalid. | — | `required` | `trusted-issuer` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -277,10 +277,20 @@ App-native OpenID Connect (the production backend).
 | `MARIMOHUB_AUTH_OIDC_CLIENT_ID` | OAuth2 client id. | Yes | — | — |
 | `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET` 🔒 | OAuth2 client secret. | Yes | — | — |
 | `MARIMOHUB_AUTH_OIDC_REDIRECT_URI` | Absolute callback URL. | Yes | — | `https://hub.example.com/api/auth/callback` |
-| `MARIMOHUB_AUTH_OIDC_AUDIENCE` | Expected ID-token audience (optional; oauth4webapi enforces the client id automatically). | — | — | — |
-| `MARIMOHUB_AUTH_OIDC_PROMPT` | OAuth `prompt` parameter. Defaults to `select_account`, so a returning user always gets the account chooser instead of being silently logged in with their last account. Override with `consent` to re-show the consent screen, or space-separated combinations. | — | `select_account` | `consent` |
+| `MARIMOHUB_AUTH_OIDC_AUDIENCE` | Optional ID-token audience. oauth4webapi always enforces the client ID. | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_PROMPT` | OAuth `prompt` value. `select_account` displays the account chooser. Use `consent` to display consent again. Space-separated combinations are valid. | — | `select_account` | `consent` |
+| `MARIMOHUB_AUTH_OIDC_SCOPES` | Space-separated scopes. Must include `openid` and `email`. Add only scopes that the provider requires for group claims. `offline_access` is invalid because marimohub stores no refresh tokens. | — | `openid email profile` | — |
+| `MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION` | Requires boolean `email_verified=true` by default. If a trusted issuer omits the claim, use `trusted-issuer`. Other present values are invalid. | — | `required` | `trusted-issuer` |
 | `MARIMOHUB_AUTH_SESSION_SECRET` 🔒 | Secret that signs the session cookie (HS256; ≥32 bytes). | Yes | — | — |
-| `MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS` | Comma-separated email-domain allowlist (requires a verified email). Required so a deployment cannot silently admit every account the IdP authenticates; set `*` to explicitly allow all domains. A single domain is also sent to Google as the `hd` hint. | Yes | — | `example.com,example.org` |
+| `MARIMOHUB_AUTH_SESSION_TTL_SECONDS` | Signed browser-session lifetime, from 300 to 86400 seconds. | — | `28800` | — |
+| `MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS` | Comma-separated email-domain allowlist. Set `*` to allow all domains. A single domain is also the Google `hd` hint. | Yes | — | `example.com,example.org` |
+| `MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM` | RFC 6901 JSON Pointer to an array of exact provider group IDs. Required for group policy. | — | — | `/groups` |
+| `MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS` | Exact comma-separated group IDs. A user must belong to at least one. Missing or malformed group data fails closed. | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS` | Exact comma-separated group IDs mapped to marimohub super-admin. | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS` | Groups granted a deployment-wide default viewer role. | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS` | Groups granted a deployment-wide default editor role. | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_DEFAULT_ADMIN_GROUPS` | Groups granted a deployment-wide default project-admin role. | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_GROUP_SESSION_TTL_SECONDS` | Maximum group-session age, from 300 to 3600 seconds. This value limits the deprovisioning delay. | — | `3600` | — |
 
 ### Dev bypass (local only)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -84,9 +84,17 @@ the `kubernetes`/`coreweave` backends) in front.
 
 - `MARIMOHUB_AUTH_BACKEND` has **no default** — an unset backend refuses to
   start rather than silently falling back to the `dev` bypass.
-- OIDC requires `MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS` (verified email):
-  marimohub will not silently admit every account the IdP can authenticate;
-  set explicit domains, or `*` to consciously allow all.
+- OIDC requires `MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS`. Set explicit domains or
+  `*` to allow all. This prevents accidental access for every IdP account.
+- OIDC requires boolean `email_verified=true` by default. `trusted-issuer`
+  permits omission only. Other present values are invalid. UserInfo must have
+  the same `sub` as the ID token.
+- Group policy accepts at most 200 group IDs and stores only mapped entitlements.
+  Group sessions and kernels expire with the entitlement credential. Active
+  connections cannot extend this deadline.
+- The OIDC issuer, callback, authorization endpoint, and logout endpoint must
+  use HTTPS and cannot contain credentials. Stored user IDs are issuer-local
+  `sub` values, so an issuer change requires an identity migration.
 - The session cookie is signed with `MARIMOHUB_AUTH_SESSION_SECRET` (HS256, ≥32
   bytes). Generate it with `openssl rand -base64 32` and treat it as a secret.
 

--- a/docs/setup/auth/oidc.md
+++ b/docs/setup/auth/oidc.md
@@ -12,7 +12,7 @@ MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=…
 MARIMOHUB_AUTH_OIDC_REDIRECT_URI=https://hub.example.com/api/auth/callback
 MARIMOHUB_AUTH_SESSION_SECRET=…            # signs the session cookie (HS256, ≥32 bytes)
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com  # REQUIRED allowlist (verified email); `*` allows all
-# MARIMOHUB_AUTH_OIDC_AUDIENCE=…           # optional: expected ID-token audience (the client id is enforced anyway)
+# MARIMOHUB_AUTH_OIDC_AUDIENCE=…           # deprecated and ignored; aud must contain the client ID
 # MARIMOHUB_AUTH_OIDC_PROMPT=consent       # optional: override the default (select_account) OAuth prompt
 # MARIMOHUB_AUTH_OIDC_SCOPES="openid email profile groups" # add only provider-required scopes
 ```
@@ -26,7 +26,8 @@ If the provider publishes UserInfo, marimohub uses it for profile claims.
 UserInfo must have the same `sub` as the validated ID token. Email verification
 is required by default. If a trusted issuer omits `email_verified`, use
 `MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION=trusted-issuer`. Any present value other
-than boolean `true` is invalid.
+than boolean `true` is invalid. A domain allowlist always requires boolean
+`true`, even under `trusted-issuer`.
 
 The signed session JWT has a 3,800-byte limit. If necessary, marimohub omits the
 profile picture first and the display name second. Required identity and
@@ -55,10 +56,11 @@ entitlements. The session cookie stores mapped entitlements, not raw groups.
 
 Group sessions last at most one hour by default. This limit bounds the delay
 after an IdP removes a user from a group. Kernels inherit the session JWT expiry
-as a fixed authorization deadline. Active editors cannot extend it. At expiry,
-the lifecycle destroys the kernel and the proxy closes WebSockets. This teardown
-skips the final capture so that the kernel stops promptly. Periodic snapshots
-limit potential data loss.
+as a fixed authorization deadline. Active editors cannot extend it. Session
+reuse keeps the earliest caller credential deadline. At expiry, the lifecycle
+destroys the kernel and the proxy closes WebSockets. This teardown skips the
+final capture so that the kernel stops promptly. Periodic snapshots limit
+potential data loss.
 
 Missing, malformed, or oversized group data cannot satisfy the login policy.
 marimohub accepts at most 200 group IDs. It does not resolve group-overage

--- a/docs/setup/auth/oidc.md
+++ b/docs/setup/auth/oidc.md
@@ -1,9 +1,8 @@
 <!-- Setup snippet — included by docs/auth.md and rendered in the deployment wizard. -->
 
-App-native OpenID Connect — the production backend. marimohub discovers the
-provider's endpoints automatically from the issuer's
-`/.well-known/openid-configuration`, so you only supply an issuer, client
-credentials, and a redirect URI.
+App-native OpenID Connect is the production backend. marimohub discovers the
+provider endpoints from `/.well-known/openid-configuration`. You supply the
+issuer, client credentials, and redirect URI.
 
 ```bash
 MARIMOHUB_AUTH_BACKEND=oidc
@@ -15,13 +14,62 @@ MARIMOHUB_AUTH_SESSION_SECRET=…            # signs the session cookie (HS256, 
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com  # REQUIRED allowlist (verified email); `*` allows all
 # MARIMOHUB_AUTH_OIDC_AUDIENCE=…           # optional: expected ID-token audience (the client id is enforced anyway)
 # MARIMOHUB_AUTH_OIDC_PROMPT=consent       # optional: override the default (select_account) OAuth prompt
+# MARIMOHUB_AUTH_OIDC_SCOPES="openid email profile groups" # add only provider-required scopes
 ```
 
 The **redirect URI** is always `https://<your-host>/api/auth/callback`. Register
-it with your provider exactly as you set it here, or login fails with a
-`redirect_uri_mismatch` error. `ALLOWED_EMAIL_DOMAINS` is **required** —
-marimohub fails closed rather than admitting every account the IdP
-authenticates; list your domains or set `*` to allow all.
+this exact value with your provider. A different value causes a
+`redirect_uri_mismatch` error. `ALLOWED_EMAIL_DOMAINS` is **required**. Set one
+or more domains, or set `*` to allow all.
+
+If the provider publishes UserInfo, marimohub uses it for profile claims.
+UserInfo must have the same `sub` as the validated ID token. Email verification
+is required by default. If a trusted issuer omits `email_verified`, use
+`MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION=trusted-issuer`. Any present value other
+than boolean `true` is invalid.
+
+The signed session JWT has a 3,800-byte limit. If necessary, marimohub omits the
+profile picture first and the display name second. Required identity and
+authorization claims are never omitted. Login fails if they exceed the limit.
+
+The issuer, callback, discovered authorization, and discovered logout endpoints
+must use HTTPS and cannot contain embedded credentials.
+
+### Groups and roles
+
+Group authorization is optional and uses exact provider group IDs. Set a JSON
+Pointer to the provider array. Then set at least one group policy:
+
+```bash
+MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM=/groups
+MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS=hub-users
+MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS=hub-platform-admins
+MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS=hub-viewers
+MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS=hub-editors
+MARIMOHUB_AUTH_OIDC_DEFAULT_ADMIN_GROUPS=hub-project-admins
+```
+
+Nested claims use JSON Pointer syntax, such as `/realm_access/roles`.
+`ALLOWED_GROUPS` controls login. The other lists map groups to internal
+entitlements. The session cookie stores mapped entitlements, not raw groups.
+
+Group sessions last at most one hour by default. This limit bounds the delay
+after an IdP removes a user from a group. Kernels inherit the session JWT expiry
+as a fixed authorization deadline. Active editors cannot extend it. At expiry,
+the lifecycle destroys the kernel and the proxy closes WebSockets. This teardown
+skips the final capture so that the kernel stops promptly. Periodic snapshots
+limit potential data loss.
+
+Missing, malformed, or oversized group data cannot satisfy the login policy.
+marimohub accepts at most 200 group IDs. It does not resolve group-overage
+references from the provider. Configure the IdP to emit only the groups that
+marimohub needs.
+Group-derived roles apply only to the browser session. They do not transfer to
+personal access tokens.
+
+The user ID is the OIDC `sub` within the configured issuer. The same `sub` from
+another issuer can identify a different person. Therefore, an issuer URL change
+is an identity migration. Reconcile stored owners and members before the change.
 
 Generate a session secret with `openssl rand -base64 32`.
 
@@ -30,8 +78,7 @@ Generate a session secret with `openssl rand -base64 32`.
 1. In the [Google Cloud Console](https://console.cloud.google.com/apis/credentials),
    open **APIs & Services → Credentials**.
 2. **Create Credentials → OAuth client ID**, application type **Web application**.
-3. Under **Authorized redirect URIs**, add `https://hub.example.com/api/auth/callback`
-   (and `http://localhost:3000/api/auth/callback` for local testing).
+3. Under **Authorized redirect URIs**, add `https://hub.example.com/api/auth/callback`.
 4. Copy the **Client ID** and **Client secret**.
 
 ```bash
@@ -41,10 +88,9 @@ MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=…
 MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com   # a single domain is also sent to Google as the `hd` hint
 ```
 
-marimohub defaults the OAuth `prompt` to `select_account`, so a returning user
-always gets the Google account chooser instead of being silently logged in with
-their last account. Override it via `MARIMOHUB_AUTH_OIDC_PROMPT` (e.g. `consent`
-to also re-show the consent screen).
+The default OAuth `prompt` is `select_account`, which displays the Google
+account chooser. Set `MARIMOHUB_AUTH_OIDC_PROMPT=consent` to display the consent
+screen again.
 
 See [Google's OpenID Connect docs](https://developers.google.com/identity/openid-connect/openid-connect).
 

--- a/internal/schemas/bucket.yml
+++ b/internal/schemas/bucket.yml
@@ -1321,6 +1321,10 @@ components:
           type: string
           format: date-time
           pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
+        authorization_expires_at:
+          type: string
+          format: date-time
+          pattern: ^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$
         last_snapshot_at:
           type: string
           format: date-time
@@ -1524,6 +1528,9 @@ components:
           type: string
         name:
           type: string
+        picture_url:
+          type: string
+          format: uri
         updated_at:
           type: string
           format: date-time

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -47,6 +47,15 @@ components:
           type: string
         email:
           type: string
+        name:
+          type:
+            - string
+            - 'null'
+        picture_url:
+          type:
+            - string
+            - 'null'
+          format: uri
         logout_url:
           type:
             - string
@@ -1423,6 +1432,11 @@ components:
           type: string
         name:
           type: string
+        picture_url:
+          type:
+            - string
+            - 'null'
+          format: uri
       required:
         - id
         - email
@@ -6022,8 +6036,8 @@ paths:
         - Users
       summary: Resolve user ids to display identities
       description: Batch-resolve opaque user ids (the auth `sub` stored as a notebook
-        `author` or session `user_id`) into `{ id, email, name }`. Ids with no
-        recorded identity are omitted from the result map.
+        `author` or session `user_id`) into `{ id, email, name, picture_url }`.
+        Ids with no recorded identity are omitted from the result map.
       parameters:
         - schema:
             type: string

--- a/packages/api/src/capabilities.test.ts
+++ b/packages/api/src/capabilities.test.ts
@@ -69,6 +69,21 @@ describe('GET /api/v1/capabilities', () => {
 		});
 	});
 
+	it('reports the role derived from the current OIDC session', async () => {
+		const authenticator: Authenticator = {
+			authenticate: async () => ({
+				id: uid('group-user'),
+				email: 'group-user@example.com',
+				entitlements: ['default-role:editor'],
+			}),
+		};
+		const deps = makeTestDeps(new MemoryBucket(), { authenticator });
+
+		expect(await expectOk(await createApi(deps).request('/api/v1/capabilities'))).toMatchObject({
+			default_role: 'editor',
+		});
+	});
+
 	it('reports the editor sandbox sharing, defaulting to shared', async () => {
 		const defaulted = makeTestDeps(new MemoryBucket(), { authenticator: authed });
 		expect(

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -208,8 +208,8 @@ export interface PolicyConfig {
 	 * implicit `admin` on every project and visibility of all projects. An
 	 * entry containing `@` matches only the login email (case-insensitive);
 	 * any other entry matches only the user id (exact) — see
-	 * `isSuperAdmin` in core. A PAT minted by a super admin carries the same
-	 * power. Unset = no super admins.
+	 * `isSuperAdmin` in core. Static super-admin status also applies to PATs;
+	 * session-only OIDC group entitlements do not. Unset = no super admins.
 	 */
 	superAdmins?: string[];
 }

--- a/packages/api/src/me.test.ts
+++ b/packages/api/src/me.test.ts
@@ -10,8 +10,28 @@ describe('GET /api/v1/me', () => {
 		expect(await expectOk(res)).toEqual({
 			id: ACTOR,
 			email: `${ACTOR}@example.com`,
+			name: null,
+			picture_url: null,
 			logout_url: null,
 			is_super_admin: false,
+		});
+	});
+
+	it('returns optional profile fields and group-derived super-admin status', async () => {
+		const authenticator: Authenticator = {
+			authenticate: async () => ({
+				id: ACTOR,
+				email: `${ACTOR}@example.com`,
+				name: 'Ada',
+				pictureUrl: 'https://images.example.com/ada.png',
+				entitlements: ['super-admin'],
+			}),
+		};
+		const { request } = createTestApi({ deps: { authenticator } });
+		expect(await expectOk(await request('GET', '/me'))).toMatchObject({
+			name: 'Ada',
+			picture_url: 'https://images.example.com/ada.png',
+			is_super_admin: true,
 		});
 	});
 

--- a/packages/api/src/routes/events.test.ts
+++ b/packages/api/src/routes/events.test.ts
@@ -138,6 +138,43 @@ describe('Event routes', () => {
 		expect(page.items.some((event) => event.event === 'token.create')).toBe(true);
 	});
 
+	it('does not copy session-only group super-admin entitlement into a PAT', async () => {
+		const deps = makeTestDeps(bucket, {
+			authenticator: {
+				authenticate: async () => ({
+					id: ACTOR,
+					email: `${ACTOR}@example.com`,
+					entitlements: ['super-admin'],
+					entitlementsExpiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+				}),
+			},
+		});
+		const sessionApp = createApi(deps);
+		expect((await sessionApp.request('/api/v1/events')).status).toBe(200);
+		const { token } = await expectOk<{ token: string }>(
+			await sessionApp.request('/api/v1/me/tokens', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ name: 'must-not-escalate' }),
+			}),
+			201,
+		);
+		const patApp = createApi({
+			...deps,
+			authenticator: composeAuthenticators(deps.services.tokens, {
+				authenticate: async () => null,
+			}),
+		});
+
+		await expectError(
+			await patApp.request('/api/v1/events', {
+				headers: { authorization: `Bearer ${token}` },
+			}),
+			403,
+			'FORBIDDEN',
+		);
+	});
+
 	it('validates the global date range and cursor', async () => {
 		const { request: adminRequest } = superAdminApi();
 		await expectError(await adminRequest('GET', '/events?from=2026-01-01'), 422);

--- a/packages/api/src/routes/sessions.appMode.test.ts
+++ b/packages/api/src/routes/sessions.appMode.test.ts
@@ -99,6 +99,55 @@ describe('Session routes (app mode)', () => {
 		expect(attached.user_id).toBe(ACTOR);
 	});
 
+	it('shared app reuse is bounded by the earliest caller credential', async () => {
+		const starter = uid('user_group_starter');
+		const starterDeadline = new Date(Date.now() + 2 * 60 * 60_000).toISOString();
+		const starterApi = createTestApi({
+			bucket,
+			userId: starter,
+			compute: makeFakeCompute(),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: starter,
+						email: `${starter}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: starterDeadline,
+					}),
+				},
+			},
+		}).request;
+		const app = await expectOk<any>(await starterApi('POST', sessionsPath(), { mode: 'app' }));
+
+		const attachingDeadline = new Date(Date.now() + 15 * 60_000).toISOString();
+		const attachingApi = createTestApi({
+			bucket,
+			userId: OTHER_EDITOR,
+			compute: makeFakeCompute(),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: OTHER_EDITOR,
+						email: `${OTHER_EDITOR}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: attachingDeadline,
+					}),
+				},
+			},
+		}).request;
+
+		const attached = await expectOk<any>(
+			await attachingApi('POST', sessionsPath(), { mode: 'app' }),
+		);
+
+		expect(attached.session_id).toBe(app.session_id);
+		expect(attached.reused).toBe(true);
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, app.session_id))
+				.authorization_expires_at,
+		).toBe(attachingDeadline);
+	});
+
 	it('a create that loses the app claim attaches to the claim holder', async () => {
 		// The holder is live for claim purposes (running) but invisible to reuse
 		// (no sandbox_url) — the shape a true concurrent-start race produces.
@@ -123,6 +172,49 @@ describe('Session routes (app mode)', () => {
 		// The loser's own record was retired, and no second app is left active.
 		const services = createServices(bucket);
 		expect(await services.sessions.countActiveAppsForProject(pid)).toBe(1);
+	});
+
+	it('an app-claim race applies the attaching credential deadline to the winner', async () => {
+		const winner = makeSession({
+			project_id: pid,
+			notebook_id: nid,
+			user_id: ACTOR,
+			status: 'running',
+			mode: 'app',
+			sandbox_url: undefined,
+		});
+		await bucket.put(paths.session(pid, winner.session_id), JSON.stringify(winner));
+		await bucket.put(
+			paths.appClaim(pid, nid),
+			JSON.stringify({ session_id: winner.session_id, claimed_at: winner.started_at }),
+		);
+		const deadline = new Date(Date.now() + 15 * 60_000).toISOString();
+		const groupEditor = createTestApi({
+			bucket,
+			userId: OTHER_EDITOR,
+			compute: makeFakeCompute(),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: OTHER_EDITOR,
+						email: `${OTHER_EDITOR}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: deadline,
+					}),
+				},
+			},
+		}).request;
+
+		const attached = await expectOk<any>(
+			await groupEditor('POST', sessionsPath(), { mode: 'app' }),
+		);
+
+		expect(attached.session_id).toBe(winner.session_id);
+		expect(attached.reused).toBe(true);
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, winner.session_id))
+				.authorization_expires_at,
+		).toBe(deadline);
 	});
 
 	it('a claim stolen mid-provision destroys the loser sandbox and attaches to the thief', async () => {

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -934,6 +934,141 @@ describe('Session routes', () => {
 		expect(stored.expires_at).toBeUndefined();
 	});
 
+	it('persists the entitlement JWT expiry as a separate non-extendable authorization deadline', async () => {
+		const authorizationExpiresAt = new Date(Date.now() + Millis.minutes(30)).toISOString();
+		const groupEditor = createTestApi({
+			bucket,
+			userId: STRANGER,
+			compute: makeFakeCompute(),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: STRANGER,
+						email: `${STRANGER}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: authorizationExpiresAt,
+					}),
+				},
+				sandbox: sandboxConfig({
+					sessionLifetime: {
+						maxLifetimeMs: Millis.hours(4),
+						idleTimeoutMs: Millis.minutes(30),
+						snapshotIntervalMs: Millis.minutes(2),
+						extensionMs: Millis.minutes(30),
+						connectionAware: true,
+						sweepIntervalMs: Millis.seconds(60),
+					},
+				}),
+			},
+		}).request;
+
+		const data = await expectOk<ApiSession>(await groupEditor('POST', sessionsPath()));
+		const stored = await createServices(bucket).sessions.getSession(pid, data.session_id);
+
+		expect(stored.authorization_expires_at).toBe(authorizationExpiresAt);
+		expect(Date.parse(stored.expires_at!)).toBeGreaterThan(Date.parse(authorizationExpiresAt));
+	});
+
+	it('fails closed when an entitlement-bearing authenticator omits its credential expiry', async () => {
+		const groupEditor = createTestApi({
+			bucket,
+			userId: STRANGER,
+			compute: makeFakeCompute(),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: STRANGER,
+						email: `${STRANGER}@example.com`,
+						entitlements: ['default-role:editor'],
+					}),
+				},
+			},
+		}).request;
+
+		await expectError(await groupEditor('POST', sessionsPath()), 403, 'FORBIDDEN');
+		expect(
+			(await createServices(bucket).sessions.listSessions()).filter(
+				(session) => session.user_id === STRANGER,
+			),
+		).toHaveLength(0);
+	});
+
+	it.each([
+		['malformed', 'not-a-timestamp'],
+		['expired', new Date(Date.now() - Millis.minutes(1)).toISOString()],
+	])('fails closed when an entitlement credential expiry is %s', async (_label, expiry) => {
+		const groupEditor = createTestApi({
+			bucket,
+			userId: STRANGER,
+			compute: makeFakeCompute(),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: STRANGER,
+						email: `${STRANGER}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: expiry,
+					}),
+				},
+			},
+		}).request;
+
+		const error = await expectError(await groupEditor('POST', sessionsPath()), 403, 'FORBIDDEN');
+		expect(error.message).toBe('Group authorization has expired; sign in again');
+		expect(
+			(await createServices(bucket).sessions.listSessions()).filter(
+				(session) => session.user_id === STRANGER,
+			),
+		).toHaveLength(0);
+	});
+
+	it('destroys the sandbox when group authorization expires during provisioning', async () => {
+		const now = Date.parse('2026-08-04T12:00:00.000Z');
+		const deadline = now + Millis.minutes(1);
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+		const { instance, calls } = makeFakeSandbox();
+		const exposePort = instance.exposePort.bind(instance);
+		instance.exposePort = async (...args) => {
+			const exposed = await exposePort(...args);
+			nowSpy.mockReturnValue(deadline);
+			return exposed;
+		};
+		const groupEditor = createTestApi({
+			bucket,
+			userId: STRANGER,
+			compute: fakeComputeFrom(instance),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: STRANGER,
+						email: `${STRANGER}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: new Date(deadline).toISOString(),
+					}),
+				},
+			},
+		}).request;
+
+		try {
+			const error = await expectError(await groupEditor('POST', sessionsPath()), 403, 'FORBIDDEN');
+			expect(error.message).toBe('Group authorization expired while starting the session');
+			expect(calls.destroy).toBe(1);
+			const [failed] = (await createServices(bucket).sessions.listSessions()).filter(
+				(session) => session.user_id === STRANGER,
+			);
+			expect(failed).toMatchObject({
+				status: 'failed',
+				authorization_expires_at: new Date(deadline).toISOString(),
+				error: {
+					code: 'FORBIDDEN',
+					message: 'Group authorization expired while starting the session',
+				},
+			});
+		} finally {
+			nowSpy.mockRestore();
+		}
+	});
+
 	it('POST /sessions as a non-member returns 403', async () => {
 		await expectError(await stranger('POST', sessionsPath()), 403, 'FORBIDDEN');
 	});
@@ -1173,6 +1308,50 @@ describe('Session routes', () => {
 
 		const all = await createServices(bucket).sessions.listSessions(nid);
 		expect(all).toHaveLength(1);
+	});
+
+	it('replaces a reusable session whose earlier group authorization has expired', async () => {
+		const now = Date.now();
+		let credentialDeadline = now + Millis.minutes(1);
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+		const { instance, calls } = makeFakeSandbox();
+		const groupEditor = createTestApi({
+			bucket,
+			userId: STRANGER,
+			compute: fakeComputeFrom(instance),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: STRANGER,
+						email: `${STRANGER}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: new Date(credentialDeadline).toISOString(),
+					}),
+				},
+			},
+		}).request;
+
+		try {
+			const first = await expectOk<ApiSession>(await groupEditor('POST', sessionsPath()));
+			credentialDeadline = now + Millis.hours(2);
+			nowSpy.mockReturnValue(now + Millis.minutes(1));
+
+			const second = await expectOk<ApiSession>(await groupEditor('POST', sessionsPath()));
+
+			expect(second.reused).toBe(false);
+			expect(second.session_id).not.toBe(first.session_id);
+			expect(calls.destroy).toBe(1);
+			const sessions = await createServices(bucket).sessions.listSessions(nid);
+			expect(sessions.find((session) => session.session_id === first.session_id)?.status).toBe(
+				'terminated',
+			);
+			expect(
+				sessions.find((session) => session.session_id === second.session_id)
+					?.authorization_expires_at,
+			).toBe(new Date(credentialDeadline).toISOString());
+		} finally {
+			nowSpy.mockRestore();
+		}
 	});
 
 	it('POST /sessions hammered for one notebook reuses one record and never trips the cap', async () => {

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -5,6 +5,7 @@ import {
 	createProjectId,
 	createServices,
 	Millis,
+	paths,
 } from '@marimo-hub/core';
 import type { NotebookId, ProjectId, Session, SessionId } from '@marimo-hub/core';
 import {
@@ -12,6 +13,7 @@ import {
 	fakeComputeFrom,
 	makeFakeCompute,
 	makeFakeSandbox,
+	makeSession,
 	uid,
 } from '@marimo-hub/core/testing';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
@@ -1352,6 +1354,88 @@ describe('Session routes', () => {
 		} finally {
 			nowSpy.mockRestore();
 		}
+	});
+
+	it('reused sessions keep the earliest credential deadline', async () => {
+		let credentialDeadline = new Date(Date.now() + Millis.hours(2)).toISOString();
+		const groupEditor = createTestApi({
+			bucket,
+			userId: STRANGER,
+			compute: makeFakeCompute(),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: STRANGER,
+						email: `${STRANGER}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: credentialDeadline,
+					}),
+				},
+			},
+		}).request;
+
+		const first = await expectOk<ApiSession>(await groupEditor('POST', sessionsPath()));
+		const shorter = new Date(Date.now() + Millis.minutes(30)).toISOString();
+		credentialDeadline = shorter;
+		const second = await expectOk<ApiSession>(await groupEditor('POST', sessionsPath()));
+
+		expect(second.session_id).toBe(first.session_id);
+		expect(second.reused).toBe(true);
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, first.session_id))
+				.authorization_expires_at,
+		).toBe(shorter);
+
+		credentialDeadline = new Date(Date.now() + Millis.hours(3)).toISOString();
+		await expectOk<ApiSession>(await groupEditor('POST', sessionsPath()));
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, first.session_id))
+				.authorization_expires_at,
+		).toBe(shorter);
+	});
+
+	it('an editor-claim race applies the attaching credential deadline to the winner', async () => {
+		const winner = makeSession({
+			project_id: pid,
+			notebook_id: nid,
+			user_id: ACTOR,
+			status: 'running',
+			sandbox_url: undefined,
+		});
+		await bucket.put(paths.session(pid, winner.session_id), JSON.stringify(winner));
+		await bucket.put(
+			paths.editorClaim(pid, nid),
+			JSON.stringify({
+				session_id: winner.session_id,
+				sharing: 'shared',
+				claimed_at: winner.started_at,
+			}),
+		);
+		const deadline = new Date(Date.now() + Millis.minutes(15)).toISOString();
+		const groupEditor = createTestApi({
+			bucket,
+			userId: STRANGER,
+			compute: makeFakeCompute(),
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: STRANGER,
+						email: `${STRANGER}@example.com`,
+						entitlements: ['default-role:editor'],
+						entitlementsExpiresAt: deadline,
+					}),
+				},
+			},
+		}).request;
+
+		const attached = await expectOk<ApiSession>(await groupEditor('POST', sessionsPath()));
+
+		expect(attached.session_id).toBe(winner.session_id);
+		expect(attached.reused).toBe(true);
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, winner.session_id))
+				.authorization_expires_at,
+		).toBe(deadline);
 	});
 
 	it('POST /sessions hammered for one notebook reuses one record and never trips the cap', async () => {

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -786,6 +786,10 @@ app.openapi(createSession, async (c) => {
 	const profileOverrideEligible = authorization.profileOverrideEligible;
 	const restrictedViewerCredentials = authorization.restrictedViewerCredentials;
 	const grants = (s: Session) => sessionGrantsFor(project, user, s, deps.policy);
+	const tightenAuthorizationDeadline = (session: Session) =>
+		authorizationExpiresAt
+			? sessions.tightenAuthorizationDeadline(pid, session.session_id, authorizationExpiresAt)
+			: Promise.resolve(session);
 
 	// Verify the notebook exists in this project — throws NotFoundError (→ 404)
 	// otherwise. Prevents provisioning a billable sandbox for a bogus notebook id.
@@ -858,9 +862,10 @@ app.openapi(createSession, async (c) => {
 			`Editing is currently owned by ${editorReuse.ownedByOther.user_id}`,
 		);
 	}
-	const reusable =
+	const reusableCandidate =
 		mode === 'edit' ? editorReuse?.session : await sessions.findReusable(pid, nid, user.id, mode);
-	if (reusable) {
+	if (reusableCandidate) {
+		const reusable = await tightenAuthorizationDeadline(reusableCandidate);
 		const authorizationExpired =
 			reusable.authorization_expires_at !== undefined &&
 			Date.now() >= Date.parse(reusable.authorization_expires_at);
@@ -1281,8 +1286,15 @@ app.openapi(createSession, async (c) => {
 		if (err instanceof EditorClaimLostError) {
 			observer.tag('editor_claim_lost', true);
 			if (session) await sessions.markTerminated(pid, session.session_id).catch(() => {});
-			const winner = await sessions.getSession(pid, err.holder).catch(() => null);
-			if (winner?.notebook_id === nid && sessionMode(winner) === 'edit') {
+			const winnerCandidate = await sessions.getSession(pid, err.holder).catch(() => null);
+			if (winnerCandidate?.notebook_id === nid && sessionMode(winnerCandidate) === 'edit') {
+				const winner = await tightenAuthorizationDeadline(winnerCandidate);
+				if (
+					winner.authorization_expires_at &&
+					Date.now() >= Date.parse(winner.authorization_expires_at)
+				) {
+					throw new ConflictError('The editor session authorization expired. Retry shortly.');
+				}
 				if (sharing === 'exclusive' && winner.user_id !== user.id) {
 					throw new EditSessionOwnedError(`Editing is currently owned by ${winner.user_id}`);
 				}
@@ -1312,8 +1324,15 @@ app.openapi(createSession, async (c) => {
 			if (session) {
 				await sessions.markTerminated(pid, session.session_id).catch(() => {});
 			}
-			const winner = await sessions.getSession(pid, err.holder).catch(() => {});
-			if (winner && winner.notebook_id === nid && sessionModePolicy(winner).singleton) {
+			const winnerCandidate = await sessions.getSession(pid, err.holder).catch(() => null);
+			if (winnerCandidate?.notebook_id === nid && sessionModePolicy(winnerCandidate).singleton) {
+				const winner = await tightenAuthorizationDeadline(winnerCandidate);
+				if (
+					winner.authorization_expires_at &&
+					Date.now() >= Date.parse(winner.authorization_expires_at)
+				) {
+					throw new ConflictError('The app session authorization expired. Retry shortly.');
+				}
 				return c.json(
 					{ success: true, data: { ...toSessionResponse(winner, grants(winner)), reused: true } },
 					200,

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -42,6 +42,7 @@ import {
 	UnavailableError,
 	EditSessionOwnedError,
 	EditSessionChangedError,
+	ForbiddenError,
 	TakeoverInProgressError,
 	TakeoverRetirementError,
 	kernelActiveConnections,
@@ -384,6 +385,20 @@ function authorizeSessionStart(
 		profileOverrideEligible: !ephemeral,
 		restrictedViewerCredentials: ephemeral,
 	};
+}
+
+function entitlementAuthorizationDeadline(user: AuthUser): string | undefined {
+	if (!user.entitlementsExpiresAt) {
+		if (user.entitlements?.length) {
+			throw new ForbiddenError('Group authorization has no credential expiry; sign in again');
+		}
+		return undefined;
+	}
+	const deadline = Date.parse(user.entitlementsExpiresAt);
+	if (!Number.isFinite(deadline) || deadline <= Date.now()) {
+		throw new ForbiddenError('Group authorization has expired; sign in again');
+	}
+	return new Date(deadline).toISOString();
 }
 
 function resolveComputeProfile(
@@ -745,6 +760,7 @@ app.openapi(createSession, async (c) => {
 		throw new NotFoundError(`Project ${pid} not found`);
 	}
 	const authorization = authorizeSessionStart(project, user, mode, deps.policy);
+	const authorizationExpiresAt = entitlementAuthorizationDeadline(user);
 	const existingEditorClaim = mode === 'edit' ? await sessions.getEditorClaim(pid, nid) : undefined;
 	const sharing = effectiveEditorSharing(existingEditorClaim, deps.policy.editorSandboxSharing);
 	const replacingAfterTakeover =
@@ -845,6 +861,9 @@ app.openapi(createSession, async (c) => {
 	const reusable =
 		mode === 'edit' ? editorReuse?.session : await sessions.findReusable(pid, nid, user.id, mode);
 	if (reusable) {
+		const authorizationExpired =
+			reusable.authorization_expires_at !== undefined &&
+			Date.now() >= Date.parse(reusable.authorization_expires_at);
 		// A role change flips the session class the caller is entitled to (a demoted
 		// editor must not keep a persisting, WIF-holding kernel; a promoted viewer's
 		// edits must stop being discarded). A stale-class session is retired below
@@ -863,7 +882,7 @@ app.openapi(createSession, async (c) => {
 				: undefined;
 		const dead =
 			!!kernelUrl && !!deps.kernelProbe && (await deps.kernelProbe(kernelUrl)) === 'dead';
-		if (!mayRetire || (!dead && !classMismatch)) {
+		if (!authorizationExpired && (!mayRetire || (!dead && !classMismatch))) {
 			return c.json(
 				{
 					success: true,
@@ -966,6 +985,7 @@ app.openapi(createSession, async (c) => {
 					mode,
 					source_version_id: sourceVersionId,
 					editor_sandbox_sharing: mode === 'edit' ? sharing : undefined,
+					authorization_expires_at: authorizationExpiresAt,
 				});
 			})
 			// The pre-flight cap check alone is raceable; re-rank now that this
@@ -1186,6 +1206,12 @@ app.openapi(createSession, async (c) => {
 				compensate: () => compute.create(sandboxId).destroy(),
 			})
 			.step('mark_running', async () => {
+				if (
+					session!.authorization_expires_at &&
+					Date.now() >= Date.parse(session!.authorization_expires_at)
+				) {
+					throw new ForbiddenError('Group authorization expired while starting the session');
+				}
 				// The lifetime clock starts here — when the kernel is live, not at record
 				// creation — so provisioning time never eats into the session TTL.
 				const ttlMs = sandbox.sessionLifetime?.maxLifetimeMs;

--- a/packages/api/src/routes/system.ts
+++ b/packages/api/src/routes/system.ts
@@ -14,6 +14,7 @@ import {
 	MeResponseSchema,
 	ok,
 	toComputeResourcesResponse,
+	subjectDefaultRole,
 } from '../shared';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../pagination';
 
@@ -45,6 +46,8 @@ app.openapi(meRoute, (c) => {
 	return ok(c, {
 		id: user.id,
 		email: user.email,
+		name: user.name ?? null,
+		picture_url: user.pictureUrl ?? null,
 		logout_url: logoutUrl,
 		is_super_admin: isSuperAdmin(user, deps.policy.superAdmins),
 	});
@@ -96,7 +99,7 @@ app.openapi(capabilitiesRoute, (c) => {
 		viewer_mode: deps.policy.viewerMode ?? 'static',
 		viewer_session_modes: [...viewerSessionModes(deps.policy.viewerMode)],
 		editor_sandbox_sharing: deps.policy.editorSandboxSharing ?? 'shared',
-		default_role: deps.policy.defaultRole ?? null,
+		default_role: subjectDefaultRole(c.get('user'), deps.policy),
 		limits: {
 			max_concurrent_sessions_per_user: deps.policy.maxConcurrentSessionsPerUser ?? null,
 			max_apps_per_project: deps.policy.maxAppsPerProject ?? null,

--- a/packages/api/src/routes/users.test.ts
+++ b/packages/api/src/routes/users.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import type { Authenticator } from '@marimo-hub/core';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
 import { ACTOR, uid } from '@marimo-hub/core/testing';
 import { createApi } from '../createApi';
@@ -22,15 +23,32 @@ describe('User routes', () => {
 		await request('GET', '/me');
 	});
 
-	it('GET /users resolves a known id to { id, email, name }', async () => {
-		const data = await expectOk<Record<string, { id: string; email: string; name: string }>>(
-			await request('GET', `/users?ids=${ACTOR}`),
-		);
+	it('GET /users resolves a known id to its display identity', async () => {
+		const data = await expectOk<
+			Record<string, { id: string; email: string; name: string; picture_url: string | null }>
+		>(await request('GET', `/users?ids=${ACTOR}`));
 		expect(data[ACTOR]).toEqual({
 			id: ACTOR,
 			email: `${ACTOR}@example.com`,
 			name: ACTOR, // email local-part fallback (stub auth supplies no name)
+			picture_url: null,
 		});
+	});
+
+	it('GET /users returns a persisted profile picture', async () => {
+		const authenticator = {
+			authenticate: async () => ({
+				id: ACTOR,
+				email: `${ACTOR}@example.com`,
+				pictureUrl: 'https://images.example.com/ada.png',
+			}),
+		};
+		const pictured = createTestApi({ bucket, deps: { authenticator } }).request;
+		await pictured('GET', '/me');
+		const data = await expectOk<Record<string, { picture_url: string | null }>>(
+			await pictured('GET', `/users?ids=${ACTOR}`),
+		);
+		expect(data[ACTOR]?.picture_url).toBe('https://images.example.com/ada.png');
 	});
 
 	it('GET /users omits ids with no recorded identity', async () => {
@@ -116,12 +134,38 @@ describe('User routes', () => {
 			expect(await expectOk(await anyone('GET', '/users/search?q=adam'))).toHaveLength(1);
 		});
 
+		it('a group-derived default role opens directory search under members-only', async () => {
+			const authenticator: Authenticator = {
+				authenticate: async () => ({
+					id: uid('ada'),
+					email: 'ada@example.com',
+					entitlements: ['default-role:viewer'],
+				}),
+			};
+			const entitled = createTestApi({ bucket, deps: { authenticator } }).request;
+
+			expect(await expectOk(await entitled('GET', '/users/search?q=adam'))).toHaveLength(1);
+		});
+
 		it('a super admin with no project involvement may search under members-only', async () => {
 			const god = createTestApi({
 				bucket,
 				userId: uid('ada'),
 				deps: { policy: { superAdmins: [uid('ada')] } },
 			}).request;
+			expect(await expectOk(await god('GET', '/users/search?q=adam'))).toHaveLength(1);
+		});
+
+		it('a group-derived super admin may search under members-only', async () => {
+			const authenticator: Authenticator = {
+				authenticate: async () => ({
+					id: uid('ada'),
+					email: 'ada@example.com',
+					entitlements: ['super-admin'],
+				}),
+			};
+			const god = createTestApi({ bucket, deps: { authenticator } }).request;
+
 			expect(await expectOk(await god('GET', '/users/search?q=adam'))).toHaveLength(1);
 		});
 	});

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -1,6 +1,12 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { ForbiddenError, isSuperAdmin, UserId } from '@marimo-hub/core';
-import { createApp, errorResponses, jsonContent, UserResponseSchema } from '../shared';
+import {
+	createApp,
+	errorResponses,
+	jsonContent,
+	subjectDefaultRole,
+	UserResponseSchema,
+} from '../shared';
 
 // --- Route definitions ---
 
@@ -11,7 +17,7 @@ const resolveUsers = createRoute({
 	summary: 'Resolve user ids to display identities',
 	description:
 		'Batch-resolve opaque user ids (the auth `sub` stored as a notebook `author` ' +
-		'or session `user_id`) into `{ id, email, name }`. Ids with no recorded ' +
+		'or session `user_id`) into `{ id, email, name, picture_url }`. Ids with no recorded ' +
 		'identity are omitted from the result map.',
 	request: {
 		query: z.object({
@@ -79,7 +85,10 @@ app.openapi(searchUsers, async (c) => {
 	// every project; under members-only, require at least one project involvement
 	// (decided from the catalog snapshot — no per-project loads) so a drive-by
 	// account cannot harvest the directory by substring.
-	if (deps.policy.defaultRole == null && !isSuperAdmin(user, deps.policy.superAdmins)) {
+	if (
+		subjectDefaultRole(user, deps.policy) == null &&
+		!isSuperAdmin(user, deps.policy.superAdmins)
+	) {
 		const snapshot = await catalog.getCurrentSnapshot();
 		const email = user.email.toLowerCase();
 		const involved = snapshot.projects.some(
@@ -95,7 +104,12 @@ app.openapi(searchUsers, async (c) => {
 	}
 
 	const matches = await identities.search(q, limit);
-	const data = matches.map(({ id, email, name }) => ({ id, email, name }));
+	const data = matches.map(({ id, email, name, picture_url }) => ({
+		id,
+		email,
+		name,
+		picture_url: picture_url ?? null,
+	}));
 	return c.json({ success: true, data }, 200);
 });
 
@@ -111,9 +125,17 @@ app.openapi(resolveUsers, async (c) => {
 
 	const resolved = requested.length > 0 ? await identities.getMany(requested) : [];
 
-	const data: Record<string, { id: string; email: string; name: string }> = {};
+	const data: Record<
+		string,
+		{ id: string; email: string; name: string; picture_url: string | null }
+	> = {};
 	for (const u of resolved) {
-		data[u.id] = { id: u.id, email: u.email, name: u.name };
+		data[u.id] = {
+			id: u.id,
+			email: u.email,
+			name: u.name,
+			picture_url: u.picture_url ?? null,
+		};
 	}
 
 	return c.json({ success: true, data }, 200);

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -2,7 +2,7 @@ import { createServer } from 'node:http';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { gzipSync } from 'node:zlib';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createServices, ProxyExposure, signProxyToken, SubdomainExposure } from '@marimo-hub/core';
 import type { Authenticator, ProjectId, UserId } from '@marimo-hub/core';
 import { ACTOR, makeFakeCompute, uid } from '@marimo-hub/core/testing';
@@ -198,6 +198,70 @@ describe('authorizeProxyRequest', () => {
 		await createServices(bucket).sessions.terminate(pid, sessionId as never);
 		const d = await authorizeProxyRequest(req(`/proxy/${token}/`), deps(ACTOR));
 		expect(d).toMatchObject({ kind: 'reject', status: 410 });
+	});
+
+	it('rejects a running kernel after its non-extendable authorization deadline', async () => {
+		const services = createServices(bucket);
+		const notebooks = await services.notebooks.listNotebooks(pid);
+		const expired = await services.sessions.createSession({
+			notebook_id: notebooks[0].id,
+			project_id: pid,
+			user_id: ACTOR,
+			authorization_expires_at: new Date(Date.now() - 1000).toISOString(),
+		});
+		await services.sessions.setRunning(pid, expired.session_id, '/proxy/x/', false, ORIGIN);
+		const expiredToken = await signProxyToken(pid, expired.session_id, SECRET);
+
+		const d = await authorizeProxyRequest(req(`/proxy/${expiredToken}/`), deps(ACTOR));
+
+		expect(d).toMatchObject({
+			kind: 'reject',
+			status: 410,
+			code: 'GONE',
+			message: 'Session authorization has expired',
+		});
+	});
+
+	it('allows requests before the authorization deadline and rejects the same session after it', async () => {
+		const now = Date.now();
+		const deadline = now + 60_000;
+		const services = createServices(bucket);
+		const notebooks = await services.notebooks.listNotebooks(pid);
+		const expiring = await services.sessions.createSession({
+			notebook_id: notebooks[0].id,
+			project_id: pid,
+			user_id: ACTOR,
+			authorization_expires_at: new Date(deadline).toISOString(),
+		});
+		await services.sessions.setRunning(pid, expiring.session_id, '/proxy/x/', false, ORIGIN);
+		const expiringToken = await signProxyToken(pid, expiring.session_id, SECRET);
+		const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+		try {
+			const before = await authorizeProxyRequest(
+				req(`/proxy/${expiringToken}/notebook`),
+				deps(ACTOR),
+			);
+			expect(before).toMatchObject({
+				kind: 'forward',
+				sessionId: expiring.session_id,
+				authorizationDeadline: deadline,
+			});
+
+			nowSpy.mockReturnValue(deadline);
+			const after = await authorizeProxyRequest(
+				req(`/proxy/${expiringToken}/notebook`),
+				deps(ACTOR),
+			);
+			expect(after).toMatchObject({
+				kind: 'reject',
+				status: 410,
+				code: 'GONE',
+				message: 'Session authorization has expired',
+			});
+		} finally {
+			nowSpy.mockRestore();
+		}
 	});
 
 	it('rejects a session whose project was soft-deleted', async () => {

--- a/packages/api/src/sandboxProxy.ts
+++ b/packages/api/src/sandboxProxy.ts
@@ -7,8 +7,8 @@
  * kernel's origin. The kernel runs under `--base-url=/proxy/<token>`, so the full
  * path is forwarded unchanged. `authorizeProxyRequest` is shared with the
  * WebSocket path (the Node entrypoint) so the two transports authorize
- * identically — but a WebSocket is authorized at the UPGRADE only: an
- * established kernel socket outlives a later revocation until it closes.
+ * identically. Entitlement-backed sessions also return a fixed deadline that
+ * the Node relay uses to close an established socket.
  */
 import type { MiddlewareHandler } from 'hono';
 import { ForbiddenError, ProxyExposure, verifyProxyToken } from '@marimo-hub/core';
@@ -19,7 +19,12 @@ import { assertSessionAccess, fail } from './shared';
 export type ProxyDecision =
 	| { kind: 'pass' } // Not a proxy path — let the normal app handle it.
 	| { kind: 'reject'; status: 401 | 403 | 404 | 410 | 503; code: string; message: string }
-	| { kind: 'forward'; targetUrl: string; sessionId: string };
+	| {
+			kind: 'forward';
+			targetUrl: string;
+			sessionId: string;
+			authorizationDeadline?: number;
+	  };
 
 const PROXY_PREFIX = /^\/proxy\/([^/]+)/;
 
@@ -80,6 +85,17 @@ export async function authorizeProxyRequest(
 	if (session.status !== 'running') {
 		return { kind: 'reject', status: 410, code: 'GONE', message: 'Session is no longer running' };
 	}
+	const authorizationDeadline = session.authorization_expires_at
+		? Date.parse(session.authorization_expires_at)
+		: undefined;
+	if (authorizationDeadline !== undefined && Date.now() >= authorizationDeadline) {
+		return {
+			kind: 'reject',
+			status: 410,
+			code: 'GONE',
+			message: 'Session authorization has expired',
+		};
+	}
 
 	const originUrl = session.sandbox_origin_url;
 	if (!originUrl) {
@@ -118,7 +134,12 @@ export async function authorizeProxyRequest(
 
 	// Forward the FULL path unchanged (marimo runs under --base-url=/proxy/<token>).
 	const targetUrl = `${trimTrailingSlash(originUrl)}${url.pathname}${url.search}`;
-	return { kind: 'forward', targetUrl, sessionId };
+	return {
+		kind: 'forward',
+		targetUrl,
+		sessionId,
+		...(authorizationDeadline !== undefined ? { authorizationDeadline } : {}),
+	};
 }
 
 /** Hop-by-hop headers that must not be copied across a proxy (RFC 7230 §6.1). */

--- a/packages/api/src/schema-conformance.test.ts
+++ b/packages/api/src/schema-conformance.test.ts
@@ -125,14 +125,16 @@ describe('schema conformance: api response shapes vs core public shapes', () => 
 		// `user_id` is intentionally surfaced (the "started by" attribution UI); the
 		// remaining fields are compute internals that stay server-side. The
 		// lifecycle-sweep bookkeeping (`expires_at`, `last_snapshot_at`,
-		// `sandbox_reclaimed_at`, `takeover_capture_completed_at`) stays internal until
-		// the UI surfaces the deadline.
+		// `authorization_expires_at`, `sandbox_reclaimed_at`,
+		// `takeover_capture_completed_at`) stays internal until the UI surfaces the
+		// deadline.
 		const internalSessionFields = [
 			'runtime',
 			'sandbox_id',
 			'sandbox_origin_url',
 			'used_fallback',
 			'expires_at',
+			'authorization_expires_at',
 			'last_snapshot_at',
 			'sandbox_reclaimed_at',
 			'takeover_capture_completed_at',

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -19,6 +19,7 @@ import {
 	sessionCan,
 	sessionGrants,
 	sessionPersistsEdits,
+	subjectDefaultRole,
 	SessionRetirer,
 	SOURCE_TYPES,
 	EDITOR_SANDBOX_SHARING_VALUES,
@@ -99,6 +100,8 @@ export function assertSessionAuthenticated(c: Context<HonoEnv>, action: string):
 		throw new ForbiddenError(`Personal access tokens cannot ${action} — sign in to do this`);
 	}
 }
+
+export { subjectDefaultRole };
 
 /** The slice of PolicyConfig the session gates need. */
 export type SessionPolicy = AuthzPolicy & {
@@ -795,6 +798,7 @@ export const UserResponseSchema = z
 		id: z.string(),
 		email: z.string(),
 		name: z.string(),
+		picture_url: z.url().nullable().optional(),
 	})
 	.openapi('User');
 
@@ -804,8 +808,10 @@ export const MeResponseSchema = z
 	.object({
 		id: z.string(),
 		email: z.string(),
+		name: z.string().nullable().optional(),
+		picture_url: z.url().nullable().optional(),
 		logout_url: z.string().nullable(),
-		/** Deployment super admin (MARIMOHUB_SUPER_ADMINS): implicit admin everywhere. */
+		/** Static or OIDC group-derived super admin: implicit admin everywhere. */
 		is_super_admin: z.boolean(),
 	})
 	.openapi('Me');

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -815,6 +815,51 @@ describe('OIDC routes', () => {
 		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
 	});
 
+	it('requires email_verified when a domain allowlist is active under trusted-issuer', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+		});
+		const { routes } = makeOidc({
+			emailVerification: 'trusted-issuer',
+			allowedEmailDomains: ['example.com'],
+		});
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('requires UserInfo email_verified with a domain allowlist under trusted-issuer', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			userinfo_endpoint: 'https://issuer.example.com/userinfo',
+		});
+		oauthMock.processUserInfoResponse.mockResolvedValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+		});
+		const { routes } = makeOidc({
+			emailVerification: 'trusted-issuer',
+			allowedEmailDomains: ['example.com'],
+		});
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
 	it('rejects explicit false even with the trusted-issuer compatibility policy', async () => {
 		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
 			sub: 'user-1',

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -1,14 +1,17 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { SignJWT } from 'jose';
 import {
+	claimAtPointer,
 	createOidcAuth,
 	normalizeEmailDomains,
 	emailDomainAllowed,
+	pictureUrlClaim,
 	sanitizeReturnTo,
 } from './index';
 
 const oauthMock = vi.hoisted(() => ({
 	ClientSecretPost: vi.fn(),
+	checkProtocol: vi.fn(),
 	authorizationCodeGrantRequest: vi.fn(),
 	calculatePKCECodeChallenge: vi.fn(),
 	discoveryRequest: vi.fn(),
@@ -18,6 +21,8 @@ const oauthMock = vi.hoisted(() => ({
 	getValidatedIdTokenClaims: vi.fn(),
 	processAuthorizationCodeResponse: vi.fn(),
 	processDiscoveryResponse: vi.fn(),
+	processUserInfoResponse: vi.fn(),
+	userInfoRequest: vi.fn(),
 	validateAuthResponse: vi.fn(),
 }));
 
@@ -44,9 +49,17 @@ const BASE_CONFIG = {
 	sessionSecret: SESSION_SECRET,
 };
 
+function utf8ByteLength(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}
+
 beforeEach(() => {
 	vi.clearAllMocks();
 	oauthMock.ClientSecretPost.mockImplementation((secret: string) => ({ secret }));
+	oauthMock.checkProtocol.mockImplementation((url: URL, enforceHttps: boolean) => {
+		if (enforceHttps && url.protocol !== 'https:') throw new Error('HTTPS required');
+		if (url.protocol !== 'https:' && url.protocol !== 'http:') throw new Error('HTTP required');
+	});
 	oauthMock.discoveryRequest.mockResolvedValue(new Response('{}'));
 	oauthMock.processDiscoveryResponse.mockReturnValue({
 		issuer: 'https://issuer.example.com',
@@ -61,7 +74,18 @@ beforeEach(() => {
 	oauthMock.generateRandomNonce.mockReturnValue('nonce-1');
 	oauthMock.validateAuthResponse.mockReturnValue(new URLSearchParams('code=abc&state=state-1'));
 	oauthMock.authorizationCodeGrantRequest.mockResolvedValue(new Response('{}'));
-	oauthMock.processAuthorizationCodeResponse.mockResolvedValue({ id_token: 'id-token' });
+	oauthMock.processAuthorizationCodeResponse.mockResolvedValue({
+		access_token: 'access-token',
+		token_type: 'bearer',
+		id_token: 'id-token',
+	});
+	oauthMock.userInfoRequest.mockResolvedValue(new Response('{}'));
+	oauthMock.processUserInfoResponse.mockResolvedValue({
+		sub: 'user-1',
+		email: 'user@example.com',
+		email_verified: true,
+		name: 'Ada Lovelace',
+	});
 	oauthMock.getValidatedIdTokenClaims.mockReturnValue({
 		sub: 'user-1',
 		email: 'user@example.com',
@@ -88,6 +112,11 @@ async function signSession(
 		sub?: string;
 		email?: unknown;
 		name?: unknown;
+		pictureUrl?: unknown;
+		entitlements?: unknown;
+		issuer?: string;
+		audience?: string;
+		typ?: string;
 		expirationTime?: string | number;
 	} = {},
 ): Promise<string> {
@@ -95,8 +124,12 @@ async function signSession(
 	const payload: Record<string, unknown> = {};
 	if (opts.email !== undefined) payload.email = opts.email;
 	if (opts.name !== undefined) payload.name = opts.name;
+	if (opts.pictureUrl !== undefined) payload.picture_url = opts.pictureUrl;
+	if (opts.entitlements !== undefined) payload.entitlements = opts.entitlements;
 	let jwt = new SignJWT(payload)
-		.setProtectedHeader({ alg: 'HS256' })
+		.setProtectedHeader({ alg: 'HS256', typ: opts.typ ?? 'mh-session+jwt' })
+		.setIssuer(opts.issuer ?? 'https://issuer.example.com/')
+		.setAudience(opts.audience ?? 'client-id')
 		.setIssuedAt()
 		.setExpirationTime(opts.expirationTime ?? '8h');
 	if (opts.sub !== undefined) jwt = jwt.setSubject(opts.sub);
@@ -125,7 +158,7 @@ async function beginOidcTransaction(
 	return cookiePair(login, TXN_COOKIE);
 }
 
-describe('createOidcAuth session-secret strength check', () => {
+describe('createOidcAuth configuration validation', () => {
 	it('throws when sessionSecret is shorter than 32 bytes', () => {
 		expect(() => createOidcAuth({ ...BASE_CONFIG, sessionSecret: 'short' })).toThrow(
 			/MARIMOHUB_AUTH_SESSION_SECRET/,
@@ -149,6 +182,143 @@ describe('createOidcAuth session-secret strength check', () => {
 		expect(result).toHaveProperty('authenticator');
 		expect(result).toHaveProperty('routes');
 	});
+
+	it('requires HTTPS issuer and redirect URLs', () => {
+		expect(() => makeOidc({ issuer: 'http://issuer.example.com' })).toThrow(
+			/OIDC issuer must be an HTTPS URL/,
+		);
+		expect(() => makeOidc({ redirectUri: 'http://hub.example.com/api/auth/callback' })).toThrow(
+			/OIDC redirect URI must be an HTTPS URL/,
+		);
+	});
+
+	it('rejects issuer URL components that are not part of an issuer identifier', () => {
+		expect(() => makeOidc({ issuer: 'https://issuer.example.com?tenant=one' })).toThrow(
+			/OIDC issuer must be an HTTPS URL/,
+		);
+		expect(() => makeOidc({ issuer: 'https://user@issuer.example.com' })).toThrow(
+			/OIDC issuer must be an HTTPS URL/,
+		);
+	});
+
+	it.each([
+		['issuer', { issuer: 'not a URL' }, /OIDC issuer must be a valid HTTPS URL/],
+		['redirect URI', { redirectUri: 'not a URL' }, /OIDC redirect URI must be a valid HTTPS URL/],
+	])('labels a malformed %s in its startup error', (_name, overrides, expected) => {
+		expect(() => makeOidc(overrides)).toThrow(expected);
+	});
+
+	it.each([
+		['issuer fragment', { issuer: 'https://issuer.example.com#fragment' }, /OIDC issuer/],
+		['issuer password', { issuer: 'https://user:password@issuer.example.com' }, /OIDC issuer/],
+		[
+			'redirect fragment',
+			{ redirectUri: 'https://hub.example.com/api/auth/callback#fragment' },
+			/OIDC redirect URI/,
+		],
+		[
+			'redirect credentials',
+			{ redirectUri: 'https://user@hub.example.com/api/auth/callback' },
+			/OIDC redirect URI/,
+		],
+	])('rejects unsafe URL configuration: %s', (_name, overrides, expected) => {
+		expect(() => makeOidc(overrides)).toThrow(expected);
+	});
+
+	it.each(['https://evil.example.com', '//evil.example.com', '/api/auth/login', 'relative'])(
+		'rejects an unsafe post-login redirect: %s',
+		(postLoginRedirect) => {
+			expect(() => makeOidc({ postLoginRedirect })).toThrow(/same-origin application path/);
+		},
+	);
+
+	it('rejects malformed group claim pointers at startup', () => {
+		expect(() =>
+			makeOidc({ groups: { claim: '/realm~2access/roles', allowed: ['hub-users'] } }),
+		).toThrow(/RFC 6901 JSON Pointer/);
+	});
+
+	it('bounds direct adapter session and group settings', () => {
+		expect(() => makeOidc({ sessionTtlSeconds: 299 })).toThrow(/session TTL/);
+		expect(() =>
+			makeOidc({
+				sessionTtlSeconds: 3601,
+				groups: { claim: '/groups', superAdmin: ['admins'] },
+			}),
+		).toThrow(/group-derived access/);
+		expect(() =>
+			makeOidc({ groups: { claim: '/groups', maxGroups: 1.5, allowed: ['hub-users'] } }),
+		).toThrow(/maxGroups/);
+	});
+
+	it.each([299, 300.5, 86_401, Number.NaN])('rejects invalid direct session TTL %s', (ttl) => {
+		expect(() => makeOidc({ sessionTtlSeconds: ttl })).toThrow(/session TTL/);
+	});
+
+	it('accepts direct session and group-count boundaries', () => {
+		expect(() => makeOidc({ sessionTtlSeconds: 300 })).not.toThrow();
+		expect(() => makeOidc({ sessionTtlSeconds: 86_400 })).not.toThrow();
+		expect(() =>
+			makeOidc({
+				sessionTtlSeconds: 3600,
+				groups: { claim: '/groups', maxGroups: 1, allowed: ['hub-users'] },
+			}),
+		).not.toThrow();
+		expect(() =>
+			makeOidc({ groups: { claim: '/groups', maxGroups: 200, allowed: ['hub-users'] } }),
+		).not.toThrow();
+	});
+
+	it.each([0, 201, Number.NaN])('rejects invalid direct maxGroups %s', (maxGroups) => {
+		expect(() =>
+			makeOidc({ groups: { claim: '/groups', maxGroups, allowed: ['hub-users'] } }),
+		).toThrow(/maxGroups/);
+	});
+
+	it('rejects unknown direct email-verification policies', () => {
+		expect(() => makeOidc({ emailVerification: 'optional' as never })).toThrow(
+			/Invalid OIDC email verification policy/,
+		);
+	});
+
+	it.each([
+		['missing openid', 'email profile', /must include openid/],
+		['missing email', 'openid profile', /must include email/],
+		[
+			'too many scopes',
+			['openid', 'email', ...Array.from({ length: 19 }, (_, i) => `s${i}`)].join(' '),
+			/invalid scope value/,
+		],
+		['oversized scope', `openid email ${'s'.repeat(201)}`, /invalid scope value/],
+		['control character', 'openid email bad\u007fscope', /invalid scope value/],
+	])('rejects invalid direct scopes: %s', (_name, scopes, expected) => {
+		expect(() => makeOidc({ scopes })).toThrow(expected);
+	});
+
+	it('does not allow direct adapter configuration to request refresh-token access', () => {
+		expect(() => makeOidc({ scopes: 'openid email offline_access' })).toThrow(/offline_access/);
+	});
+
+	it('requires at least one non-empty direct group policy', () => {
+		expect(() => makeOidc({ groups: { claim: '/groups' } })).toThrow(
+			/requires at least one group policy/,
+		);
+		expect(() => makeOidc({ groups: { claim: '/groups', allowed: [] } })).toThrow(
+			/1 to 200 valid group ids/,
+		);
+	});
+
+	it.each([
+		['oversized group list', Array.from({ length: 201 }, (_, i) => `group-${i}`)],
+		['empty group id', ['']],
+		['oversized group id', ['g'.repeat(257)]],
+		['control character', ['admin\u007fgroup']],
+		['non-string runtime value', [42] as unknown as string[]],
+	])('rejects invalid direct group policies: %s', (_name, allowed) => {
+		expect(() => makeOidc({ groups: { claim: '/groups', allowed } })).toThrow(
+			/1 to 200 valid group ids/,
+		);
+	});
 });
 
 describe('normalizeEmailDomains', () => {
@@ -165,6 +335,66 @@ describe('normalizeEmailDomains', () => {
 
 	it('returns an empty array for undefined', () => {
 		expect(normalizeEmailDomains(undefined)).toEqual([]);
+	});
+});
+
+describe('claimAtPointer', () => {
+	it('resolves nested keys and RFC 6901 escape sequences', () => {
+		expect(
+			claimAtPointer(
+				{ realm: { 'access/roles': { '~admins': ['admin'] } } },
+				'/realm/access~1roles/~0admins',
+			),
+		).toEqual(['admin']);
+	});
+
+	it.each(['', 'groups', '/bad~2escape'])('rejects an invalid pointer: %s', (pointer) => {
+		expect(claimAtPointer({ groups: ['admin'] }, pointer)).toBeUndefined();
+	});
+
+	it('does not traverse arrays, nulls, missing keys, or inherited properties', () => {
+		expect(claimAtPointer({ groups: ['admin'] }, '/groups/0')).toBeUndefined();
+		expect(claimAtPointer({ realm: null }, '/realm/groups')).toBeUndefined();
+		expect(claimAtPointer({ realm: {} }, '/realm/groups')).toBeUndefined();
+		const inherited = Object.create({ groups: ['admin'] }) as Record<string, unknown>;
+		expect(claimAtPointer(inherited, '/groups')).toBeUndefined();
+	});
+});
+
+describe('pictureUrlClaim', () => {
+	it('accepts and normalizes an HTTPS URL', () => {
+		expect(pictureUrlClaim('https://images.example.com/avatar.png?size=64')).toBe(
+			'https://images.example.com/avatar.png?size=64',
+		);
+	});
+
+	it('accepts a normalized URL at the 2048-byte boundary', () => {
+		const prefix = 'https://images.example.com/';
+		const value = `${prefix}${'a'.repeat(2048 - utf8ByteLength(prefix))}`;
+
+		expect(utf8ByteLength(new URL(value).toString())).toBe(2048);
+		expect(pictureUrlClaim(value)).toBe(value);
+	});
+
+	it('rejects a short Unicode input whose normalized URL exceeds the byte limit', () => {
+		const value = `https://images.example.com/${'💥'.repeat(200)}`;
+		const normalized = new URL(value).toString();
+
+		expect(value.length).toBeLessThan(2048);
+		expect(utf8ByteLength(normalized)).toBeGreaterThan(2048);
+		expect(pictureUrlClaim(value)).toBeUndefined();
+	});
+
+	it.each([
+		['HTTP', 'http://images.example.com/avatar.png'],
+		['credentials', 'https://user:password@images.example.com/avatar.png'],
+		['data URL', 'data:image/png;base64,AAAA'],
+		['relative URL', '/avatar.png'],
+		['malformed URL', 'not a URL'],
+		['oversized URL', `https://images.example.com/${'a'.repeat(2049)}`],
+		['non-string value', 42],
+	])('rejects an unsafe or malformed picture value: %s', (_name, value) => {
+		expect(pictureUrlClaim(value)).toBeUndefined();
 	});
 });
 
@@ -379,6 +609,40 @@ describe('OIDC routes', () => {
 		expect(res.headers.get('set-cookie') ?? '').toContain(`${TXN_COOKIE}=`);
 	});
 
+	it('sets the complete browser-cookie security policy and configured lifetime', async () => {
+		const { routes } = makeOidc({ sessionTtlSeconds: 900 });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+		const setCookie = res.headers.get('set-cookie') ?? '';
+
+		expect(setCookie).toContain(`${SESSION_COOKIE}=`);
+		expect(setCookie).toContain('HttpOnly');
+		expect(setCookie).toContain('Secure');
+		expect(setCookie).toContain('SameSite=Lax');
+		expect(setCookie).toContain('Path=/');
+		expect(setCookie).toContain('Max-Age=900');
+	});
+
+	it('defaults group-derived sessions to a one-hour deprovisioning bound', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			groups: ['hub-users'],
+		});
+		const { routes } = makeOidc({ groups: { claim: '/groups', allowed: ['hub-users'] } });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('set-cookie') ?? '').toContain('Max-Age=3600');
+	});
+
 	it('returns to the redirect_url deep link after a successful callback', async () => {
 		const { routes } = makeOidc({ postLoginRedirect: '/app' });
 		const deepLink = '/p/proj-1/notebooks/nb-1?tab=files#cell-3';
@@ -520,7 +784,7 @@ describe('OIDC routes', () => {
 		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
 	});
 
-	it('tolerates a provider that omits email_verified (no allowlist)', async () => {
+	it('rejects a provider that omits email_verified by default', async () => {
 		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
 			sub: 'user-1',
 			email: 'user@example.com',
@@ -532,9 +796,102 @@ describe('OIDC routes', () => {
 			headers: { cookie: txn },
 		});
 
-		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('allows missing email_verified only with the trusted-issuer policy', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+		});
+		const { routes } = makeOidc({ emailVerification: 'trusted-issuer' });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
 		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
 	});
+
+	it('rejects explicit false even with the trusted-issuer compatibility policy', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: false,
+		});
+		const { routes } = makeOidc({ emailVerification: 'trusted-issuer' });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it.each([
+		['string false', 'false'],
+		['null', null],
+		['zero', 0],
+		['positive number', 1],
+		['fractional number', 0.5],
+		['object', {}],
+	])(
+		'rejects a present malformed ID-token email_verified under trusted-issuer: %s',
+		async (_label, emailVerified) => {
+			oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+				sub: 'user-1',
+				email: 'user@example.com',
+				email_verified: emailVerified,
+			});
+			const { routes } = makeOidc({ emailVerification: 'trusted-issuer' });
+			const txn = await beginOidcTransaction(routes);
+
+			const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+				headers: { cookie: txn },
+			});
+
+			expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+			expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+		},
+	);
+
+	it.each([
+		['string false', 'false'],
+		['null', null],
+		['zero', 0],
+		['positive number', 1],
+		['fractional number', 0.5],
+		['object', {}],
+	])(
+		'rejects a present malformed UserInfo email_verified under trusted-issuer: %s',
+		async (_label, emailVerified) => {
+			oauthMock.processDiscoveryResponse.mockReturnValue({
+				issuer: 'https://issuer.example.com',
+				authorization_endpoint: 'https://issuer.example.com/authorize',
+				token_endpoint: 'https://issuer.example.com/token',
+				jwks_uri: 'https://issuer.example.com/jwks',
+				userinfo_endpoint: 'https://issuer.example.com/userinfo',
+			});
+			oauthMock.processUserInfoResponse.mockResolvedValue({
+				sub: 'user-1',
+				email: 'user@example.com',
+				email_verified: emailVerified,
+			});
+			const { routes } = makeOidc({ emailVerification: 'trusted-issuer' });
+			const txn = await beginOidcTransaction(routes);
+
+			const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+				headers: { cookie: txn },
+			});
+
+			expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+			expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+		},
+	);
 
 	it('rejects a restricted-domain callback when the email domain is not allowed', async () => {
 		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
@@ -566,6 +923,428 @@ describe('OIDC routes', () => {
 		});
 
 		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('uses validated UserInfo claims and binds them to the ID-token subject', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			userinfo_endpoint: 'https://issuer.example.com/userinfo',
+		});
+		oauthMock.processUserInfoResponse.mockResolvedValue({
+			sub: 'user-1',
+			email: 'fresh@example.com',
+			email_verified: true,
+			name: 'Fresh Name',
+			picture: 'https://images.example.com/ada.png',
+		});
+		const { authenticator, routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(oauthMock.userInfoRequest).toHaveBeenCalledWith(
+			expect.any(Object),
+			{ client_id: 'client-id' },
+			'access-token',
+		);
+		expect(oauthMock.processUserInfoResponse).toHaveBeenCalledWith(
+			expect.any(Object),
+			{ client_id: 'client-id' },
+			'user-1',
+			expect.any(Response),
+		);
+		const sessionCookie = cookiePair(res, SESSION_COOKIE);
+		await expect(
+			authenticator.authenticate(requestWithCookie(sessionCookie.split('=')[1])),
+		).resolves.toEqual({
+			id: 'user-1',
+			email: 'fresh@example.com',
+			name: 'Fresh Name',
+			pictureUrl: 'https://images.example.com/ada.png',
+		});
+	});
+
+	it('rejects a UserInfo response for a different subject', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			userinfo_endpoint: 'https://issuer.example.com/userinfo',
+		});
+		oauthMock.processUserInfoResponse.mockResolvedValue({
+			sub: 'attacker',
+			email: 'attacker@example.com',
+			email_verified: true,
+		});
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('fails closed when the advertised UserInfo endpoint cannot be validated', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			userinfo_endpoint: 'https://issuer.example.com/userinfo',
+		});
+		oauthMock.processUserInfoResponse.mockRejectedValue(new Error('invalid UserInfo signature'));
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('does not combine a UserInfo email with ID-token verification', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			userinfo_endpoint: 'https://issuer.example.com/userinfo',
+		});
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'verified@example.com',
+			email_verified: true,
+		});
+		oauthMock.processUserInfoResponse.mockResolvedValue({
+			sub: 'user-1',
+			email: 'unverified@example.com',
+		});
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('uses the coherent ID-token email pair when UserInfo omits email', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			userinfo_endpoint: 'https://issuer.example.com/userinfo',
+		});
+		oauthMock.processUserInfoResponse.mockResolvedValue({
+			sub: 'user-1',
+			name: 'UserInfo Name',
+		});
+		const { authenticator, routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+		const sessionCookie = cookiePair(res, SESSION_COOKIE);
+
+		await expect(
+			authenticator.authenticate(requestWithCookie(sessionCookie.split('=')[1])),
+		).resolves.toMatchObject({
+			email: 'user@example.com',
+			name: 'UserInfo Name',
+		});
+	});
+
+	it('maps exact nested provider groups to bounded internal entitlements', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			realm_access: { roles: ['hub-users', 'hub-admins'] },
+		});
+		const { authenticator, routes } = makeOidc({
+			groups: {
+				claim: '/realm_access/roles',
+				allowed: ['hub-users'],
+				superAdmin: ['hub-admins'],
+				defaultRoles: { editor: ['hub-editors'], admin: ['hub-admins'] },
+			},
+		});
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		const sessionCookie = cookiePair(res, SESSION_COOKIE);
+		await expect(
+			authenticator.authenticate(requestWithCookie(sessionCookie.split('=')[1])),
+		).resolves.toMatchObject({
+			entitlements: ['super-admin', 'default-role:admin'],
+		});
+	});
+
+	it('retains the group-authorization expiry when the policy maps no role', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			groups: ['hub-users'],
+		});
+		const { authenticator, routes } = makeOidc({
+			groups: { claim: '/groups', allowed: ['hub-users'] },
+		});
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+		const sessionCookie = cookiePair(res, SESSION_COOKIE);
+		const user = await authenticator.authenticate(requestWithCookie(sessionCookie.split('=')[1]));
+
+		expect(user).not.toHaveProperty('entitlements');
+		expect(Date.parse(user!.entitlementsExpiresAt!)).toBeGreaterThan(Date.now() + 3500_000);
+	});
+
+	it('fails closed when no configured login group matches', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			groups: ['other'],
+		});
+		const { routes } = makeOidc({ groups: { claim: '/groups', allowed: ['hub-users'] } });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=group_not_allowed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('fails closed when a required login-group claim is missing', async () => {
+		const { routes } = makeOidc({ groups: { claim: '/groups', allowed: ['hub-users'] } });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=group_not_allowed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it.each([
+		{ groups: 'admins' },
+		{ groups: Array.from({ length: 201 }, (_, i) => `group-${i}`) },
+		{ groups: ['ok', 42] },
+		{ groups: [''] },
+		{ groups: ['g'.repeat(257)] },
+		{ groups: ['admin\u007fgroup'] },
+	])('rejects malformed or oversized group claims', async (extraClaims) => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			...extraClaims,
+		});
+		const { routes } = makeOidc({ groups: { claim: '/groups', superAdmin: ['admins'] } });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+	});
+
+	it('honors a lower configured group-count limit at its exact boundary', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			groups: ['hub-users', 'hub-editors'],
+		});
+		const accepted = makeOidc({
+			groups: { claim: '/groups', maxGroups: 2, allowed: ['hub-users'] },
+		});
+		const acceptedTxn = await beginOidcTransaction(accepted.routes);
+		const acceptedResponse = await accepted.routes.request(
+			'/api/auth/callback?code=abc&state=state-1',
+			{ headers: { cookie: acceptedTxn } },
+		);
+		expect(acceptedResponse.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
+
+		const rejected = makeOidc({
+			groups: { claim: '/groups', maxGroups: 1, allowed: ['hub-users'] },
+		});
+		const rejectedTxn = await beginOidcTransaction(rejected.routes);
+		const rejectedResponse = await rejected.routes.request(
+			'/api/auth/callback?code=abc&state=state-1',
+			{ headers: { cookie: rejectedTxn } },
+		);
+		expect(rejectedResponse.headers.get('location')).toBe('/?auth_error=auth_failed');
+	});
+
+	it('does not fall back to ID-token groups when UserInfo contains malformed groups', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			userinfo_endpoint: 'https://issuer.example.com/userinfo',
+		});
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			groups: ['hub-users'],
+		});
+		oauthMock.processUserInfoResponse.mockResolvedValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			groups: 'hub-users',
+		});
+		const { routes } = makeOidc({ groups: { claim: '/groups', allowed: ['hub-users'] } });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('drops unsafe profile-picture URLs instead of persisting them', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			picture: 'http://attacker.example/avatar.png',
+		});
+		const { authenticator, routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		const sessionCookie = cookiePair(res, SESSION_COOKIE);
+		const user = await authenticator.authenticate(requestWithCookie(sessionCookie.split('=')[1]));
+		expect(user).not.toHaveProperty('pictureUrl');
+	});
+
+	it('keeps a maximum-claims cookie below browser limits by dropping the picture', async () => {
+		const picturePrefix = 'https://images.example.com/';
+		const picture = `${picturePrefix}${'a'.repeat(2048 - utf8ByteLength(picturePrefix))}`;
+		const subject = 's'.repeat(512);
+		const email = `${'e'.repeat(308)}@example.com`;
+		const name = 'N'.repeat(200);
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: subject,
+			email,
+			email_verified: true,
+			name,
+			picture,
+			groups: ['hub-users'],
+		});
+		const { authenticator, routes } = makeOidc({
+			groups: {
+				claim: '/groups',
+				allowed: ['hub-users'],
+				superAdmin: ['hub-users'],
+				defaultRoles: { admin: ['hub-users'] },
+			},
+		});
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		const sessionCookie = cookiePair(res, SESSION_COOKIE);
+		const token = sessionCookie.slice(`${SESSION_COOKIE}=`.length);
+		const sessionSetCookie = res.headers
+			.getSetCookie()
+			.find((value) => value.startsWith(`${SESSION_COOKIE}=`));
+		expect(utf8ByteLength(token)).toBeLessThanOrEqual(3800);
+		expect(utf8ByteLength(sessionCookie)).toBeLessThan(4096);
+		expect(utf8ByteLength(sessionSetCookie!)).toBeLessThan(4096);
+		await expect(authenticator.authenticate(requestWithCookie(token))).resolves.toMatchObject({
+			id: subject,
+			email,
+			name,
+			entitlements: ['super-admin', 'default-role:admin'],
+		});
+		expect(await authenticator.authenticate(requestWithCookie(token))).not.toHaveProperty(
+			'pictureUrl',
+		);
+	});
+
+	it('drops the name after the picture when the picture-only fallback is still too large', async () => {
+		const subject = 's'.repeat(512);
+		const email = `${'e'.repeat(308)}@example.com`;
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: subject,
+			email,
+			email_verified: true,
+			name: 'N'.repeat(200),
+			picture: 'https://images.example.com/avatar.png',
+		});
+		const { authenticator, routes } = makeOidc({ clientId: 'c'.repeat(1800) });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		const sessionCookie = cookiePair(res, SESSION_COOKIE);
+		const token = sessionCookie.slice(`${SESSION_COOKIE}=`.length);
+		expect(utf8ByteLength(token)).toBeLessThanOrEqual(3800);
+		const user = await authenticator.authenticate(requestWithCookie(token));
+		expect(user).not.toHaveProperty('pictureUrl');
+		expect(user).not.toHaveProperty('name');
+	});
+
+	it.each([
+		['without optional profile claims', {}],
+		[
+			'after removing optional profile claims',
+			{ name: 'N'.repeat(200), picture: 'https://images.example.com/avatar.png' },
+		],
+	])('fails closed when required claims exceed the JWT budget %s', async (_label, profile) => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 's'.repeat(512),
+			email: `${'e'.repeat(308)}@example.com`,
+			email_verified: true,
+			...profile,
+		});
+		const { routes } = makeOidc({ clientId: 'c'.repeat(1900) });
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
 		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
 		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
 	});
@@ -613,11 +1392,90 @@ describe('OIDC authenticate (cookie session)', () => {
 		expect(user).toEqual({ id: 'user-1', email: 'user@example.com', name: 'Ada L.' });
 	});
 
+	it('trims the display name and drops control characters', async () => {
+		const auth = makeAuthenticator();
+		const trimmed = await signSession({
+			sub: 'user-1',
+			email: 'user@example.com',
+			name: '  Ada L.  ',
+		});
+		const controlled = await signSession({
+			sub: 'user-1',
+			email: 'user@example.com',
+			name: 'Ada\nAdmin',
+		});
+
+		expect(await auth.authenticate(requestWithCookie(trimmed))).toMatchObject({ name: 'Ada L.' });
+		expect(await auth.authenticate(requestWithCookie(controlled))).not.toHaveProperty('name');
+	});
+
+	it('accepts only safe profile pictures from a session payload', async () => {
+		const auth = makeAuthenticator();
+		const safe = await signSession({
+			sub: 'user-1',
+			email: 'user@example.com',
+			pictureUrl: 'https://images.example.com/ada.png',
+		});
+		const unsafe = await signSession({
+			sub: 'user-1',
+			email: 'user@example.com',
+			pictureUrl: 'http://images.example.com/ada.png',
+		});
+
+		expect(await auth.authenticate(requestWithCookie(safe))).toMatchObject({
+			pictureUrl: 'https://images.example.com/ada.png',
+		});
+		expect(await auth.authenticate(requestWithCookie(unsafe))).not.toHaveProperty('pictureUrl');
+	});
+
+	it('retains only recognized authorization entitlements from a session payload', async () => {
+		const auth = makeAuthenticator();
+		const expiration = Math.floor(Date.now() / 1000) + 3600;
+		const token = await signSession({
+			sub: 'user-1',
+			email: 'user@example.com',
+			entitlements: ['super-admin', 'default-role:editor', 'provider-admin', 42],
+			expirationTime: expiration,
+		});
+
+		expect(await auth.authenticate(requestWithCookie(token))).toMatchObject({
+			entitlements: ['super-admin', 'default-role:editor'],
+			entitlementsExpiresAt: new Date(expiration * 1000).toISOString(),
+		});
+	});
+
+	it.each([undefined, 'super-admin', { role: 'super-admin' }])(
+		'does not accept a non-array entitlement payload: %j',
+		async (entitlements) => {
+			const auth = makeAuthenticator();
+			const token = await signSession({
+				sub: 'user-1',
+				email: 'user@example.com',
+				entitlements,
+			});
+
+			expect(await auth.authenticate(requestWithCookie(token))).not.toHaveProperty('entitlements');
+		},
+	);
+
 	it('leaves name undefined when the cookie carries no (or a non-string) name', async () => {
 		const auth = makeAuthenticator();
 		const token = await signSession({ sub: 'user-1', email: 'user@example.com', name: 42 });
 		const user = await auth.authenticate(requestWithCookie(token));
 		expect(user?.name).toBeUndefined();
+	});
+
+	it('drops an oversized display name from a valid session', async () => {
+		const auth = makeAuthenticator();
+		const token = await signSession({
+			sub: 'user-1',
+			email: 'user@example.com',
+			name: 'a'.repeat(201),
+		});
+		expect(await auth.authenticate(requestWithCookie(token))).toEqual({
+			id: 'user-1',
+			email: 'user@example.com',
+		});
 	});
 
 	it('rejects a cookie signed with the wrong secret (tampered)', async () => {
@@ -653,6 +1511,16 @@ describe('OIDC authenticate (cookie session)', () => {
 		expect(await auth.authenticate(requestWithCookie(token))).toBeNull();
 	});
 
+	it.each([
+		{ issuer: 'https://other-issuer.example.com/' },
+		{ audience: 'other-client' },
+		{ typ: 'mh-oidc-txn+jwt' },
+	])('rejects a session outside its issuer, audience, or token type', async (claims) => {
+		const auth = makeAuthenticator();
+		const token = await signSession({ sub: 'user-1', email: 'user@example.com', ...claims });
+		expect(await auth.authenticate(requestWithCookie(token))).toBeNull();
+	});
+
 	it('rejects a cookie missing the email claim', async () => {
 		const auth = makeAuthenticator();
 		const token = await signSession({ sub: 'user-1' });
@@ -665,19 +1533,53 @@ describe('OIDC authenticate (cookie session)', () => {
 		expect(await auth.authenticate(requestWithCookie(token))).toBeNull();
 	});
 
+	it.each([
+		'',
+		'user',
+		'@example.com',
+		'user@',
+		'user @example.com',
+		'user@example.com\nadmin@example.com',
+		`${'a'.repeat(310)}@example.com`,
+	])('rejects a malformed session email: %j', async (email) => {
+		const auth = makeAuthenticator();
+		const token = await signSession({ sub: 'user-1', email });
+		expect(await auth.authenticate(requestWithCookie(token))).toBeNull();
+	});
+
 	it('rejects a cookie missing the sub claim', async () => {
 		const auth = makeAuthenticator();
 		const token = await signSession({ email: 'user@example.com' });
 		expect(await auth.authenticate(requestWithCookie(token))).toBeNull();
 	});
 
+	it.each(['', 'user\nadmin', 'u'.repeat(513)])(
+		'rejects a malformed session subject: %j',
+		async (sub) => {
+			const auth = makeAuthenticator();
+			const token = await signSession({ sub, email: 'user@example.com' });
+			expect(await auth.authenticate(requestWithCookie(token))).toBeNull();
+		},
+	);
+
 	it('returns null when no cookie header is present', async () => {
 		const auth = makeAuthenticator();
 		expect(await auth.authenticate(new Request('http://x'))).toBeNull();
 	});
 
-	// An unsigned alg:none token must never authenticate. The adapter passes no
-	// `algorithms` pin, so this relies on jose restricting a symmetric key to HS*.
+	it('returns null for a malformed percent-encoded cookie', async () => {
+		const auth = makeAuthenticator();
+		expect(
+			await auth.authenticate(
+				new Request('http://x', { headers: { cookie: `${SESSION_COOKIE}=%not-encoded` } }),
+			),
+		).toBeNull();
+	});
+
+	it('exposes the local logout route so the HTTP-only cookie can be cleared', () => {
+		expect(makeAuthenticator().logoutUrl?.()).toBe('/api/auth/logout');
+	});
+
 	it('rejects an unsigned alg:none session cookie', async () => {
 		const auth = makeAuthenticator();
 		const b64url = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url');
@@ -697,20 +1599,28 @@ describe('OIDC callback integrity (security)', () => {
 	/** Mint a transaction cookie the way `/api/auth/login` does, with a chosen secret. */
 	async function signTxn(opts: {
 		secret: string;
-		verifier?: string;
+		verifier?: unknown;
+		includeVerifier?: boolean;
 		state?: string;
 		returnTo?: string;
+		issuer?: string;
+		audience?: string;
+		typ?: string;
+		expirationTime?: string | number;
 	}) {
 		const secret = new TextEncoder().encode(opts.secret);
-		return new SignJWT({
-			verifier: opts.verifier ?? 'verifier-1',
+		const payload: Record<string, unknown> = {
 			state: opts.state ?? 'state-1',
 			nonce: 'nonce-1',
 			returnTo: opts.returnTo ?? null,
-		})
-			.setProtectedHeader({ alg: 'HS256' })
+		};
+		if (opts.includeVerifier !== false) payload.verifier = opts.verifier ?? 'verifier-1';
+		return new SignJWT(payload)
+			.setProtectedHeader({ alg: 'HS256', typ: opts.typ ?? 'mh-oidc-txn+jwt' })
+			.setIssuer(opts.issuer ?? 'https://issuer.example.com/')
+			.setAudience(opts.audience ?? 'client-id')
 			.setIssuedAt()
-			.setExpirationTime('10m')
+			.setExpirationTime(opts.expirationTime ?? '10m')
 			.sign(secret);
 	}
 
@@ -723,6 +1633,26 @@ describe('OIDC callback integrity (security)', () => {
 
 		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
 			headers: { cookie: `${TXN_COOKIE}=${forgedTxn}` },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/?auth_error=session_expired');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it.each([
+		['wrong issuer', { issuer: 'https://other-issuer.example.com/' }],
+		['wrong audience', { audience: 'other-client' }],
+		['wrong token type', { typ: 'mh-session+jwt' }],
+		['expired token', { expirationTime: Math.floor(Date.now() / 1000) - 60 }],
+		['missing verifier', { includeVerifier: false }],
+		['non-string verifier', { verifier: 42 }],
+	])('rejects an invalid transaction cookie: %s', async (_name, overrides) => {
+		const { routes } = makeOidc();
+		const txn = await signTxn({ secret: SESSION_SECRET, ...overrides });
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: `${TXN_COOKIE}=${txn}` },
 		});
 
 		expect(res.status).toBe(302);
@@ -743,6 +1673,40 @@ describe('OIDC callback integrity (security)', () => {
 
 		expect(res.status).toBe(302);
 		expect(res.headers.get('location')).toBe('/');
+	});
+
+	it.each([undefined, null, 42, '', 'user\nadmin', 'u'.repeat(513)])(
+		'fails auth_failed for an invalid ID-token subject: %j',
+		async (sub) => {
+			oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+				sub,
+				email: 'user@example.com',
+				email_verified: true,
+			});
+			const { routes } = makeOidc();
+			const txn = await beginOidcTransaction(routes);
+
+			const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+				headers: { cookie: txn },
+			});
+
+			expect(res.status).toBe(302);
+			expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+			expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+		},
+	);
+
+	it('fails auth_failed when the validated token has no claims', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue(undefined);
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
 	});
 
 	it('fails auth_failed when the ID token has a sub but no email', async () => {
@@ -776,6 +1740,51 @@ describe('OIDC callback integrity (security)', () => {
 		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
 		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
 	});
+
+	it.each([
+		'',
+		'user',
+		'@example.com',
+		'user@',
+		'user @example.com',
+		'user@example.com\nadmin@example.com',
+		`${'a'.repeat(310)}@example.com`,
+	])('fails auth_failed for a malformed ID-token email: %j', async (email) => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email,
+			email_verified: true,
+		});
+		const { routes } = makeOidc();
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=auth_failed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
+	it.each(['true', 1, null])(
+		'rejects a non-boolean email_verified claim under strict policy: %j',
+		async (emailVerified) => {
+			oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+				sub: 'user-1',
+				email: 'user@example.com',
+				email_verified: emailVerified,
+			});
+			const { routes } = makeOidc();
+			const txn = await beginOidcTransaction(routes);
+
+			const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+				headers: { cookie: txn },
+			});
+
+			expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+			expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+		},
+	);
 });
 
 describe('OIDC login discovery failure', () => {
@@ -794,5 +1803,48 @@ describe('OIDC login discovery failure', () => {
 		const body = (await res.json()) as { success: boolean; error: { code: string } };
 		expect(body.success).toBe(false);
 		expect(body.error.code).toBe('OIDC_ERROR');
+	});
+
+	it.each([
+		['HTTP', 'http://issuer.example.com/authorize'],
+		['credentials', 'https://user:password@issuer.example.com/authorize'],
+		['non-HTTP(S)', 'javascript:alert(1)'],
+	])('rejects a discovered %s authorization endpoint', async (_label, endpoint) => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: endpoint,
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+		});
+		const { routes } = makeOidc();
+
+		const res = await routes.request('/api/auth/login');
+
+		expect(res.status).toBe(500);
+		expect(await res.json()).toMatchObject({
+			success: false,
+			error: { code: 'OIDC_ERROR', message: 'Invalid authorization endpoint' },
+		});
+		expect(res.headers.get('location')).toBeNull();
+	});
+
+	it.each([
+		['HTTP', 'http://issuer.example.com/logout'],
+		['credentials', 'https://user:password@issuer.example.com/logout'],
+		['non-HTTP(S)', 'data:text/plain,logout'],
+	])('does not redirect to a discovered %s logout endpoint', async (_label, endpoint) => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			end_session_endpoint: endpoint,
+		});
+		const { routes } = makeOidc({ postLoginRedirect: '/signed-out' });
+
+		const res = await routes.request('/api/auth/logout');
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/signed-out');
 	});
 });

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -648,7 +648,7 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		if (emailVerified !== undefined && emailVerified !== true) {
 			return callbackError(c, 'email_not_verified', returnTo);
 		}
-		if (emailVerification === 'required' && emailVerified !== true) {
+		if ((emailVerification === 'required' || restrictDomains) && emailVerified !== true) {
 			return callbackError(c, 'email_not_verified', returnTo);
 		}
 

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -20,8 +20,23 @@ import type { Context } from 'hono';
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
 import { jwtVerify, SignJWT } from 'jose';
 import * as oauth from 'oauth4webapi';
-import { UserId } from '@marimo-hub/core';
-import type { Authenticator, AuthUser } from '@marimo-hub/core';
+import { AUTH_ENTITLEMENTS, UserId } from '@marimo-hub/core';
+import type { AuthEntitlement, Authenticator, AuthUser, Role } from '@marimo-hub/core';
+
+export type EmailVerificationPolicy = 'required' | 'trusted-issuer';
+
+export interface OidcGroupPolicy {
+	/** JSON Pointer locating the provider's group array, e.g. `/groups`. */
+	claim: string;
+	/** At least one exact group match is required to sign in. */
+	allowed?: string[];
+	/** Groups mapped to deployment super-admin. */
+	superAdmin?: string[];
+	/** Groups mapped to a per-user deployment-wide default project role. */
+	defaultRoles?: Partial<Record<Role, string[]>>;
+	/** Maximum accepted group count (default 200, maximum 200). */
+	maxGroups?: number;
+}
 
 export interface OidcConfig {
 	/** OIDC issuer URL (its `/.well-known/openid-configuration` is discovered). */
@@ -38,6 +53,10 @@ export interface OidcConfig {
 	audience?: string;
 	/** OAuth scopes (default `openid email profile`). */
 	scopes?: string;
+	/** Handling for an absent `email_verified` claim (default `required`). */
+	emailVerification?: EmailVerificationPolicy;
+	/** Optional provider-group extraction and entitlement mapping. */
+	groups?: OidcGroupPolicy;
 	/** OAuth `prompt` parameter (default `select_account`). */
 	prompt?: string;
 	/** Secret used to sign the session + transaction cookies (HS256). */
@@ -64,6 +83,178 @@ const TXN_COOKIE = 'mh_oidc_txn';
 
 /** Generous bound for an in-app deep link; anything longer is dropped, not truncated. */
 const MAX_RETURN_TO_LENGTH = 512;
+const MAX_SUBJECT_LENGTH = 512;
+const MAX_EMAIL_LENGTH = 320;
+const MAX_NAME_LENGTH = 200;
+const MAX_PICTURE_URL_INPUT_LENGTH = 2048;
+const MAX_PICTURE_URL_BYTES = 2048;
+// Leaves room for the cookie name and attributes under common 4096-byte limits.
+const MAX_SESSION_JWT_BYTES = 3800;
+const MAX_GROUPS = 200;
+const MAX_GROUP_LENGTH = 256;
+const AUTH_ENTITLEMENT_SET: ReadonlySet<string> = new Set(AUTH_ENTITLEMENTS);
+
+function utf8ByteLength(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}
+
+function hasControlCharacters(value: string): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code <= 0x1f || code === 0x7f) return true;
+	}
+	return false;
+}
+
+function validSubject(value: unknown): value is string {
+	return (
+		typeof value === 'string' &&
+		value.length > 0 &&
+		value.length <= MAX_SUBJECT_LENGTH &&
+		!hasControlCharacters(value)
+	);
+}
+
+function validEmail(value: unknown): value is string {
+	if (
+		typeof value !== 'string' ||
+		value.length === 0 ||
+		value.length > MAX_EMAIL_LENGTH ||
+		hasControlCharacters(value) ||
+		/\s/.test(value)
+	) {
+		return false;
+	}
+	const at = value.lastIndexOf('@');
+	return at > 0 && at < value.length - 1;
+}
+
+function displayNameClaim(value: unknown): string | undefined {
+	if (typeof value !== 'string' || hasControlCharacters(value)) return undefined;
+	const name = value.trim();
+	return name.length > 0 && name.length <= MAX_NAME_LENGTH ? name : undefined;
+}
+
+export function pictureUrlClaim(value: unknown): string | undefined {
+	if (typeof value !== 'string' || value.length > MAX_PICTURE_URL_INPUT_LENGTH) return undefined;
+	try {
+		const url = new URL(value);
+		if (url.protocol !== 'https:' || url.username || url.password) return undefined;
+		const normalized = url.toString();
+		return utf8ByteLength(normalized) <= MAX_PICTURE_URL_BYTES ? normalized : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Resolve an RFC 6901 JSON Pointer without evaluating provider-controlled code. */
+export function claimAtPointer(claims: unknown, pointer: string): unknown {
+	if (!pointer.startsWith('/')) return undefined;
+	let value: unknown = claims;
+	for (const rawSegment of pointer.slice(1).split('/')) {
+		if (!/^(?:[^~]|~[01])*$/.test(rawSegment)) return undefined;
+		const segment = rawSegment.replaceAll('~1', '/').replaceAll('~0', '~');
+		if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+		if (!Object.hasOwn(value, segment)) return undefined;
+		value = (value as Record<string, unknown>)[segment];
+	}
+	return value;
+}
+
+function validJsonPointer(pointer: string): boolean {
+	return (
+		pointer.startsWith('/') &&
+		pointer
+			.slice(1)
+			.split('/')
+			.every((segment) => /^(?:[^~]|~[01])*$/.test(segment))
+	);
+}
+
+function parseUrl(value: string, label: string): URL {
+	try {
+		return new URL(value);
+	} catch {
+		throw new Error(`${label} must be a valid HTTPS URL`);
+	}
+}
+
+function discoveredEndpoint(
+	as: oauth.AuthorizationServer,
+	endpoint: 'authorization_endpoint' | 'end_session_endpoint',
+): URL | undefined {
+	const value = as[endpoint];
+	if (value === undefined) return undefined;
+	let url: URL;
+	try {
+		url = new URL(value);
+		oauth.checkProtocol(url, true);
+	} catch {
+		throw new Error(`OIDC ${endpoint} must be a valid HTTPS URL`);
+	}
+	if (url.username || url.password) {
+		throw new Error(`OIDC ${endpoint} must not contain credentials`);
+	}
+	return url;
+}
+
+function validateGroupPolicy(policy: OidcGroupPolicy): void {
+	const lists = [
+		policy.allowed,
+		policy.superAdmin,
+		policy.defaultRoles?.viewer,
+		policy.defaultRoles?.editor,
+		policy.defaultRoles?.admin,
+	].filter((list): list is string[] => list !== undefined);
+	if (lists.length === 0) throw new Error('OIDC groups claim requires at least one group policy');
+	for (const list of lists) {
+		if (
+			list.length === 0 ||
+			list.length > MAX_GROUPS ||
+			list.some(
+				(group) =>
+					typeof group !== 'string' ||
+					group.length === 0 ||
+					group.length > MAX_GROUP_LENGTH ||
+					hasControlCharacters(group),
+			)
+		) {
+			throw new Error('OIDC group policies must contain 1 to 200 valid group ids');
+		}
+	}
+}
+
+function parseGroups(value: unknown, maxGroups: number): string[] | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value) || value.length > maxGroups) throw new Error('invalid groups claim');
+	const groups: string[] = [];
+	for (const group of value) {
+		if (
+			typeof group !== 'string' ||
+			group.length === 0 ||
+			group.length > MAX_GROUP_LENGTH ||
+			hasControlCharacters(group)
+		) {
+			throw new Error('invalid groups claim');
+		}
+		groups.push(group);
+	}
+	return groups;
+}
+
+function mappedEntitlements(groups: readonly string[], policy: OidcGroupPolicy): AuthEntitlement[] {
+	const memberships = new Set(groups);
+	const entitlements = new Set<AuthEntitlement>();
+	if (policy.superAdmin?.some((group) => memberships.has(group))) {
+		entitlements.add('super-admin');
+	}
+	for (const role of ['viewer', 'editor', 'admin'] as const) {
+		if (policy.defaultRoles?.[role]?.some((group) => memberships.has(group))) {
+			entitlements.add(`default-role:${role}`);
+		}
+	}
+	return [...entitlements];
+}
 
 /**
  * Validate a client-supplied post-login destination (`?redirect_url=` on the
@@ -129,13 +320,71 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 	}
 	const secret = secretBytes;
 	const scopes = config.scopes ?? 'openid email profile';
-	const postLoginRedirect = config.postLoginRedirect ?? '/';
-	const sessionTtl = config.sessionTtlSeconds ?? 8 * 60 * 60;
+	const configuredPostLoginRedirect = config.postLoginRedirect ?? '/';
+	const sanitizedPostLoginRedirect = sanitizeReturnTo(configuredPostLoginRedirect);
+	if (!sanitizedPostLoginRedirect) {
+		throw new Error('OIDC post-login redirect must be a same-origin application path');
+	}
+	const postLoginRedirect = sanitizedPostLoginRedirect;
+	const sessionTtl = config.sessionTtlSeconds ?? (config.groups ? 60 * 60 : 8 * 60 * 60);
+	const emailVerification = config.emailVerification ?? 'required';
+	const maxGroups = config.groups?.maxGroups ?? MAX_GROUPS;
+	const scopeValues = new Set(scopes.split(/\s+/).filter(Boolean));
+	if (!Number.isInteger(sessionTtl) || sessionTtl < 300 || sessionTtl > 86_400) {
+		throw new Error('OIDC session TTL must be an integer between 300 and 86400 seconds');
+	}
+	if (config.groups && sessionTtl > 3600) {
+		throw new Error('OIDC sessions containing group-derived access must not exceed 3600 seconds');
+	}
+	if (emailVerification !== 'required' && emailVerification !== 'trusted-issuer') {
+		throw new Error('Invalid OIDC email verification policy');
+	}
+	if (!scopeValues.has('openid')) {
+		throw new Error('OIDC scopes must include openid');
+	}
+	if (!scopeValues.has('email')) {
+		throw new Error('OIDC scopes must include email');
+	}
+	if (scopeValues.has('offline_access')) {
+		throw new Error('OIDC scopes must not include offline_access');
+	}
+	if (
+		scopeValues.size > 20 ||
+		[...scopeValues].some((scope) => scope.length > 200 || hasControlCharacters(scope))
+	) {
+		throw new Error('OIDC scopes contain an invalid scope value');
+	}
+	if (!Number.isInteger(maxGroups) || maxGroups < 1 || maxGroups > MAX_GROUPS) {
+		throw new Error(`OIDC maxGroups must be between 1 and ${MAX_GROUPS}`);
+	}
+	if (config.groups && !validJsonPointer(config.groups.claim)) {
+		throw new Error('OIDC groups claim must be an RFC 6901 JSON Pointer');
+	}
+	if (config.groups) validateGroupPolicy(config.groups);
 	// Normalize the email-domain allowlist once. Empty means "no restriction".
 	const allowedDomains = normalizeEmailDomains(config.allowedEmailDomains);
 	const restrictDomains = allowedDomains.length > 0;
 
-	const issuerUrl = new URL(config.issuer);
+	const issuerUrl = parseUrl(config.issuer, 'OIDC issuer');
+	if (
+		issuerUrl.protocol !== 'https:' ||
+		issuerUrl.username ||
+		issuerUrl.password ||
+		issuerUrl.search ||
+		issuerUrl.hash
+	) {
+		throw new Error('OIDC issuer must be an HTTPS URL without credentials, query, or fragment');
+	}
+	const redirectUrl = parseUrl(config.redirectUri, 'OIDC redirect URI');
+	if (
+		redirectUrl.protocol !== 'https:' ||
+		redirectUrl.username ||
+		redirectUrl.password ||
+		redirectUrl.hash
+	) {
+		throw new Error('OIDC redirect URI must be an HTTPS URL without credentials or a fragment');
+	}
+	const sessionIssuer = issuerUrl.href;
 	const client: oauth.Client = { client_id: config.clientId };
 	const clientAuth = oauth.ClientSecretPost(config.clientSecret);
 
@@ -150,16 +399,45 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		return asPromise;
 	}
 
-	async function signSession(user: AuthUser): Promise<string> {
-		// `name` is carried in the session cookie (sourced from the OIDC `name`
-		// claim, which the default `profile` scope provides) so the identity
-		// directory can render this user without a second round-trip to the IdP.
-		return new SignJWT({ email: user.email, name: user.name })
-			.setProtectedHeader({ alg: 'HS256' })
+	async function mintSession(
+		user: AuthUser,
+		name: string | undefined,
+		pictureUrl: string | undefined,
+		issuedAt: number,
+		expiresAt: number,
+	): Promise<string> {
+		return new SignJWT({
+			email: user.email,
+			...(name !== undefined ? { name } : {}),
+			...(pictureUrl !== undefined ? { picture_url: pictureUrl } : {}),
+			...(user.entitlements !== undefined ? { entitlements: user.entitlements } : {}),
+		})
+			.setProtectedHeader({ alg: 'HS256', typ: 'mh-session+jwt' })
+			.setIssuer(sessionIssuer)
+			.setAudience(config.clientId)
 			.setSubject(user.id)
-			.setIssuedAt()
-			.setExpirationTime(`${sessionTtl}s`)
+			.setIssuedAt(issuedAt)
+			.setExpirationTime(expiresAt)
 			.sign(secret);
+	}
+
+	async function signSession(user: AuthUser): Promise<string> {
+		const issuedAt = Math.floor(Date.now() / 1000);
+		const expiresAt = issuedAt + sessionTtl;
+		let token = await mintSession(user, user.name, user.pictureUrl, issuedAt, expiresAt);
+		if (utf8ByteLength(token) <= MAX_SESSION_JWT_BYTES) return token;
+
+		if (user.pictureUrl !== undefined) {
+			token = await mintSession(user, user.name, undefined, issuedAt, expiresAt);
+			if (utf8ByteLength(token) <= MAX_SESSION_JWT_BYTES) return token;
+		}
+
+		if (user.name !== undefined) {
+			token = await mintSession(user, undefined, undefined, issuedAt, expiresAt);
+			if (utf8ByteLength(token) <= MAX_SESSION_JWT_BYTES) return token;
+		}
+
+		throw new Error(`OIDC session JWT exceeds ${MAX_SESSION_JWT_BYTES} bytes`);
 	}
 
 	const authenticator: Authenticator = {
@@ -168,10 +446,34 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 			const match = cookie.match(new RegExp(`(?:^|; )${SESSION_COOKIE}=([^;]+)`));
 			if (!match) return null;
 			try {
-				const { payload } = await jwtVerify(decodeURIComponent(match[1]), secret);
-				if (!payload.sub || typeof payload.email !== 'string') return null;
-				const name = typeof payload.name === 'string' ? payload.name : undefined;
-				return { id: UserId.parse(payload.sub), email: payload.email, name };
+				const { payload } = await jwtVerify(decodeURIComponent(match[1]), secret, {
+					algorithms: ['HS256'],
+					typ: 'mh-session+jwt',
+					issuer: sessionIssuer,
+					audience: config.clientId,
+				});
+				if (!validSubject(payload.sub) || !validEmail(payload.email)) return null;
+				const name = displayNameClaim(payload.name);
+				const pictureUrl = pictureUrlClaim(payload.picture_url);
+				const hasGroupAuthorization = Array.isArray(payload.entitlements);
+				const entitlements = hasGroupAuthorization
+					? payload.entitlements.filter(
+							(value): value is AuthEntitlement =>
+								typeof value === 'string' && AUTH_ENTITLEMENT_SET.has(value),
+						)
+					: undefined;
+				const entitlementsExpiresAt =
+					hasGroupAuthorization && typeof payload.exp === 'number'
+						? new Date(payload.exp * 1000).toISOString()
+						: undefined;
+				return {
+					id: UserId.parse(payload.sub),
+					email: payload.email,
+					...(name ? { name } : {}),
+					...(pictureUrl ? { pictureUrl } : {}),
+					...(entitlements?.length ? { entitlements } : {}),
+					...(entitlementsExpiresAt ? { entitlementsExpiresAt } : {}),
+				};
 			} catch {
 				return null;
 			}
@@ -224,7 +526,9 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 
 		// Stash the PKCE/transaction values in a short-lived signed cookie.
 		const txn = await new SignJWT({ verifier: codeVerifier, state, nonce, returnTo })
-			.setProtectedHeader({ alg: 'HS256' })
+			.setProtectedHeader({ alg: 'HS256', typ: 'mh-oidc-txn+jwt' })
+			.setIssuer(sessionIssuer)
+			.setAudience(config.clientId)
 			.setIssuedAt()
 			.setExpirationTime('10m')
 			.sign(secret);
@@ -236,13 +540,24 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 			maxAge: 600,
 		});
 
-		if (!as.authorization_endpoint) {
+		let url: URL | undefined;
+		try {
+			url = discoveredEndpoint(as, 'authorization_endpoint');
+		} catch {
+			return c.json(
+				{
+					success: false,
+					error: { code: 'OIDC_ERROR', message: 'Invalid authorization endpoint' },
+				},
+				500,
+			);
+		}
+		if (!url) {
 			return c.json(
 				{ success: false, error: { code: 'OIDC_ERROR', message: 'No authorization endpoint' } },
 				500,
 			);
 		}
-		const url = new URL(as.authorization_endpoint);
 		url.searchParams.set('response_type', 'code');
 		url.searchParams.set('client_id', config.clientId);
 		url.searchParams.set('redirect_uri', config.redirectUri);
@@ -272,7 +587,12 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		let expectedNonce: string | undefined;
 		let returnTo: string | null = null;
 		try {
-			const { payload } = await jwtVerify(txnCookie, secret);
+			const { payload } = await jwtVerify(txnCookie, secret, {
+				algorithms: ['HS256'],
+				typ: 'mh-oidc-txn+jwt',
+				issuer: sessionIssuer,
+				audience: config.clientId,
+			});
 			if (typeof payload.verifier !== 'string') throw new Error('missing verifier');
 			verifier = payload.verifier;
 			expectedState = typeof payload.state === 'string' ? payload.state : undefined;
@@ -286,6 +606,7 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 
 		const as = await authServer();
 		let claims: oauth.IDToken | undefined;
+		let userInfo: oauth.UserInfoResponse | undefined;
 		try {
 			// validateAuthResponse checks `state` and surfaces error responses; the
 			// grant request + processing run the token exchange and verify the
@@ -304,39 +625,70 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 				requireIdToken: true,
 			});
 			claims = oauth.getValidatedIdTokenClaims(result);
+			if (!claims || !validSubject(claims.sub)) throw new Error('invalid subject');
+			if (as.userinfo_endpoint) {
+				const userInfoResponse = await oauth.userInfoRequest(as, client, result.access_token);
+				userInfo = await oauth.processUserInfoResponse(as, client, claims.sub, userInfoResponse);
+				if (userInfo.sub !== claims.sub) throw new Error('userinfo subject mismatch');
+			}
 		} catch {
 			return callbackError(c, 'auth_failed', returnTo);
 		}
 
-		if (!claims?.sub || typeof claims.email !== 'string') {
+		if (!claims || !validSubject(claims.sub)) {
 			return callbackError(c, 'auth_failed', returnTo);
 		}
+		const identityClaims = userInfo?.email !== undefined ? userInfo : claims;
+		if (!validEmail(identityClaims.email)) return callbackError(c, 'auth_failed', returnTo);
+		const email = identityClaims.email;
+		const emailVerified = identityClaims.email_verified;
 
-		// The email is an authorization credential (project email-invites match on
-		// it), so a provider-declared UNVERIFIED address must never mint a session:
-		// on IdPs with open self-registration (e.g. default Keycloak) it is
-		// attacker-chosen. Providers that omit the claim entirely are tolerated
-		// here — rejecting absence would break IdPs that never send it — but the
-		// domain-allowlist branch below stays strict and demands `true`.
-		if (claims.email_verified === false) {
+		// Email participates in project authorization, so a present verification
+		// claim must be exactly true. Only omission is covered by trusted-issuer.
+		if (emailVerified !== undefined && emailVerified !== true) {
+			return callbackError(c, 'email_not_verified', returnTo);
+		}
+		if (emailVerification === 'required' && emailVerified !== true) {
 			return callbackError(c, 'email_not_verified', returnTo);
 		}
 
-		if (restrictDomains) {
-			// Require a provider-verified address before trusting its domain — an
-			// unverified email could carry an attacker-chosen `@marimo.io` value.
-			if (claims.email_verified !== true) {
-				return callbackError(c, 'email_not_verified', returnTo);
-			}
-			if (!emailDomainAllowed(claims.email, allowedDomains)) {
-				return callbackError(c, 'domain_not_allowed', returnTo);
-			}
+		if (restrictDomains && !emailDomainAllowed(email, allowedDomains)) {
+			return callbackError(c, 'domain_not_allowed', returnTo);
 		}
 
-		// The `name` claim rides along with the default `profile` scope. When the
-		// provider omits it, the identity directory falls back to the email.
-		const name = typeof claims.name === 'string' ? claims.name : undefined;
-		const session = await signSession({ id: UserId.parse(claims.sub), email: claims.email, name });
+		let entitlements: AuthEntitlement[] | undefined;
+		if (config.groups) {
+			let rawGroups = userInfo ? claimAtPointer(userInfo, config.groups.claim) : undefined;
+			if (rawGroups === undefined) rawGroups = claimAtPointer(claims, config.groups.claim);
+			let groups: string[];
+			try {
+				groups = parseGroups(rawGroups, maxGroups) ?? [];
+			} catch {
+				return callbackError(c, 'auth_failed', returnTo);
+			}
+			if (
+				config.groups.allowed?.length &&
+				!config.groups.allowed.some((group) => groups.includes(group))
+			) {
+				return callbackError(c, 'group_not_allowed', returnTo);
+			}
+			entitlements = mappedEntitlements(groups, config.groups);
+		}
+
+		const name = displayNameClaim(userInfo?.name) ?? displayNameClaim(claims.name);
+		const pictureUrl = pictureUrlClaim(userInfo?.picture) ?? pictureUrlClaim(claims.picture);
+		let session: string;
+		try {
+			session = await signSession({
+				id: UserId.parse(claims.sub),
+				email,
+				...(name ? { name } : {}),
+				...(pictureUrl ? { pictureUrl } : {}),
+				...(config.groups ? { entitlements: entitlements ?? [] } : {}),
+			});
+		} catch {
+			return callbackError(c, 'auth_failed', returnTo);
+		}
 		setCookie(c, SESSION_COOKIE, session, {
 			httpOnly: true,
 			secure: true,
@@ -351,8 +703,13 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 	routes.get('/api/auth/logout', async (c) => {
 		deleteCookie(c, SESSION_COOKIE, { path: '/' });
 		const as = await authServer();
-		if (as.end_session_endpoint) {
-			const url = new URL(as.end_session_endpoint);
+		let url: URL | undefined;
+		try {
+			url = discoveredEndpoint(as, 'end_session_endpoint');
+		} catch {
+			return c.redirect(postLoginRedirect);
+		}
+		if (url) {
 			url.searchParams.set('client_id', config.clientId);
 			return c.redirect(url.toString());
 		}

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -4965,7 +4965,7 @@ export interface paths {
 		};
 		/**
 		 * Resolve user ids to display identities
-		 * @description Batch-resolve opaque user ids (the auth `sub` stored as a notebook `author` or session `user_id`) into `{ id, email, name }`. Ids with no recorded identity are omitted from the result map.
+		 * @description Batch-resolve opaque user ids (the auth `sub` stored as a notebook `author` or session `user_id`) into `{ id, email, name, picture_url }`. Ids with no recorded identity are omitted from the result map.
 		 */
 		get: {
 			parameters: {
@@ -5277,6 +5277,9 @@ export interface components {
 		Me: {
 			id: string;
 			email: string;
+			name?: string | null;
+			/** Format: uri */
+			picture_url?: string | null;
 			logout_url: string | null;
 			is_super_admin: boolean;
 		};
@@ -5833,6 +5836,8 @@ export interface components {
 			id: string;
 			email: string;
 			name: string;
+			/** Format: uri */
+			picture_url?: string | null;
 		};
 		ApiTokenCreated: components['schemas']['ApiToken'] & {
 			token: string;

--- a/packages/config/src/auth.test.ts
+++ b/packages/config/src/auth.test.ts
@@ -17,6 +17,54 @@ const oidcEnv = {
 	MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: 'example.com',
 };
 
+function getConfigError(run: () => unknown): ConfigError {
+	try {
+		run();
+	} catch (error) {
+		expect(error).toBeInstanceOf(ConfigError);
+		return error as ConfigError;
+	}
+	throw new Error('Expected configuration to fail');
+}
+
+describe('makeAuth selector errors', () => {
+	it('fails closed when the backend is unset and provides actionable metadata', () => {
+		const error = getConfigError(() => makeAuth({}));
+
+		expect(error.opts).toEqual({
+			variable: 'MARIMOHUB_AUTH_BACKEND',
+			remediation: 'Set it to oidc (production), cloudflare-access (Workers), or dev (local only).',
+			docs: 'docs/configuration.md#auth',
+		});
+		expect(error.format()).toContain('Refusing to start');
+		expect(error.format()).toContain('MARIMOHUB_AUTH_BACKEND');
+	});
+
+	it('rejects an unknown backend and lists the supported values', () => {
+		const error = getConfigError(() => makeAuth({ MARIMOHUB_AUTH_BACKEND: 'oauth' }));
+
+		expect(error.message).toBe('Unknown MARIMOHUB_AUTH_BACKEND: oauth');
+		expect(error.opts.variable).toBe('MARIMOHUB_AUTH_BACKEND');
+		expect(error.opts.remediation).toContain('oidc, cloudflare-access, dev');
+	});
+
+	it('still supports the explicit local-development backend', async () => {
+		const { authenticator, authRoutes } = makeAuth({
+			MARIMOHUB_AUTH_BACKEND: 'dev',
+			MARIMOHUB_AUTH_DEV_USER_ID: 'local-user',
+			MARIMOHUB_AUTH_DEV_EMAIL: 'local@example.com',
+			MARIMOHUB_AUTH_DEV_NAME: 'Local User',
+		});
+
+		expect(authRoutes).toBeUndefined();
+		await expect(authenticator.authenticate(new Request('http://localhost'))).resolves.toEqual({
+			id: 'local-user',
+			email: 'local@example.com',
+			name: 'Local User',
+		});
+	});
+});
+
 describe('makeAuth oidc required vars', () => {
 	it('throws when MARIMOHUB_AUTH_SESSION_SECRET is missing', () => {
 		const { MARIMOHUB_AUTH_SESSION_SECRET: _omit, ...env } = oidcEnv;
@@ -32,6 +80,209 @@ describe('makeAuth oidc required vars', () => {
 		const env: Record<string, string | undefined> = { ...oidcEnv };
 		delete env[key];
 		expect(() => makeAuth(env)).toThrow(new RegExp(key));
+	});
+
+	it.each([undefined, '', '   ', ',,,'])('requires a deliberate email allowlist (%j)', (value) => {
+		const error = getConfigError(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: value }),
+		);
+
+		expect(error.opts.variable).toBe('MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS');
+		expect(error.opts.remediation).toContain('"*" to allow all');
+		expect(error.opts.docs).toBe('docs/configuration.md#auth');
+	});
+
+	it('accepts only an explicit wildcard as the allow-all choice', () => {
+		expect(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: '  *  ' }),
+		).not.toThrow();
+	});
+
+	it('requires openid and email scopes and rejects unused offline access', () => {
+		expect(() => makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_SCOPES: 'openid profile' })).toThrow(
+			/MARIMOHUB_AUTH_OIDC_SCOPES must include openid and email/,
+		);
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_SCOPES: 'openid email offline_access',
+			}),
+		).toThrow(/must not request offline_access/);
+	});
+
+	it.each([
+		[
+			'too many values',
+			['openid', 'email', ...Array.from({ length: 19 }, (_, i) => `s${i}`)].join(' '),
+		],
+		['oversized value', `openid email ${'s'.repeat(201)}`],
+		['NUL in value', 'openid email bad\0scope'],
+		['DEL in value', 'openid email bad\u007fscope'],
+	])('rejects invalid scope configuration: %s', (_name, scopes) => {
+		expect(() => makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_SCOPES: scopes })).toThrow(
+			/MARIMOHUB_AUTH_OIDC_SCOPES contains an invalid scope value/,
+		);
+	});
+
+	it('deduplicates scopes and accepts the supported boundary count', () => {
+		const twentyScopes = [
+			'openid',
+			'email',
+			...Array.from({ length: 18 }, (_, i) => `scope-${i}`),
+		].join(' ');
+
+		expect(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_SCOPES: 'openid email email profile' }),
+		).not.toThrow();
+		expect(() => makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_SCOPES: twentyScopes })).not.toThrow();
+	});
+
+	it('requires a claim pointer and policy for group authorization', () => {
+		expect(() => makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: 'hub-users' })).toThrow(
+			/GROUPS_CLAIM/,
+		);
+		expect(() => makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups' })).toThrow(
+			/requires at least one group policy/,
+		);
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+				MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: 'hub-users',
+			}),
+		).not.toThrow();
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/realm~2access/roles',
+				MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: 'hub-users',
+			}),
+		).toThrow(/RFC 6901 JSON Pointer/);
+	});
+
+	it.each([
+		['missing leading slash', 'groups'],
+		['invalid tilde escape', '/realm~2access/roles'],
+		['oversized pointer', `/${'a'.repeat(512)}`],
+	])('rejects an invalid group claim pointer: %s', (_name, claim) => {
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: claim,
+				MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: 'hub-users',
+			}),
+		).toThrow(/RFC 6901 JSON Pointer/);
+	});
+
+	it.each([
+		'MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS',
+		'MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS',
+		'MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS',
+		'MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS',
+		'MARIMOHUB_AUTH_OIDC_DEFAULT_ADMIN_GROUPS',
+	])('accepts %s as an independent group policy', (key) => {
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/realm~1access/~0roles',
+				[key]: 'group-1, group-2',
+			}),
+		).not.toThrow();
+	});
+
+	it.each([
+		['too many groups', Array.from({ length: 201 }, (_, i) => `group-${i}`).join(',')],
+		['oversized group id', 'g'.repeat(257)],
+		['control character', 'hub-users,admin\u007fgroup'],
+	])('rejects invalid group lists: %s', (_name, groups) => {
+		const error = getConfigError(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+				MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: groups,
+			}),
+		);
+
+		expect(error.message).toContain('expected at most 200 group ids');
+		expect(error.opts.variable).toBe('MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS');
+	});
+
+	it('requires HTTPS issuer and redirect URLs', () => {
+		expect(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_ISSUER: 'http://accounts.example.com' }),
+		).toThrow(/OIDC issuer must be an HTTPS URL/);
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_REDIRECT_URI: 'http://hub.example.com/api/auth/callback',
+			}),
+		).toThrow(/OIDC redirect URI must be an HTTPS URL/);
+	});
+
+	it('bounds both ordinary and group-derived session lifetimes', () => {
+		expect(() => makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_SESSION_TTL_SECONDS: '299' })).toThrow(
+			/AUTH_SESSION_TTL_SECONDS/,
+		);
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+				MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: 'hub-users',
+				MARIMOHUB_AUTH_OIDC_GROUP_SESSION_TTL_SECONDS: '3601',
+			}),
+		).toThrow(/GROUP_SESSION_TTL_SECONDS/);
+	});
+
+	it.each(['300.5', 'abc', 'NaN', '299', '86401'])('rejects invalid session TTL %s', (ttl) => {
+		expect(() => makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_SESSION_TTL_SECONDS: ttl })).toThrow(
+			/expected an integer from 300 to 86400/,
+		);
+	});
+
+	it.each(['299', '3601', '1.5', 'forever'])('rejects invalid group session TTL %s', (ttl) => {
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+				MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: 'hub-users',
+				MARIMOHUB_AUTH_OIDC_GROUP_SESSION_TTL_SECONDS: ttl,
+			}),
+		).toThrow(/expected an integer from 300 to 3600/);
+	});
+
+	it('accepts inclusive TTL boundaries and ignores group TTL without a group policy', () => {
+		expect(() => makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_SESSION_TTL_SECONDS: '300' })).not.toThrow();
+		expect(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_SESSION_TTL_SECONDS: '86400' }),
+		).not.toThrow();
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+				MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: 'hub-users',
+				MARIMOHUB_AUTH_OIDC_GROUP_SESSION_TTL_SECONDS: '300',
+			}),
+		).not.toThrow();
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+				MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS: 'hub-users',
+				MARIMOHUB_AUTH_OIDC_GROUP_SESSION_TTL_SECONDS: '3600',
+			}),
+		).not.toThrow();
+		expect(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_GROUP_SESSION_TTL_SECONDS: 'not-used' }),
+		).not.toThrow();
+	});
+
+	it('accepts only the explicit email-verification policies', () => {
+		expect(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION: 'optional' }),
+		).toThrow(/AUTH_OIDC_EMAIL_VERIFICATION/);
+		expect(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION: 'trusted-issuer' }),
+		).not.toThrow();
 	});
 });
 

--- a/packages/config/src/auth.ts
+++ b/packages/config/src/auth.ts
@@ -1,8 +1,9 @@
 import type { Authenticator } from '@marimo-hub/core';
 import { createOidcAuth } from '@marimo-hub/auth-oidc';
+import type { EmailVerificationPolicy, OidcGroupPolicy } from '@marimo-hub/auth-oidc';
 import { DevAuthenticator } from '@marimo-hub/auth-dev';
 import type { Hono } from 'hono';
-import { parseList, requiredVar } from './env';
+import { parseEnumOr, parseList, requiredVar } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
 
@@ -41,6 +42,116 @@ function parseEmailDomains(raw: string | undefined): string[] | undefined {
 	return domains;
 }
 
+const DEFAULT_SESSION_TTL_SECONDS = 8 * 60 * 60;
+const DEFAULT_GROUP_SESSION_TTL_SECONDS = 60 * 60;
+
+function hasAsciiAtOrBelow(value: string, limit: number): boolean {
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code <= limit || code === 0x7f) return true;
+	}
+	return false;
+}
+
+function parseSeconds(env: Env, key: string, fallback: number, min: number, max: number): number {
+	const raw = env[key]?.trim();
+	if (!raw) return fallback;
+	const value = Number(raw);
+	if (!Number.isInteger(value) || value < min || value > max) {
+		throw new ConfigError(`Invalid ${key}: ${raw} (expected an integer from ${min} to ${max})`, {
+			variable: key,
+		});
+	}
+	return value;
+}
+
+function parseScopes(raw: string | undefined): string {
+	const scopes = [...new Set((raw?.trim() || 'openid email profile').split(/\s+/).filter(Boolean))];
+	if (!scopes.includes('openid') || !scopes.includes('email')) {
+		throw new ConfigError('MARIMOHUB_AUTH_OIDC_SCOPES must include openid and email.', {
+			variable: 'MARIMOHUB_AUTH_OIDC_SCOPES',
+		});
+	}
+	if (scopes.includes('offline_access')) {
+		throw new ConfigError(
+			'MARIMOHUB_AUTH_OIDC_SCOPES must not request offline_access; marimohub does not retain refresh tokens.',
+			{ variable: 'MARIMOHUB_AUTH_OIDC_SCOPES' },
+		);
+	}
+	if (
+		scopes.length > 20 ||
+		scopes.some((scope) => scope.length > 200 || hasAsciiAtOrBelow(scope, 0x20))
+	) {
+		throw new ConfigError('MARIMOHUB_AUTH_OIDC_SCOPES contains an invalid scope value.', {
+			variable: 'MARIMOHUB_AUTH_OIDC_SCOPES',
+		});
+	}
+	return scopes.join(' ');
+}
+
+function checkedGroups(env: Env, key: string): string[] | undefined {
+	const groups = parseList(env[key]);
+	if (
+		groups &&
+		(groups.length > 200 ||
+			groups.some((group) => group.length > 256 || hasAsciiAtOrBelow(group, 0x1f)))
+	) {
+		throw new ConfigError(
+			`Invalid ${key}: expected at most 200 group ids of at most 256 characters.`,
+			{
+				variable: key,
+			},
+		);
+	}
+	return groups;
+}
+
+function parseGroupPolicy(env: Env): OidcGroupPolicy | undefined {
+	const claim = env.MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM?.trim();
+	const allowed = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS');
+	const superAdmin = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS');
+	const viewer = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS');
+	const editor = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS');
+	const admin = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_DEFAULT_ADMIN_GROUPS');
+	const configured = Boolean(claim || allowed || superAdmin || viewer || editor || admin);
+	if (!configured) return undefined;
+	if (
+		!claim ||
+		!claim.startsWith('/') ||
+		claim.length > 512 ||
+		!claim
+			.slice(1)
+			.split('/')
+			.every((segment) => /^(?:[^~]|~[01])*$/.test(segment))
+	) {
+		throw new ConfigError(
+			'MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM must be an RFC 6901 JSON Pointer such as /groups.',
+			{
+				variable: 'MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM',
+			},
+		);
+	}
+	if (!allowed && !superAdmin && !viewer && !editor && !admin) {
+		throw new ConfigError('An OIDC groups claim requires at least one group policy.', {
+			variable: 'MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM',
+		});
+	}
+	return {
+		claim,
+		...(allowed ? { allowed } : {}),
+		...(superAdmin ? { superAdmin } : {}),
+		...(viewer || editor || admin
+			? {
+					defaultRoles: {
+						...(viewer ? { viewer } : {}),
+						...(editor ? { editor } : {}),
+						...(admin ? { admin } : {}),
+					},
+				}
+			: {}),
+	};
+}
+
 export function makeAuth(env: Env): { authenticator: Authenticator; authRoutes?: Hono } {
 	const backend = env.MARIMOHUB_AUTH_BACKEND;
 	if (!backend) {
@@ -62,15 +173,41 @@ export function makeAuth(env: Env): { authenticator: Authenticator; authRoutes?:
 		});
 	switch (backend) {
 		case 'oidc': {
+			const groups = parseGroupPolicy(env);
+			const sessionTtlSeconds = parseSeconds(
+				env,
+				'MARIMOHUB_AUTH_SESSION_TTL_SECONDS',
+				DEFAULT_SESSION_TTL_SECONDS,
+				300,
+				86_400,
+			);
+			const groupSessionTtlSeconds = groups
+				? parseSeconds(
+						env,
+						'MARIMOHUB_AUTH_OIDC_GROUP_SESSION_TTL_SECONDS',
+						DEFAULT_GROUP_SESSION_TTL_SECONDS,
+						300,
+						3600,
+					)
+				: sessionTtlSeconds;
 			const { authenticator, routes } = createOidcAuth({
 				issuer: oidc('MARIMOHUB_AUTH_OIDC_ISSUER'),
 				clientId: oidc('MARIMOHUB_AUTH_OIDC_CLIENT_ID'),
 				clientSecret: oidc('MARIMOHUB_AUTH_OIDC_CLIENT_SECRET'),
 				redirectUri: oidc('MARIMOHUB_AUTH_OIDC_REDIRECT_URI'),
 				audience: env.MARIMOHUB_AUTH_OIDC_AUDIENCE,
+				scopes: parseScopes(env.MARIMOHUB_AUTH_OIDC_SCOPES),
+				emailVerification: parseEnumOr<EmailVerificationPolicy>(
+					env,
+					'MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION',
+					['required', 'trusted-issuer'],
+					'required',
+				),
 				sessionSecret: oidc('MARIMOHUB_AUTH_SESSION_SECRET'),
+				sessionTtlSeconds: Math.min(sessionTtlSeconds, groupSessionTtlSeconds),
 				allowedEmailDomains: parseEmailDomains(env.MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS),
 				prompt: env.MARIMOHUB_AUTH_OIDC_PROMPT?.trim() || undefined,
+				...(groups ? { groups } : {}),
 			});
 			return { authenticator, authRoutes: routes };
 		}

--- a/packages/config/src/spec.test.ts
+++ b/packages/config/src/spec.test.ts
@@ -58,6 +58,16 @@ describe('config registry sanity', () => {
 		}
 	});
 
+	it('marks the ignored OIDC audience setting as deprecated', () => {
+		const audience = CONFIG_SPEC.flatMap((group) => group.backends)
+			.flatMap((backend) => backend.vars)
+			.find((variable) => variable.id === 'MARIMOHUB_AUTH_OIDC_AUDIENCE');
+
+		expect(audience?.name).toContain('deprecated');
+		expect(audience?.description).toContain('ignored');
+		expect(audience?.description).toContain('client ID');
+	});
+
 	it('selector values are unique within a group, and only appear where a group has a selector', () => {
 		for (const g of CONFIG_SPEC) {
 			const selectorValues = g.backends

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -738,8 +738,9 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 					},
 					{
 						id: 'MARIMOHUB_AUTH_OIDC_AUDIENCE',
-						name: 'OIDC audience',
-						description: 'Optional ID-token audience. oauth4webapi always enforces the client ID.',
+						name: 'OIDC audience (deprecated)',
+						description:
+							'Deprecated and ignored. The ID-token `aud` claim must contain the configured client ID.',
 					},
 					{
 						id: 'MARIMOHUB_AUTH_OIDC_PROMPT',

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -739,16 +739,32 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 					{
 						id: 'MARIMOHUB_AUTH_OIDC_AUDIENCE',
 						name: 'OIDC audience',
-						description:
-							'Expected ID-token audience (optional; oauth4webapi enforces the client id automatically).',
+						description: 'Optional ID-token audience. oauth4webapi always enforces the client ID.',
 					},
 					{
 						id: 'MARIMOHUB_AUTH_OIDC_PROMPT',
 						name: 'OIDC prompt',
 						description:
-							'OAuth `prompt` parameter. Defaults to `select_account`, so a returning user always gets the account chooser instead of being silently logged in with their last account. Override with `consent` to re-show the consent screen, or space-separated combinations.',
+							'OAuth `prompt` value. `select_account` displays the account chooser. Use `consent` to display consent again. Space-separated combinations are valid.',
 						default: 'select_account',
 						example: 'consent',
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_SCOPES',
+						name: 'OIDC scopes',
+						description:
+							'Space-separated scopes. Must include `openid` and `email`. Add only scopes that the provider requires for group claims. `offline_access` is invalid because marimohub stores no refresh tokens.',
+						default: 'openid email profile',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION',
+						name: 'Email verification policy',
+						description:
+							'Requires boolean `email_verified=true` by default. If a trusted issuer omits the claim, use `trusted-issuer`. Other present values are invalid.',
+						default: 'required',
+						example: 'trusted-issuer',
+						optIn: true,
 					},
 					{
 						id: 'MARIMOHUB_AUTH_SESSION_SECRET',
@@ -758,12 +774,66 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						secret: true,
 					},
 					{
+						id: 'MARIMOHUB_AUTH_SESSION_TTL_SECONDS',
+						name: 'Auth session lifetime',
+						description: 'Signed browser-session lifetime, from 300 to 86400 seconds.',
+						default: '28800',
+						optIn: true,
+					},
+					{
 						id: 'MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS',
 						name: 'Allowed email domains',
 						description:
-							'Comma-separated email-domain allowlist (requires a verified email). Required so a deployment cannot silently admit every account the IdP authenticates; set `*` to explicitly allow all domains. A single domain is also sent to Google as the `hd` hint.',
+							'Comma-separated email-domain allowlist. Set `*` to allow all domains. A single domain is also the Google `hd` hint.',
 						example: 'example.com,example.org',
 						required: true,
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM',
+						name: 'Groups claim pointer',
+						description:
+							'RFC 6901 JSON Pointer to an array of exact provider group IDs. Required for group policy.',
+						example: '/groups',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS',
+						name: 'Allowed login groups',
+						description:
+							'Exact comma-separated group IDs. A user must belong to at least one. Missing or malformed group data fails closed.',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS',
+						name: 'Super-admin groups',
+						description: 'Exact comma-separated group IDs mapped to marimohub super-admin.',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS',
+						name: 'Default viewer groups',
+						description: 'Groups granted a deployment-wide default viewer role.',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS',
+						name: 'Default editor groups',
+						description: 'Groups granted a deployment-wide default editor role.',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_DEFAULT_ADMIN_GROUPS',
+						name: 'Default admin groups',
+						description: 'Groups granted a deployment-wide default project-admin role.',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_AUTH_OIDC_GROUP_SESSION_TTL_SECONDS',
+						name: 'Group authorization lifetime',
+						description:
+							'Maximum group-session age, from 300 to 3600 seconds. This value limits the deprovisioning delay.',
+						default: '3600',
+						optIn: true,
 					},
 				],
 			},

--- a/packages/core/src/authz.test.ts
+++ b/packages/core/src/authz.test.ts
@@ -70,6 +70,31 @@ describe('authz', () => {
 			expect(effectiveRole(project, STRANGER, { defaultRole: 'viewer' })).toBe('viewer');
 		});
 
+		it('maps a group-derived entitlement to the highest per-user default role', () => {
+			const entitled = {
+				...STRANGER,
+				entitlements: ['default-role:viewer', 'default-role:editor'] as const,
+			};
+			expect(effectiveRole(project, entitled)).toBe('editor');
+			expect(effectiveRole(project, entitled, { defaultRole: 'viewer' })).toBe('editor');
+		});
+
+		it('keeps a higher deployment default when group entitlements are lower', () => {
+			const entitled = {
+				...STRANGER,
+				entitlements: ['default-role:editor', 'default-role:viewer'] as const,
+			};
+			expect(effectiveRole(project, entitled, { defaultRole: 'admin' })).toBe('admin');
+		});
+
+		it('does not let a default-role entitlement override explicit membership', () => {
+			const entitledViewer = {
+				...VIEWER,
+				entitlements: ['default-role:admin'] as const,
+			};
+			expect(effectiveRole(project, entitledViewer)).toBe('viewer');
+		});
+
 		it('does not let the default role override an explicit membership', () => {
 			expect(effectiveRole(project, VIEWER, { defaultRole: 'admin' })).toBe('viewer');
 			expect(effectiveRole(project, OWNER, { defaultRole: 'viewer' })).toBe('admin');
@@ -82,6 +107,7 @@ describe('authz', () => {
 
 		it('super admin outranks an explicit lower membership', () => {
 			expect(effectiveRole(project, VIEWER, { superAdmins: [VIEWER.id] })).toBe('admin');
+			expect(effectiveRole(project, { ...VIEWER, entitlements: ['super-admin'] })).toBe('admin');
 		});
 	});
 
@@ -120,6 +146,16 @@ describe('authz', () => {
 			// gains nothing.
 			const bystander = subject('other_id', 'user_god@example.com');
 			expect(isSuperAdmin(bystander, ['user_god'])).toBe(false);
+		});
+
+		it('accepts only the normalized super-admin entitlement', () => {
+			expect(isSuperAdmin({ ...STRANGER, entitlements: ['super-admin'] })).toBe(true);
+			expect(
+				isSuperAdmin({
+					...STRANGER,
+					entitlements: ['default-role:admin'],
+				}),
+			).toBe(false);
 		});
 	});
 
@@ -180,6 +216,15 @@ describe('authz', () => {
 		it('makes every project visible when a default role is set', () => {
 			expect(canSeeProjectEntry(entry, STRANGER, { defaultRole: 'viewer' })).toBe(true);
 			expect(canSeeProjectEntry(entry, STRANGER, { defaultRole: 'editor' })).toBe(true);
+		});
+
+		it('makes every project visible for a group-derived default role', () => {
+			expect(
+				canSeeProjectEntry(entry, {
+					...STRANGER,
+					entitlements: ['default-role:viewer'],
+				}),
+			).toBe(true);
 		});
 
 		it('restricts visibility to owner and members under none (null default)', () => {

--- a/packages/core/src/authz.ts
+++ b/packages/core/src/authz.ts
@@ -5,11 +5,10 @@
  * answers *what* an authenticated caller may do on a given project.
  *
  * Writes are gated by the role matrix (see development_docs/bucket_spec.md §12)
- * against the target project. Reads are gated at `viewer`: with a
- * `defaultRole` set (the usual editor/viewer deployment) every authenticated
- * user is at least a viewer, so reads stay open; with `MARIMOHUB_DEFAULT_ROLE`
- * unset (`none`), reads are membership-gated — a non-member cannot see the
- * project at all. A project's `owner` is implicitly admin.
+ * against the target project. Reads are gated at `viewer`: with a default role
+ * set by deployment policy or a mapped OIDC entitlement, the user is at least
+ * a viewer, so reads stay open. Otherwise reads are membership-gated and a
+ * non-member cannot see the project. A project's `owner` is implicitly admin.
  *
  * A member row carries either a `user_id` or an `email` (a pending invite for
  * someone who hasn't logged in yet). The caller is therefore matched as a
@@ -26,6 +25,20 @@ import type { IdentitySubject } from './identityMatch';
 import type { Project } from './schema';
 
 const RANK: Record<Role, number> = { viewer: 1, editor: 2, admin: 3 };
+const ENTITLEMENT_ROLE: Partial<Record<string, Role>> = {
+	'default-role:viewer': 'viewer',
+	'default-role:editor': 'editor',
+	'default-role:admin': 'admin',
+};
+
+export function subjectDefaultRole(subject: AuthSubject, policy?: AuthzPolicy): Role | null {
+	let role = policy?.defaultRole ?? null;
+	for (const entitlement of subject.entitlements ?? []) {
+		const candidate = ENTITLEMENT_ROLE[entitlement];
+		if (candidate && (role === null || RANK[candidate] > RANK[role])) role = candidate;
+	}
+	return role;
+}
 
 /**
  * The authenticated caller as authorization sees them. Structurally a subset
@@ -46,13 +59,16 @@ export interface AuthzPolicy {
 }
 
 /**
- * Whether the caller is a deployment super admin (config:
- * MARIMOHUB_SUPER_ADMINS). Super admins hold implicit `admin` on every project
- * and see all projects in listings. Entries match by id or email per the
- * namespace rule in {@link refMatchesSubject}.
+ * Whether the caller is a deployment super admin, either from static config or
+ * a mapped OIDC session entitlement. Super admins hold implicit `admin` on
+ * every project and see all projects in listings. Static entries match by id or
+ * email per the namespace rule in {@link refMatchesSubject}.
  */
 export function isSuperAdmin(subject: AuthSubject, superAdmins?: readonly string[]): boolean {
-	return anyRefMatchesSubject(superAdmins, subject);
+	return (
+		subject.entitlements?.includes('super-admin') === true ||
+		anyRefMatchesSubject(superAdmins, subject)
+	);
 }
 
 /**
@@ -63,7 +79,7 @@ export function isSuperAdmin(subject: AuthSubject, superAdmins?: readonly string
  * the owner nor an explicit member. Left undefined it preserves the
  * members-only behavior; passed `editor` it lets every logged-in user edit
  * notebooks. The default never overrides an explicit membership — it only
- * fills the gap when there is none. A super admin (`policy.superAdmins`) is
+ * fills the gap when there is none. A static or group-derived super admin is
  * `admin` everywhere, regardless of membership.
  *
  * When both an id row and an email row match the same caller (added by id and
@@ -83,7 +99,7 @@ export function effectiveRole(
 		if (best === null || RANK[member.role] > RANK[best]) best = member.role;
 		if (best === 'admin') break;
 	}
-	return best ?? policy?.defaultRole ?? null;
+	return best ?? subjectDefaultRole(subject, policy);
 }
 
 /** True if the caller's role on the project is at least `min`. */
@@ -135,7 +151,7 @@ export function canSeeProjectEntry(
 	policy?: AuthzPolicy,
 ): boolean | null {
 	if (isSuperAdmin(subject, policy?.superAdmins)) return true;
-	if (policy?.defaultRole != null) return true;
+	if (subjectDefaultRole(subject, policy) != null) return true;
 	if (entry.owner === subject.id) return true;
 	if (entry.member_ids === undefined) return null;
 	if (entry.member_ids.includes(subject.id)) return true;

--- a/packages/core/src/identityMatch.ts
+++ b/packages/core/src/identityMatch.ts
@@ -6,11 +6,13 @@
  */
 
 import type { UserId } from './ids';
+import type { AuthEntitlement } from './ports/auth';
 
 /** The authenticated caller reduced to what identity matching needs. */
 export interface IdentitySubject {
 	id: UserId;
 	email: string;
+	entitlements?: readonly AuthEntitlement[];
 }
 
 /** A member reference: exactly one of a user id or an email. */

--- a/packages/core/src/ports/auth.test.ts
+++ b/packages/core/src/ports/auth.test.ts
@@ -1,0 +1,10 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { AuthEntitlement, AuthUser } from './auth';
+
+describe('AuthUser', () => {
+	it('exposes resolved entitlements as readonly authorization data', () => {
+		expectTypeOf<AuthUser['entitlements']>().toEqualTypeOf<
+			readonly AuthEntitlement[] | undefined
+		>();
+	});
+});

--- a/packages/core/src/ports/auth.ts
+++ b/packages/core/src/ports/auth.ts
@@ -31,7 +31,7 @@ export interface AuthUser {
 	/** Validated HTTPS profile-picture URL, used only for presentation. */
 	pictureUrl?: string;
 	/** Provider groups mapped to marimohub-owned authorization capabilities. */
-	entitlements?: AuthEntitlement[];
+	entitlements?: readonly AuthEntitlement[];
 	/** Expiry of the credential that supplied group authorization. */
 	entitlementsExpiresAt?: string;
 }

--- a/packages/core/src/ports/auth.ts
+++ b/packages/core/src/ports/auth.ts
@@ -9,6 +9,15 @@
  */
 import type { UserId } from '../ids';
 
+export const AUTH_ENTITLEMENTS = [
+	'super-admin',
+	'default-role:viewer',
+	'default-role:editor',
+	'default-role:admin',
+] as const;
+
+export type AuthEntitlement = (typeof AUTH_ENTITLEMENTS)[number];
+
 export interface AuthUser {
 	id: UserId;
 	email: string;
@@ -19,6 +28,12 @@ export interface AuthUser {
 	 * directory so opaque user ids (`sub`) can be rendered as a person.
 	 */
 	name?: string;
+	/** Validated HTTPS profile-picture URL, used only for presentation. */
+	pictureUrl?: string;
+	/** Provider groups mapped to marimohub-owned authorization capabilities. */
+	entitlements?: AuthEntitlement[];
+	/** Expiry of the credential that supplied group authorization. */
+	entitlementsExpiresAt?: string;
 }
 
 export interface Authenticator {

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import {
 	CatalogSchema,
 	EventSchema,
+	IdentitySchema,
 	NotebookIdSchema,
 	parseStored,
 	readStored,
@@ -33,6 +34,32 @@ import {
 	ACTOR,
 	NOW,
 } from './testing';
+
+describe('IdentitySchema', () => {
+	const identity = {
+		id: 'user-1',
+		email: 'user@example.com',
+		name: 'User',
+		updated_at: NOW,
+	};
+
+	it('accepts an HTTPS profile-picture URL', () => {
+		expect(
+			IdentitySchema.safeParse({
+				...identity,
+				picture_url: 'https://images.example.com/avatar.png',
+			}).success,
+		).toBe(true);
+	});
+
+	it.each([
+		['HTTP', 'http://images.example.com/avatar.png'],
+		['non-HTTP', 'ftp://images.example.com/avatar.png'],
+		['invalid', 'not-a-url'],
+	])('rejects a %s profile-picture URL', (_label, pictureUrl) => {
+		expect(IdentitySchema.safeParse({ ...identity, picture_url: pictureUrl }).success).toBe(false);
+	});
+});
 
 describe('parseStored', () => {
 	const schema = z.object({ a: z.number() });

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -725,7 +725,7 @@ export const IdentitySchema = z.object({
 	id: UserIdSchema,
 	email: z.string(),
 	name: z.string(),
-	picture_url: z.url().optional(),
+	picture_url: z.url({ protocol: /^https$/ }).optional(),
 	updated_at: z.iso.datetime(),
 });
 

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -581,6 +581,8 @@ export const SessionSchema = z.looseObject({
 	 * (connection-aware extension). Absent on records that predate the sweep.
 	 */
 	expires_at: z.iso.datetime().optional(),
+	/** Non-extendable expiry of the entitlement credential that authorized this kernel. */
+	authorization_expires_at: z.iso.datetime().optional(),
 	/**
 	 * Last time the periodic snapshotter saved the notebook back to the bucket.
 	 * Cadence bookkeeping only — `commitSession` dedupes unchanged content, so this
@@ -723,6 +725,7 @@ export const IdentitySchema = z.object({
 	id: UserIdSchema,
 	email: z.string(),
 	name: z.string(),
+	picture_url: z.url().optional(),
 	updated_at: z.iso.datetime(),
 });
 

--- a/packages/core/src/services/content/ProjectService.test.ts
+++ b/packages/core/src/services/content/ProjectService.test.ts
@@ -120,6 +120,14 @@ describe('ProjectService', () => {
 			expect(list.map((p) => p.name)).toEqual(['A']);
 		});
 
+		it('returns all projects when the caller has a default-role entitlement', async () => {
+			await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			const list = await projects.listProjects({
+				subject: { ...STRANGER, entitlements: ['default-role:viewer'] },
+			});
+			expect(list.map((p) => p.name)).toEqual(['A']);
+		});
+
 		it('hides projects a caller does not own or belong to when defaultRole is null', async () => {
 			await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
 			// Owner sees it; a stranger does not.

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -1,5 +1,5 @@
 import type { Bucket } from '../../ports/bucket';
-import { canAct, canSeeProjectEntry, isSuperAdmin } from '../../authz';
+import { canAct, canSeeProjectEntry, isSuperAdmin, subjectDefaultRole } from '../../authz';
 import type { AuthSubject, AuthzPolicy } from '../../authz';
 import { memberRefMatchesSelector, normalizeEmail } from '../../identityMatch';
 import { mapWithConcurrency } from '../../concurrency';
@@ -73,7 +73,7 @@ export class ProjectService {
 		const live = snapshot.projects.filter((p) => p.status !== 'deleted');
 		if (
 			!filter ||
-			filter.policy?.defaultRole != null ||
+			subjectDefaultRole(filter.subject, filter.policy) != null ||
 			isSuperAdmin(filter.subject, filter.policy?.superAdmins)
 		) {
 			return live.map(toPublicProjectEntry);

--- a/packages/core/src/services/identity/IdentityService.test.ts
+++ b/packages/core/src/services/identity/IdentityService.test.ts
@@ -26,6 +26,17 @@ describe('IdentityService', () => {
 			expect((await identities.get(uid('sub-2')))?.name).toBe('grace');
 		});
 
+		it('persists a validated profile-picture URL when supplied', async () => {
+			await identities.upsert({
+				id: uid('sub-picture'),
+				email: 'ada@x.io',
+				pictureUrl: 'https://images.example.com/ada.png',
+			});
+			expect(await identities.get(uid('sub-picture'))).toMatchObject({
+				picture_url: 'https://images.example.com/ada.png',
+			});
+		});
+
 		it('skips re-writing when the identity is unchanged since last write', async () => {
 			const put = vi.spyOn(bucket, 'put');
 			const user = { id: uid('sub-3'), email: 'ada@x.io', name: 'Ada' };
@@ -37,14 +48,20 @@ describe('IdentityService', () => {
 			expect(put).toHaveBeenCalledTimes(1);
 		});
 
-		it('re-writes when the email or name changes', async () => {
+		it('re-writes when the email, name, or profile picture changes', async () => {
 			const put = vi.spyOn(bucket, 'put');
 
 			await identities.upsert({ id: uid('sub-4'), email: 'ada@x.io', name: 'Ada' });
 			await identities.upsert({ id: uid('sub-4'), email: 'ada@x.io', name: 'Ada L.' });
 			await identities.upsert({ id: uid('sub-4'), email: 'ada2@x.io', name: 'Ada L.' });
+			await identities.upsert({
+				id: uid('sub-4'),
+				email: 'ada2@x.io',
+				name: 'Ada L.',
+				pictureUrl: 'https://images.example.com/ada.png',
+			});
 
-			expect(put).toHaveBeenCalledTimes(3);
+			expect(put).toHaveBeenCalledTimes(4);
 			expect(await identities.get(uid('sub-4'))).toMatchObject({
 				email: 'ada2@x.io',
 				name: 'Ada L.',

--- a/packages/core/src/services/identity/IdentityService.ts
+++ b/packages/core/src/services/identity/IdentityService.ts
@@ -12,9 +12,9 @@ import { listAllKeys } from '../catalog/storage';
 
 /**
  * User-identity directory: maps a stable user id (the auth `sub`) to its current
- * `{ email, name }`. Records are upserted on each authenticated request so they
- * stay fresh, and resolved at read time to render opaque `author`/`user_id`
- * foreign keys as a person.
+ * `{ email, name, picture_url? }`. Records are upserted on each authenticated
+ * request so they stay fresh, and resolved at read time to render opaque
+ * `author`/`user_id` foreign keys as a person.
  *
  * Unlike the rest of the store (immutable / append-only content + the
  * CAS-guarded catalog pointer), an identity object is mutable and last-writer-
@@ -45,8 +45,8 @@ export class IdentityService {
 
 	constructor(private bucket: Bucket) {}
 
-	private static signature(email: string, name: string): string {
-		return `${email}\0${name}`;
+	private static signature(email: string, name: string, pictureUrl?: string): string {
+		return `${email}\0${name}\0${pictureUrl ?? ''}`;
 	}
 
 	/** Display name for a user, falling back to the email local-part. */
@@ -64,13 +64,14 @@ export class IdentityService {
 	 */
 	async upsert(user: AuthUser): Promise<void> {
 		const name = IdentityService.displayName(user);
-		const sig = IdentityService.signature(user.email, name);
+		const sig = IdentityService.signature(user.email, name, user.pictureUrl);
 		if (this.written.get(user.id) === sig) return;
 
 		const record: Identity = {
 			id: user.id,
 			email: user.email,
 			name,
+			...(user.pictureUrl ? { picture_url: user.pictureUrl } : {}),
 			updated_at: new Date().toISOString(),
 		};
 		await this.bucket.put(paths.identity(user.id), JSON.stringify(record));

--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -164,6 +164,46 @@ describe('ReconciliationService', () => {
 		expect(stored.sandbox_reclaimed_at).toBeUndefined();
 	});
 
+	it('Rule 1: expireStale cannot make reconciliation commit after authorization expiry', async () => {
+		const session = await putSession({
+			status: 'running',
+			sandbox_id: terminalId,
+			started_at: iso(-60 * 60_000),
+			last_heartbeat: iso(-10 * 60_000),
+			authorization_expires_at: iso(-1),
+		});
+		compute.active = [{ id: terminalId }];
+
+		expect(await sessions.expireStale()).toBe(1);
+		expect((await sessions.getSession(projectId, session.session_id)).status).toBe('expired');
+		const result = await reconciler.reconcile();
+
+		expect(result.reclaimed).toBe(1);
+		expect(compute.destroyed).toEqual([terminalId]);
+		expect(notebooks.commitSession).not.toHaveBeenCalled();
+	});
+
+	it('Rule 1: authorization expiry at the boundary overrides provision grace', async () => {
+		const now = Date.parse('2026-08-04T12:00:00.000Z');
+		vi.spyOn(Date, 'now').mockReturnValue(now);
+		const session = await putSession({
+			status: 'expired',
+			sandbox_id: terminalId,
+			started_at: new Date(now - 60_000).toISOString(),
+			authorization_expires_at: new Date(now).toISOString(),
+		});
+		compute.active = [{ id: terminalId }];
+
+		const result = await reconciler.reconcile();
+
+		expect(result.reclaimed).toBe(1);
+		expect(compute.destroyed).toEqual([terminalId]);
+		expect(notebooks.commitSession).not.toHaveBeenCalled();
+		expect(
+			(await sessions.getSession(projectId, session.session_id)).sandbox_reclaimed_at,
+		).toBeDefined();
+	});
+
 	it('Rule 1: counts reclaimed only once the destroy is confirmed', async () => {
 		const session = await createSession(terminalId);
 		await sessions.terminate(projectId, session.session_id);

--- a/packages/core/src/services/runtime/ReconciliationService.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.ts
@@ -130,13 +130,20 @@ export class ReconciliationService {
 				// `expireStale()` runs immediately before this sweep, so a provision
 				// slower than the heartbeat TTL arrives here `expired` while it is still
 				// restoring files; tearing it down mid-restore mirror-deletes bucket keys.
+				const authorizationExpired =
+					session.authorization_expires_at !== undefined &&
+					now >= Date.parse(session.authorization_expires_at);
 				if (
 					session.status === 'expired' &&
+					!authorizationExpired &&
 					now - Date.parse(session.started_at) < RECLAIM_PROVISION_GRACE_MS
 				) {
 					continue;
 				}
-				const save = !liveNotebooks.has(session.notebook_id) && sessionPersistsEdits(session);
+				const save =
+					!authorizationExpired &&
+					!liveNotebooks.has(session.notebook_id) &&
+					sessionPersistsEdits(session);
 				if (await this.retirer.reclaim(session, save)) reclaimed++;
 			} else if (isLive && !activeIds.has(sandboxId)) {
 				// Rule 2 — live record, sandbox gone (crashed / idle-timed-out). The

--- a/packages/core/src/services/runtime/SessionRetirer.test.ts
+++ b/packages/core/src/services/runtime/SessionRetirer.test.ts
@@ -112,6 +112,24 @@ describe('SessionRetirer', () => {
 		});
 	});
 
+	it('can destroy immediately without capturing after an authorization deadline', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const session = await persistentSession();
+		await sessions.beginTerminating(projectId, session.session_id);
+
+		await retirer({ create: () => instance, proxy: async () => null }).retire(session, {
+			captureBeforeDestroy: false,
+		});
+
+		expect(calls.destroy).toBe(1);
+		expect(notebooks.getNotebook).not.toHaveBeenCalled();
+		expect(notebooks.commitSession).not.toHaveBeenCalled();
+		expect((await sessions.getSession(projectId, session.session_id)).status).toBe('terminated');
+		expect(await sessions.getEditorClaim(projectId, notebookId)).toMatchObject({
+			session_id: null,
+		});
+	});
+
 	it('captures an owner-scoped filesystem snapshot during takeover', async () => {
 		const { instance, calls } = makeFakeSandbox();
 		const compute = snapshotProvider(instance);

--- a/packages/core/src/services/runtime/SessionRetirer.ts
+++ b/packages/core/src/services/runtime/SessionRetirer.ts
@@ -58,10 +58,12 @@ export class SessionRetirer {
 	 */
 	async retire(
 		session: Session,
-		opts: { teardown?: boolean; markTerminated?: boolean } = {},
+		opts: { teardown?: boolean; markTerminated?: boolean; captureBeforeDestroy?: boolean } = {},
 	): Promise<void> {
 		const sandboxDestroyed =
-			opts.teardown === false ? !session.sandbox_id : await this.teardownSandbox(session);
+			opts.teardown === false
+				? !session.sandbox_id
+				: await this.teardownSandbox(session, opts.captureBeforeDestroy ?? true);
 		if (opts.markTerminated !== false) {
 			await this.deps.sessions
 				.markTerminated(session.project_id, session.session_id)
@@ -268,36 +270,38 @@ export class SessionRetirer {
 	 * Best-effort persistence followed by a destruction attempt. The return value
 	 * fences editor-claim release until the provider confirms destruction.
 	 */
-	private async teardownSandbox(session: Session): Promise<boolean> {
+	private async teardownSandbox(session: Session, captureBeforeDestroy = true): Promise<boolean> {
 		if (!session.sandbox_id) return true;
 		const sandbox = this.deps.compute.create(session.sandbox_id);
 		let persisted = false;
-		try {
-			const persistEdits =
-				sessionPersistsEdits(session) && (await this.deps.sessions.ownsEditorClaim(session));
-			persisted = persistEdits;
-			persisted = await this.provisioner.captureSession(
-				sandbox,
-				this.deps.notebooks,
-				this.deps.bucket,
-				session.project_id,
-				session.notebook_id,
-				session.user_id,
-				this.deps.persistWorkspace,
-				this.deps.workdir,
-				{ persistEdits },
-			);
-		} catch (err) {
-			logOperationalError(
-				'session_capture_failed',
-				{
-					operation: 'session_retire.capture_session',
-					project_id: session.project_id,
-					notebook_id: session.notebook_id,
-					session_id: session.session_id,
-				},
-				err,
-			);
+		if (captureBeforeDestroy) {
+			try {
+				const persistEdits =
+					sessionPersistsEdits(session) && (await this.deps.sessions.ownsEditorClaim(session));
+				persisted = persistEdits;
+				persisted = await this.provisioner.captureSession(
+					sandbox,
+					this.deps.notebooks,
+					this.deps.bucket,
+					session.project_id,
+					session.notebook_id,
+					session.user_id,
+					this.deps.persistWorkspace,
+					this.deps.workdir,
+					{ persistEdits },
+				);
+			} catch (err) {
+				logOperationalError(
+					'session_capture_failed',
+					{
+						operation: 'session_retire.capture_session',
+						project_id: session.project_id,
+						notebook_id: session.notebook_id,
+						session_id: session.session_id,
+					},
+					err,
+				);
+			}
 		}
 		if (persisted) {
 			await captureFilesystemSnapshot(

--- a/packages/core/src/services/runtime/SessionService.test.ts
+++ b/packages/core/src/services/runtime/SessionService.test.ts
@@ -307,6 +307,35 @@ describe('SessionService', () => {
 			expect(result.status).toBe('running');
 			expect(result.expires_at).toBe(deadline);
 		});
+
+		it('preserves the authorization deadline independently of the extendable lifetime', async () => {
+			const authorizationDeadline = new Date(Date.now() + 30_000).toISOString();
+			const created = await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+				authorization_expires_at: authorizationDeadline,
+			});
+			const lifetimeDeadline = new Date(Date.now() + 60_000).toISOString();
+
+			const running = await sessions.setRunning(
+				projectId,
+				created.session_id,
+				'http://kernel',
+				false,
+				undefined,
+				lifetimeDeadline,
+			);
+			const extended = await sessions.extendExpiry(
+				projectId,
+				created.session_id,
+				new Date(Date.now() + 120_000).toISOString(),
+			);
+
+			expect(running.authorization_expires_at).toBe(authorizationDeadline);
+			expect(extended.authorization_expires_at).toBe(authorizationDeadline);
+			expect(extended.expires_at).not.toBe(lifetimeDeadline);
+		});
 	});
 
 	describe('lifecycle mutators', () => {

--- a/packages/core/src/services/runtime/SessionService.test.ts
+++ b/packages/core/src/services/runtime/SessionService.test.ts
@@ -368,6 +368,57 @@ describe('SessionService', () => {
 			expect(result.expires_at).toBeUndefined();
 		});
 
+		it('tightens authorization to the earliest credential deadline', async () => {
+			const created = await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+			});
+			const later = new Date(Date.now() + 120_000).toISOString();
+			const earlier = new Date(Date.now() + 60_000).toISOString();
+
+			const first = await sessions.tightenAuthorizationDeadline(
+				projectId,
+				created.session_id,
+				later,
+			);
+			const tightened = await sessions.tightenAuthorizationDeadline(
+				projectId,
+				created.session_id,
+				earlier,
+			);
+			const unchanged = await sessions.tightenAuthorizationDeadline(
+				projectId,
+				created.session_id,
+				later,
+			);
+
+			expect(first.authorization_expires_at).toBe(later);
+			expect(tightened.authorization_expires_at).toBe(earlier);
+			expect(unchanged.authorization_expires_at).toBe(earlier);
+		});
+
+		it('keeps the earliest deadline across concurrent reuse requests', async () => {
+			const created = await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+			});
+			const deadlines = [30_000, 90_000, 60_000].map((offset) =>
+				new Date(Date.now() + offset).toISOString(),
+			);
+
+			await Promise.all(
+				deadlines.map((deadline) =>
+					sessions.tightenAuthorizationDeadline(projectId, created.session_id, deadline),
+				),
+			);
+
+			expect(
+				(await sessions.getSession(projectId, created.session_id)).authorization_expires_at,
+			).toBe(deadlines[0]);
+		});
+
 		it('markSnapshotted records the save time, including on an expired record', async () => {
 			const created = await sessions.createSession({
 				notebook_id: notebookId,

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -59,6 +59,8 @@ export interface CreateSessionInput {
 	/** `app` only: the notebook's head version at provision, for staleness detection. */
 	source_version_id?: VersionId;
 	editor_sandbox_sharing?: EditorSandboxSharing;
+	/** Non-extendable expiry of the entitlement credential that authorized the session. */
+	authorization_expires_at?: string;
 	session_id?: SessionId;
 }
 
@@ -140,6 +142,9 @@ export class SessionService {
 			...(input.source_version_id ? { source_version_id: input.source_version_id } : {}),
 			...(input.editor_sandbox_sharing
 				? { editor_sandbox_sharing: input.editor_sandbox_sharing }
+				: {}),
+			...(input.authorization_expires_at
+				? { authorization_expires_at: input.authorization_expires_at }
 				: {}),
 			runtime: input.runtime,
 			sandbox_id: input.sandbox_id,

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -207,6 +207,23 @@ export class SessionService {
 		});
 	}
 
+	/** Apply a credential deadline without ever extending an existing bound. */
+	async tightenAuthorizationDeadline(
+		projectId: ProjectId,
+		id: SessionId,
+		deadline: string,
+	): Promise<Session> {
+		return this.mutate(projectId, id, (session) => {
+			if (
+				session.authorization_expires_at !== undefined &&
+				Date.parse(session.authorization_expires_at) <= Date.parse(deadline)
+			) {
+				return null;
+			}
+			return { ...session, authorization_expires_at: deadline };
+		});
+	}
+
 	/** Record when the periodic snapshotter last saved this session. Pure cadence
 	 * bookkeeping — never touches status, so it also applies to an `expired` record
 	 * whose sandbox is still being snapshotted while editors remain connected. */

--- a/packages/core/src/services/runtime/sessionLifecycle.test.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.test.ts
@@ -109,7 +109,12 @@ describe('SessionLifecycleService', () => {
 
 		it('extends the deadline instead of reaping while editors are connected', async () => {
 			probe.mockResolvedValue(2);
-			const s = await putSession({ expires_at: iso(-1000), last_snapshot_at: iso(0) });
+			const authorizationExpiresAt = iso(60 * 60 * 1000);
+			const s = await putSession({
+				expires_at: iso(-1000),
+				authorization_expires_at: authorizationExpiresAt,
+				last_snapshot_at: iso(0),
+			});
 
 			const result = await makeService().sweep(now);
 
@@ -119,6 +124,26 @@ describe('SessionLifecycleService', () => {
 			const stored = await getStored(s);
 			expect(stored.status).toBe('running');
 			expect(stored.expires_at).toBe(iso(EXTENSION_MS));
+			expect(stored.authorization_expires_at).toBe(authorizationExpiresAt);
+		});
+
+		it('destroys an entitlement-authorized kernel at its deadline despite active connections', async () => {
+			probe.mockResolvedValue(2);
+			const s = await putSession({
+				sandbox_url: 'https://kernel.example.com/',
+				expires_at: iso(60 * 60 * 1000),
+				authorization_expires_at: iso(-1000),
+				last_snapshot_at: iso(0),
+			});
+
+			const result = await makeService().sweep(now);
+
+			expect(probe).toHaveBeenCalled();
+			expect(result.extended).toBe(0);
+			expect(result.reapedExpired).toBe(1);
+			expect(sandboxCalls.destroy).toBe(1);
+			expect(notebooks.commitSession).not.toHaveBeenCalled();
+			expect((await getStored(s)).status).toBe('terminated');
 		});
 
 		it('extends (not reaps) on a null probe while the heartbeat is fresh', async () => {
@@ -358,6 +383,23 @@ describe('SessionLifecycleService', () => {
 			expect(result.reclaimed).toBe(0);
 			expect(sandboxCalls.destroy).toBe(0);
 			expect((await getStored(s)).sandbox_reclaimed_at).toBeUndefined();
+		});
+
+		it('authorization expiry overrides active editors and the provision-reclaim grace', async () => {
+			probe.mockResolvedValue(3);
+			const s = await putSession({
+				status: 'expired',
+				started_at: iso(-6 * 60 * 1000),
+				last_heartbeat: iso(-6 * 60 * 1000),
+				authorization_expires_at: iso(-1000),
+			});
+
+			const result = await makeService().sweep(now);
+
+			expect(result.reclaimed).toBe(1);
+			expect(sandboxCalls.destroy).toBe(1);
+			expect(notebooks.commitSession).not.toHaveBeenCalled();
+			expect((await getStored(s)).sandbox_reclaimed_at).toBeDefined();
 		});
 
 		it('destroys WITHOUT saving when a newer live session owns the notebook', async () => {

--- a/packages/core/src/services/runtime/sessionLifecycle.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.ts
@@ -181,6 +181,8 @@ export class SessionLifecycleService {
 
 			const heartbeatStale = now - Date.parse(s.last_heartbeat) > this.cfg.idleTimeoutMs;
 			const pastDeadline = !!s.expires_at && now >= Date.parse(s.expires_at);
+			const pastAuthorizationDeadline =
+				!!s.authorization_expires_at && now >= Date.parse(s.authorization_expires_at);
 
 			// Only probe when a reap decision hinges on it (cost control: one exec per
 			// near-deadline/stale session per sweep, nothing for healthy ones). Only an
@@ -189,7 +191,8 @@ export class SessionLifecycleService {
 			// connection count feeds the "~N connected" stop-confirm hint.
 			let active: number | null = null;
 			const reapCandidate =
-				s.status === 'expired' || (s.status === 'running' && (pastDeadline || heartbeatStale));
+				s.status === 'expired' ||
+				(s.status === 'running' && (pastDeadline || pastAuthorizationDeadline || heartbeatStale));
 			const connectionCountCheck =
 				s.status === 'running' &&
 				(sessionModePolicy(s).singleton ||
@@ -209,7 +212,7 @@ export class SessionLifecycleService {
 
 			if (isTerminal(s.status)) {
 				const superseded = liveNotebooks.has(s.notebook_id);
-				if (s.status === 'expired' && hasEditors) {
+				if (s.status === 'expired' && hasEditors && !pastAuthorizationDeadline) {
 					// Editors can still be connected to an `expired` record's kernel —
 					// heartbeats travel browser→API while the websocket goes browser→kernel
 					// directly, so an API-path outage or a throttled background tab stalls
@@ -223,11 +226,16 @@ export class SessionLifecycleService {
 					// provision window (a teardown mid-restore mirror-deletes bucket keys).
 					if (
 						s.status === 'expired' &&
+						!pastAuthorizationDeadline &&
 						now - Date.parse(s.started_at) < RECLAIM_PROVISION_GRACE_MS
 					) {
 						return;
 					}
-					const save = s.status === 'expired' && !superseded && sessionPersistsEdits(s);
+					const save =
+						s.status === 'expired' &&
+						!pastAuthorizationDeadline &&
+						!superseded &&
+						sessionPersistsEdits(s);
 					// Only `expired` reclaims are counted: for terminated/failed records the
 					// confirm-destroy is a routine no-op, not a recovered leak.
 					if ((await this.retirer.reclaim(s, save)) && s.status === 'expired') {
@@ -242,6 +250,11 @@ export class SessionLifecycleService {
 				// corroboration that the kernel is really gone.
 				const mayHaveEditors =
 					hasEditors || (this.cfg.connectionAware && active === null && !heartbeatStale);
+
+				if (pastAuthorizationDeadline) {
+					if (await this.gracefulTeardown(s, false)) result.reapedExpired++;
+					return;
+				}
 
 				if (heartbeatStale && !hasEditors) {
 					if (await this.gracefulTeardown(s)) result.reapedIdle++;
@@ -311,12 +324,12 @@ export class SessionLifecycleService {
 	 * inside teardown silently failed, the terminal record re-enters the sweep
 	 * as a reclaim candidate, so nothing is leaked.
 	 */
-	private async gracefulTeardown(s: Session): Promise<boolean> {
+	private async gracefulTeardown(s: Session, captureBeforeDestroy = true): Promise<boolean> {
 		const claimed = await this.sessions
 			.beginTerminating(s.project_id, s.session_id)
 			.catch(() => null);
 		if (!claimed?.transitioned) return false;
-		await this.retirer.retire(s);
+		await this.retirer.retire(s, { captureBeforeDestroy });
 		return true;
 	}
 }

--- a/packages/core/src/services/secrets/AesGcmSecretCodec.test.ts
+++ b/packages/core/src/services/secrets/AesGcmSecretCodec.test.ts
@@ -46,7 +46,8 @@ describe('AesGcmSecretCodec', () => {
 	it('fails on a tampered ciphertext', async () => {
 		const codec = new AesGcmSecretCodec({ kek: KEK });
 		const envelope = await codec.encrypt('value', { path: PATH });
-		const tampered = { ...envelope, ciphertext: `A${envelope.ciphertext.slice(1)}` };
+		const replacement = envelope.ciphertext.startsWith('A') ? 'B' : 'A';
+		const tampered = { ...envelope, ciphertext: `${replacement}${envelope.ciphertext.slice(1)}` };
 		await expect(codec.decrypt(tampered, { path: PATH })).rejects.toThrow(ValidationError);
 	});
 

--- a/packages/web/src/components/Header/Header.test.tsx
+++ b/packages/web/src/components/Header/Header.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useLocation } from 'react-router-dom';
 import { AuthProvider } from '@/context/AuthContext';
@@ -56,7 +56,7 @@ function setup(
 		value: { writeText: clipboard },
 		configurable: true,
 	});
-	renderWithClient(
+	const rendered = renderWithClient(
 		<ThemeProvider>
 			<AuthProvider>
 				<>
@@ -67,7 +67,7 @@ function setup(
 		</ThemeProvider>,
 		{ route: '/' },
 	);
-	return { user, clipboard };
+	return { user, clipboard, ...rendered };
 }
 
 async function openUserMenu(user: ReturnType<typeof userEvent.setup>) {
@@ -94,6 +94,32 @@ describe('Header', () => {
 
 		expect(screen.getByText(USER.email)).toBeInTheDocument();
 		expect(screen.getByText(USER.id)).toBeInTheDocument();
+	});
+
+	it('renders the validated profile picture without sending a referrer', async () => {
+		const picture = 'https://images.example.com/ada.png';
+		const { container } = setup(undefined, { ...USER, name: 'Ada', picture_url: picture });
+		await waitFor(() => expect(container.querySelector('img')).toBeInTheDocument());
+		const image = container.querySelector('img');
+		expect(image).toHaveAttribute('src', picture);
+		expect(image).toHaveAttribute('referrerpolicy', 'no-referrer');
+	});
+
+	it('falls back to the user initial when the profile picture fails', async () => {
+		const { container } = setup(undefined, {
+			...USER,
+			name: 'Ada',
+			picture_url: 'https://images.example.com/missing.png',
+		});
+		const image = await waitFor(() => {
+			const element = container.querySelector('img');
+			if (!element) throw new Error('Expected profile image to render');
+			return element;
+		});
+		fireEvent.error(image);
+
+		expect(container.querySelector('img')).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'User menu' })).toHaveTextContent('A');
 	});
 
 	it('copies the user id — invites are addressed by id, not email', async () => {

--- a/packages/web/src/components/Header/Header.tsx
+++ b/packages/web/src/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, Copy, KeyRound, Moon, Puzzle, Shield, Sun } from 'lucide-r
 import { toast } from 'sonner';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/context/ThemeContext';
-import { Brand } from '@/components/ui';
+import { Brand, UserAvatar } from '@/components/ui';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { ApiTokensDialog } from '@/components/Account/ApiTokensDialog';
@@ -37,15 +37,17 @@ export function Header() {
 					{theme === 'dark' ? <Sun className="size-4" /> : <Moon className="size-4" />}
 				</Button>
 
-				{user && (
+				{user ? (
 					<MenuTrigger>
 						<Button
 							aria-label="User menu"
 							className="flex items-center gap-1.5 rounded-full border border-input bg-card p-1 pr-2.5 shadow-xs transition-all hover:border-ring hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:min-h-11"
 						>
-							<span className="flex size-6 items-center justify-center rounded-full bg-gradient-to-br from-teal-500/15 to-teal-600/25 text-[11px] font-semibold text-primary ring-1 ring-primary/20">
-								{user.email.charAt(0).toUpperCase()}
-							</span>
+							<UserAvatar
+								pictureUrl={user.picture_url}
+								label={user.name ?? user.email}
+								className="size-6 text-[11px]"
+							/>
 							<ChevronDown className="size-3 text-muted-foreground" />
 						</Button>
 						<Popover
@@ -116,7 +118,7 @@ export function Header() {
 							</Menu>
 						</Popover>
 					</MenuTrigger>
-				)}
+				) : null}
 			</div>
 
 			<ApiTokensDialog isOpen={tokensDialog.isOpen} onClose={tokensDialog.close} />

--- a/packages/web/src/components/Project/ProjectMembersDialog.tsx
+++ b/packages/web/src/components/Project/ProjectMembersDialog.tsx
@@ -9,6 +9,7 @@ import {
 	displayName,
 	IconButton,
 	Tooltip,
+	UserAvatar,
 	UserLabel,
 } from '@/components/ui';
 import {
@@ -354,12 +355,11 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 						>
 							<div className="flex flex-wrap items-center justify-between gap-3">
 								<div className="flex min-w-0 items-center gap-3">
-									<span
-										aria-hidden="true"
-										className="flex size-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-teal-500/15 to-teal-600/25 text-xs font-semibold text-primary ring-1 ring-primary/20"
-									>
-										{currentDisplayName.charAt(0).toUpperCase()}
-									</span>
+									<UserAvatar
+										pictureUrl={currentIdentity?.picture_url ?? user?.picture_url}
+										label={currentDisplayName}
+										className="size-9 text-xs"
+									/>
 									<div className="min-w-0">
 										<h3
 											id="your-access-heading"

--- a/packages/web/src/components/SignIn/SignIn.test.tsx
+++ b/packages/web/src/components/SignIn/SignIn.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithClient } from '@/test/render';
+import { SignIn } from './SignIn';
+
+const signIn = vi.hoisted(() => vi.fn());
+
+vi.mock('@/context/AuthContext', () => ({
+	useAuth: () => ({ signIn }),
+}));
+
+afterEach(() => {
+	signIn.mockClear();
+});
+
+describe('SignIn OIDC errors', () => {
+	it.each([
+		[
+			'domain_not_allowed',
+			'That account isn’t allowed to access this marimohub. Sign in with an authorized email address.',
+		],
+		[
+			'email_not_verified',
+			'Your email address isn’t verified with your identity provider. Verify it there, then try again.',
+		],
+		[
+			'group_not_allowed',
+			'That account is not in a group allowed to access this marimohub. Contact your administrator.',
+		],
+		['session_expired', 'Your sign-in session expired before it completed. Please try again.'],
+		['auth_failed', 'Sign-in failed. Please try again.'],
+	])('renders a helpful message for %s', (code, expected) => {
+		renderWithClient(<SignIn />, { route: `/?auth_error=${code}` });
+
+		expect(screen.getByRole('alert')).toHaveTextContent(expected);
+		expect(screen.getByRole('button', { name: 'Try a different account' })).toBeInTheDocument();
+	});
+
+	it('uses the generic message for an unknown or attacker-supplied code', () => {
+		renderWithClient(<SignIn />, { route: '/?auth_error=unexpected%3Cscript%3E' });
+
+		expect(screen.getByRole('alert')).toHaveTextContent('Sign-in failed. Please try again.');
+		expect(screen.queryByText(/script/i)).not.toBeInTheDocument();
+	});
+
+	it('does not show an error before a failed sign-in', () => {
+		renderWithClient(<SignIn />, { route: '/' });
+
+		expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Sign in to continue' })).toBeInTheDocument();
+	});
+
+	it('retries through the normal sign-in action', async () => {
+		const user = userEvent.setup();
+		renderWithClient(<SignIn />, { route: '/?auth_error=group_not_allowed' });
+
+		await user.click(screen.getByRole('button', { name: 'Try a different account' }));
+		expect(signIn).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/web/src/components/SignIn/SignIn.tsx
+++ b/packages/web/src/components/SignIn/SignIn.tsx
@@ -13,6 +13,8 @@ const AUTH_ERROR_MESSAGES: Record<string, string> = {
 		'That account isn’t allowed to access this marimohub. Sign in with an authorized email address.',
 	email_not_verified:
 		'Your email address isn’t verified with your identity provider. Verify it there, then try again.',
+	group_not_allowed:
+		'That account is not in a group allowed to access this marimohub. Contact your administrator.',
 	session_expired: 'Your sign-in session expired before it completed. Please try again.',
 	auth_failed: 'Sign-in failed. Please try again.',
 };

--- a/packages/web/src/components/ui/UserAvatar.test.tsx
+++ b/packages/web/src/components/ui/UserAvatar.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { UserAvatar } from './UserAvatar';
+
+const FIRST_URL = 'https://identity.example/avatar/first.png';
+const SECOND_URL = 'https://identity.example/avatar/second.png';
+
+function image(): HTMLImageElement | null {
+	return document.querySelector('img');
+}
+
+describe('UserAvatar', () => {
+	it('renders the identity-provider picture with privacy attributes', () => {
+		render(<UserAvatar pictureUrl={FIRST_URL} label="Ada" />);
+
+		expect(image()).toHaveAttribute('src', FIRST_URL);
+		expect(image()).toHaveAttribute('alt', '');
+		expect(image()).toHaveAttribute('referrerpolicy', 'no-referrer');
+	});
+
+	it('falls back to the initial when the picture fails', () => {
+		render(<UserAvatar pictureUrl={FIRST_URL} label="Ada" />);
+
+		fireEvent.error(image()!);
+
+		expect(image()).not.toBeInTheDocument();
+		expect(screen.getByText('A')).toBeInTheDocument();
+	});
+
+	it('does not retry a failed picture during unrelated rerenders', () => {
+		const view = render(<UserAvatar pictureUrl={FIRST_URL} label="Ada" />);
+		fireEvent.error(image()!);
+
+		view.rerender(<UserAvatar pictureUrl={FIRST_URL} label="Alice" className="size-8" />);
+
+		expect(image()).not.toBeInTheDocument();
+		expect(screen.getByText('A')).toBeInTheDocument();
+	});
+
+	it('tries a new URL after the previous URL fails', () => {
+		const view = render(<UserAvatar pictureUrl={FIRST_URL} label="Ada" />);
+		fireEvent.error(image()!);
+
+		view.rerender(<UserAvatar pictureUrl={SECOND_URL} label="Ada" />);
+
+		expect(image()).toHaveAttribute('src', SECOND_URL);
+	});
+
+	it('retries a failed URL after the URL changes away and back', () => {
+		const view = render(<UserAvatar pictureUrl={FIRST_URL} label="Ada" />);
+		fireEvent.error(image()!);
+
+		view.rerender(<UserAvatar pictureUrl={SECOND_URL} label="Ada" />);
+		view.rerender(<UserAvatar pictureUrl={FIRST_URL} label="Ada" />);
+
+		expect(image()).toHaveAttribute('src', FIRST_URL);
+	});
+
+	it('ignores an error from an image removed by a URL change', () => {
+		const view = render(<UserAvatar pictureUrl={FIRST_URL} label="Ada" />);
+		const removedImage = image()!;
+
+		view.rerender(<UserAvatar pictureUrl={SECOND_URL} label="Ada" />);
+		fireEvent.error(removedImage);
+
+		expect(image()).toHaveAttribute('src', SECOND_URL);
+	});
+
+	it.each([undefined, null, ''] as const)('uses the initial without a picture URL (%s)', (url) => {
+		render(<UserAvatar pictureUrl={url} label="ada" />);
+
+		expect(image()).not.toBeInTheDocument();
+		expect(screen.getByText('A')).toBeInTheDocument();
+	});
+
+	it('uses the first trimmed Unicode code point as the initial', () => {
+		render(<UserAvatar label="  🐍 developer" />);
+
+		expect(screen.getByText('🐍')).toBeInTheDocument();
+		expect(screen.queryByText('\uFFFD')).not.toBeInTheDocument();
+	});
+
+	it('preserves an astral initial after the picture fails', () => {
+		render(<UserAvatar pictureUrl={FIRST_URL} label="🦊 Fox" />);
+
+		fireEvent.error(image()!);
+
+		expect(screen.getByText('🦊')).toBeInTheDocument();
+	});
+
+	it('renders no initial for a whitespace-only label', () => {
+		const { container } = render(<UserAvatar label="   " />);
+
+		expect(container.querySelector('span')).toBeEmptyDOMElement();
+	});
+});

--- a/packages/web/src/components/ui/UserAvatar.tsx
+++ b/packages/web/src/components/ui/UserAvatar.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+
+export interface UserAvatarProps {
+	pictureUrl?: string | null;
+	label: string;
+	className?: string;
+}
+
+export function UserAvatar({ pictureUrl, label, className }: UserAvatarProps) {
+	const [failedUrl, setFailedUrl] = useState<string | null>(null);
+	const showPicture = Boolean(pictureUrl && pictureUrl !== failedUrl);
+
+	return (
+		<span
+			aria-hidden="true"
+			className={cn(
+				'relative flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-gradient-to-br from-teal-500/15 to-teal-600/25 font-semibold text-primary ring-1 ring-primary/20',
+				className,
+			)}
+		>
+			{showPicture ? (
+				<img
+					src={pictureUrl ?? undefined}
+					alt=""
+					referrerPolicy="no-referrer"
+					className="size-full object-cover"
+					onError={() => setFailedUrl(pictureUrl ?? null)}
+				/>
+			) : (
+				label.charAt(0).toUpperCase()
+			)}
+		</span>
+	);
+}

--- a/packages/web/src/components/ui/UserAvatar.tsx
+++ b/packages/web/src/components/ui/UserAvatar.tsx
@@ -7,10 +7,28 @@ export interface UserAvatarProps {
 	className?: string;
 }
 
-export function UserAvatar({ pictureUrl, label, className }: UserAvatarProps) {
-	const [failedUrl, setFailedUrl] = useState<string | null>(null);
-	const showPicture = Boolean(pictureUrl && pictureUrl !== failedUrl);
+function AvatarContent({ pictureUrl, label }: Pick<UserAvatarProps, 'pictureUrl' | 'label'>) {
+	const [pictureFailed, setPictureFailed] = useState(false);
+	const initialCodePoint = label.trim().codePointAt(0);
+	const initial =
+		initialCodePoint === undefined ? '' : String.fromCodePoint(initialCodePoint).toUpperCase();
 
+	if (!pictureUrl || pictureFailed) {
+		return initial;
+	}
+
+	return (
+		<img
+			src={pictureUrl}
+			alt=""
+			referrerPolicy="no-referrer"
+			className="size-full object-cover"
+			onError={() => setPictureFailed(true)}
+		/>
+	);
+}
+
+export function UserAvatar({ pictureUrl, label, className }: UserAvatarProps) {
 	return (
 		<span
 			aria-hidden="true"
@@ -19,17 +37,7 @@ export function UserAvatar({ pictureUrl, label, className }: UserAvatarProps) {
 				className,
 			)}
 		>
-			{showPicture ? (
-				<img
-					src={pictureUrl ?? undefined}
-					alt=""
-					referrerPolicy="no-referrer"
-					className="size-full object-cover"
-					onError={() => setFailedUrl(pictureUrl ?? null)}
-				/>
-			) : (
-				label.charAt(0).toUpperCase()
-			)}
+			<AvatarContent key={pictureUrl ?? ''} pictureUrl={pictureUrl} label={label} />
 		</span>
 	);
 }

--- a/packages/web/src/components/ui/index.ts
+++ b/packages/web/src/components/ui/index.ts
@@ -58,6 +58,9 @@ export { SessionStatusDot } from './SessionStatusDot';
 export { UserLabel, displayName } from './UserLabel';
 export type { UserLabelProps } from './UserLabel';
 
+export { UserAvatar } from './UserAvatar';
+export type { UserAvatarProps } from './UserAvatar';
+
 export { CopyField } from './CopyField';
 export type { CopyFieldProps } from './CopyField';
 


### PR DESCRIPTION
Expands the OIDC authenticator to derive authorization from token claims:

- **Group policies** — an RFC 6901 groups claim (`MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM`) drives allowed-group gating, super-admin membership, and default org roles (viewer / editor / admin).
- **Email verification policy** — configurable enforcement of the `email_verified` claim.
- **Scopes & session TTLs** — configurable OIDC scopes and session TTLs, with a shorter TTL for group-derived sessions.

All configured via `MARIMOHUB_AUTH_OIDC_*` env vars in `packages/config`.

Group/role context is threaded through core authz, identity, and session services, and reflected in the API routes, web sign-in / avatar UI, docs, and the generated OpenAPI / bucket specs.