### PR TITLE
feat(api,web): super-admin area with users directory and deployment config

### DIFF
--- a/internal/schemas/allowed-breaking/api.md
+++ b/internal/schemas/allowed-breaking/api.md
@@ -8,3 +8,10 @@ GET /api/v1/projects/{pid}/secrets `api path removed without deprecation`
 POST /api/v1/projects/{pid}/secrets/validate `api path removed without deprecation`
 DELETE /api/v1/projects/{pid}/secrets/{name} `api path removed without deprecation`
 PUT /api/v1/projects/{pid}/secrets/{name} `api path removed without deprecation`
+
+GET /api/v1/version removed the required property `data/backends` from the response with the `200` status
+GET /api/v1/version removed the required property `data/image` from the response with the `200` status
+GET /api/v1/version removed the required property `data/node` from the response with the `200` status
+GET /api/v1/version removed the required property `data/replica` from the response with the `200` status
+GET /api/v1/version removed the required property `data/sandbox_image` from the response with the `200` status
+GET /api/v1/version removed the required property `data/started_at` from the response with the `200` status

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -100,47 +100,8 @@ components:
       properties:
         version:
           type: string
-        image:
-          type:
-            - string
-            - 'null'
-        sandbox_image:
-          type:
-            - string
-            - 'null'
-        started_at:
-          type:
-            - string
-            - 'null'
-        replica:
-          type:
-            - string
-            - 'null'
-        node:
-          type:
-            - string
-            - 'null'
-        backends:
-          type: object
-          properties:
-            storage:
-              type: string
-            compute:
-              type: string
-            auth:
-              type: string
-          required:
-            - storage
-            - compute
-            - auth
       required:
         - version
-        - image
-        - sandbox_image
-        - started_at
-        - replica
-        - node
-        - backends
     Capabilities:
       type: object
       properties:
@@ -454,6 +415,162 @@ components:
         - event
         - actor
       additionalProperties: {}
+    AdminUserPage:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminUser'
+        next_cursor:
+          type:
+            - string
+            - 'null'
+      required:
+        - items
+        - next_cursor
+    AdminUser:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        name:
+          type: string
+        updated_at:
+          type: string
+          format: date-time
+        is_super_admin:
+          type: boolean
+      required:
+        - id
+        - email
+        - name
+        - updated_at
+        - is_super_admin
+    DeploymentConfig:
+      type: object
+      properties:
+        deployment:
+          $ref: '#/components/schemas/AdminDeployment'
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConfigGroup'
+        policy:
+          $ref: '#/components/schemas/AdminPolicy'
+      required:
+        - deployment
+        - groups
+        - policy
+    AdminDeployment:
+      type:
+        - object
+        - 'null'
+      properties:
+        version:
+          type: string
+        image:
+          type:
+            - string
+            - 'null'
+        sandbox_image:
+          type:
+            - string
+            - 'null'
+        started_at:
+          type:
+            - string
+            - 'null'
+        replica:
+          type:
+            - string
+            - 'null'
+        node:
+          type:
+            - string
+            - 'null'
+        backends:
+          type:
+            - object
+            - 'null'
+          properties:
+            storage:
+              type: string
+            compute:
+              type: string
+            auth:
+              type: string
+          required:
+            - storage
+            - compute
+            - auth
+      required:
+        - version
+        - image
+        - sandbox_image
+        - started_at
+        - replica
+        - node
+        - backends
+    ConfigGroup:
+      type: object
+      properties:
+        name:
+          type: string
+        backend:
+          type:
+            - string
+            - 'null'
+        settings:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConfigSetting'
+      required:
+        - name
+        - backend
+        - settings
+    ConfigSetting:
+      type: object
+      properties:
+        key:
+          type: string
+        name:
+          type: string
+        value:
+          type:
+            - string
+            - 'null'
+        secret:
+          type: boolean
+        set:
+          type: boolean
+      required:
+        - key
+        - name
+        - value
+        - secret
+        - set
+    AdminPolicy:
+      type: object
+      properties:
+        default_role:
+          type:
+            - string
+            - 'null'
+          enum:
+            - admin
+            - editor
+            - viewer
+            - null
+        super_admins:
+          type: array
+          items:
+            type: string
+      required:
+        - default_role
+        - super_admins
     NotebookPage:
       type: object
       properties:
@@ -1373,7 +1490,10 @@ paths:
     get:
       tags:
         - System
-      summary: Get deployment version info
+      summary: Get the deployment version
+      description: Just the version string. The rest of the build/runtime identity
+        (image, replica, backends, …) is super-admin material on `GET
+        /api/v1/admin/config`.
       responses:
         '200':
           description: Deployment version information
@@ -2328,6 +2448,124 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/admin/users:
+    get:
+      tags:
+        - Admin
+      summary: List all users in the identity directory
+      description: 'Every user who has signed in at least once, name-sorted. Currently
+        a single page (`next_cursor` is always null). Super-admin only, and
+        session-only: a PAT — even a super admin’s — is rejected with 403.'
+      security: &a1
+        - cookieAuth: []
+      responses:
+        '200':
+          description: The user directory, name-sorted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/AdminUserPage'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Insufficient role
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/admin/config:
+    get:
+      tags:
+        - Admin
+      summary: Describe the deployment's configuration
+      description: Read-only view of every configuration group (storage, compute,
+        auth, …) as resolved from the serving replica's environment at boot;
+        secret values are never included, only whether they are set. Super-admin
+        only, session-only.
+      security: *a1
+      responses:
+        '200':
+          description: The deployment configuration, secrets redacted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/DeploymentConfig'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Insufficient role
           content:
             application/json:
               schema:
@@ -5829,8 +6067,7 @@ paths:
         scripts, the CLI): send it as `Authorization: Bearer mhub_pat_…`. The
         plaintext token is returned once, in this response, and never again.
         Requires session (SSO) auth — a token cannot mint tokens.'
-      security: &a1
-        - cookieAuth: []
+      security: *a1
       requestBody:
         required: true
         content:

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -214,6 +214,35 @@ export interface PolicyConfig {
 	superAdmins?: string[];
 }
 
+export interface ConfigSettingSummary {
+	/** Env var id, e.g. `MARIMOHUB_AUTH_OIDC_ISSUER`. */
+	key: string;
+	/** Human-readable name from the config spec. */
+	name: string;
+	/** The configured (or default) value; always null when `secret`. */
+	value: string | null;
+	secret: boolean;
+	/** Whether the env var is explicitly set in this deployment. */
+	set: boolean;
+}
+
+/**
+ * Read-only description of the deployment's configuration, served by the
+ * super-admin `GET /api/v1/admin/config` route. Assembled by
+ * `@marimo-hub/config` from its config spec — secret values are never copied
+ * in, only whether they are set. Values reflect the serving replica's
+ * environment at boot.
+ */
+export interface ConfigSummary {
+	groups: {
+		/** Spec group name, e.g. `Auth`, `Storage`. */
+		name: string;
+		/** The resolved backend selector for the group; null for selector-less groups. */
+		backend: string | null;
+		settings: ConfigSettingSummary[];
+	}[];
+}
+
 /**
  * Everything the API needs, injected at composition time. This replaces the
  * Cloudflare-specific `Bindings: Env` coupling — routes read it from the Hono
@@ -265,6 +294,12 @@ export interface ApiDeps {
 	 * AI (the proxy 404s, no AI config injected into sessions).
 	 */
 	ai?: AiProxyConfig;
+	/**
+	 * Configuration summary for the super-admin settings page. Absent
+	 * (library/Workers wiring, tests): the route serves no groups, with the
+	 * policy-derived fields still filled.
+	 */
+	configSummary?: ConfigSummary;
 	/** Optional project integration service; absence disables its routes and injection. */
 	integrations?: ProjectIntegrationsService;
 	/**

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -12,6 +12,7 @@ import {
 } from '@marimo-hub/core';
 import type { ApiDeps } from './context';
 import { describeError, errorMetadata, logEvent } from './log';
+import adminApp from './routes/admin';
 import { createAiProxy } from './routes/ai';
 import eventsApp from './routes/events';
 import gitSyncApp from './routes/gitSync';
@@ -361,6 +362,7 @@ export function createApi(rawDeps: ApiDeps) {
 	app.route(API_PREFIX, systemApp);
 	app.route(API_PREFIX, projectsApp);
 	app.route(API_PREFIX, eventsApp);
+	app.route(API_PREFIX, adminApp);
 	app.route(API_PREFIX, notebooksApp);
 	app.route(API_PREFIX, sessionsApp);
 	app.route(API_PREFIX, integrationsApp);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,7 @@
 export { createApi, generateOpenApiDocument } from './createApi';
 export type {
 	ApiDeps,
+	ConfigSummary,
 	HonoEnv,
 	SandboxUserHomeResolver,
 	Services,

--- a/packages/api/src/routes/admin.test.ts
+++ b/packages/api/src/routes/admin.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { composeAuthenticators, paths } from '@marimo-hub/core';
+import type { MemoryBucket } from '@marimo-hub/core/testing';
+import { ACTOR, uid } from '@marimo-hub/core/testing';
+import type { ConfigSummary } from '../context';
+import { createApi, generateOpenApiDocument } from '../createApi';
+import {
+	createInitializedBucket,
+	createTestApi,
+	expectError,
+	expectOk,
+	makeTestDeps,
+} from '../testing';
+
+interface AdminUser {
+	id: string;
+	email: string;
+	name: string;
+	updated_at: string;
+	is_super_admin: boolean;
+}
+
+describe('Admin routes', () => {
+	let bucket: MemoryBucket;
+
+	beforeEach(async () => {
+		bucket = await createInitializedBucket();
+	});
+
+	function superAdminApi(deps: Record<string, unknown> = {}) {
+		return createTestApi({
+			bucket,
+			userId: ACTOR,
+			deps: { policy: { superAdmins: [ACTOR] }, ...deps },
+		});
+	}
+
+	it('rejects unauthenticated requests with 401', async () => {
+		const app = createApi(makeTestDeps(bucket));
+		for (const path of ['/api/v1/admin/users', '/api/v1/admin/config']) {
+			await expectError(await app.request(path), 401, 'UNAUTHORIZED');
+		}
+	});
+
+	it('rejects non-super-admins with 403', async () => {
+		const { request } = createTestApi({ bucket, userId: ACTOR });
+		await expectError(await request('GET', '/admin/users'), 403, 'FORBIDDEN');
+		await expectError(await request('GET', '/admin/config'), 403, 'FORBIDDEN');
+	});
+
+	it('rejects a super admin PAT with 403 — admin endpoints are session-only', async () => {
+		const session = superAdminApi();
+		const composed = createApi({
+			...session.deps,
+			authenticator: composeAuthenticators(session.deps.services.tokens, {
+				authenticate: async () => null,
+			}),
+		});
+		await session.request('GET', '/me');
+		const { token } = await expectOk<{ token: string }>(
+			await session.request('POST', '/me/tokens', { name: 'ci' }),
+			201,
+		);
+		for (const path of ['/api/v1/admin/users', '/api/v1/admin/config']) {
+			const res = await composed.request(path, {
+				headers: { authorization: `Bearer ${token}` },
+			});
+			await expectError(res, 403, 'FORBIDDEN');
+		}
+	});
+
+	it('grants access to a super admin configured by email, not just by id', async () => {
+		const { request } = createTestApi({
+			bucket,
+			userId: ACTOR,
+			// createTestApi authenticates the caller as `${ACTOR}@example.com`.
+			deps: { policy: { superAdmins: [`${ACTOR}@example.com`] } },
+		});
+		await expectOk(await request('GET', '/admin/users'));
+		await expectOk(await request('GET', '/admin/config'));
+	});
+
+	it('advertises only cookieAuth (not bearerAuth) for the admin routes', () => {
+		const doc = generateOpenApiDocument() as {
+			paths: Record<string, Record<string, { security?: unknown }>>;
+		};
+		expect(doc.paths['/api/v1/admin/users'].get.security).toEqual([{ cookieAuth: [] }]);
+		expect(doc.paths['/api/v1/admin/config'].get.security).toEqual([{ cookieAuth: [] }]);
+	});
+
+	describe('GET /admin/users', () => {
+		it('lists the directory name-sorted with computed super-admin flags', async () => {
+			const { request, deps } = createTestApi({
+				bucket,
+				userId: ACTOR,
+				// One super admin matched by email, one by id, plus the caller.
+				deps: { policy: { superAdmins: [ACTOR, 'ada@x.io', uid('usr_alan')] } },
+			});
+			await deps.services.identities.upsert({
+				id: uid('usr_ada'),
+				email: 'Ada@X.io',
+				name: 'Ada Lovelace',
+			});
+			await deps.services.identities.upsert({
+				id: uid('usr_grace'),
+				email: 'grace@x.io',
+				name: 'Grace Hopper',
+			});
+			await deps.services.identities.upsert({
+				id: uid('usr_alan'),
+				email: 'alan@y.io',
+				name: 'Alan Turing',
+			});
+
+			const { items, next_cursor } = await expectOk<{
+				items: AdminUser[];
+				next_cursor: string | null;
+			}>(await request('GET', '/admin/users'));
+			expect(next_cursor).toBeNull();
+			const seeded = items.filter((u) => u.id !== ACTOR);
+			expect(seeded.map((u) => u.name)).toEqual(['Ada Lovelace', 'Alan Turing', 'Grace Hopper']);
+			expect(seeded.map((u) => u.is_super_admin)).toEqual([true, true, false]);
+			expect(seeded[0]).toMatchObject({
+				id: uid('usr_ada'),
+				email: 'Ada@X.io',
+				updated_at: expect.any(String),
+			});
+		});
+
+		it('includes the caller (upserted by the auth middleware)', async () => {
+			const { request } = superAdminApi();
+			const { items } = await expectOk<{ items: AdminUser[] }>(
+				await request('GET', '/admin/users'),
+			);
+			expect(items.map((u) => u.id)).toContain(ACTOR);
+			expect(items.find((u) => u.id === ACTOR)?.is_super_admin).toBe(true);
+		});
+
+		it('skips a corrupt directory record instead of failing the whole list', async () => {
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+			try {
+				const { request, deps } = superAdminApi();
+				await deps.services.identities.upsert({
+					id: uid('usr_ada'),
+					email: 'ada@x.io',
+					name: 'Ada Lovelace',
+				});
+				await bucket.put(`${paths.identitiesPrefix}corrupt.json`, '{"not": "an identity"}');
+
+				const { items } = await expectOk<{ items: AdminUser[] }>(
+					await request('GET', '/admin/users'),
+				);
+				expect(items.map((u) => u.id)).toContain(uid('usr_ada'));
+			} finally {
+				log.mockRestore();
+			}
+		});
+
+		it('maps a directory-scan failure to a 500 envelope', async () => {
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+			try {
+				const { request, deps } = superAdminApi();
+				vi.spyOn(deps.services.identities, 'list').mockRejectedValue(
+					new Error('bucket unavailable'),
+				);
+				const error = await expectError(
+					await request('GET', '/admin/users'),
+					500,
+					'INTERNAL_ERROR',
+				);
+				expect(error.message).not.toContain('bucket unavailable');
+			} finally {
+				log.mockRestore();
+			}
+		});
+	});
+
+	describe('GET /admin/config', () => {
+		const configSummary: ConfigSummary = {
+			groups: [
+				{
+					name: 'Auth',
+					backend: 'oidc',
+					settings: [
+						{
+							key: 'MARIMOHUB_AUTH_OIDC_ISSUER',
+							name: 'OIDC issuer',
+							value: 'https://accounts.example.com',
+							secret: false,
+							set: true,
+						},
+						{
+							key: 'MARIMOHUB_AUTH_OIDC_CLIENT_SECRET',
+							name: 'OIDC client secret',
+							value: null,
+							secret: true,
+							set: true,
+						},
+					],
+				},
+				{ name: 'Server / API', backend: null, settings: [] },
+			],
+		};
+
+		it('serves the grouped summary with deployment and policy bits, secrets stay null', async () => {
+			const { request } = superAdminApi({
+				configSummary,
+				policy: { superAdmins: [ACTOR, 'ops@example.com'], defaultRole: 'editor' },
+				version: {
+					version: 'a1b2c3d',
+					image: 'ghcr.io/marimo-team/marimohub:a1b2c3d',
+					startedAt: '2026-06-24T12:05:00Z',
+					replica: 'marimohub-abc123',
+					node: 'v24.3.0',
+					backends: { storage: 's3', compute: 'coreweave', auth: 'oidc' },
+				},
+			});
+			const data = await expectOk<any>(await request('GET', '/admin/config'));
+			expect(data).toEqual({
+				deployment: {
+					version: 'a1b2c3d',
+					image: 'ghcr.io/marimo-team/marimohub:a1b2c3d',
+					sandbox_image: null,
+					started_at: '2026-06-24T12:05:00Z',
+					replica: 'marimohub-abc123',
+					node: 'v24.3.0',
+					backends: { storage: 's3', compute: 'coreweave', auth: 'oidc' },
+				},
+				groups: configSummary.groups,
+				policy: { default_role: 'editor', super_admins: [ACTOR, 'ops@example.com'] },
+			});
+		});
+
+		it('nulls the value of a secret setting even if a summary carried one', async () => {
+			const leaky: ConfigSummary = {
+				groups: [
+					{
+						name: 'Auth',
+						backend: 'oidc',
+						settings: [{ key: 'X', name: 'X', value: 'oops-a-secret', secret: true, set: true }],
+					},
+				],
+			};
+			const { request } = superAdminApi({ configSummary: leaky });
+			const data = await expectOk<any>(await request('GET', '/admin/config'));
+			expect(data.groups[0].settings[0].value).toBeNull();
+			expect(JSON.stringify(data)).not.toContain('oops-a-secret');
+		});
+
+		it('serves an empty summary when the wiring provides none', async () => {
+			const { request } = superAdminApi();
+			const data = await expectOk<any>(await request('GET', '/admin/config'));
+			expect(data).toEqual({
+				deployment: null,
+				groups: [],
+				policy: { default_role: null, super_admins: [ACTOR] },
+			});
+		});
+	});
+});

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -1,0 +1,120 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import { isSuperAdmin } from '@marimo-hub/core';
+import {
+	AdminUserResponseSchema,
+	assertSessionAuthenticated,
+	assertSuperAdmin,
+	commonErrors,
+	createApp,
+	DeploymentConfigResponseSchema,
+	errorResponses,
+	jsonContent,
+	SESSION_ONLY_SECURITY,
+} from '../shared';
+import { pageSchema } from '../pagination';
+
+const listUsers = createRoute({
+	method: 'get',
+	path: '/admin/users',
+	tags: ['Admin'],
+	summary: 'List all users in the identity directory',
+	description:
+		'Every user who has signed in at least once, name-sorted. Currently a single page ' +
+		'(`next_cursor` is always null). Super-admin only, and session-only: a PAT — even a ' +
+		'super admin’s — is rejected with 403.',
+	security: SESSION_ONLY_SECURITY,
+	responses: {
+		200: jsonContent(
+			z.object({
+				success: z.literal(true),
+				data: pageSchema(AdminUserResponseSchema, 'AdminUserPage'),
+			}),
+			'The user directory, name-sorted',
+		),
+		...commonErrors(),
+		...errorResponses(403),
+	},
+});
+
+const getConfig = createRoute({
+	method: 'get',
+	path: '/admin/config',
+	tags: ['Admin'],
+	summary: "Describe the deployment's configuration",
+	description:
+		'Read-only view of every configuration group (storage, compute, auth, …) as resolved from ' +
+		"the serving replica's environment at boot; secret values are never included, only whether " +
+		'they are set. Super-admin only, session-only.',
+	security: SESSION_ONLY_SECURITY,
+	responses: {
+		200: jsonContent(
+			z.object({ success: z.literal(true), data: DeploymentConfigResponseSchema }),
+			'The deployment configuration, secrets redacted',
+		),
+		...commonErrors(),
+		...errorResponses(403),
+	},
+});
+
+const app = createApp();
+
+app.openapi(listUsers, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	assertSessionAuthenticated(c, 'access admin endpoints');
+	assertSuperAdmin(user, deps.policy);
+
+	const all = await deps.services.identities.list();
+	const items = all
+		.map((u) => ({
+			id: u.id,
+			email: u.email,
+			name: u.name,
+			updated_at: u.updated_at,
+			is_super_admin: isSuperAdmin({ id: u.id, email: u.email }, deps.policy.superAdmins),
+		}))
+		.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+	// The directory is served whole (same O(low-thousands) bound as user
+	// search); the page envelope reserves room for a real cursor later.
+	return c.json({ success: true, data: { items, next_cursor: null } }, 200);
+});
+
+app.openapi(getConfig, (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	assertSessionAuthenticated(c, 'access admin endpoints');
+	assertSuperAdmin(user, deps.policy);
+
+	const v = deps.version;
+	return c.json(
+		{
+			success: true,
+			data: {
+				deployment: v
+					? {
+							version: v.version,
+							image: v.image ?? null,
+							sandbox_image: v.sandboxImage ?? null,
+							started_at: v.startedAt ?? null,
+							replica: v.replica ?? null,
+							node: v.node ?? null,
+							backends: v.backends ?? null,
+						}
+					: null,
+				groups: (deps.configSummary?.groups ?? []).map((group) => ({
+					...group,
+					// Belt-and-braces: the summary builder already withholds secret
+					// values, but never trust a future source to have done so.
+					settings: group.settings.map((s) => ({ ...s, value: s.secret ? null : s.value })),
+				})),
+				policy: {
+					default_role: deps.policy.defaultRole ?? null,
+					super_admins: deps.policy.superAdmins ?? [],
+				},
+			},
+		},
+		200,
+	);
+});
+
+export default app;

--- a/packages/api/src/routes/system.ts
+++ b/packages/api/src/routes/system.ts
@@ -54,7 +54,10 @@ const versionRoute = createRoute({
 	method: 'get',
 	path: '/version',
 	tags: ['System'],
-	summary: 'Get deployment version info',
+	summary: 'Get the deployment version',
+	description:
+		'Just the version string. The rest of the build/runtime identity (image, replica, ' +
+		'backends, …) is super-admin material on `GET /api/v1/admin/config`.',
 	responses: {
 		200: jsonContent(
 			z.object({ success: z.literal(true), data: DeploymentInfoResponseSchema }),
@@ -66,15 +69,7 @@ const versionRoute = createRoute({
 
 app.openapi(versionRoute, (c) => {
 	const v = c.get('deps').version;
-	return ok(c, {
-		version: v?.version ?? 'dev',
-		image: v?.image ?? null,
-		sandbox_image: v?.sandboxImage ?? null,
-		started_at: v?.startedAt ?? null,
-		replica: v?.replica ?? null,
-		node: v?.node ?? null,
-		backends: v?.backends ?? { storage: 'unknown', compute: 'unknown', auth: 'unknown' },
-	});
+	return ok(c, { version: v?.version ?? 'dev' });
 });
 
 const capabilitiesRoute = createRoute({

--- a/packages/api/src/routes/tokens.ts
+++ b/packages/api/src/routes/tokens.ts
@@ -1,15 +1,15 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { ForbiddenError, TokenId } from '@marimo-hub/core';
+import { TokenId } from '@marimo-hub/core';
 import type { PublicToken } from '@marimo-hub/core';
-import type { Context } from 'hono';
-import type { HonoEnv } from '../context';
 import { appendAudit } from '../log';
 import {
+	assertSessionAuthenticated,
 	commonErrors,
 	createApp,
 	errorResponses,
 	jsonBody,
 	jsonContent,
+	SESSION_ONLY_SECURITY,
 	SuccessResponseSchema,
 } from '../shared';
 
@@ -50,12 +50,6 @@ const TokenIdParam = z.object({
 });
 
 // --- Route definitions ---
-
-// Token management is session-only: a PAT is rejected with 403 (see
-// assertSessionAuthenticated). Override the global disjunctive security so the
-// generated OpenAPI advertises ONLY cookieAuth for these routes — a client must
-// not pick a bearer token it can't use here.
-const SESSION_ONLY_SECURITY = [{ cookieAuth: [] }];
 
 const createToken = createRoute({
 	method: 'post',
@@ -114,18 +108,6 @@ const revokeToken = createRoute({
 
 // --- App ---
 
-/**
- * Token-authenticated requests may not manage tokens: a leaked PAT must not
- * mint replacements or revoke its neighbors. Gate on the `authMethod` flag the
- * authN middleware set — not a re-parse of the Authorization header, which
- * would risk disagreeing with the authenticator over scheme casing/whitespace.
- */
-function assertSessionAuthenticated(c: Context<HonoEnv>): void {
-	if (c.get('authMethod') === 'pat') {
-		throw new ForbiddenError('Personal access tokens cannot manage tokens — sign in to do this');
-	}
-}
-
 // Explicit pick: the stored record also carries `user_id` (always the caller's
 // own id on these self-service routes), which the response contract omits.
 function toResponse(record: PublicToken) {
@@ -141,7 +123,7 @@ function toResponse(record: PublicToken) {
 const app = createApp();
 
 app.openapi(createToken, async (c) => {
-	assertSessionAuthenticated(c);
+	assertSessionAuthenticated(c, 'manage tokens');
 	const deps = c.get('deps');
 	const user = c.get('user');
 	const { name, expires_in_days } = c.req.valid('json');
@@ -165,7 +147,7 @@ app.openapi(createToken, async (c) => {
 });
 
 app.openapi(listTokens, async (c) => {
-	assertSessionAuthenticated(c);
+	assertSessionAuthenticated(c, 'manage tokens');
 	const deps = c.get('deps');
 	const user = c.get('user');
 	const records = await deps.services.tokens.list(user.id);
@@ -173,7 +155,7 @@ app.openapi(listTokens, async (c) => {
 });
 
 app.openapi(revokeToken, async (c) => {
-	assertSessionAuthenticated(c);
+	assertSessionAuthenticated(c, 'manage tokens');
 	const deps = c.get('deps');
 	const user = c.get('user');
 	const { tokenId } = c.req.valid('param');

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -80,6 +80,26 @@ export function assertSuperAdmin(subject: AuthSubject, policy?: AuthzPolicy): vo
 	}
 }
 
+/**
+ * OpenAPI security override for session-only routes: the generated spec
+ * advertises ONLY cookieAuth, so a client must not pick a bearer token it
+ * can't use there. Pair with `assertSessionAuthenticated`, which enforces it.
+ */
+export const SESSION_ONLY_SECURITY = [{ cookieAuth: [] }];
+
+/**
+ * Reject PAT-authenticated requests on routes that must be session-only (token
+ * management, admin surfaces): a leaked PAT must not reach them. Gates on the
+ * `authMethod` flag the authN middleware set — not a re-parse of the
+ * Authorization header, which would risk disagreeing with the authenticator
+ * over scheme casing/whitespace.
+ */
+export function assertSessionAuthenticated(c: Context<HonoEnv>, action: string): void {
+	if (c.get('authMethod') === 'pat') {
+		throw new ForbiddenError(`Personal access tokens cannot ${action} — sign in to do this`);
+	}
+}
+
 /** The slice of PolicyConfig the session gates need. */
 export type SessionPolicy = AuthzPolicy & {
 	viewerMode?: ViewerMode;
@@ -790,8 +810,50 @@ export const MeResponseSchema = z
 	})
 	.openapi('Me');
 
-/** Read-only deployment identity/metadata surfaced by `GET /api/v1/version`. */
-export const DeploymentInfoResponseSchema = z
+// --- Admin (/api/v1/admin/*) ---
+
+/** A directory entry on the super-admin users page. */
+export const AdminUserResponseSchema = z
+	.object({
+		id: z.string(),
+		email: z.string(),
+		name: z.string(),
+		/**
+		 * When the identity record was last written — a coarse activity signal
+		 * (refreshed on sign-in, identity changes, and server restarts), not a
+		 * precise last-seen timestamp.
+		 */
+		updated_at: z.string().openapi({ format: 'date-time' }),
+		/** Whether this user matches an entry in MARIMOHUB_SUPER_ADMINS. */
+		is_super_admin: z.boolean(),
+	})
+	.openapi('AdminUser');
+
+export const ConfigSettingSchema = z
+	.object({
+		/** Env var id, e.g. `MARIMOHUB_AUTH_OIDC_ISSUER`. */
+		key: z.string(),
+		name: z.string(),
+		/** Configured (or default) value; always null when `secret`. */
+		value: z.string().nullable(),
+		secret: z.boolean(),
+		/** Whether the env var is explicitly set in this deployment. */
+		set: z.boolean(),
+	})
+	.openapi('ConfigSetting');
+
+export const ConfigGroupSchema = z
+	.object({
+		/** Spec group name, e.g. `Auth`, `Storage`. */
+		name: z.string(),
+		/** The group's resolved backend selector; null for selector-less groups. */
+		backend: z.string().nullable(),
+		settings: z.array(ConfigSettingSchema),
+	})
+	.openapi('ConfigGroup');
+
+/** Build/runtime identity of the serving replica, super-admin only. */
+export const AdminDeploymentSchema = z
 	.object({
 		version: z.string(),
 		image: z.string().nullable(),
@@ -799,11 +861,47 @@ export const DeploymentInfoResponseSchema = z
 		started_at: z.string().nullable(),
 		replica: z.string().nullable(),
 		node: z.string().nullable(),
-		backends: z.object({
-			storage: z.string(),
-			compute: z.string(),
-			auth: z.string(),
-		}),
+		backends: z
+			.object({
+				storage: z.string(),
+				compute: z.string(),
+				auth: z.string(),
+			})
+			.nullable(),
+	})
+	.openapi('AdminDeployment');
+
+/**
+ * The effective (parsed) authorization policy, as the server enforces it —
+ * unlike the raw env values in `groups`, which may be unset or carry defaults.
+ */
+export const AdminPolicySchema = z
+	.object({
+		default_role: z.enum(ROLES).nullable(),
+		/** Raw MARIMOHUB_SUPER_ADMINS entries (emails or user ids). */
+		super_admins: z.array(z.string()),
+	})
+	.openapi('AdminPolicy');
+
+/** Read-only deployment configuration surfaced by `GET /api/v1/admin/config`. */
+export const DeploymentConfigResponseSchema = z
+	.object({
+		/** Null when the wiring provides no version metadata (library/Workers, tests). */
+		deployment: AdminDeploymentSchema.nullable(),
+		/** Empty when the wiring provides no summary (library/Workers). */
+		groups: z.array(ConfigGroupSchema),
+		policy: AdminPolicySchema,
+	})
+	.openapi('DeploymentConfig');
+
+/**
+ * The deployment version surfaced by `GET /api/v1/version`. Just the version:
+ * the rest of the build/runtime identity (image, replica, backends, …) is
+ * super-admin material, served by `GET /api/v1/admin/config`.
+ */
+export const DeploymentInfoResponseSchema = z
+	.object({
+		version: z.string(),
 	})
 	.openapi('DeploymentInfo');
 

--- a/packages/api/src/version.test.ts
+++ b/packages/api/src/version.test.ts
@@ -9,7 +9,9 @@ const authed: Authenticator = {
 };
 
 describe('GET /api/v1/version', () => {
-	it('returns the full deployment metadata when configured', async () => {
+	// The rest of the build/runtime identity (image, replica, backends, …) is
+	// super-admin material on GET /api/v1/admin/config, not served here.
+	it('returns only the version string when configured', async () => {
 		const deps = makeTestDeps(new MemoryBucket(), {
 			authenticator: authed,
 			version: {
@@ -23,29 +25,13 @@ describe('GET /api/v1/version', () => {
 			},
 		});
 		const res = await createApi(deps).request('/api/v1/version');
-		expect(await expectOk(res)).toEqual({
-			version: 'a1b2c3d',
-			image: 'ghcr.io/marimo-team/marimohub:a1b2c3d',
-			sandbox_image: 'ghcr.io/marimo-team/marimo-sandbox:latest',
-			started_at: '2026-06-24T12:05:00Z',
-			replica: 'marimohub-abc123',
-			node: 'v24.3.0',
-			backends: { storage: 's3', compute: 'coreweave', auth: 'oidc' },
-		});
+		expect(await expectOk(res)).toEqual({ version: 'a1b2c3d' });
 	});
 
-	it('falls back to dev / null / unknown when no version is wired', async () => {
+	it('falls back to dev when no version is wired', async () => {
 		const deps = makeTestDeps(new MemoryBucket(), { authenticator: authed });
 		const res = await createApi(deps).request('/api/v1/version');
-		expect(await expectOk(res)).toEqual({
-			version: 'dev',
-			image: null,
-			sandbox_image: null,
-			started_at: null,
-			replica: null,
-			node: null,
-			backends: { storage: 'unknown', compute: 'unknown', auth: 'unknown' },
-		});
+		expect(await expectOk(res)).toEqual({ version: 'dev' });
 	});
 
 	it('requires authentication (not a public endpoint)', async () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -43,6 +43,10 @@ export type ApiToken = components['schemas']['ApiToken'];
 export type ApiTokenCreated = components['schemas']['ApiTokenCreated'];
 export type AuditLogEntry = components['schemas']['AuditLogEntry'];
 export type AuditLogPage = components['schemas']['AuditLogPage'];
+/** A directory entry from the super-admin `GET /api/v1/admin/users`. */
+export type AdminUser = components['schemas']['AdminUser'];
+/** Redacted deployment configuration from the super-admin `GET /api/v1/admin/config`. */
+export type DeploymentConfig = components['schemas']['DeploymentConfig'];
 
 export interface ApiError {
 	code: string;

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -60,7 +60,10 @@ export interface paths {
 			path?: never;
 			cookie?: never;
 		};
-		/** Get deployment version info */
+		/**
+		 * Get the deployment version
+		 * @description Just the version string. The rest of the build/runtime identity (image, replica, backends, …) is super-admin material on `GET /api/v1/admin/config`.
+		 */
 		get: {
 			parameters: {
 				query?: never;
@@ -1094,6 +1097,168 @@ export interface paths {
 				};
 				/** @description Not found */
 				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/admin/users': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * List all users in the identity directory
+		 * @description Every user who has signed in at least once, name-sorted. Currently a single page (`next_cursor` is always null). Super-admin only, and session-only: a PAT — even a super admin’s — is rejected with 403.
+		 */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description The user directory, name-sorted */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['AdminUserPage'];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Insufficient role */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/admin/config': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Describe the deployment's configuration
+		 * @description Read-only view of every configuration group (storage, compute, auth, …) as resolved from the serving replica's environment at boot; secret values are never included, only whether they are set. Super-admin only, session-only.
+		 */
+		get: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description The deployment configuration, secrets redacted */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['DeploymentConfig'];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Insufficient role */
+				403: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -5141,16 +5306,6 @@ export interface components {
 		};
 		DeploymentInfo: {
 			version: string;
-			image: string | null;
-			sandbox_image: string | null;
-			started_at: string | null;
-			replica: string | null;
-			node: string | null;
-			backends: {
-				storage: string;
-				compute: string;
-				auth: string;
-			};
 		};
 		Capabilities: {
 			federation: {
@@ -5281,6 +5436,53 @@ export interface components {
 			actor: string;
 		} & {
 			[key: string]: unknown;
+		};
+		AdminUserPage: {
+			items: components['schemas']['AdminUser'][];
+			next_cursor: string | null;
+		};
+		AdminUser: {
+			id: string;
+			email: string;
+			name: string;
+			/** Format: date-time */
+			updated_at: string;
+			is_super_admin: boolean;
+		};
+		DeploymentConfig: {
+			deployment: components['schemas']['AdminDeployment'];
+			groups: components['schemas']['ConfigGroup'][];
+			policy: components['schemas']['AdminPolicy'];
+		};
+		AdminDeployment: {
+			version: string;
+			image: string | null;
+			sandbox_image: string | null;
+			started_at: string | null;
+			replica: string | null;
+			node: string | null;
+			backends: {
+				storage: string;
+				compute: string;
+				auth: string;
+			} | null;
+		} | null;
+		ConfigGroup: {
+			name: string;
+			backend: string | null;
+			settings: components['schemas']['ConfigSetting'][];
+		};
+		ConfigSetting: {
+			key: string;
+			name: string;
+			value: string | null;
+			secret: boolean;
+			set: boolean;
+		};
+		AdminPolicy: {
+			/** @enum {string|null} */
+			default_role: 'admin' | 'editor' | 'viewer' | null;
+			super_admins: string[];
 		};
 		NotebookPage: {
 			items: components['schemas']['SnapshotNotebookEntry'][];

--- a/packages/config/src/configSummary.test.ts
+++ b/packages/config/src/configSummary.test.ts
@@ -85,6 +85,12 @@ describe('buildConfigSummary', () => {
 		expect(keys.some((k) => k.includes('_E2B_'))).toBe(false);
 	});
 
+	it('folds selector casing/whitespace like the wiring does', () => {
+		const auth = group(buildConfigSummary({ MARIMOHUB_AUTH_BACKEND: ' OIDC ' }), 'Auth');
+		expect(auth.backend).toBe('oidc');
+		expect(auth.settings.map((s) => s.key)).toContain('MARIMOHUB_AUTH_OIDC_ISSUER');
+	});
+
 	it('treats an explicitly-empty env var as set, with its empty value', () => {
 		const summary = buildConfigSummary({
 			MARIMOHUB_AUTH_BACKEND: 'oidc',

--- a/packages/config/src/configSummary.test.ts
+++ b/packages/config/src/configSummary.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { buildConfigSummary } from './configSummary';
+import { CONFIG_SPEC } from './spec';
+
+function group(summary: ReturnType<typeof buildConfigSummary>, name: string) {
+	const found = summary.groups.find((g) => g.name === name);
+	if (!found) throw new Error(`no group ${name}`);
+	return found;
+}
+
+describe('buildConfigSummary', () => {
+	it('covers every spec group', () => {
+		const summary = buildConfigSummary({});
+		expect(summary.groups.map((g) => g.name)).toEqual(CONFIG_SPEC.map((g) => g.name));
+	});
+
+	it('redacts secret values while surfacing non-secrets', () => {
+		const summary = buildConfigSummary({
+			MARIMOHUB_AUTH_BACKEND: 'oidc',
+			MARIMOHUB_AUTH_OIDC_ISSUER: 'https://accounts.example.com',
+			MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: 'hunter2',
+			MARIMOHUB_AUTH_SESSION_SECRET: 'a'.repeat(32),
+			MARIMOHUB_STORAGE_S3_BUCKET: 'my-bucket',
+			MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY: 'sekrit',
+		});
+
+		const auth = group(summary, 'Auth');
+		expect(auth.backend).toBe('oidc');
+		const byKey = Object.fromEntries(auth.settings.map((s) => [s.key, s]));
+		expect(byKey.MARIMOHUB_AUTH_OIDC_ISSUER).toMatchObject({
+			value: 'https://accounts.example.com',
+			secret: false,
+			set: true,
+		});
+		expect(byKey.MARIMOHUB_AUTH_OIDC_CLIENT_SECRET).toMatchObject({
+			value: null,
+			secret: true,
+			set: true,
+		});
+		expect(byKey.MARIMOHUB_AUTH_OIDC_REDIRECT_URI).toMatchObject({ value: null, set: false });
+
+		const storage = group(summary, 'Storage');
+		expect(storage.backend).toBe('s3');
+		const s3 = Object.fromEntries(storage.settings.map((s) => [s.key, s]));
+		expect(s3.MARIMOHUB_STORAGE_S3_BUCKET).toMatchObject({ value: 'my-bucket', set: true });
+		expect(s3.MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY).toMatchObject({ value: null, secret: true });
+
+		expect(JSON.stringify(summary)).not.toContain('hunter2');
+		expect(JSON.stringify(summary)).not.toContain('sekrit');
+	});
+
+	it('falls back to spec defaults for values and selectors', () => {
+		const summary = buildConfigSummary({ MARIMOHUB_AUTH_BACKEND: 'dev' });
+
+		const auth = group(summary, 'Auth');
+		const byKey = Object.fromEntries(auth.settings.map((s) => [s.key, s]));
+		expect(byKey.MARIMOHUB_AUTH_DEV_EMAIL).toMatchObject({ value: 'user@localhost', set: false });
+
+		// Storage has a spec default selector; Server / API has no selector at all.
+		expect(group(summary, 'Storage').backend).toBe('s3');
+		expect(group(summary, 'Server / API').backend).toBeNull();
+		expect(group(summary, 'Server / API').settings.length).toBeGreaterThan(0);
+	});
+
+	it('reports an unset or unknown backend as-is with no backend-specific settings', () => {
+		expect(group(buildConfigSummary({}), 'Auth')).toEqual({
+			backend: 'unset',
+			name: 'Auth',
+			settings: [],
+		});
+		expect(group(buildConfigSummary({ MARIMOHUB_AUTH_BACKEND: 'bogus' }), 'Auth')).toEqual({
+			backend: 'bogus',
+			name: 'Auth',
+			settings: [],
+		});
+	});
+
+	it('includes pseudo-backend (selector-less) vars alongside the selected backend', () => {
+		const summary = buildConfigSummary({ MARIMOHUB_COMPUTE_BACKEND: 'coreweave' });
+		const compute = group(summary, 'Compute');
+		const keys = compute.settings.map((s) => s.key);
+		// Shared vars apply to every compute backend.
+		expect(keys).toContain('MARIMOHUB_COMPUTE_IMAGE');
+		// Another backend's vars must not bleed in.
+		expect(keys.some((k) => k.includes('_E2B_'))).toBe(false);
+	});
+
+	it('treats an explicitly-empty env var as set, with its empty value', () => {
+		const summary = buildConfigSummary({
+			MARIMOHUB_AUTH_BACKEND: 'oidc',
+			MARIMOHUB_AUTH_OIDC_ISSUER: '',
+		});
+		const issuer = group(summary, 'Auth').settings.find(
+			(s) => s.key === 'MARIMOHUB_AUTH_OIDC_ISSUER',
+		);
+		expect(issuer).toMatchObject({ value: '', set: true });
+	});
+
+	// Redaction rides on the spec's `secret` flags; this heuristic catches a
+	// future spec entry that forgets to set one. A credential-looking id must
+	// either be flagged secret or be listed here with a reason.
+	it('flags every credential-looking spec var as secret', () => {
+		const knownNonSecrets = new Set([
+			// Names of k8s Secret objects, not their contents.
+			'MARIMOHUB_COMPUTE_KUBERNETES_TLS_SECRET',
+			'MARIMOHUB_COMPUTE_KUBERNETES_IMAGE_PULL_SECRET',
+			// LLM token limits/TTLs, not credentials.
+			'MARIMOHUB_AI_MAX_TOKENS',
+			'MARIMOHUB_AI_TOKEN_TTL_SECONDS',
+			// Key label, toggle, region, TTL for the secrets subsystem — no material.
+			'MARIMOHUB_SECRETS_KEK_ID',
+			'MARIMOHUB_SECRETS_AWS',
+			'MARIMOHUB_SECRETS_AWS_REGION',
+			'MARIMOHUB_SECRETS_AWS_CACHE_TTL_SECONDS',
+		]);
+		const suspicious = /SECRET|TOKEN|PASSWORD|API_KEY|ACCESS_KEY|PRIVATE|CONNECTION_STRING/;
+		const unflagged = CONFIG_SPEC.flatMap((g) => g.backends)
+			.flatMap((b) => b.vars)
+			.filter((v) => suspicious.test(v.id) && v.secret !== true && !knownNonSecrets.has(v.id))
+			.map((v) => v.id);
+		expect(unflagged).toEqual([]);
+	});
+});

--- a/packages/config/src/configSummary.ts
+++ b/packages/config/src/configSummary.ts
@@ -1,0 +1,44 @@
+import type { ConfigSummary } from '@marimo-hub/api';
+import type { Env } from './env';
+import type { ConfigBackend } from './spec';
+import { CONFIG_SPEC } from './spec';
+
+/**
+ * Assemble the read-only configuration summary served by the super-admin
+ * settings endpoint. Derived from `CONFIG_SPEC` (not hand-listed) so new vars
+ * show up without touching this file, and so the spec's `secret` flag is the
+ * single source of truth for redaction: a secret var only reports whether it
+ * is set — its value is never copied out of the env.
+ *
+ * Per group, the vars shown are the selected backend's (per the group's
+ * selector env var, falling back to the spec default) plus any pseudo-backend
+ * vars that apply regardless of selection.
+ */
+export function buildConfigSummary(env: Env): ConfigSummary {
+	return {
+		groups: CONFIG_SPEC.map((group) => {
+			const backend = group.selector
+				? (env[group.selector] ?? group.selectorDefault ?? 'unset')
+				: null;
+			const applies = (b: ConfigBackend) =>
+				b.selectorValue === undefined || b.selectorValue === backend;
+			return {
+				name: group.name,
+				backend,
+				settings: group.backends.filter(applies).flatMap((b) =>
+					b.vars.map((v) => {
+						const secret = v.secret === true;
+						const raw = env[v.id];
+						return {
+							key: v.id,
+							name: v.name,
+							value: secret ? null : (raw ?? v.default ?? null),
+							secret,
+							set: raw !== undefined,
+						};
+					}),
+				),
+			};
+		}),
+	};
+}

--- a/packages/config/src/configSummary.ts
+++ b/packages/config/src/configSummary.ts
@@ -1,5 +1,6 @@
 import type { ConfigSummary } from '@marimo-hub/api';
 import type { Env } from './env';
+import { readFolded } from './env';
 import type { ConfigBackend } from './spec';
 import { CONFIG_SPEC } from './spec';
 
@@ -17,8 +18,12 @@ import { CONFIG_SPEC } from './spec';
 export function buildConfigSummary(env: Env): ConfigSummary {
 	return {
 		groups: CONFIG_SPEC.map((group) => {
+			// Fold the selector like the most lenient wiring does (exposure/AI
+			// accept any casing), so the directory tracks the backend actually
+			// selected. The strict selectors (storage/compute/auth) reject non-
+			// canonical casing at boot, so folding can never diverge from them.
 			const backend = group.selector
-				? (env[group.selector] ?? group.selectorDefault ?? 'unset')
+				? (readFolded(env, group.selector) ?? group.selectorDefault ?? 'unset')
 				: null;
 			const applies = (b: ConfigBackend) =>
 				b.selectorValue === undefined || b.selectorValue === backend;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -33,6 +33,7 @@ import type {
 import type { ApiDeps, SessionLifetimeConfig } from '@marimo-hub/api';
 import { makeAi } from './ai';
 import { makeAuth } from './auth';
+import { buildConfigSummary } from './configSummary';
 import { makeCompute, resolveSandboxImages } from './compute';
 import {
 	parseComputeProfileOverride,
@@ -366,6 +367,9 @@ export function createFromEnv(
 				DEFAULT_MAX_APPS_PER_PROJECT,
 			),
 		},
+		// Read-only configuration for the super-admin settings page (secrets
+		// redacted at assembly).
+		configSummary: buildConfigSummary(env),
 		// Workload Identity Federation (no-op unless the WIF env vars are configured).
 		...makeWif(env),
 		// Managed AI proxy (no-op unless MARIMOHUB_AI_BACKEND is configured).

--- a/packages/core/src/services/identity/IdentityService.test.ts
+++ b/packages/core/src/services/identity/IdentityService.test.ts
@@ -83,6 +83,54 @@ describe('IdentityService', () => {
 		});
 	});
 
+	describe('list', () => {
+		it('returns every directory record', async () => {
+			await identities.upsert({ id: uid('a'), email: 'a@x.io', name: 'Aye' });
+			await identities.upsert({ id: uid('b'), email: 'b@x.io', name: 'Bee' });
+
+			const all = await identities.list();
+			expect(all.map((u) => u.id).sort()).toEqual([uid('a'), uid('b')]);
+		});
+
+		it('returns an empty list for an empty directory', async () => {
+			expect(await identities.list()).toEqual([]);
+		});
+
+		it('serves repeat calls within the TTL from the cached directory', async () => {
+			const list = vi.spyOn(bucket, 'list');
+			await identities.list();
+			await identities.list();
+			expect(list).toHaveBeenCalledTimes(1);
+		});
+
+		it('skips corrupt directory records instead of failing the scan', async () => {
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+			try {
+				await identities.upsert({ id: uid('a'), email: 'a@x.io', name: 'Aye' });
+				await bucket.put(`${paths.identitiesPrefix}corrupt.json`, '{"not": "an identity"}');
+
+				expect((await identities.list()).map((u) => u.id)).toEqual([uid('a')]);
+			} finally {
+				log.mockRestore();
+			}
+		});
+
+		it('propagates a cold-scan failure instead of serving an empty directory', async () => {
+			vi.spyOn(bucket, 'list').mockRejectedValue(new Error('bucket unavailable'));
+			await expect(identities.list()).rejects.toThrow('bucket unavailable');
+		});
+
+		it('recovers after a failed cold scan on the next call', async () => {
+			await identities.upsert({ id: uid('a'), email: 'a@x.io', name: 'Aye' });
+			const list = vi.spyOn(bucket, 'list').mockRejectedValueOnce(new Error('transient'));
+
+			await expect(identities.list()).rejects.toThrow('transient');
+			// The failed single-flight must not be cached as the directory.
+			expect((await identities.list()).map((u) => u.id)).toEqual([uid('a')]);
+			expect(list).toHaveBeenCalledTimes(2);
+		});
+	});
+
 	describe('search', () => {
 		beforeEach(async () => {
 			await identities.upsert({ id: uid('usr_ada'), email: 'ada@x.io', name: 'Ada Lovelace' });

--- a/packages/core/src/services/identity/IdentityService.ts
+++ b/packages/core/src/services/identity/IdentityService.ts
@@ -104,7 +104,11 @@ export class IdentityService {
 		return results.filter((r): r is Identity => r !== null);
 	}
 
-	private async listAll(): Promise<Identity[]> {
+	/**
+	 * The full directory, served from the SWR cache. Records exist only for users
+	 * who have signed in at least once.
+	 */
+	async list(): Promise<Identity[]> {
 		if (this.directory && Date.now() - this.directory.at < IdentityService.DIRECTORY_TTL_MS) {
 			return this.directory.entries;
 		}
@@ -159,7 +163,7 @@ export class IdentityService {
 	async search(query: string, limit = 10): Promise<Identity[]> {
 		const q = foldCase(query);
 		if (!q) return [];
-		const all = await this.listAll();
+		const all = await this.list();
 		return all
 			.filter(
 				(u) =>
@@ -180,7 +184,7 @@ export class IdentityService {
 	async getByEmail(email: string): Promise<Identity | null> {
 		const target = normalizeEmail(email);
 		if (!target) return null;
-		const all = await this.listAll();
+		const all = await this.list();
 		const matches = all.filter((u) => normalizeEmail(u.email) === target);
 		if (matches.length === 0) return null;
 		return matches.reduce((a, b) => (a.updated_at >= b.updated_at ? a : b));

--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { screen } from '@testing-library/react';
-import { installMatchMedia, jsonOk, renderWithClient } from '@/test/render';
+import { installMatchMedia, jsonError, jsonOk, renderWithClient } from '@/test/render';
 import App from './App';
 
 afterEach(() => {
@@ -11,33 +11,135 @@ afterEach(() => {
 });
 
 describe('App routes', () => {
-	it('redirects a non-super-admin away from the audit log page', async () => {
+	it.each(['/admin/audit-logs', '/admin/users', '/admin/settings'])(
+		'redirects a non-super-admin away from %s',
+		async (path) => {
+			installMatchMedia(false);
+			const requests: string[] = [];
+			vi.stubGlobal(
+				'fetch',
+				vi.fn(async (input: RequestInfo | URL) => {
+					const url = String(input);
+					requests.push(url);
+					if (url === '/api/v1/me') {
+						return jsonOk({
+							id: 'user-one',
+							email: 'user@example.com',
+							logout_url: null,
+							is_super_admin: false,
+						});
+					}
+					if (url === '/api/v1/projects') return jsonOk({ items: [], next_cursor: null });
+					if (url === '/api/v1/version') return jsonOk({ version: 'test' });
+					throw new Error(`unexpected fetch: ${url}`);
+				}),
+			);
+			window.history.replaceState({}, '', path);
+
+			renderWithClient(<App />, { toaster: false });
+
+			expect(await screen.findByRole('heading', { name: 'Projects' })).toBeInTheDocument();
+			expect(window.location.pathname).toBe('/');
+			expect(requests.some((url) => url.startsWith('/api/v1/events?'))).toBe(false);
+			expect(requests.some((url) => url.startsWith('/api/v1/admin/'))).toBe(false);
+		},
+	);
+
+	it('redirects /admin to /admin/users for a super admin', async () => {
 		installMatchMedia(false);
-		const requests: string[] = [];
 		vi.stubGlobal(
 			'fetch',
 			vi.fn(async (input: RequestInfo | URL) => {
 				const url = String(input);
-				requests.push(url);
 				if (url === '/api/v1/me') {
 					return jsonOk({
 						id: 'user-one',
-						email: 'user@example.com',
+						email: 'admin@example.com',
 						logout_url: null,
-						is_super_admin: false,
+						is_super_admin: true,
 					});
 				}
-				if (url === '/api/v1/projects') return jsonOk({ items: [], next_cursor: null });
-				if (url === '/api/v1/version') return jsonOk({ version: 'test', backends: {} });
+				if (url === '/api/v1/admin/users') return jsonOk({ items: [] });
+				if (url === '/api/v1/version') return jsonOk({ version: 'test' });
 				throw new Error(`unexpected fetch: ${url}`);
 			}),
 		);
-		window.history.replaceState({}, '', '/admin/audit-logs');
+		window.history.replaceState({}, '', '/admin');
 
 		renderWithClient(<App />, { toaster: false });
 
-		expect(await screen.findByRole('heading', { name: 'Projects' })).toBeInTheDocument();
-		expect(window.location.pathname).toBe('/');
-		expect(requests.some((url) => url.startsWith('/api/v1/events?'))).toBe(false);
+		expect(await screen.findByRole('heading', { name: 'Users' })).toBeInTheDocument();
+		expect(window.location.pathname).toBe('/admin/users');
+	});
+
+	it('shows the error boundary when an admin endpoint fails', async () => {
+		installMatchMedia(false);
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url === '/api/v1/me') {
+					return jsonOk({
+						id: 'user-one',
+						email: 'admin@example.com',
+						logout_url: null,
+						is_super_admin: true,
+					});
+				}
+				if (url === '/api/v1/admin/users') {
+					return jsonError('INTERNAL_ERROR', 'Internal server error', 500);
+				}
+				if (url === '/api/v1/version') return jsonOk({ version: 'test' });
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		window.history.replaceState({}, '', '/admin/users');
+
+		renderWithClient(<App />, { toaster: false });
+
+		expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+		expect(screen.getByText('Internal server error')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+	});
+
+	it('shows the users page with the admin nav to a super admin', async () => {
+		installMatchMedia(false);
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url === '/api/v1/me') {
+					return jsonOk({
+						id: 'user-one',
+						email: 'admin@example.com',
+						logout_url: null,
+						is_super_admin: true,
+					});
+				}
+				if (url === '/api/v1/admin/users') {
+					return jsonOk({
+						items: [
+							{
+								id: 'user-ada',
+								email: 'ada@example.com',
+								name: 'Ada Lovelace',
+								updated_at: '2026-08-01T00:00:00.000Z',
+								is_super_admin: true,
+							},
+						],
+					});
+				}
+				if (url === '/api/v1/version') return jsonOk({ version: 'test' });
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		window.history.replaceState({}, '', '/admin/users');
+
+		renderWithClient(<App />, { toaster: false });
+
+		expect(await screen.findByRole('heading', { name: 'Users' })).toBeInTheDocument();
+		expect(screen.getByRole('navigation', { name: 'Admin' })).toBeInTheDocument();
+		expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+		expect(window.location.pathname).toBe('/admin/users');
 	});
 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -12,8 +12,11 @@ import { SignIn } from '@/components/SignIn/SignIn';
 import { ErrorBoundary, Button } from '@/components/ui';
 import { Toaster } from '@/components/ui/sonner';
 import { ApiRequestError } from '@/api/client';
+import { AdminLayout } from '@/components/Admin/AdminLayout';
 
 const AuditLogPage = lazy(() => import('@/components/AuditLog/AuditLogPage'));
+const AdminUsersPage = lazy(() => import('@/components/Admin/AdminUsersPage'));
+const AdminSettingsPage = lazy(() => import('@/components/Admin/AdminSettingsPage'));
 
 function AuthGate({ children }: { children: React.ReactNode }) {
 	const { isPending, error, user, signIn, refetchUser } = useAuth();
@@ -78,11 +81,6 @@ function PageFallback() {
 	);
 }
 
-function SuperAdminAuditLogs() {
-	const { user } = useAuth();
-	return user?.is_super_admin ? <AuditLogPage /> : <Navigate to="/" replace />;
-}
-
 function StandardLayout() {
 	return (
 		<div className="flex min-h-dvh flex-col">
@@ -93,7 +91,12 @@ function StandardLayout() {
 						<Routes>
 							<Route path="/" element={<ProjectList />} />
 							<Route path="/projects/:pid" element={<Project />} />
-							<Route path="/admin/audit-logs" element={<SuperAdminAuditLogs />} />
+							<Route path="/admin" element={<AdminLayout />}>
+								<Route index element={<Navigate to="/admin/users" replace />} />
+								<Route path="users" element={<AdminUsersPage />} />
+								<Route path="settings" element={<AdminSettingsPage />} />
+								<Route path="audit-logs" element={<AuditLogPage />} />
+							</Route>
 							<Route path="*" element={<Navigate to="/" replace />} />
 						</Routes>
 					</Suspense>

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -17,6 +17,7 @@ import {
 	systemKeys,
 	integrationKeys,
 	auditKeys,
+	adminKeys,
 } from './queryKeys';
 import type { AuditLogFilters } from './queryKeys';
 import type {
@@ -163,6 +164,24 @@ export function useUserSearchQuery(query: string) {
 		enabled: q.length >= 2,
 		staleTime: 30 * 1000,
 		placeholderData: keepPreviousData,
+	});
+}
+
+// Admin (super-admin pages)
+
+/** The full user directory (everyone who has signed in at least once), name-sorted. */
+export function useAdminUsersQuery() {
+	return useSuspenseQuery({
+		queryKey: adminKeys.users(),
+		queryFn: async () => (await apiData(apiClient.GET('/api/v1/admin/users'))).items,
+	});
+}
+
+/** The deployment's configuration, grouped per the config spec, secrets redacted server-side. */
+export function useDeploymentConfigQuery() {
+	return useSuspenseQuery({
+		queryKey: adminKeys.config(),
+		queryFn: () => apiData(apiClient.GET('/api/v1/admin/config')),
 	});
 }
 

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -60,6 +60,12 @@ export const auditKeys = {
 	list: (filters: AuditLogFilters) => [...auditKeys.all, 'list', filters] as const,
 };
 
+export const adminKeys = {
+	all: ['admin'] as const,
+	users: () => [...adminKeys.all, 'users'] as const,
+	config: () => [...adminKeys.all, 'config'] as const,
+};
+
 export const sessionKeys = {
 	all: ['sessions'] as const,
 	detail: (sid: string) => [...sessionKeys.all, 'detail', sid] as const,

--- a/packages/web/src/components/Admin/AdminLayout.tsx
+++ b/packages/web/src/components/Admin/AdminLayout.tsx
@@ -1,0 +1,44 @@
+import { Navigate, NavLink, Outlet } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
+import { cn } from '@/lib/utils';
+
+const TABS = [
+	{ to: '/admin/users', label: 'Users' },
+	{ to: '/admin/settings', label: 'Settings' },
+	{ to: '/admin/audit-logs', label: 'Audit logs' },
+];
+
+/** Super-admin gate + tab bar shared by every `/admin/*` page. */
+export function AdminLayout() {
+	const { user } = useAuth();
+	if (!user?.is_super_admin) return <Navigate to="/" replace />;
+
+	return (
+		<div className="flex min-h-0 flex-1 flex-col">
+			<nav
+				aria-label="Admin"
+				className="flex shrink-0 gap-1 border-b bg-background px-6 pt-2 max-md:px-3"
+			>
+				{TABS.map((tab) => (
+					<NavLink
+						key={tab.to}
+						to={tab.to}
+						className={({ isActive }) =>
+							cn(
+								'-mb-px rounded-t-md border-b-2 px-3 py-2 text-sm font-medium outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring',
+								isActive
+									? 'border-primary text-foreground'
+									: 'border-transparent text-muted-foreground hover:text-foreground',
+							)
+						}
+					>
+						{tab.label}
+					</NavLink>
+				))}
+			</nav>
+			<div className="flex min-h-0 flex-1 overflow-hidden">
+				<Outlet />
+			</div>
+		</div>
+	);
+}

--- a/packages/web/src/components/Admin/AdminSettingsPage.test.tsx
+++ b/packages/web/src/components/Admin/AdminSettingsPage.test.tsx
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { jsonError, jsonOk, renderWithClient } from '@/test/render';
+import { ErrorBoundary } from '@/components/ui';
+import type { DeploymentConfig } from '@/types';
+import AdminSettingsPage from './AdminSettingsPage';
+
+const CONFIG: DeploymentConfig = {
+	deployment: {
+		version: '0.2.0',
+		image: 'ghcr.io/marimo-team/marimohub:0.2.0',
+		sandbox_image: null,
+		started_at: '2026-08-01T00:00:00.000Z',
+		replica: 'marimohub-abc123',
+		node: 'v24.3.0',
+		backends: { storage: 's3', compute: 'coreweave', auth: 'oidc' },
+	},
+	groups: [
+		{
+			name: 'Auth',
+			backend: 'oidc',
+			settings: [
+				{
+					key: 'MARIMOHUB_AUTH_OIDC_ISSUER',
+					name: 'OIDC issuer',
+					value: 'https://accounts.example.com',
+					secret: false,
+					set: true,
+				},
+				{
+					key: 'MARIMOHUB_AUTH_OIDC_CLIENT_SECRET',
+					name: 'OIDC client secret',
+					value: null,
+					secret: true,
+					set: true,
+				},
+				{
+					key: 'MARIMOHUB_AUTH_OIDC_AUDIENCE',
+					name: 'OIDC audience',
+					value: null,
+					secret: false,
+					set: false,
+				},
+			],
+		},
+		{
+			name: 'Storage',
+			backend: 's3',
+			settings: [
+				{
+					key: 'MARIMOHUB_STORAGE_S3_BUCKET',
+					name: 'S3 bucket',
+					value: 'my-bucket',
+					secret: false,
+					set: true,
+				},
+			],
+		},
+		// Groups with no applicable settings are hidden entirely.
+		{ name: 'Managed AI', backend: 'unset', settings: [] },
+	],
+	policy: { default_role: 'editor', super_admins: ['ops@example.com', 'user-root'] },
+};
+
+function setup(config: DeploymentConfig = CONFIG) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url === '/api/v1/admin/config') return jsonOk(config);
+			throw new Error(`unexpected fetch: ${url}`);
+		}),
+	);
+	renderWithClient(<AdminSettingsPage />);
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('AdminSettingsPage', () => {
+	it('renders the deployment section with a linked release version', async () => {
+		setup();
+
+		expect(await screen.findByRole('heading', { name: 'Deployment' })).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: /0\.2\.0/ })).toHaveAttribute(
+			'href',
+			'https://github.com/marimo-team/marimohub/releases/tag/v0.2.0',
+		);
+		expect(screen.getByText('ghcr.io/marimo-team/marimohub:0.2.0')).toBeInTheDocument();
+		expect(screen.getByText('marimohub-abc123')).toBeInTheDocument();
+		expect(screen.getByText('s3 · coreweave · oidc')).toBeInTheDocument();
+		// Null fields (sandbox image) render no row.
+		expect(screen.queryByText('Sandbox image')).not.toBeInTheDocument();
+	});
+
+	it('renders every non-empty group with its backend — secrets only as set/not set', async () => {
+		setup();
+
+		expect(await screen.findByRole('heading', { name: 'Auth' })).toBeInTheDocument();
+		expect(screen.getByText('oidc')).toBeInTheDocument();
+		expect(screen.getByText('https://accounts.example.com')).toBeInTheDocument();
+		// The secret row shows presence, never a value.
+		expect(screen.getByText('OIDC client secret')).toBeInTheDocument();
+		expect(screen.getByText('Set')).toBeInTheDocument();
+		// Non-secret but unset.
+		expect(screen.getByText('Not set')).toBeInTheDocument();
+
+		expect(screen.getByRole('heading', { name: 'Storage' })).toBeInTheDocument();
+		expect(screen.getByText('my-bucket')).toBeInTheDocument();
+
+		// The empty Managed AI group is skipped.
+		expect(screen.queryByRole('heading', { name: 'Managed AI' })).not.toBeInTheDocument();
+
+		expect(screen.getByText('editor')).toBeInTheDocument();
+		expect(screen.getByText('ops@example.com')).toBeInTheDocument();
+		expect(screen.getByText('user-root')).toBeInTheDocument();
+	});
+
+	it('handles a deployment with no summary (nulls) gracefully', async () => {
+		setup({ deployment: null, groups: [], policy: { default_role: null, super_admins: [] } });
+
+		expect(
+			await screen.findByText('This deployment reports no configuration.'),
+		).toBeInTheDocument();
+		expect(screen.queryByRole('heading', { name: 'Deployment' })).not.toBeInTheDocument();
+		expect(screen.getByText('none — writes are members-only')).toBeInTheDocument();
+		expect(screen.getByText('None configured')).toBeInTheDocument();
+	});
+
+	it('surfaces a fetch failure to the error boundary', async () => {
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			vi.stubGlobal(
+				'fetch',
+				vi.fn(async () => jsonError('INTERNAL_ERROR', 'Internal server error', 500)),
+			);
+			renderWithClient(
+				<ErrorBoundary>
+					<AdminSettingsPage />
+				</ErrorBoundary>,
+			);
+			expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+			expect(screen.getByText('Internal server error')).toBeInTheDocument();
+		} finally {
+			log.mockRestore();
+		}
+	});
+});

--- a/packages/web/src/components/Admin/AdminSettingsPage.tsx
+++ b/packages/web/src/components/Admin/AdminSettingsPage.tsx
@@ -1,0 +1,191 @@
+import type { ReactNode } from 'react';
+import { ExternalLink, Lock, ShieldCheck } from 'lucide-react';
+import { Chip, PageContainer, PageHeader } from '@/components/ui';
+import { useDeploymentConfigQuery } from '@/api/hooks';
+import { versionHref } from '@/lib/deployment';
+import { formatRelative } from '@/lib/time';
+import type { DeploymentConfig } from '@/types';
+
+type ConfigSetting = DeploymentConfig['groups'][number]['settings'][number];
+
+function DeploymentRow({ label, value }: { label: string; value: ReactNode }) {
+	return (
+		<div className="flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0">
+			<span className="shrink-0 text-sm font-medium">{label}</span>
+			<span className="min-w-0 truncate text-right font-mono text-xs">{value}</span>
+		</div>
+	);
+}
+
+function DeploymentSection({
+	deployment,
+}: {
+	deployment: NonNullable<DeploymentConfig['deployment']>;
+}) {
+	const href = versionHref(deployment.version);
+	return (
+		<section className="mb-6">
+			<h2 className="mb-2 text-sm font-semibold">Deployment</h2>
+			<div className="overflow-hidden rounded-xl border bg-card shadow-xs">
+				<DeploymentRow
+					label="Version"
+					value={
+						href ? (
+							<a
+								href={href}
+								target="_blank"
+								rel="noreferrer"
+								className="inline-flex items-center gap-1 underline-offset-4 hover:underline"
+							>
+								{deployment.version}
+								<ExternalLink className="size-3 shrink-0 text-muted-foreground" />
+							</a>
+						) : (
+							deployment.version
+						)
+					}
+				/>
+				{deployment.image !== null && (
+					<DeploymentRow
+						label="Image"
+						value={<span title={deployment.image}>{deployment.image}</span>}
+					/>
+				)}
+				{deployment.sandbox_image !== null && (
+					<DeploymentRow
+						label="Sandbox image"
+						value={<span title={deployment.sandbox_image}>{deployment.sandbox_image}</span>}
+					/>
+				)}
+				{deployment.started_at !== null && (
+					<DeploymentRow
+						label="Started"
+						value={
+							<time dateTime={deployment.started_at} title={deployment.started_at}>
+								{formatRelative(deployment.started_at) || deployment.started_at}
+							</time>
+						}
+					/>
+				)}
+				{deployment.replica !== null && (
+					<DeploymentRow label="Replica" value={deployment.replica} />
+				)}
+				{deployment.node !== null && <DeploymentRow label="Node runtime" value={deployment.node} />}
+				{deployment.backends !== null && (
+					<DeploymentRow
+						label="Backends"
+						value={`${deployment.backends.storage} · ${deployment.backends.compute} · ${deployment.backends.auth}`}
+					/>
+				)}
+			</div>
+		</section>
+	);
+}
+
+function SettingRow({ setting }: { setting: ConfigSetting }) {
+	return (
+		<div className="flex items-center justify-between gap-4 border-b px-4 py-3 last:border-b-0">
+			<span className="flex min-w-0 flex-col gap-0.5">
+				<span className="text-sm font-medium">{setting.name}</span>
+				<span className="truncate font-mono text-xs text-muted-foreground">{setting.key}</span>
+			</span>
+			{setting.secret ? (
+				<span className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+					<Lock className="size-3" />
+					{setting.set ? 'Set' : 'Not set'}
+				</span>
+			) : setting.value === null ? (
+				<span className="shrink-0 text-xs text-muted-foreground">Not set</span>
+			) : (
+				<span className="max-w-[50%] truncate text-right font-mono text-xs">{setting.value}</span>
+			)}
+		</div>
+	);
+}
+
+export default function AdminSettingsPage() {
+	const { data: config } = useDeploymentConfigQuery();
+	const groups = config.groups.filter((group) => group.settings.length > 0);
+
+	return (
+		<PageContainer>
+			<title>Settings · marimohub</title>
+			<PageHeader>
+				<div className="flex min-w-0 flex-col gap-0.5">
+					<h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+					<p className="text-sm text-muted-foreground">
+						Read-only deployment configuration — set via MARIMOHUB_* environment variables, read at
+						boot. Secrets show only whether they are set.
+					</p>
+				</div>
+			</PageHeader>
+
+			{config.deployment && <DeploymentSection deployment={config.deployment} />}
+
+			<section className="mb-6">
+				<h2 className="mb-2 text-sm font-semibold">Access</h2>
+				<div className="overflow-hidden rounded-xl border bg-card shadow-xs">
+					<div className="flex items-center justify-between gap-4 border-b px-4 py-3">
+						<span className="flex min-w-0 flex-col gap-0.5">
+							<span className="text-sm font-medium">Default role</span>
+							<span className="font-mono text-xs text-muted-foreground">
+								MARIMOHUB_DEFAULT_ROLE
+							</span>
+						</span>
+						{config.policy.default_role === null ? (
+							<span className="text-xs text-muted-foreground">none — writes are members-only</span>
+						) : (
+							<span className="font-mono text-xs">{config.policy.default_role}</span>
+						)}
+					</div>
+					<div className="flex items-start justify-between gap-4 px-4 py-3">
+						<span className="flex min-w-0 flex-col gap-0.5">
+							<span className="flex items-center gap-1.5 text-sm font-medium">
+								<ShieldCheck className="size-3.5 text-primary" />
+								Super admins
+							</span>
+							<span className="font-mono text-xs text-muted-foreground">
+								MARIMOHUB_SUPER_ADMINS
+							</span>
+						</span>
+						{config.policy.super_admins.length === 0 ? (
+							<span className="text-xs text-muted-foreground">None configured</span>
+						) : (
+							<ul className="flex max-w-[60%] flex-col items-end gap-1">
+								{config.policy.super_admins.map((entry) => (
+									<li key={entry} className="max-w-full truncate font-mono text-xs">
+										{entry}
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+				</div>
+				<p className="mt-2 text-xs text-muted-foreground">
+					Entries containing “@” match by login email; anything else matches a user id exactly. A
+					configured super admin appears on the Users page only after their first sign-in.
+				</p>
+			</section>
+
+			{groups.length === 0 ? (
+				<p className="rounded-xl border border-dashed bg-card/50 px-4 py-6 text-sm text-muted-foreground">
+					This deployment reports no configuration.
+				</p>
+			) : (
+				groups.map((group) => (
+					<section key={group.name} className="mb-6">
+						<div className="mb-2 flex items-center gap-2">
+							<h2 className="text-sm font-semibold">{group.name}</h2>
+							{group.backend !== null && <Chip>{group.backend}</Chip>}
+						</div>
+						<div className="overflow-hidden rounded-xl border bg-card shadow-xs">
+							{group.settings.map((setting) => (
+								<SettingRow key={setting.key} setting={setting} />
+							))}
+						</div>
+					</section>
+				))
+			)}
+		</PageContainer>
+	);
+}

--- a/packages/web/src/components/Admin/AdminUsersPage.test.tsx
+++ b/packages/web/src/components/Admin/AdminUsersPage.test.tsx
@@ -70,9 +70,13 @@ describe('AdminUsersPage', () => {
 		expect(screen.getByText('No users matching "zzz-nope"')).toBeInTheDocument();
 	});
 
-	it('shows the empty state for an empty directory', async () => {
-		setup([]);
+	it('shows the empty state for an empty directory, even with a whitespace query', async () => {
+		const user = setup([]);
 		expect(await screen.findByText('No users yet')).toBeInTheDocument();
+
+		await user.type(screen.getByRole('searchbox', { name: 'Search users' }), '   ');
+		expect(screen.getByText('No users yet')).toBeInTheDocument();
+		expect(screen.queryByText(/No users matching/)).not.toBeInTheDocument();
 	});
 
 	// The race where a super admin was removed from MARIMOHUB_SUPER_ADMINS while

--- a/packages/web/src/components/Admin/AdminUsersPage.test.tsx
+++ b/packages/web/src/components/Admin/AdminUsersPage.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { jsonError, jsonOk, renderWithClient } from '@/test/render';
+import { ErrorBoundary } from '@/components/ui';
+import type { AdminUser } from '@/types';
+import AdminUsersPage from './AdminUsersPage';
+
+const USERS: AdminUser[] = [
+	{
+		id: 'user-ada',
+		email: 'ada@example.com',
+		name: 'Ada Lovelace',
+		updated_at: '2026-08-01T12:00:00.000Z',
+		is_super_admin: true,
+	},
+	{
+		id: 'user-grace',
+		email: 'grace@example.com',
+		name: 'Grace Hopper',
+		updated_at: '2026-08-02T09:30:00.000Z',
+		is_super_admin: false,
+	},
+];
+
+function setup(items: AdminUser[] = USERS) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url === '/api/v1/admin/users') return jsonOk({ items, next_cursor: null });
+			throw new Error(`unexpected fetch: ${url}`);
+		}),
+	);
+	renderWithClient(<AdminUsersPage />);
+	return userEvent.setup();
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('AdminUsersPage', () => {
+	it('renders the directory with a super-admin badge only where deserved', async () => {
+		setup();
+
+		expect(await screen.findByText('Ada Lovelace')).toBeInTheDocument();
+		expect(screen.getByText('Grace Hopper')).toBeInTheDocument();
+		expect(screen.getByText('grace@example.com')).toBeInTheDocument();
+		expect(screen.getByText('user-grace')).toBeInTheDocument();
+
+		const rows = screen.getAllByTestId('admin-user-row');
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toHaveTextContent('Super admin');
+		expect(rows[1]).not.toHaveTextContent('Super admin');
+	});
+
+	it('filters by name, email, or id from the search box', async () => {
+		const user = setup();
+		await screen.findByText('Ada Lovelace');
+
+		await user.type(screen.getByRole('searchbox', { name: 'Search users' }), 'grace');
+		expect(screen.getAllByTestId('admin-user-row')).toHaveLength(1);
+		expect(screen.getByText('Grace Hopper')).toBeInTheDocument();
+		expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+
+		await user.clear(screen.getByRole('searchbox', { name: 'Search users' }));
+		await user.type(screen.getByRole('searchbox', { name: 'Search users' }), 'zzz-nope');
+		expect(screen.getByText('No users matching "zzz-nope"')).toBeInTheDocument();
+	});
+
+	it('shows the empty state for an empty directory', async () => {
+		setup([]);
+		expect(await screen.findByText('No users yet')).toBeInTheDocument();
+	});
+
+	// The race where a super admin was removed from MARIMOHUB_SUPER_ADMINS while
+	// their tab was open: /me still says super admin, but the API now refuses.
+	it('surfaces a 403 to the error boundary instead of rendering an empty page', async () => {
+		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+		try {
+			vi.stubGlobal(
+				'fetch',
+				vi.fn(async () => jsonError('FORBIDDEN', 'Requires super admin', 403)),
+			);
+			renderWithClient(
+				<ErrorBoundary>
+					<AdminUsersPage />
+				</ErrorBoundary>,
+			);
+			expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
+			expect(screen.getByText('Requires super admin')).toBeInTheDocument();
+		} finally {
+			log.mockRestore();
+		}
+	});
+});

--- a/packages/web/src/components/Admin/AdminUsersPage.tsx
+++ b/packages/web/src/components/Admin/AdminUsersPage.tsx
@@ -22,7 +22,10 @@ const ROW_GRID = 'grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto]';
 export default function AdminUsersPage() {
 	const search = useSearchField();
 	const { data: users } = useAdminUsersQuery();
-	const filtered = filterBySearch(users, search.query, (u) => `${u.name} ${u.email} ${u.id}`);
+	// Trimmed so a whitespace-only query counts as no search (filterBySearch
+	// semantics) — an empty directory then shows its own empty state.
+	const query = search.query.trim();
+	const filtered = filterBySearch(users, query, (u) => `${u.name} ${u.email} ${u.id}`);
 
 	return (
 		<PageContainer>
@@ -48,10 +51,10 @@ export default function AdminUsersPage() {
 			</div>
 
 			{filtered.length === 0 ? (
-				search.query ? (
+				query ? (
 					<EmptyState
 						icon={<SearchX />}
-						message={`No users matching "${search.query}"`}
+						message={`No users matching "${query}"`}
 						description="Try a different search term."
 					/>
 				) : (

--- a/packages/web/src/components/Admin/AdminUsersPage.tsx
+++ b/packages/web/src/components/Admin/AdminUsersPage.tsx
@@ -1,0 +1,106 @@
+import { SearchX, ShieldCheck, Users } from 'lucide-react';
+import { Chip, EmptyState, PageContainer, PageHeader, SearchField } from '@/components/ui';
+import { useAdminUsersQuery } from '@/api/hooks';
+import { useSearchField } from '@/hooks/useSearchField';
+import { filterBySearch } from '@/lib/search';
+
+const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
+	year: 'numeric',
+	month: 'short',
+	day: 'numeric',
+	hour: 'numeric',
+	minute: '2-digit',
+});
+
+function formatTimestamp(value: string): string {
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? value : dateTimeFormatter.format(date);
+}
+
+const ROW_GRID = 'grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)_auto]';
+
+export default function AdminUsersPage() {
+	const search = useSearchField();
+	const { data: users } = useAdminUsersQuery();
+	const filtered = filterBySearch(users, search.query, (u) => `${u.name} ${u.email} ${u.id}`);
+
+	return (
+		<PageContainer>
+			<title>Users · marimohub</title>
+			<PageHeader>
+				<div className="flex min-w-0 flex-col gap-0.5">
+					<h1 className="text-2xl font-semibold tracking-tight">Users</h1>
+					<p className="text-sm text-muted-foreground">
+						{users.length} user{users.length !== 1 ? 's' : ''} · everyone who has signed in at least
+						once
+					</p>
+				</div>
+			</PageHeader>
+
+			<div className="mb-4">
+				<SearchField
+					aria-label="Search users"
+					placeholder="Search users..."
+					value={search.query}
+					onChange={search.setQuery}
+					inputRef={search.inputRef}
+				/>
+			</div>
+
+			{filtered.length === 0 ? (
+				search.query ? (
+					<EmptyState
+						icon={<SearchX />}
+						message={`No users matching "${search.query}"`}
+						description="Try a different search term."
+					/>
+				) : (
+					<EmptyState
+						icon={<Users />}
+						message="No users yet"
+						description="Users appear here after their first sign-in."
+					/>
+				)
+			) : (
+				<div className="overflow-hidden rounded-xl border bg-card shadow-xs">
+					<div
+						className={`grid ${ROW_GRID} gap-3 border-b bg-muted/60 px-4 py-2 text-xs font-medium text-muted-foreground`}
+					>
+						<span>User</span>
+						<span>User id</span>
+						<span
+							className="text-right"
+							title="Approximate — when this user's identity record was last refreshed"
+						>
+							Last active
+						</span>
+					</div>
+					{filtered.map((user) => (
+						<div
+							key={user.id}
+							data-testid="admin-user-row"
+							className={`grid ${ROW_GRID} items-center gap-3 border-b px-4 py-3 last:border-b-0`}
+						>
+							<span className="flex min-w-0 flex-col gap-0.5">
+								<span className="flex min-w-0 items-center gap-2">
+									<span className="truncate text-sm font-medium">{user.name}</span>
+									{user.is_super_admin && (
+										<Chip>
+											<ShieldCheck className="size-3" />
+											Super admin
+										</Chip>
+									)}
+								</span>
+								<span className="truncate text-xs text-muted-foreground">{user.email}</span>
+							</span>
+							<span className="truncate font-mono text-xs text-muted-foreground">{user.id}</span>
+							<span className="text-right text-xs tabular-nums text-muted-foreground">
+								{formatTimestamp(user.updated_at)}
+							</span>
+						</div>
+					))}
+				</div>
+			)}
+		</PageContainer>
+	);
+}

--- a/packages/web/src/components/Footer/Footer.test.tsx
+++ b/packages/web/src/components/Footer/Footer.test.tsx
@@ -1,53 +1,28 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router-dom';
 import { AuthProvider } from '@/context/AuthContext';
 import { jsonOk, renderWithClient } from '@/test/render';
 import { Footer } from './Footer';
 
 const USER = { id: 'usr-123', email: 'ada@example.com' };
 
-const VERSION = {
-	version: '0.2.0',
-	image: 'ghcr.io/marimo-team/marimohub:0.2.0',
-	sandbox_image: null,
-	started_at: null,
-	replica: null,
-	node: null,
-	backends: { storage: 's3', compute: 'coreweave', auth: 'oidc' },
-};
-
-const CAPABILITIES = {
-	federation: { available: true },
-	integrations: { available: false },
-	viewer_mode: 'interactive',
-	viewer_session_modes: ['edit', 'run'],
-	editor_sandbox_sharing: 'shared',
-	default_role: null,
-	limits: {
-		max_concurrent_sessions_per_user: 5,
-		max_apps_per_project: null,
-		max_request_bytes: 1,
-		max_versions_per_notebook: 100,
-		default_page_size: 50,
-		max_page_size: 200,
-	},
-	sandbox_images: ['ghcr.io/marimo-team/marimo-sandbox:1.2.3'],
-	compute_profiles: [{ name: 'small', cpu: '1', memory: '2Gi' }],
-	compute_profile_override: 'editors',
-};
+function LocationProbe() {
+	return <span data-testid="location">{useLocation().pathname}</span>;
+}
 
 function setup({
-	version = VERSION,
+	version = '0.2.0',
 	me = USER as Record<string, unknown>,
-}: { version?: typeof VERSION; me?: Record<string, unknown> } = {}) {
-	const capabilitiesFetch = vi.fn(() => jsonOk(CAPABILITIES));
+}: { version?: string; me?: Record<string, unknown> } = {}) {
+	const capabilitiesFetch = vi.fn(() => jsonOk({}));
 	vi.stubGlobal(
 		'fetch',
 		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 			const url = String(input);
 			if (url === '/api/v1/me') return jsonOk(me);
-			if (url === '/api/v1/version') return jsonOk(version);
+			if (url === '/api/v1/version') return jsonOk({ version });
 			if (url === '/api/v1/capabilities') return capabilitiesFetch();
 			throw new Error(`unexpected fetch: ${init?.method ?? 'GET'} ${url}`);
 		}),
@@ -56,6 +31,7 @@ function setup({
 	renderWithClient(
 		<AuthProvider>
 			<Footer />
+			<LocationProbe />
 		</AuthProvider>,
 		{ route: '/' },
 	);
@@ -63,7 +39,7 @@ function setup({
 }
 
 async function openPopover(user: ReturnType<typeof userEvent.setup>) {
-	await user.click(screen.getByRole('button', { name: 'Version info' }));
+	await user.click(screen.getByRole('button', { name: 'About marimohub' }));
 	await waitFor(() => expect(screen.getByText('marimohub')).toBeInTheDocument());
 }
 
@@ -85,7 +61,7 @@ describe('Footer', () => {
 	});
 
 	it('links a git SHA version to its commit', async () => {
-		const { user } = setup({ version: { ...VERSION, version: 'a1b2c3d' } });
+		const { user } = setup({ version: 'a1b2c3d' });
 		await openPopover(user);
 
 		const link = await screen.findByRole('link', { name: /a1b2c3d/ });
@@ -93,7 +69,7 @@ describe('Footer', () => {
 	});
 
 	it('renders git-describe versions as plain text — no such release tag exists', async () => {
-		const { user } = setup({ version: { ...VERSION, version: '0.2.0-5-gdeadbeef' } });
+		const { user } = setup({ version: '0.2.0-5-gdeadbeef' });
 		await openPopover(user);
 
 		expect(await screen.findByText('0.2.0-5-gdeadbeef')).toBeInTheDocument();
@@ -101,34 +77,45 @@ describe('Footer', () => {
 	});
 
 	it('renders dev builds as plain text', async () => {
-		const { user } = setup({ version: { ...VERSION, version: 'dev' } });
+		const { user } = setup({ version: 'dev' });
 		await openPopover(user);
 
 		expect(await screen.findByText('dev')).toBeInTheDocument();
 		expect(screen.queryByRole('link', { name: /dev/ })).not.toBeInTheDocument();
 	});
 
-	it('hides the policy section (and skips the fetch) for regular users', async () => {
+	it('shows source and issue links to everyone', async () => {
+		const { user } = setup();
+		await openPopover(user);
+
+		expect(screen.getByRole('link', { name: /Source/ })).toHaveAttribute(
+			'href',
+			'https://github.com/marimo-team/marimohub',
+		);
+		expect(screen.getByRole('link', { name: /Report an issue/ })).toHaveAttribute(
+			'href',
+			'https://github.com/marimo-team/marimohub/issues',
+		);
+	});
+
+	it('hides the settings shortcut (and never fetches capabilities) for regular users', async () => {
 		const { user, capabilitiesFetch } = setup();
 		await openPopover(user);
 
-		expect(screen.queryByText('Policy')).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: /Deployment settings/ })).not.toBeInTheDocument();
 		expect(capabilitiesFetch).not.toHaveBeenCalled();
 	});
 
-	it('shows deployment policy to super admins', async () => {
-		const { user } = setup({ me: { ...USER, is_super_admin: true } });
+	it('navigates super admins to the admin settings page', async () => {
+		const { user, capabilitiesFetch } = setup({ me: { ...USER, is_super_admin: true } });
 		await openPopover(user);
 
-		expect(await screen.findByText('Policy')).toBeInTheDocument();
-		expect(screen.getByText('interactive')).toBeInTheDocument();
-		expect(screen.getByText('members only')).toBeInTheDocument();
-		// integrations unavailable → only federation listed
-		expect(screen.getByText('federation')).toBeInTheDocument();
-		expect(
-			screen.getByText(/5 sessions\/user · ∞ apps\/project · 100 versions/),
-		).toBeInTheDocument();
-		expect(screen.getByText('ghcr.io/marimo-team/marimo-sandbox:1.2.3')).toBeInTheDocument();
-		expect(screen.getByText('small (override: editors)')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: /Deployment settings/ }));
+
+		expect(screen.getByTestId('location')).toHaveTextContent('/admin/settings');
+		// The popover closed itself on navigation.
+		expect(screen.queryByRole('link', { name: /Source/ })).not.toBeInTheDocument();
+		// Deployment detail now lives on the settings page — no capabilities fetch here.
+		expect(capabilitiesFetch).not.toHaveBeenCalled();
 	});
 });

--- a/packages/web/src/components/Footer/Footer.tsx
+++ b/packages/web/src/components/Footer/Footer.tsx
@@ -1,75 +1,40 @@
 import type { ReactNode } from 'react';
-import { Info, ExternalLink } from 'lucide-react';
-import { useCapabilitiesQuery, useVersionQuery } from '@/api/hooks';
+import { useNavigate } from 'react-router-dom';
+import { Bug, Code2, ExternalLink, Info, Settings2 } from 'lucide-react';
+import { useVersionQuery } from '@/api/hooks';
 import { Popover } from '@/components/ui';
 import { useAuth } from '@/context/AuthContext';
-import { formatRelative } from '@/lib/time';
+import { SOURCE_URL, versionHref } from '@/lib/deployment';
 
-/** Source repository — the UI derives release/commit + issue links from it. */
-const SOURCE_URL = 'https://github.com/marimo-team/marimohub';
+const ROW_CLASS =
+	'flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring [&_svg]:size-3.5 [&_svg]:shrink-0';
 
-/**
- * MARIMOHUB_VERSION is either a release tag (`0.2.0`) or a git SHA (`a1b2c3d`);
- * only one of those has a release page, so pick the GitHub URL per shape. Any
- * other value (`dev`, git-describe suffixes like `0.2.0-5-gdeadbeef`) has no
- * page at all.
- */
-function versionHref(version: string): string | null {
-	if (/^v?\d+\.\d+\.\d+$/.test(version)) {
-		return `${SOURCE_URL}/releases/tag/${version.startsWith('v') ? version : `v${version}`}`;
-	}
-	if (/^[0-9a-f]{7,40}$/i.test(version)) {
-		return `${SOURCE_URL}/commit/${version}`;
-	}
-	return null;
-}
-
-function InfoRow({ label, value }: { label: string; value: ReactNode }) {
+function LinkRow({ href, icon, children }: { href: string; icon: ReactNode; children: ReactNode }) {
 	return (
-		<>
-			<dt className="text-muted-foreground">{label}</dt>
-			<dd className="min-w-0 break-all text-foreground">{value}</dd>
-		</>
-	);
-}
-
-/** A timestamp shown as a relative phrase, with the exact value on hover. */
-function Timestamp({ iso }: { iso: string }) {
-	return (
-		<time dateTime={iso} title={iso} className="tabular-nums">
-			{formatRelative(iso) || iso}
-		</time>
+		<a href={href} target="_blank" rel="noreferrer" className={ROW_CLASS}>
+			{icon}
+			<span className="flex-1">{children}</span>
+			<ExternalLink className="text-muted-foreground/50" />
+		</a>
 	);
 }
 
 /**
- * Slim bottom bar with a single info affordance: clicking it opens a popover with
- * the deployment's version, image, start time, replica, runtime, and active
- * backends (from `GET /api/v1/version`). Super admins additionally see the
- * deployment policy (from `GET /api/v1/capabilities`). The bar renders even while
- * the queries are in flight or have failed — the popover just shows what's known —
- * so it never blocks or shifts the layout.
+ * Slim bottom bar with a single info affordance: a compact popover with the
+ * deployment version (linked to its release/commit when the shape allows) and
+ * source/issue links. Super admins get a shortcut to the admin settings page,
+ * where the full deployment/config detail lives. The bar renders even while
+ * the version query is in flight or has failed — the popover just shows what's
+ * known — so it never blocks or shifts the layout.
  */
 export function Footer() {
 	const { data: v } = useVersionQuery();
 	const { user } = useAuth();
+	const navigate = useNavigate();
 	const isSuperAdmin = user?.is_super_admin ?? false;
-	const { data: caps } = useCapabilitiesQuery(isSuperAdmin);
 
-	const href = v ? versionHref(v.version) : null;
-	const versionValue = href ? (
-		<a
-			href={href}
-			target="_blank"
-			rel="noreferrer"
-			className="inline-flex items-center gap-1 text-foreground underline-offset-4 hover:underline"
-		>
-			<span className="tabular-nums">{v!.version}</span>
-			<ExternalLink className="size-3 shrink-0 text-muted-foreground" />
-		</a>
-	) : (
-		<span className="tabular-nums">{v?.version ?? 'unknown'}</span>
-	);
+	const version = v?.version ?? 'unknown';
+	const href = versionHref(version);
 
 	return (
 		<footer className="flex shrink-0 items-center justify-between border-t bg-background px-4 py-2 max-md:px-3">
@@ -77,97 +42,54 @@ export function Footer() {
 				MARIMOHUB
 			</span>
 			<Popover
-				label="Version info"
+				label="About marimohub"
 				placement="top end"
 				trigger={<Info className="size-3.5" />}
 				triggerClassName="rounded-full text-muted-foreground transition-colors hover:text-foreground"
 			>
-				<div className="flex min-w-[16rem] flex-col gap-2 text-xs">
-					<div className="font-medium text-foreground">marimohub</div>
-					<dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
-						<InfoRow label="Version" value={versionValue} />
-						{v?.image && <InfoRow label="Image" value={v.image} />}
-						{v?.sandbox_image && <InfoRow label="Sandbox image" value={v.sandbox_image} />}
-						{v?.started_at && <InfoRow label="Started" value={<Timestamp iso={v.started_at} />} />}
-						{v?.replica && <InfoRow label="Replica" value={v.replica} />}
-						{v?.node && (
-							<InfoRow label="Node" value={<span className="tabular-nums">{v.node}</span>} />
-						)}
-						{v?.backends && (
-							<InfoRow
-								label="Backends"
-								value={
-									<span className="tabular-nums">
-										{v.backends.storage} · {v.backends.compute} · {v.backends.auth}
-									</span>
-								}
-							/>
-						)}
-					</dl>
-					{isSuperAdmin && caps && (
-						<div className="border-t pt-2">
-							<div className="mb-1 font-medium text-foreground">Policy</div>
-							<dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
-								<InfoRow label="Viewer mode" value={caps.viewer_mode} />
-								<InfoRow label="Sandbox sharing" value={caps.editor_sandbox_sharing} />
-								<InfoRow label="Default role" value={caps.default_role ?? 'members only'} />
-								<InfoRow
-									label="Features"
-									value={
-										[
-											caps.federation.available && 'federation',
-											caps.integrations.available && 'integrations',
-										]
-											.filter(Boolean)
-											.join(' · ') || 'none'
-									}
-								/>
-								<InfoRow
-									label="Limits"
-									value={
-										<span className="tabular-nums">
-											{caps.limits.max_concurrent_sessions_per_user ?? '∞'} sessions/user ·{' '}
-											{caps.limits.max_apps_per_project ?? '∞'} apps/project ·{' '}
-											{caps.limits.max_versions_per_notebook} versions/notebook
-										</span>
-									}
-								/>
-								{caps.sandbox_images.length > 0 && (
-									<InfoRow label="Images" value={caps.sandbox_images.join(', ')} />
-								)}
-								{caps.compute_profiles.length > 0 && (
-									<InfoRow
-										label="Profiles"
-										value={
-											caps.compute_profiles.map((p) => p.name).join(' · ') +
-											(caps.compute_profile_override === 'none'
-												? ''
-												: ` (override: ${caps.compute_profile_override})`)
-										}
-									/>
-								)}
-							</dl>
+				{({ close }) => (
+					<div className="flex w-56 flex-col">
+						<div className="flex items-baseline justify-between gap-3 px-2 pb-2 pt-0.5">
+							<span className="text-sm font-semibold">marimohub</span>
+							{href ? (
+								<a
+									href={href}
+									target="_blank"
+									rel="noreferrer"
+									className="inline-flex items-center gap-1 font-mono text-xs tabular-nums text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+								>
+									{version}
+									<ExternalLink className="size-3 shrink-0" />
+								</a>
+							) : (
+								<span className="font-mono text-xs tabular-nums text-muted-foreground">
+									{version}
+								</span>
+							)}
 						</div>
-					)}
-					<div className="flex gap-3 border-t pt-2 text-muted-foreground">
-						<a
-							href={SOURCE_URL}
-							target="_blank"
-							rel="noreferrer"
-							className="underline-offset-4 hover:text-foreground hover:underline"
-						>
-							Source
-						</a>
-						<a
-							href={`${SOURCE_URL}/issues`}
-							target="_blank"
-							rel="noreferrer"
-							className="underline-offset-4 hover:text-foreground hover:underline"
-						>
-							Report an issue
-						</a>
+						<div className="flex flex-col gap-0.5 border-t pt-1.5">
+							<LinkRow href={SOURCE_URL} icon={<Code2 />}>
+								Source
+							</LinkRow>
+							<LinkRow href={`${SOURCE_URL}/issues`} icon={<Bug />}>
+								Report an issue
+							</LinkRow>
+							{isSuperAdmin && (
+								<button
+									type="button"
+									className={ROW_CLASS}
+									onClick={() => {
+										close();
+										void navigate('/admin/settings');
+									}}
+								>
+									<Settings2 />
+									<span className="flex-1">Deployment settings</span>
+								</button>
+							)}
+						</div>
 					</div>
-				</div>
+				)}
 			</Popover>
 		</footer>
 	);

--- a/packages/web/src/components/Header/Header.test.tsx
+++ b/packages/web/src/components/Header/Header.test.tsx
@@ -137,14 +137,14 @@ describe('Header', () => {
 		const { user } = setup();
 		await openUserMenu(user);
 		expect(screen.queryByRole('menuitem', { name: /Org integrations/ })).not.toBeInTheDocument();
-		expect(screen.queryByRole('menuitem', { name: /Audit logs/ })).not.toBeInTheDocument();
+		expect(screen.queryByRole('menuitem', { name: /Admin/ })).not.toBeInTheDocument();
 	});
 
-	it('navigates super admins to the audit log page', async () => {
+	it('navigates super admins to the admin section', async () => {
 		const { user } = setup(undefined, { ...USER, is_super_admin: true });
 		await openUserMenu(user);
-		await user.click(screen.getByRole('menuitem', { name: /Audit logs/ }));
-		expect(screen.getByTestId('location')).toHaveTextContent('/admin/audit-logs');
+		await user.click(screen.getByRole('menuitem', { name: /Admin/ }));
+		expect(screen.getByTestId('location')).toHaveTextContent('/admin/users');
 	});
 
 	it('opens the org integrations dialog for a super admin and lists the org entries', async () => {

--- a/packages/web/src/components/Header/Header.tsx
+++ b/packages/web/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { MenuTrigger, Button, Popover, Menu, MenuItem, Separator } from 'react-aria-components';
-import { ChevronDown, Copy, KeyRound, Moon, Puzzle, ScrollText, Sun } from 'lucide-react';
+import { ChevronDown, Copy, KeyRound, Moon, Puzzle, Shield, Sun } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/context/ThemeContext';
@@ -60,7 +60,7 @@ export function Header() {
 										void copy(user.id).then((ok) => ok && toast.success('User id copied'));
 									} else if (key === 'api-tokens') tokensDialog.open();
 									else if (key === 'org-integrations') orgIntegrationsDialog.open();
-									else if (key === 'audit-logs') void navigate('/admin/audit-logs');
+									else if (key === 'admin') void navigate('/admin/users');
 								}}
 							>
 								<MenuItem
@@ -99,11 +99,11 @@ export function Header() {
 								)}
 								{user.is_super_admin && (
 									<MenuItem
-										id="audit-logs"
+										id="admin"
 										className="flex cursor-pointer items-center gap-2 px-3 py-2 text-[13px] outline-none transition-colors focus:bg-muted max-md:min-h-11"
 									>
-										<ScrollText className="size-3.5" />
-										Audit logs
+										<Shield className="size-3.5" />
+										Admin
 									</MenuItem>
 								)}
 								<Separator className="h-px bg-border" />

--- a/packages/web/src/components/ui/Popover.test.tsx
+++ b/packages/web/src/components/ui/Popover.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Popover } from './Popover';
+
+describe('Popover', () => {
+	it('renders plain children when opened', async () => {
+		const user = userEvent.setup();
+		render(
+			<Popover label="Info" trigger={<span>i</span>}>
+				<p>Plain body</p>
+			</Popover>,
+		);
+
+		expect(screen.queryByText('Plain body')).not.toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Info' }));
+		expect(await screen.findByText('Plain body')).toBeInTheDocument();
+	});
+
+	// Pins the render-prop contract: react-aria's Dialog invokes function
+	// children with a working `close` — the Footer's settings shortcut relies
+	// on it to dismiss the popover on in-app navigation.
+	it('invokes function children with a working close handler', async () => {
+		const user = userEvent.setup();
+		render(
+			<Popover label="Info" trigger={<span>i</span>}>
+				{({ close }) => (
+					<button type="button" onClick={close}>
+						Close me
+					</button>
+				)}
+			</Popover>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Info' }));
+		await user.click(await screen.findByRole('button', { name: 'Close me' }));
+		await waitFor(() =>
+			expect(screen.queryByRole('button', { name: 'Close me' })).not.toBeInTheDocument(),
+		);
+	});
+});

--- a/packages/web/src/components/ui/Popover.tsx
+++ b/packages/web/src/components/ui/Popover.tsx
@@ -80,6 +80,8 @@ export function Popover({
 					className,
 				)}
 			>
+				{/* Dialog implements the function-children form: it invokes them with
+			    its render props (including `close`), so both shapes pass through. */}
 				<Dialog className="p-3 outline-none">{children}</Dialog>
 			</AriaPopover>
 		</DialogTrigger>

--- a/packages/web/src/components/ui/Popover.tsx
+++ b/packages/web/src/components/ui/Popover.tsx
@@ -13,8 +13,12 @@ import { cn } from '@/lib/utils';
 export interface PopoverProps {
 	/** The clickable trigger content (wrapped in a focusable button). */
 	trigger: ReactNode;
-	/** Popover body. Only mounted while open, so timers inside it run only then. */
-	children: ReactNode;
+	/**
+	 * Popover body. Only mounted while open, so timers inside it run only then.
+	 * The render-prop form receives `close` for content that must dismiss the
+	 * popover itself (e.g. an in-app navigation link).
+	 */
+	children: ReactNode | ((opts: { close: () => void }) => ReactNode);
 	/** Accessible label for the trigger button. */
 	label?: string;
 	/** Optional hover/focus tooltip on the trigger — a quick hint before pressing. */

--- a/packages/web/src/lib/deployment.ts
+++ b/packages/web/src/lib/deployment.ts
@@ -1,0 +1,18 @@
+/** Source repository — the UI derives release/commit + issue links from it. */
+export const SOURCE_URL = 'https://github.com/marimo-team/marimohub';
+
+/**
+ * MARIMOHUB_VERSION is either a release tag (`0.2.0`) or a git SHA (`a1b2c3d`);
+ * only one of those has a release page, so pick the GitHub URL per shape. Any
+ * other value (`dev`, git-describe suffixes like `0.2.0-5-gdeadbeef`) has no
+ * page at all.
+ */
+export function versionHref(version: string): string | null {
+	if (/^v?\d+\.\d+\.\d+$/.test(version)) {
+		return `${SOURCE_URL}/releases/tag/${version.startsWith('v') ? version : `v${version}`}`;
+	}
+	if (/^[0-9a-f]{7,40}$/i.test(version)) {
+		return `${SOURCE_URL}/commit/${version}`;
+	}
+	return null;
+}

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -28,6 +28,8 @@ import type {
 	ApiTokenCreated as ClientApiTokenCreated,
 	AuditLogEntry as ClientAuditLogEntry,
 	AuditLogPage as ClientAuditLogPage,
+	AdminUser as ClientAdminUser,
+	DeploymentConfig as ClientDeploymentConfig,
 	ApiResponse as ClientApiResponse,
 	ApiError as ClientApiError,
 } from '@marimo-hub/client';
@@ -72,6 +74,10 @@ export type ApiToken = ClientApiToken;
 export type ApiTokenCreated = ClientApiTokenCreated;
 export type AuditLogEntry = ClientAuditLogEntry;
 export type AuditLogPage = ClientAuditLogPage;
+/** A directory entry on the super-admin users page. */
+export type AdminUser = ClientAdminUser;
+/** Redacted deployment configuration for the super-admin settings page. */
+export type DeploymentConfig = ClientDeploymentConfig;
 export type ApiResponse<T> = ClientApiResponse<T>;
 export type ApiError = ClientApiError;
 export type User = ClientUser;


### PR DESCRIPTION
Adds a super-admin section to the web app: **/admin/users** (identity directory with computed super-admin badges and client-side search) and **/admin/settings** (read-only deployment view: build/runtime identity, effective access policy, and every config group from the spec with secrets redacted). Both live under a shared `AdminLayout` tab nav alongside the existing audit-logs page; the Header menu collapses to a single **Admin** item.

## API

- `GET /api/v1/admin/users` — directory page envelope (`next_cursor` reserved), name-sorted, `is_super_admin` computed against `MARIMOHUB_SUPER_ADMINS`.
- `GET /api/v1/admin/config` — `deployment` + `groups` (derived from `CONFIG_SPEC` in `@marimo-hub/config`, threaded via `ApiDeps.configSummary`; secret values are never copied, and the handler re-redacts) + `policy` (parsed `default_role`, raw super-admin entries).
- Both **super-admin only** and **session-only** — PATs get 403, and the spec advertises cookieAuth only.

## Breaking change (allowlisted)

`GET /api/v1/version` now returns only `{ version }`. The build/runtime identity (image, replica, node, backends) was visible to every signed-in user; it moved to the admin config endpoint. The 6 oasdiff findings are allowlisted in `internal/schemas/allowed-breaking/api.md` (remove after merge). The footer popover slims accordingly: version + source/issue links, plus a settings shortcut for admins.

## Notes

- Users appear in the directory only after first sign-in; the settings page shows the raw super-admin entries to cover configured-but-never-signed-in admins.
- A new spec test enforces that credential-looking config vars are flagged `secret` (with a reasoned allowlist for name-references/limits).
- Coverage includes 401/403/PAT-rejection, corrupt directory records, scan-failure → 500 without leaking the cause, redaction (builder and handler), and web guard/error-boundary paths.