### PR TITLE
fix(client): preserve request bodies in Firefox

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -47,10 +47,15 @@ describe('apiData', () => {
 		);
 
 		const [input, init] = fn.mock.calls[0] ?? [];
-		expect(input).toBe('/api/v1/projects');
-		expect(init?.method).toBe('POST');
-		expect(new Headers(init?.headers).get('content-type')).toBe('application/json');
-		expect(init?.body).toBe(JSON.stringify({ name: 'Example', description: 'Typed request' }));
+		expect(input).toBeInstanceOf(Request);
+		expect(init).toBeUndefined();
+		const request = input as Request;
+		expect(new URL(request.url).pathname).toBe('/api/v1/projects');
+		expect(request.method).toBe('POST');
+		expect(request.headers.get('content-type')).toBe('application/json');
+		expect(await request.clone().text()).toBe(
+			JSON.stringify({ name: 'Example', description: 'Typed request' }),
+		);
 	});
 
 	it('throws ApiRequestError with the server code/message on { success: false }', async () => {
@@ -103,9 +108,10 @@ describe('apiData', () => {
 
 	it('throws NETWORK_ERROR when the request times out', async () => {
 		stubFetch(
-			(_input, init) =>
+			(input) =>
 				new Promise<Response>((_resolve, reject) => {
-					init?.signal?.addEventListener('abort', () =>
+					const signal = input instanceof Request ? input.signal : undefined;
+					signal?.addEventListener('abort', () =>
 						reject(new DOMException('The operation was aborted', 'AbortError')),
 					);
 				}),

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -91,24 +91,11 @@ const timeoutMiddleware: Middleware = {
 const defaultBaseUrl =
 	typeof globalThis.location === 'object' ? globalThis.location.origin : 'http://localhost';
 
-async function dispatchRequest(request: Request): Promise<Response> {
-	const url = new URL(request.url);
-	const input =
-		url.origin === defaultBaseUrl ? `${url.pathname}${url.search}${url.hash}` : url.href;
-	return globalThis.fetch(input, {
-		body: request.body ? await request.clone().text() : undefined,
-		cache: request.cache,
-		credentials: request.credentials,
-		headers: request.headers,
-		integrity: request.integrity,
-		keepalive: request.keepalive,
-		method: request.method,
-		mode: request.mode,
-		redirect: request.redirect,
-		referrer: request.referrer,
-		referrerPolicy: request.referrerPolicy,
-		signal: request.signal,
-	});
+function dispatchRequest(request: Request): Promise<Response> {
+	// Forward the Request itself rather than reconstructing RequestInit. The
+	// reconstruction dropped JSON bodies in Firefox after request middleware ran.
+	// Native fetch preserves the request's internal body stream across browsers.
+	return globalThis.fetch(request);
 }
 
 export function createApiClient(options: ClientOptions = {}) {


### PR DESCRIPTION
## Summary

Forward the typed API client's `Request` directly to native `fetch` instead of rebuilding a `RequestInit` from it.

After request middleware runs, the reconstruction path sends an empty body in Firefox while retaining `Content-Type: application/json`. As a result, every body-bearing SPA mutation fails with `Malformed JSON in request body` (for example creating notebooks/integrations or changing project roles).

Native `fetch(request)` preserves the internal body stream and all request properties, including the timeout middleware's combined abort signal.

## Regression coverage

- update the client serialization test to assert against the final `Request` and its JSON body
- update the timeout test to observe the final `Request.signal`

## Verification

- `@marimo-hub/client`: 15/15 tests pass
- production web and server bundles build through the Nix package
- real Firefox test against the unmodified deployment reproduced a POST with `Content-Type: application/json` and `body: undefined`
- real Firefox test against the patched production bundle successfully created a notebook through the SPA, with no malformed-body error

I did not run the repository-wide `pnpm check` or all-package `pnpm test`; the focused client tests, production package build, and browser regression were run.
