### PR TITLE
fix(dev): avoid startup race between vp pack --watch and node --watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"license": "Apache-2.0",
 	"type": "module",
 	"scripts": {
-		"dev": "pnpm exec vp run --filter @marimo-hub/server build && concurrently -k -n build,server,web -c blue,green,magenta \"pnpm --filter @marimo-hub/server exec vp pack --watch\" \"MARIMOHUB_STORAGE_BACKEND=memory MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true MARIMOHUB_COMPUTE_BACKEND=local MARIMOHUB_AUTH_BACKEND=dev node --env-file-if-exists=apps/server/.env --watch apps/server/dist/index.mjs\" \"pnpm --filter @marimo-hub/web dev\"",
+		"dev": "pnpm exec vp run --filter @marimo-hub/server build && concurrently -k -n build,server,web -c blue,green,magenta \"pnpm --filter @marimo-hub/server exec vp pack --watch --no-clean\" \"MARIMOHUB_STORAGE_BACKEND=memory MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true MARIMOHUB_COMPUTE_BACKEND=local MARIMOHUB_AUTH_BACKEND=dev node --env-file-if-exists=apps/server/.env --watch apps/server/dist/index.mjs\" \"pnpm --filter @marimo-hub/web dev\"",
 		"ready": "vp fmt && vp lint && pnpm typecheck && vp run -r test && vp run -r build",
 		"check": "vp check",
 		"typecheck": "vp run -r typecheck",


### PR DESCRIPTION
`pnpm dev` pre-builds `apps/server/dist`, then starts `vp pack --watch` and `node --watch dist/index.mjs` concurrently. `vp pack` cleans `dist/` at watch startup, so `index.mjs` disappears for ~1s — node detects the change, restarts into the empty directory, and crashes with `MODULE_NOT_FOUND` (sometimes recovering, sometimes landing on a half-written bundle).

`--no-clean` makes the initial rebuild overwrite in place; verified the file never disappears and the server boots cleanly. Only affects the dev loop — the cached `build` task and Docker builds still clean by default.