### PR TITLE
fix(client): forward request bodies in Firefox

### DIFF
--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -53,6 +53,38 @@ describe('apiData', () => {
 		expect(init?.body).toBe(JSON.stringify({ name: 'Example', description: 'Typed request' }));
 	});
 
+	it('forwards the body even when the Request.body getter is missing (Firefox)', async () => {
+		// Firefox never shipped the Request.body stream getter (Bugzilla #1387483);
+		// the dispatcher must not rely on it to detect a payload.
+		class BodyGetterlessRequest extends Request {
+			override get body(): Request['body'] {
+				return undefined as unknown as null;
+			}
+		}
+		vi.stubGlobal('Request', BodyGetterlessRequest);
+		const fn = stubFetch(async () => jsonResponse({ success: true, data: null }));
+
+		await apiData(
+			apiClient.POST('/api/v1/projects', {
+				body: { name: 'Firefox', description: 'No Request.body getter' },
+			}),
+		);
+
+		const [, init] = fn.mock.calls[0] ?? [];
+		expect(init?.body).toBe(
+			JSON.stringify({ name: 'Firefox', description: 'No Request.body getter' }),
+		);
+	});
+
+	it('omits the body for bodyless requests', async () => {
+		const fn = stubFetch(async () => jsonResponse({ success: true, data: null }));
+
+		await apiData(apiClient.GET('/api/v1/me'));
+
+		const [, init] = fn.mock.calls[0] ?? [];
+		expect(init?.body).toBeUndefined();
+	});
+
 	it('throws ApiRequestError with the server code/message on { success: false }', async () => {
 		stubFetch(async () =>
 			jsonResponse({ success: false, error: { code: 'FORBIDDEN', message: 'nope' } }, 403),

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -85,6 +85,21 @@ describe('apiData', () => {
 		expect(init?.body).toBeUndefined();
 	});
 
+	it('sends a bodyless POST without a body or content type', async () => {
+		const fn = stubFetch(async () => jsonResponse({ success: true, data: null }));
+
+		await apiData(
+			apiClient.POST('/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/heartbeat', {
+				params: { path: { pid: 'p1', nid: 'n1', sid: 's1' } },
+			}),
+		);
+
+		const [, init] = fn.mock.calls[0] ?? [];
+		expect(init?.method).toBe('POST');
+		expect(init?.body).toBeUndefined();
+		expect(new Headers(init?.headers).get('content-type')).toBeNull();
+	});
+
 	it('throws ApiRequestError with the server code/message on { success: false }', async () => {
 		stubFetch(async () =>
 			jsonResponse({ success: false, error: { code: 'FORBIDDEN', message: 'nope' } }, 403),

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -95,12 +95,15 @@ async function dispatchRequest(request: Request): Promise<Response> {
 	const url = new URL(request.url);
 	const input =
 		url.origin === defaultBaseUrl ? `${url.pathname}${url.search}${url.hash}` : url.href;
-	// Read the body via clone().text() rather than gating on `request.body`:
-	// Firefox has no Request.body getter (Bugzilla #1387483), so that check
-	// silently dropped every POST/PUT/PATCH payload there.
-	const body = await request.clone().text();
+	// Firefox has no Request.body getter (Bugzilla #1387483), so detect a
+	// payload by reading it; '' maps to undefined so a bodyless POST does not
+	// pick up a spurious text/plain content-type.
+	const body =
+		request.method === 'GET' || request.method === 'HEAD'
+			? undefined
+			: (await request.clone().text()) || undefined;
 	return globalThis.fetch(input, {
-		body: body === '' ? undefined : body,
+		body,
 		cache: request.cache,
 		credentials: request.credentials,
 		headers: request.headers,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -95,8 +95,12 @@ async function dispatchRequest(request: Request): Promise<Response> {
 	const url = new URL(request.url);
 	const input =
 		url.origin === defaultBaseUrl ? `${url.pathname}${url.search}${url.hash}` : url.href;
+	// Read the body via clone().text() rather than gating on `request.body`:
+	// Firefox has no Request.body getter (Bugzilla #1387483), so that check
+	// silently dropped every POST/PUT/PATCH payload there.
+	const body = await request.clone().text();
 	return globalThis.fetch(input, {
-		body: request.body ? await request.clone().text() : undefined,
+		body: body === '' ? undefined : body,
 		cache: request.cache,
 		credentials: request.credentials,
 		headers: request.headers,


### PR DESCRIPTION
Firefox never shipped the `Request.body` stream getter ([Bugzilla #1387483](https://bugzilla.mozilla.org/show_bug.cgi?id=1387483)), so `dispatchRequest`'s `request.body ? … : undefined` gate dropped every POST/PUT/PATCH payload there — e.g. `POST /api/v1/projects` failed, so projects couldn't be created in Firefox.

Fix: read the body via `request.clone().text()` unconditionally and map `''` to `undefined` (keeps GET/HEAD legal and avoids a spurious `text/plain` Content-Type on bodyless POSTs).

Regression test stubs a Firefox-like `Request` (no `body` getter) and asserts the JSON body still reaches `fetch`; it fails without the fix.

Note: root `pnpm typecheck` is currently red from a pre-existing error in `packages/auth-oidc` (`src/index.ts:458`), unrelated to this change.