### PR TITLE
fix(api): retry and log sandbox proxy upstream failures

### DIFF
--- a/packages/api/src/log.test.ts
+++ b/packages/api/src/log.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { bestEffort, describeError, logEvent } from './log';
+import { bestEffort, describeError, errorMetadataChain, logEvent } from './log';
 
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -97,6 +97,41 @@ describe('describeError', () => {
 			{ path: 'meta.title', message: 'Required' },
 			{ path: 'status', message: 'Invalid enum value' },
 		]);
+	});
+});
+
+describe('errorMetadataChain', () => {
+	it('keeps enum-ish codes down the cause chain but never free-form text', () => {
+		// The shape undici throws for a failed proxy fetch: a bland TypeError whose
+		// cause carries the diagnostic code — and whose message can quote the
+		// requested URL, token-bearing path included.
+		const cause = Object.assign(
+			new Error('connect ECONNRESET http://kernel:2718/proxy/secret-token/assets/app.js'),
+			{ code: 'ECONNRESET' },
+		);
+		const err = Object.assign(new TypeError('fetch failed'), { cause });
+
+		const out = errorMetadataChain(err);
+
+		expect(out).toEqual({
+			error_name: 'TypeError',
+			cause: { error_name: 'Error', error_code: 'ECONNRESET' },
+		});
+		expect(JSON.stringify(out)).not.toContain('secret-token');
+	});
+
+	it('renders a non-Error cause without echoing it, and stops at the depth limit', () => {
+		const err = Object.assign(new Error('outer'), {
+			cause: Object.assign(new Error('inner'), { cause: 'raw secret string' }),
+		});
+		expect(errorMetadataChain(err)).toEqual({
+			error_name: 'Error',
+			cause: { error_name: 'Error', cause: { error_name: 'non-error(string)' } },
+		});
+		expect(errorMetadataChain(err, 1)).toEqual({
+			error_name: 'Error',
+			cause: { error_name: 'Error' },
+		});
 	});
 });
 

--- a/packages/api/src/log.ts
+++ b/packages/api/src/log.ts
@@ -32,6 +32,22 @@ export function errorMetadata(err: unknown): Record<string, string | number> {
 	return out;
 }
 
+/**
+ * {@link errorMetadata} applied down the `cause` chain. Undici fetch failures
+ * put the diagnostic code (ECONNRESET, UND_ERR_SOCKET, ENOTFOUND…) on a nested
+ * cause, not the top-level `TypeError: fetch failed` — this keeps that signal
+ * while staying free-form-text-safe (a fetch error's message can quote the
+ * requested URL, which may carry a routing token in its path).
+ */
+export function errorMetadataChain(err: unknown, depth = 3): Record<string, unknown> {
+	const out: Record<string, unknown> = errorMetadata(err);
+	const cause = err instanceof Error ? (err as Error & { cause?: unknown }).cause : undefined;
+	if (cause !== undefined && cause !== null && depth > 0) {
+		out.cause = errorMetadataChain(cause, depth - 1);
+	}
+	return out;
+}
+
 export async function bestEffort(
 	operation: string,
 	fields: Record<string, unknown>,

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -377,12 +377,22 @@ describe('forwardHttp', () => {
 		expect(seen.origin).toBe(origin);
 	});
 
+	/** A port with nothing listening: reserve an ephemeral one, then free it. */
+	async function closedPort(): Promise<number> {
+		const s = createServer();
+		await new Promise<void>((resolve) => s.listen(0, '127.0.0.1', resolve));
+		const port = (s.address() as AddressInfo).port;
+		await new Promise<void>((resolve) => s.close(() => resolve()));
+		return port;
+	}
+
 	it('returns 502 and logs a structured event when the kernel is unreachable', async () => {
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const deadOrigin = `http://127.0.0.1:${await closedPort()}`;
 		try {
 			const res = await forwardHttp(
 				new Request('https://hub/x'),
-				'http://127.0.0.1:1/proxy/tok/down',
+				`${deadOrigin}/proxy/tok/down`,
 				'sess-123',
 			);
 			expect(res.status).toBe(502);
@@ -397,13 +407,20 @@ describe('forwardHttp', () => {
 				level: 'warn',
 				session_id: 'sess-123',
 				method: 'GET',
-				target: 'http://127.0.0.1:1',
+				target: deadOrigin,
 				attempt: 1,
 				will_retry: true,
 			});
 			expect(events[1]).toMatchObject({ attempt: 2, will_retry: false });
-			// The routing token in the path must not reach the logs.
-			for (const e of events) expect(JSON.stringify(e)).not.toContain('/proxy/tok');
+			for (const e of events) {
+				const line = JSON.stringify(e);
+				// The diagnostic code survives (it lives on the fetch error's cause)…
+				expect(line).toContain('ECONNREFUSED');
+				// …but never free-form error text: no message/stack that could quote
+				// the token-bearing target URL, and no token.
+				expect(line).not.toContain('/proxy/tok');
+				expect(line).not.toContain('fetch failed');
+			}
 		} finally {
 			logSpy.mockRestore();
 		}

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -306,9 +306,31 @@ describe('authorizeProxyRequest', () => {
 describe('forwardHttp', () => {
 	let server: Server;
 	let origin: string;
+	let flakyHits: number;
+
+	beforeEach(() => {
+		flakyHits = 0;
+	});
 
 	beforeAll(async () => {
 		server = createServer((req, res) => {
+			if (req.url === '/flaky') {
+				// First connection dies mid-request (a closed keep-alive socket, from
+				// the client's perspective); subsequent attempts succeed.
+				flakyHits++;
+				if (flakyHits === 1) {
+					req.socket.destroy();
+					return;
+				}
+				res.writeHead(200, { 'content-type': 'text/plain' });
+				res.end('recovered');
+				return;
+			}
+			if (req.url === '/badgateway') {
+				res.writeHead(502, { 'content-type': 'text/plain' });
+				res.end('upstream ingress says no');
+				return;
+			}
 			if (req.url === '/setcookie') {
 				res.writeHead(200, {
 					'set-cookie': 'mh_session=attacker; Path=/',
@@ -355,9 +377,88 @@ describe('forwardHttp', () => {
 		expect(seen.origin).toBe(origin);
 	});
 
-	it('returns 502 when the kernel is unreachable', async () => {
-		const res = await forwardHttp(new Request('https://hub/x'), 'http://127.0.0.1:1/down');
-		expect(res.status).toBe(502);
+	it('returns 502 and logs a structured event when the kernel is unreachable', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			const res = await forwardHttp(
+				new Request('https://hub/x'),
+				'http://127.0.0.1:1/proxy/tok/down',
+				'sess-123',
+			);
+			expect(res.status).toBe(502);
+			expect(await res.text()).toBe('Kernel unavailable');
+
+			const events = logSpy.mock.calls
+				.map(([line]) => JSON.parse(line as string) as Record<string, unknown>)
+				.filter((e) => e.event === 'sandbox_proxy_upstream_error');
+			// GET → one retry → two logged attempts, both failed.
+			expect(events).toHaveLength(2);
+			expect(events[0]).toMatchObject({
+				level: 'warn',
+				session_id: 'sess-123',
+				method: 'GET',
+				target: 'http://127.0.0.1:1',
+				attempt: 1,
+				will_retry: true,
+			});
+			expect(events[1]).toMatchObject({ attempt: 2, will_retry: false });
+			// The routing token in the path must not reach the logs.
+			for (const e of events) expect(JSON.stringify(e)).not.toContain('/proxy/tok');
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it('retries a GET once when the connection drops, and succeeds on the fresh connection', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			const res = await forwardHttp(new Request('https://hub/x'), `${origin}/flaky`);
+			expect(res.status).toBe(200);
+			expect(await res.text()).toBe('recovered');
+			expect(flakyHits).toBe(2);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it('does not retry a request with a body', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			const res = await forwardHttp(
+				new Request('https://hub/x', { method: 'POST', body: 'cell code' }),
+				`${origin}/flaky`,
+			);
+			expect(res.status).toBe(502);
+			expect(flakyHits).toBe(1);
+		} finally {
+			logSpy.mockRestore();
+		}
+	});
+
+	it('passes an upstream gateway status through verbatim and logs it', async () => {
+		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			const res = await forwardHttp(
+				new Request('https://hub/x'),
+				`${origin}/badgateway`,
+				'sess-123',
+			);
+			expect(res.status).toBe(502);
+			expect(await res.text()).toBe('upstream ingress says no');
+
+			const events = logSpy.mock.calls
+				.map(([line]) => JSON.parse(line as string) as Record<string, unknown>)
+				.filter((e) => e.event === 'sandbox_proxy_upstream_gateway_status');
+			expect(events).toHaveLength(1);
+			expect(events[0]).toMatchObject({
+				level: 'warn',
+				session_id: 'sess-123',
+				status: 502,
+				target: origin,
+			});
+		} finally {
+			logSpy.mockRestore();
+		}
 	});
 
 	it('strips hub credentials (Cookie/Authorization/CF-Access) before the kernel sees the request', async () => {

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -377,18 +377,14 @@ describe('forwardHttp', () => {
 		expect(seen.origin).toBe(origin);
 	});
 
-	/** A port with nothing listening: reserve an ephemeral one, then free it. */
-	async function closedPort(): Promise<number> {
-		const s = createServer();
-		await new Promise<void>((resolve) => s.listen(0, '127.0.0.1', resolve));
-		const port = (s.address() as AddressInfo).port;
-		await new Promise<void>((resolve) => s.close(() => resolve()));
-		return port;
-	}
-
 	it('returns 502 and logs a structured event when the kernel is unreachable', async () => {
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-		const deadOrigin = `http://127.0.0.1:${await closedPort()}`;
+		// A deterministic dead endpoint: a server we keep listening (so no other
+		// process can grab the port) that kills every connection on accept.
+		const dead = createServer();
+		dead.on('connection', (socket) => socket.destroy());
+		await new Promise<void>((resolve) => dead.listen(0, '127.0.0.1', resolve));
+		const deadOrigin = `http://127.0.0.1:${(dead.address() as AddressInfo).port}`;
 		try {
 			const res = await forwardHttp(
 				new Request('https://hub/x'),
@@ -413,16 +409,21 @@ describe('forwardHttp', () => {
 			});
 			expect(events[1]).toMatchObject({ attempt: 2, will_retry: false });
 			for (const e of events) {
-				const line = JSON.stringify(e);
-				// The diagnostic code survives (it lives on the fetch error's cause)…
-				expect(line).toContain('ECONNREFUSED');
+				// A diagnostic code survives on the fetch error's cause (which exact
+				// code — ECONNRESET vs UND_ERR_SOCKET — depends on RST timing, so the
+				// precise-code property is pinned in log.test.ts instead)…
+				const error = e.error as { error_name: string; cause?: { error_code?: unknown } };
+				expect(error.error_name).toBe('TypeError');
+				expect(typeof error.cause?.error_code).toBe('string');
 				// …but never free-form error text: no message/stack that could quote
 				// the token-bearing target URL, and no token.
+				const line = JSON.stringify(e);
 				expect(line).not.toContain('/proxy/tok');
 				expect(line).not.toContain('fetch failed');
 			}
 		} finally {
 			logSpy.mockRestore();
+			await new Promise<void>((resolve) => dead.close(() => resolve()));
 		}
 	});
 

--- a/packages/api/src/sandboxProxy.ts
+++ b/packages/api/src/sandboxProxy.ts
@@ -13,7 +13,7 @@
 import type { MiddlewareHandler } from 'hono';
 import { ForbiddenError, ProxyExposure, verifyProxyToken } from '@marimo-hub/core';
 import type { ApiDeps, HonoEnv } from './context';
-import { describeError, logEvent } from './log';
+import { errorMetadataChain, logEvent } from './log';
 import { assertSessionAccess, fail } from './shared';
 
 /** Outcome of routing a `/proxy/<token>/…` request. */
@@ -237,7 +237,9 @@ export async function forwardHttp(
 		// Node's fetch requires this when streaming a request body.
 		(init as { duplex?: string }).duplex = 'half';
 	}
-	// The token in the path routes to the session; keep it out of logs.
+	// The token in the path routes to the session; keep it out of logs. That is
+	// also why the error below is logged as metadata, not free-form text — a
+	// fetch failure's message/stack can quote the target URL.
 	const target = new URL(targetUrl).origin;
 	let upstream: Response | undefined;
 	const attempts = retryable ? 2 : 1;
@@ -254,7 +256,7 @@ export async function forwardHttp(
 				target,
 				attempt,
 				will_retry: attempt < attempts,
-				error: describeError(err),
+				error: errorMetadataChain(err),
 			});
 		}
 	}

--- a/packages/api/src/sandboxProxy.ts
+++ b/packages/api/src/sandboxProxy.ts
@@ -13,6 +13,7 @@
 import type { MiddlewareHandler } from 'hono';
 import { ForbiddenError, ProxyExposure, verifyProxyToken } from '@marimo-hub/core';
 import type { ApiDeps, HonoEnv } from './context';
+import { describeError, logEvent } from './log';
 import { assertSessionAccess, fail } from './shared';
 
 /** Outcome of routing a `/proxy/<token>/…` request. */
@@ -206,29 +207,73 @@ function responseHeaders(headers: Headers): Headers {
 	return out;
 }
 
+/** Upstream statuses that mean "a gateway between hub and kernel failed", not the kernel itself. */
+const GATEWAY_STATUSES = new Set([502, 503, 504]);
+
 /**
  * Forward an authorized HTTP request to the kernel and return its response,
  * streaming the body. WebSocket upgrades are handled separately (the Node
  * entrypoint) since `fetch` can't carry them on every runtime.
+ *
+ * GET/HEAD get one immediate retry when the fetch itself throws: the common
+ * cause is the kernel (uvicorn, ~5s keep-alive) closing a pooled connection
+ * the hub is about to reuse — a race that bursts of parallel asset requests
+ * hit, and that a fresh connection resolves. Requests with a body are never
+ * retried (the stream is already consumed).
  */
-export async function forwardHttp(request: Request, targetUrl: string): Promise<Response> {
+export async function forwardHttp(
+	request: Request,
+	targetUrl: string,
+	sessionId?: string,
+): Promise<Response> {
 	const init: RequestInit = {
 		method: request.method,
 		headers: requestHeaders(request, targetUrl),
 		redirect: 'manual',
 	};
-	if (request.method !== 'GET' && request.method !== 'HEAD') {
+	const retryable = request.method === 'GET' || request.method === 'HEAD';
+	if (!retryable) {
 		init.body = request.body;
 		// Node's fetch requires this when streaming a request body.
 		(init as { duplex?: string }).duplex = 'half';
 	}
-	let upstream: Response;
-	try {
-		upstream = await fetch(targetUrl, init);
-	} catch {
+	// The token in the path routes to the session; keep it out of logs.
+	const target = new URL(targetUrl).origin;
+	let upstream: Response | undefined;
+	const attempts = retryable ? 2 : 1;
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		try {
+			upstream = await fetch(targetUrl, init);
+			break;
+		} catch (err) {
+			logEvent({
+				level: 'warn',
+				event: 'sandbox_proxy_upstream_error',
+				session_id: sessionId ?? null,
+				method: request.method,
+				target,
+				attempt,
+				will_retry: attempt < attempts,
+				error: describeError(err),
+			});
+		}
+	}
+	if (!upstream) {
 		// Kernel unreachable (e.g. torn down mid-request) — a gateway failure, not a
 		// server bug, so don't surface a 500 through the error handler.
 		return new Response('Kernel unavailable', { status: 502 });
+	}
+	if (GATEWAY_STATUSES.has(upstream.status)) {
+		// Passed through verbatim, but a 502/503/504 minted between hub and kernel
+		// (e.g. the sandbox-side ingress) is invisible without this line.
+		logEvent({
+			level: 'warn',
+			event: 'sandbox_proxy_upstream_gateway_status',
+			session_id: sessionId ?? null,
+			method: request.method,
+			target,
+			status: upstream.status,
+		});
 	}
 	return new Response(upstream.body, {
 		status: upstream.status,
@@ -250,6 +295,6 @@ export function sandboxProxyMiddleware(deps: ApiDeps): MiddlewareHandler<HonoEnv
 		if (decision.kind === 'reject') {
 			return fail(c, decision.code, decision.message, decision.status);
 		}
-		return forwardHttp(c.req.raw, decision.targetUrl);
+		return forwardHttp(c.req.raw, decision.targetUrl, decision.sessionId);
 	};
 }

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -453,9 +453,12 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 				if (!validSubject(payload.sub) || !validEmail(payload.email)) return null;
 				const name = displayNameClaim(payload.name);
 				const pictureUrl = pictureUrlClaim(payload.picture_url);
-				const hasGroupAuthorization = Array.isArray(payload.entitlements);
+				// Alias into a const: `Array.isArray` narrows a const binding, but not a
+				// mutable index-signature access like `payload.entitlements`.
+				const entitlementsClaim = payload.entitlements;
+				const hasGroupAuthorization = Array.isArray(entitlementsClaim);
 				const entitlements = hasGroupAuthorization
-					? payload.entitlements.filter(
+					? entitlementsClaim.filter(
 							(value): value is AuthEntitlement =>
 								typeof value === 'string' && AUTH_ENTITLEMENT_SET.has(value),
 						)


### PR DESCRIPTION
Intermittent 502s on iframe static assets in `proxy` exposure mode (reported on a k8s deployment) were undiagnosable: `forwardHttp` swallowed hub→kernel fetch errors and returned a bare 502.

- Log a structured `sandbox_proxy_upstream_error` event on fetch failure (session id, method, target origin — token kept out of logs), and `sandbox_proxy_upstream_gateway_status` when an upstream 502/503/504 is passed through.
- Retry GET/HEAD once when the fetch throws — absorbs the keep-alive reset race (uvicorn ~5s idle close vs pooled connections) that bursts of parallel asset requests hit. Bodied requests are never retried.
- Tests against a real HTTP server: connection-drop retry, no retry for POST, log shape, token-not-in-logs, gateway pass-through.

Also includes a separable 3-line fix for `auth-oidc`, which failed `pnpm typecheck` on main (TS 6 doesn't narrow `Array.isArray` through an alias of an index-signature property; CI's `vp check` is lint-only so it slipped through).