### PR TITLE
fix(compute-local): inject marimo flags when setup commands prefix uv run

### DIFF
--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -39,6 +39,13 @@ describe('prepareMarimoCommand (pure)', () => {
 		);
 	});
 
+	it('injects `--with marimo` when setup commands prefix the uv run command', () => {
+		const command = 'if test -f pyproject.toml; then uv sync; fi && uv run --no-sync marimo edit';
+		expect(prepareMarimoCommand(command, '127.0.0.1')).toBe(
+			'if test -f pyproject.toml; then uv sync; fi && uv run --with marimo --no-sync marimo edit',
+		);
+	});
+
 	it('does not double-inject `--with marimo`', () => {
 		const already = 'uv run --with marimo marimo edit';
 		expect(prepareMarimoCommand(already, '127.0.0.1')).toBe(already);

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -87,6 +87,24 @@ describe('prepareMarimoCommand (pure)', () => {
 			'uv run --with marimo marimo edit --host 0.0.0.0 && tool --host 1.2.3.4',
 		);
 	});
+
+	it('stops the launch segment at a pipe, not a trailing command (Docker mode)', () => {
+		expect(prepareMarimoCommand('uv run marimo edit | tee log', '0.0.0.0')).toBe(
+			'uv run --with marimo marimo edit --host 0.0.0.0 | tee log',
+		);
+	});
+
+	it('stops the launch segment at a semicolon, not a trailing command (Docker mode)', () => {
+		expect(prepareMarimoCommand('uv run marimo edit; touch done', '0.0.0.0')).toBe(
+			'uv run --with marimo marimo edit --host 0.0.0.0; touch done',
+		);
+	});
+
+	it('does not truncate the launch segment at an `&&` inside quotes', () => {
+		expect(prepareMarimoCommand('uv run marimo edit -c "a && b"', '0.0.0.0')).toBe(
+			'uv run --with marimo marimo edit -c "a && b" --host 0.0.0.0',
+		);
+	});
 });
 
 describe('rewriteWorkspace (pure)', () => {

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -68,6 +68,25 @@ describe('prepareMarimoCommand (pure)', () => {
 			'uv run --with marimo marimo edit --host 1.2.3.4',
 		);
 	});
+
+	it('appends `--host` to the launch segment when setup commands prefix it (Docker mode)', () => {
+		const command = 'if test -f pyproject.toml; then uv sync; fi && uv run --no-sync marimo edit';
+		expect(prepareMarimoCommand(command, '0.0.0.0')).toBe(
+			'if test -f pyproject.toml; then uv sync; fi && uv run --with marimo --no-sync marimo edit --host 0.0.0.0',
+		);
+	});
+
+	it('appends `--host` to the launch segment, not a trailing command (Docker mode)', () => {
+		expect(prepareMarimoCommand('uv run marimo edit && sh notify.sh', '0.0.0.0')).toBe(
+			'uv run --with marimo marimo edit --host 0.0.0.0 && sh notify.sh',
+		);
+	});
+
+	it('scopes `--host` detection to the launch segment, ignoring a trailing flag', () => {
+		expect(prepareMarimoCommand('uv run marimo edit && tool --host 1.2.3.4', '0.0.0.0')).toBe(
+			'uv run --with marimo marimo edit --host 0.0.0.0 && tool --host 1.2.3.4',
+		);
+	});
 });
 
 describe('rewriteWorkspace (pure)', () => {

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -131,15 +131,20 @@ export function prepareMarimoCommand(cmd: string, bindHost: string): string {
 	const uvRunPrefix = /(^|&&\s*)uv run (?=[^&]*\bmarimo\b)/;
 	const match = uvRunPrefix.exec(cmd);
 	if (!match) return cmd;
+	// Localize edits to the launch segment (`uv run … marimo …`), which runs from
+	// `uv run` to the next `&&` (or end of string). Flags injected outside it would
+	// land on an unrelated setup/teardown command.
 	const launchStart = match.index + match[1].length;
-	let out = cmd;
-	if (!out.slice(launchStart).includes('--with marimo')) {
-		out = out.replace(uvRunPrefix, '$1uv run --with marimo ');
+	const nextSep = cmd.slice(launchStart).search(/&&/);
+	const launchEnd = nextSep === -1 ? cmd.length : launchStart + nextSep;
+	let segment = cmd.slice(launchStart, launchEnd);
+	if (!segment.includes('--with marimo')) {
+		segment = segment.replace(/^uv run /, 'uv run --with marimo ');
 	}
-	if (bindHost !== '127.0.0.1' && !out.slice(launchStart).includes('--host')) {
-		out = `${out} --host ${bindHost}`;
+	if (bindHost !== '127.0.0.1' && !segment.includes('--host')) {
+		segment = segment.replace(/\s*$/, ` --host ${bindHost}$&`);
 	}
-	return out;
+	return cmd.slice(0, launchStart) + segment + cmd.slice(launchEnd);
 }
 
 export interface LocalComputeOptions {

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -118,6 +118,27 @@ export function rewriteWorkspace(cmd: string, root: string): string {
 }
 
 /**
+ * Scan from `start` for the end of the current shell command, i.e. the first
+ * top-level (outside single/double quotes) separator — `&&`, `||`, `|`, `;`, or
+ * a backgrounding `&`. Returns `cmd.length` if none. Not a full shell parser:
+ * it tracks quoting so an `&&` inside a quoted argument is not mistaken for a
+ * separator, which is enough for the launch commands we rewrite.
+ */
+function commandSegmentEnd(cmd: string, start: number): number {
+	let quote: '"' | "'" | null = null;
+	for (let i = start; i < cmd.length; i++) {
+		const ch = cmd[i];
+		if (quote) {
+			if (ch === quote) quote = null;
+			continue;
+		}
+		if (ch === '"' || ch === "'") quote = ch;
+		else if (ch === ';' || ch === '|' || ch === '&') return i;
+	}
+	return cmd.length;
+}
+
+/**
  * Adjust a `uv run … marimo …` command for local execution. Pure (no `this`) so
  * the branchy rewrite logic is unit-testable:
  *  - inject `--with marimo` so marimo is available even if the notebook's
@@ -132,11 +153,10 @@ export function prepareMarimoCommand(cmd: string, bindHost: string): string {
 	const match = uvRunPrefix.exec(cmd);
 	if (!match) return cmd;
 	// Localize edits to the launch segment (`uv run … marimo …`), which runs from
-	// `uv run` to the next `&&` (or end of string). Flags injected outside it would
-	// land on an unrelated setup/teardown command.
+	// `uv run` to the next top-level separator (or end of string). Flags injected
+	// outside it would land on an unrelated setup/teardown command.
 	const launchStart = match.index + match[1].length;
-	const nextSep = cmd.slice(launchStart).search(/&&/);
-	const launchEnd = nextSep === -1 ? cmd.length : launchStart + nextSep;
+	const launchEnd = commandSegmentEnd(cmd, launchStart);
 	let segment = cmd.slice(launchStart, launchEnd);
 	if (!segment.includes('--with marimo')) {
 		segment = segment.replace(/^uv run /, 'uv run --with marimo ');

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -124,15 +124,19 @@ export function rewriteWorkspace(cmd: string, root: string): string {
  *    pyproject.toml doesn't declare it (installed into an ephemeral env);
  *  - append `--host <bindHost>` when binding a non-default interface (Docker:
  *    0.0.0.0), so the kernel is reachable through the published port.
- * Non-`uv run` commands and already-configured ones pass through unchanged.
+ * Commands without a `uv run` launch segment and already-configured ones pass
+ * through unchanged.
  */
 export function prepareMarimoCommand(cmd: string, bindHost: string): string {
-	if (!cmd.startsWith('uv run ')) return cmd;
+	const uvRunPrefix = /(^|&&\s*)uv run (?=[^&]*\bmarimo\b)/;
+	const match = uvRunPrefix.exec(cmd);
+	if (!match) return cmd;
+	const launchStart = match.index + match[1].length;
 	let out = cmd;
-	if (!out.includes('--with marimo')) {
-		out = out.replace(/^uv run /, 'uv run --with marimo ');
+	if (!out.slice(launchStart).includes('--with marimo')) {
+		out = out.replace(uvRunPrefix, '$1uv run --with marimo ');
 	}
-	if (bindHost !== '127.0.0.1' && out.includes('marimo') && !out.includes('--host')) {
+	if (bindHost !== '127.0.0.1' && !out.slice(launchStart).includes('--host')) {
 		out = `${out} --host ${bindHost}`;
 	}
 	return out;


### PR DESCRIPTION
## What

`prepareMarimoCommand` only recognized a launch command that *started* with `uv run `. Commands with setup steps prefixed before the launch — e.g. `if test -f pyproject.toml; then uv sync; fi && uv run --no-sync marimo edit` — passed through unchanged, so `--with marimo` and `--host` were never injected.

## Change

- Match the `uv run` launch segment anywhere (start or after `&&`), requiring a `marimo` token in that segment.
- Inject `--with marimo` / `--host` relative to the matched launch segment rather than the whole string.
- Add a test covering a setup-prefixed command.