### PR TITLE
ci(e2e): run Playwright suite on firefox and webkit via matrix

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,8 +16,13 @@ concurrency:
 
 jobs:
   e2e:
+    name: e2e (${{ matrix.browser }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       # The Playwright webServer shells out to `pnpm exec vp run`, so pnpm must be
@@ -32,12 +37,14 @@ jobs:
           cache: true
           run-install: |
             - args: ['--frozen-lockfile']
-      - run: pnpm --filter @marimo-hub/e2e install-browser
+      - run: pnpm --filter @marimo-hub/e2e exec playwright install --with-deps ${{ matrix.browser }}
       - run: pnpm e2e
+        env:
+          E2E_BROWSER: ${{ matrix.browser }}
       - name: Upload report
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.browser }}
           path: apps/e2e/playwright-report/
           retention-days: 7

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -2,4 +2,9 @@
 
 Browser end-to-end tests (Playwright) run against the in-memory/dev-auth stack.
 
+CI runs the suite on chromium, firefox, and webkit (one matrix job each).
+Locally `pnpm e2e` runs chromium only; to run another browser, install it
+(`pnpm exec playwright install --with-deps firefox`) and select it with
+`E2E_BROWSER=firefox pnpm e2e` (comma-separate to run several).
+
 Part of [marimohub](../../README.md).

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -8,6 +8,20 @@ const repoRoot = path.resolve(here, '../..');
 const PORT = 4321;
 const BASE_URL = `http://localhost:${PORT}`;
 
+// CI runs one browser per matrix job via E2E_BROWSER (see .github/workflows/e2e.yml).
+// The local default is chromium so `pnpm e2e` only needs the chromium install.
+const allProjects = [
+	{ name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+	{ name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+	{ name: 'webkit', use: { ...devices['Desktop Safari'] } },
+];
+const browsers = (process.env.E2E_BROWSER ?? 'chromium').split(',');
+for (const browser of browsers) {
+	if (!allProjects.some((p) => p.name === browser)) {
+		throw new Error(`Unknown E2E_BROWSER "${browser}" (expected chromium, firefox, or webkit)`);
+	}
+}
+
 // Boots apps/server serving the prebuilt SPA, wired to the local ports (memory
 // storage, dev auth, no compute) for zero external deps. State is shared across
 // the single server process, so tests run serially with unique names.
@@ -22,7 +36,7 @@ export default defineConfig({
 		baseURL: BASE_URL,
 		trace: 'on-first-retry',
 	},
-	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+	projects: allProjects.filter((p) => browsers.includes(p.name)),
 	// Builds web + server (cached `vp run` tasks) and serves the SPA from
 	// packages/web/dist. A warm `e2e:serve` server is reused via reuseExistingServer.
 	webServer: {


### PR DESCRIPTION
Adds firefox and webkit (Safari engine) to the e2e tests as a CI matrix — jobs run in parallel, so wall-clock time is unchanged. The full suite runs on every browser (it's only 4 tests; a subset would save nothing).

- Playwright config selects projects via `E2E_BROWSER` (default chromium, so local `pnpm e2e` needs no extra installs); unknown values throw
- Each matrix job installs only its browser and uploads a per-browser failure report
- Verified locally: all tests pass on firefox and webkit

Note: check names change to `e2e (chromium|firefox|webkit)` — update branch protection if `e2e` was required.