### PR TITLE
feat(errors): typed error handling end-to-end

### DIFF
--- a/examples/cloudflare-worker/src/tieredCompute.test.ts
+++ b/examples/cloudflare-worker/src/tieredCompute.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SandboxId } from '@marimo-hub/core';
+import type { ActiveSandbox, SandboxInstance, SandboxProvider } from '@marimo-hub/core/ports';
+import { TieredComputeProvider } from './tieredCompute';
+
+const SANDBOX_ID = 'sb-test' as SandboxId;
+
+function fakeInstance(supportsBucketMount: boolean): SandboxInstance {
+	return {
+		supportsBucketMount,
+		exec: async () => ({ success: true as const, stdout: '', stderr: '' }),
+	} as unknown as SandboxInstance;
+}
+
+function fakeProvider(opts: { flag: boolean; reachable?: boolean }): SandboxProvider {
+	return {
+		create: () => fakeInstance(opts.flag),
+		proxy: async () => null,
+		listActive: async (): Promise<ActiveSandbox[]> => {
+			if (opts.reachable === false) throw new Error('unreachable');
+			return [];
+		},
+	} as SandboxProvider;
+}
+
+// The provisioner reads `supportsBucketMount` to decide between hard-failing a
+// mount and copying files. The tiered wrapper must forward the pinned backend's
+// answer — a wrapper that erases it silently re-enables mount-failure fallback
+// on the mount-capable (Cloudflare) branch.
+describe('TieredSandboxInstance supportsBucketMount', () => {
+	it('is undefined until the backend is pinned (legacy provisioner path)', () => {
+		const tiered = new TieredComputeProvider(
+			fakeProvider({ flag: false }),
+			fakeProvider({ flag: true }),
+		);
+		expect(tiered.create(SANDBOX_ID).supportsBucketMount).toBeUndefined();
+	});
+
+	it('reflects the primary backend once an operation pins it', async () => {
+		const tiered = new TieredComputeProvider(
+			fakeProvider({ flag: false }),
+			fakeProvider({ flag: true }),
+		);
+		const instance = tiered.create(SANDBOX_ID);
+		await instance.exec('true');
+		expect(instance.supportsBucketMount).toBe(false);
+	});
+
+	it('reflects the mount-capable fallback when the primary is unreachable', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const tiered = new TieredComputeProvider(
+			fakeProvider({ flag: false, reachable: false }),
+			fakeProvider({ flag: true }),
+		);
+		const instance = tiered.create(SANDBOX_ID);
+		await instance.exec('true');
+		expect(instance.supportsBucketMount).toBe(true);
+		vi.restoreAllMocks();
+	});
+});

--- a/examples/cloudflare-worker/src/tieredCompute.ts
+++ b/examples/cloudflare-worker/src/tieredCompute.ts
@@ -43,6 +43,18 @@ import type { SandboxId } from '@marimo-hub/core';
 class TieredSandboxInstance implements SandboxInstance {
 	/** Memoised backend choice — resolved once, then every op routes to it. */
 	private backend?: Promise<SandboxInstance>;
+	/** The settled backend, once {@link pick} completes, so sync reads can see it. */
+	private resolved?: SandboxInstance;
+
+	/**
+	 * Reflects the pinned backend's capability (E2B false, Cloudflare true).
+	 * `undefined` until the backend is chosen, which keeps the provisioner on its
+	 * legacy try-mount-then-copy path; by the mount step the provisioner has
+	 * already exec'd against the sandbox, so the backend is always pinned.
+	 */
+	get supportsBucketMount(): boolean | undefined {
+		return this.resolved?.supportsBucketMount;
+	}
 
 	constructor(
 		private readonly id: SandboxId,
@@ -65,7 +77,12 @@ class TieredSandboxInstance implements SandboxInstance {
 	 * probe on every reconnect.
 	 */
 	private resolve(): Promise<SandboxInstance> {
-		if (!this.backend) this.backend = this.pick();
+		if (!this.backend) {
+			this.backend = this.pick().then((backend) => {
+				this.resolved = backend;
+				return backend;
+			});
+		}
 		return this.backend;
 	}
 

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -81,21 +81,37 @@ components:
               type: string
               enum:
                 - BAD_REQUEST
-                - UNAUTHORIZED
-                - FORBIDDEN
+                - PRECONDITION_FAILED
                 - NOT_FOUND
                 - CONFLICT
-                - GONE
-                - PRECONDITION_FAILED
-                - PAYLOAD_TOO_LARGE
+                - EDIT_SESSION_OWNED
+                - EDIT_SESSION_CHANGED
+                - TAKEOVER_IN_PROGRESS
+                - FORBIDDEN
                 - VALIDATION_ERROR
-                - RESOURCE_EXHAUSTED
                 - NOT_INITIALIZED
-                - NO_HTML_SNAPSHOT
                 - SERVICE_UNAVAILABLE
+                - RESOURCE_EXHAUSTED
+                - UNAUTHORIZED
+                - GONE
+                - PAYLOAD_TOO_LARGE
+                - NO_HTML_SNAPSHOT
                 - INTERNAL_ERROR
             message:
               type: string
+            details:
+              type: array
+              items:
+                type: object
+                properties:
+                  field:
+                    type: string
+                  message:
+                    type: string
+                required:
+                  - field
+                  - message
+              description: Field-level validation failures.
             request_id:
               type: string
           required:
@@ -1620,8 +1636,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -1701,8 +1729,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -1773,8 +1813,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -1881,8 +1933,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -1950,8 +2014,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2016,8 +2092,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2111,8 +2199,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2206,8 +2306,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2277,8 +2389,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2389,8 +2513,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2471,8 +2607,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2530,8 +2678,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2589,8 +2749,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2670,8 +2842,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2791,8 +2975,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -2927,8 +3123,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3008,8 +3216,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3173,8 +3393,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3252,8 +3490,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3377,14 +3627,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '412':
           description: Precondition failed (If-Match did not match the current version)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3459,8 +3727,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3533,8 +3813,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3621,8 +3913,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3705,8 +4009,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3769,8 +4085,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3837,8 +4165,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -3919,8 +4259,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4013,8 +4371,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4094,8 +4464,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4170,8 +4552,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4241,8 +4635,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4316,8 +4722,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4399,8 +4817,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4504,6 +4934,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
           content:
@@ -4520,6 +4956,12 @@ paths:
                 example: '5'
               required: true
               description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4600,8 +5042,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4650,8 +5104,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4737,8 +5203,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4835,8 +5313,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -4920,8 +5410,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5035,8 +5537,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5111,8 +5625,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5205,8 +5731,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5280,8 +5818,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5355,6 +5905,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
           content:
@@ -5371,6 +5927,12 @@ paths:
                 example: '5'
               required: true
               description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5449,8 +6011,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5533,8 +6107,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5611,8 +6197,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5719,8 +6317,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5788,8 +6398,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5875,8 +6497,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -5941,6 +6575,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
           content:
@@ -5957,6 +6597,12 @@ paths:
                 example: '5'
               required: true
               description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -6141,6 +6787,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
           content:
@@ -6157,6 +6809,12 @@ paths:
                 example: '5'
               required: true
               description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -6212,8 +6870,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:
@@ -6274,8 +6944,20 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
           content:
             application/json:
               schema:

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -26,6 +26,7 @@ import usersApp from './routes/users';
 import { createOidcDiscovery } from './oidcDiscovery';
 import { sandboxProxyMiddleware } from './sandboxProxy';
 import { createApp, fail } from './shared';
+import type { ErrorCode } from './shared';
 
 const OPENAPI_DOC = {
 	openapi: '3.1.0' as const,
@@ -127,10 +128,14 @@ export function createApi(rawDeps: ApiDeps) {
 			for (const [name, value] of res.headers) {
 				if (name.toLowerCase() !== 'content-type') c.header(name, value);
 			}
+			const errorCodesByStatus: Partial<Record<number, ErrorCode>> = {
+				400: 'BAD_REQUEST',
+				401: 'UNAUTHORIZED',
+				403: 'FORBIDDEN',
+				404: 'NOT_FOUND',
+			};
 			const code =
-				{ 400: 'BAD_REQUEST', 401: 'UNAUTHORIZED', 403: 'FORBIDDEN', 404: 'NOT_FOUND' }[
-					res.status
-				] ?? (res.status >= 500 ? 'INTERNAL_ERROR' : 'BAD_REQUEST');
+				errorCodesByStatus[res.status] ?? (res.status >= 500 ? 'INTERNAL_ERROR' : 'BAD_REQUEST');
 			if (res.status >= 500) {
 				logEvent({
 					level: 'error',
@@ -177,6 +182,7 @@ export function createApi(rawDeps: ApiDeps) {
 	// Correlation id: reuse an inbound `X-Request-Id` or mint one, echo it on the
 	// response header, and thread it into error envelopes + logs for tracing.
 	app.use(`${API_PREFIX}/*`, requestId());
+	app.use('/api/sync/*', requestId());
 
 	// Body-size cap: the API buffers request bodies in full (Hono parses JSON in
 	// memory), so an unbounded POST could OOM the service. Reject anything past

--- a/packages/api/src/integrations/archive.ts
+++ b/packages/api/src/integrations/archive.ts
@@ -40,10 +40,8 @@ function parseZip(bytes: Uint8Array): ArchiveFile[] {
 	let unzipped: Record<string, Uint8Array>;
 	try {
 		unzipped = unzipSync(bytes);
-	} catch (err) {
-		throw new BadRequestError(
-			`Invalid zip archive${err instanceof Error ? `: ${err.message}` : ''}`,
-		);
+	} catch {
+		throw new BadRequestError('Invalid zip archive');
 	}
 	const files = new Map<string, Uint8Array>();
 	for (const [path, body] of Object.entries(unzipped)) {
@@ -185,10 +183,8 @@ function gunzip(bytes: Uint8Array): Uint8Array {
 	let out: Uint8Array;
 	try {
 		out = gunzipSync(bytes);
-	} catch (err) {
-		throw new BadRequestError(
-			`Invalid gzip archive${err instanceof Error ? `: ${err.message}` : ''}`,
-		);
+	} catch {
+		throw new BadRequestError('Invalid gzip archive');
 	}
 	if (out.length > MAX_DECOMPRESSED_BYTES) {
 		throw new BadRequestError('Decompressed archive exceeds the size limit');

--- a/packages/api/src/routes/gitSync.test.ts
+++ b/packages/api/src/routes/gitSync.test.ts
@@ -63,7 +63,7 @@ describe('Git sync routes', () => {
 		'X-Marimohub-Commit': 'abc123',
 	});
 
-	it('rejects creating a synced notebook whose repo is not owner/repo or a URL (400)', async () => {
+	it('rejects creating a synced notebook whose repo is not owner/repo or a URL (422)', async () => {
 		await expectError(
 			await request('POST', `/projects/${projectId}/notebooks/git`, {
 				title: 'Bad repo',
@@ -72,8 +72,8 @@ describe('Git sync routes', () => {
 				branch: 'main',
 				entry_notebook: 'app.py',
 			}),
-			400,
-			'BAD_REQUEST',
+			422,
+			'VALIDATION_ERROR',
 		);
 	});
 
@@ -183,8 +183,8 @@ describe('Git sync routes', () => {
 					'X-Marimohub-Root-Path': 'apps',
 				},
 			}),
-			400,
-			'BAD_REQUEST',
+			422,
+			'VALIDATION_ERROR',
 		);
 
 		expect(error.message).toContain('X-Marimohub-Repo received "other/repo", expected "org/repo"');

--- a/packages/api/src/routes/gitSync.test.ts
+++ b/packages/api/src/routes/gitSync.test.ts
@@ -79,7 +79,12 @@ describe('Git sync routes', () => {
 
 	it('rejects a request with no Authorization header (401)', async () => {
 		const { notebookId } = await createSyncedNotebook();
-		await expectError(await syncRequest({ notebookId }), 401, 'UNAUTHORIZED');
+		const error = await expectError(
+			await syncRequest({ notebookId, headers: { 'X-Request-Id': 'sync-req-123' } }),
+			401,
+			'UNAUTHORIZED',
+		);
+		expect(error.request_id).toBe('sync-req-123');
 	});
 
 	it('rejects a malformed Authorization header (400)', async () => {

--- a/packages/api/src/routes/gitSync.ts
+++ b/packages/api/src/routes/gitSync.ts
@@ -1,4 +1,3 @@
-import { bearerAuth } from 'hono/bearer-auth';
 import {
 	BadRequestError,
 	NotebookId,
@@ -7,8 +6,7 @@ import {
 	toPublicNotebookMeta,
 } from '@marimo-hub/core';
 import { parseWorkspaceArchive } from '../integrations/archive';
-import { createApp } from '../shared';
-import type { HonoEnv } from '../context';
+import { createApp, fail } from '../shared';
 
 const app = createApp();
 
@@ -18,30 +16,26 @@ function header(c: { req: { header(name: string): string | undefined } }, name: 
 	return value;
 }
 
-function authError(code: string, message: string) {
-	return { success: false as const, error: { code, message } };
-}
-
-app.use(
-	'/projects/:pid/notebooks/:nid',
-	bearerAuth<HonoEnv>({
-		verifyToken: async (token, c) => {
-			const pidRaw = c.req.param('pid');
-			const nidRaw = c.req.param('nid');
-			if (!ProjectId.is(pidRaw) || !NotebookId.is(nidRaw)) return false;
-			return c.get('deps').services.notebooks.synced.verifyToken(pidRaw, nidRaw, token);
-		},
-		noAuthenticationHeader: {
-			message: () => authError('UNAUTHORIZED', 'Missing sync token'),
-		},
-		invalidAuthenticationHeader: {
-			message: () => authError('BAD_REQUEST', 'Malformed authorization header'),
-		},
-		invalidToken: {
-			message: () => authError('UNAUTHORIZED', 'Invalid sync token'),
-		},
-	}),
-);
+app.use('/projects/:pid/notebooks/:nid', async (c, next) => {
+	const authorization = c.req.header('authorization');
+	if (!authorization) {
+		c.header('WWW-Authenticate', 'Bearer');
+		return fail(c, 'UNAUTHORIZED', 'Missing sync token', 401);
+	}
+	const match = /^Bearer\s+(\S+)$/i.exec(authorization);
+	if (!match) return fail(c, 'BAD_REQUEST', 'Malformed authorization header', 400);
+	const pidRaw = c.req.param('pid');
+	const nidRaw = c.req.param('nid');
+	const valid =
+		ProjectId.is(pidRaw) &&
+		NotebookId.is(nidRaw) &&
+		(await c.get('deps').services.notebooks.synced.verifyToken(pidRaw, nidRaw, match[1]));
+	if (!valid) {
+		c.header('WWW-Authenticate', 'Bearer');
+		return fail(c, 'UNAUTHORIZED', 'Invalid sync token', 401);
+	}
+	return next();
+});
 
 app.post('/projects/:pid/notebooks/:nid', async (c) => {
 	const deps = c.get('deps');

--- a/packages/api/src/routes/integrations.test.ts
+++ b/packages/api/src/routes/integrations.test.ts
@@ -108,7 +108,7 @@ describe('Integrations routes', () => {
 		expect(JSON.stringify(events)).not.toContain('sup3r-secret');
 	});
 
-	it('returns a sanitized 500 and logs safe diagnostics for malformed stored JSON', async () => {
+	it('returns a sanitized 503 and logs safe diagnostics for malformed stored JSON', async () => {
 		const pid = await createProject();
 		const created = await createPg(pid);
 		const key = paths
@@ -119,10 +119,13 @@ describe('Integrations routes', () => {
 
 		const res = await request('GET', `/projects/${pid}/integrations/${created.id}`);
 		const body = (await res.json()) as Record<string, unknown>;
-		expect(res.status).toBe(500);
+		expect(res.status).toBe(503);
 		expect(body).toMatchObject({
 			success: false,
-			error: { code: 'INTERNAL_ERROR', message: 'Internal server error' },
+			error: {
+				code: 'SERVICE_UNAVAILABLE',
+				message: 'Stored data is temporarily unavailable',
+			},
 		});
 		expect(JSON.stringify(body)).not.toContain(key);
 		expect(JSON.stringify(body)).not.toContain('stored-secret-do-not-log');

--- a/packages/api/src/routes/notebooks.test.ts
+++ b/packages/api/src/routes/notebooks.test.ts
@@ -234,13 +234,14 @@ describe('Notebook routes', () => {
 				compute_profile: 'large',
 			};
 			await expectError(await profileApi()('POST', nb(''), { ...body, compute_profile: 'x' }), 400);
-			await expectError(await profileApi('none')('POST', nb(''), body), 400);
+			await expectError(await profileApi('none')('POST', nb(''), body), 403, 'FORBIDDEN');
 			await expectError(
 				await profileApi('none')('POST', nb(''), {
 					...body,
 					compute_profile: 'default',
 				}),
-				400,
+				403,
+				'FORBIDDEN',
 			);
 		});
 
@@ -397,7 +398,7 @@ describe('Notebook routes', () => {
 			root_path: '',
 			entry_notebook: 'app.py',
 		};
-		await expectError(await request('PATCH', nb(`/${local.id}/source`), body), 400, 'BAD_REQUEST');
+		await expectError(await request('PATCH', nb(`/${local.id}/source`), body), 409, 'CONFLICT');
 
 		const synced = await expectOk<any>(
 			await request('POST', nb('/git'), {

--- a/packages/api/src/routes/notebooks.test.ts
+++ b/packages/api/src/routes/notebooks.test.ts
@@ -632,8 +632,8 @@ describe('Notebook routes', () => {
 					'X-Marimohub-Commit': 'abc123',
 				},
 			}),
-			400,
-			'BAD_REQUEST',
+			422,
+			'VALIDATION_ERROR',
 		);
 
 		await expectError(

--- a/packages/api/src/routes/notebooks.ts
+++ b/packages/api/src/routes/notebooks.ts
@@ -3,6 +3,7 @@ import type { Context } from 'hono';
 import { zipSync } from 'fflate';
 import {
 	BadRequestError,
+	ForbiddenError,
 	NotebookId,
 	NotFoundError,
 	ProjectId,
@@ -150,7 +151,7 @@ function checkComputeProfile(
 	if (value === undefined) return value;
 	const profiles = sandbox.computeProfiles ?? [];
 	if (sandbox.computeProfileOverride !== 'editors') {
-		throw new BadRequestError('This deployment does not allow compute profile selection');
+		throw new ForbiddenError('This deployment does not allow compute profile selection');
 	}
 	if (value === null) return value;
 	const known = profiles.some((profile) => profile.name === value);
@@ -264,7 +265,7 @@ const updateGitSource = createRoute({
 			'Git source updated',
 		),
 		...commonErrors(),
-		...errorResponses(400, 403, 404),
+		...errorResponses(400, 403, 404, 409),
 	},
 });
 
@@ -317,7 +318,7 @@ const updateNotebook = createRoute({
 			EtagResponseHeader,
 		),
 		...commonErrors(),
-		...errorResponses(403, 404, 412),
+		...errorResponses(403, 404, 409, 412),
 	},
 });
 
@@ -424,7 +425,7 @@ const restoreVersion = createRoute({
 			'Version restored as a new save; returns the updated notebook',
 		),
 		...commonErrors(),
-		...errorResponses(403, 404),
+		...errorResponses(403, 404, 409),
 	},
 });
 

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -117,7 +117,7 @@ describe('Session routes', () => {
 		expect(all).toHaveLength(0);
 	});
 
-	it('POST /sessions for an unsynced GitHub notebook returns 400 and does not provision', async () => {
+	it('POST /sessions for an unsynced GitHub notebook returns 409 and does not provision', async () => {
 		const services = createServices(bucket);
 		const { meta } = await services.notebooks.synced.create(
 			pid,
@@ -132,7 +132,7 @@ describe('Session routes', () => {
 		);
 		const path = `/projects/${pid}/notebooks/${meta.id}/sessions`;
 
-		await expectError(await owner('POST', path), 400, 'BAD_REQUEST');
+		await expectError(await owner('POST', path), 409, 'CONFLICT');
 		expect(await services.sessions.listSessions(meta.id)).toHaveLength(0);
 	});
 
@@ -418,8 +418,8 @@ describe('Session routes', () => {
 				expected_activity: state.holder!.activity.state,
 				acknowledge_disruption: true,
 			}),
-			503,
-			'SERVICE_UNAVAILABLE',
+			409,
+			'CONFLICT',
 		);
 
 		expect(takeoverSandbox.calls.destroy).toBe(0);
@@ -489,7 +489,12 @@ describe('Session routes', () => {
 		const activity = makeFakeSandbox();
 		activity.instance.exec = async () => {
 			await services.projects.removeMember(pid, STRANGER, ACTOR);
-			return { success: false, stdout: '', stderr: '' };
+			return {
+				success: false,
+				stdout: '',
+				stderr: '',
+				error: { code: 'COMMAND_FAILED' },
+			};
 		};
 		const exclusiveOther = exclusiveApi(STRANGER, fakeComputeFrom(activity.instance), {
 			policy: { defaultRole: undefined },
@@ -524,7 +529,12 @@ describe('Session routes', () => {
 				new Date().toISOString(),
 			);
 			await services.sessions.markTerminated(pid, persistent.session_id);
-			return { success: false, stdout: '', stderr: '' };
+			return {
+				success: false,
+				stdout: '',
+				stderr: '',
+				error: { code: 'COMMAND_FAILED' },
+			};
 		};
 		const exclusiveOther = exclusiveApi(STRANGER, fakeComputeFrom(activity.instance));
 
@@ -535,8 +545,8 @@ describe('Session routes', () => {
 				expected_activity: 'unknown',
 				acknowledge_disruption: true,
 			}),
-			503,
-			'SERVICE_UNAVAILABLE',
+			409,
+			'CONFLICT',
 		);
 
 		expect(activity.calls.destroy).toBe(0);

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -664,7 +664,7 @@ app.openapi(takeoverEditorSession, async (c) => {
 		await assertAccess();
 		const currentClaim = await deps.services.sessions.getEditorClaim(pid, nid);
 		if (effectiveEditorSharing(currentClaim, deps.policy.editorSandboxSharing) !== 'exclusive') {
-			throw new BadRequestError('Takeover is only available in exclusive editor mode');
+			throw new ConflictError('Takeover is only available in exclusive editor mode');
 		}
 		const claim = await deps.services.sessions.reserveTakeover(pid, nid, {
 			takeoverId: body.takeover_id,
@@ -686,10 +686,19 @@ app.openapi(takeoverEditorSession, async (c) => {
 					body.takeover_id,
 					crypto.randomUUID(),
 				);
-				if (!completed) throw new Error('Another request owns the takeover drain lease');
+				if (!completed) throw new ConflictError('Another request owns the takeover drain lease');
 				await audit('session.takeover.success');
 				return c.json({ success: true }, 200);
-			} catch {
+			} catch (err) {
+				if (err instanceof ConflictError) throw err;
+				logEvent({
+					level: 'error',
+					event: 'session_takeover_drain_failed',
+					project_id: pid,
+					notebook_id: nid,
+					takeover_id: body.takeover_id,
+					error: errorMetadata(err),
+				});
 				throw new UnavailableError(
 					'The prior editor is still shutting down; retry this takeover shortly',
 				);
@@ -697,7 +706,7 @@ app.openapi(takeoverEditorSession, async (c) => {
 		}
 		if (holder.notebook_id !== nid || holder.user_id === user.id || holder.ephemeral) {
 			await deps.services.sessions.cancelRequestedTakeover(pid, nid, body.takeover_id);
-			throw new BadRequestError('The selected session cannot be taken over');
+			throw new ConflictError('The selected session cannot be taken over');
 		}
 		const activity = await inspectEditorActivity(deps, holder);
 		observer.tag('activity', activity.state);
@@ -716,6 +725,9 @@ app.openapi(takeoverEditorSession, async (c) => {
 			await sessionRetirer(deps).retireForTakeover(holder, user.id);
 			await deps.services.sessions.setTakeoverPhase(pid, nid, body.takeover_id, 'ready');
 		} catch (err) {
+			if (err instanceof TakeoverRetirementError && err.cause instanceof ConflictError) {
+				throw err.cause;
+			}
 			if (err instanceof TakeoverRetirementError && err.drainStarted) {
 				await deps.services.sessions
 					.setTakeoverPhase(pid, nid, body.takeover_id, 'draining')
@@ -723,6 +735,14 @@ app.openapi(takeoverEditorSession, async (c) => {
 			} else {
 				await deps.services.sessions.cancelRequestedTakeover(pid, nid, body.takeover_id);
 			}
+			logEvent({
+				level: 'error',
+				event: 'session_takeover_retirement_failed',
+				project_id: pid,
+				notebook_id: nid,
+				takeover_id: body.takeover_id,
+				error: errorMetadata(err instanceof TakeoverRetirementError ? err.cause : err),
+			});
 			throw new UnavailableError(
 				'Could not safely save and stop the current editor; no replacement was started',
 			);
@@ -807,7 +827,7 @@ app.openapi(createSession, async (c) => {
 		? undefined
 		: notebook.source.current_version_id;
 	if (!workspacePolicy.persistSessionEdits && !syncedVersionId) {
-		throw new BadRequestError('Synced notebook has not been synced yet');
+		throw new ConflictError('Synced notebook has not been synced yet');
 	}
 	const workspacePrefix = syncedVersionId
 		? paths.project(pid).notebook(nid).version(syncedVersionId).workspacePrefix

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -725,7 +725,14 @@ app.openapi(takeoverEditorSession, async (c) => {
 			await sessionRetirer(deps).retireForTakeover(holder, user.id);
 			await deps.services.sessions.setTakeoverPhase(pid, nid, body.takeover_id, 'ready');
 		} catch (err) {
-			if (err instanceof TakeoverRetirementError && err.cause instanceof ConflictError) {
+			// Only the pre-drain lease race surfaces as a 409; once the drain has
+			// started, even a ConflictError cause must fall through to the phase
+			// bookkeeping and log below, or the persisted takeover state goes stale.
+			if (
+				err instanceof TakeoverRetirementError &&
+				err.cause instanceof ConflictError &&
+				!err.drainStarted
+			) {
 				throw err.cause;
 			}
 			if (err instanceof TakeoverRetirementError && err.drainStarted) {

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -392,7 +392,10 @@ describe('forwardHttp', () => {
 				'sess-123',
 			);
 			expect(res.status).toBe(502);
-			expect(await res.text()).toBe('Kernel unavailable');
+			expect(await res.json()).toEqual({
+				success: false,
+				error: { code: 'SERVICE_UNAVAILABLE', message: 'Kernel unavailable' },
+			});
 
 			const events = logSpy.mock.calls
 				.map(([line]) => JSON.parse(line as string) as Record<string, unknown>)

--- a/packages/api/src/sandboxProxy.ts
+++ b/packages/api/src/sandboxProxy.ts
@@ -19,7 +19,12 @@ import { assertSessionAccess, fail } from './shared';
 /** Outcome of routing a `/proxy/<token>/…` request. */
 export type ProxyDecision =
 	| { kind: 'pass' } // Not a proxy path — let the normal app handle it.
-	| { kind: 'reject'; status: 401 | 403 | 404 | 410 | 503; code: string; message: string }
+	| {
+			kind: 'reject';
+			status: 401 | 403 | 404 | 410 | 503;
+			code: 'UNAUTHORIZED' | 'FORBIDDEN' | 'NOT_FOUND' | 'GONE' | 'SERVICE_UNAVAILABLE';
+			message: string;
+	  }
 	| {
 			kind: 'forward';
 			targetUrl: string;
@@ -263,7 +268,13 @@ export async function forwardHttp(
 	if (!upstream) {
 		// Kernel unreachable (e.g. torn down mid-request) — a gateway failure, not a
 		// server bug, so don't surface a 500 through the error handler.
-		return new Response('Kernel unavailable', { status: 502 });
+		return Response.json(
+			{
+				success: false,
+				error: { code: 'SERVICE_UNAVAILABLE', message: 'Kernel unavailable' },
+			},
+			{ status: 502 },
+		);
 	}
 	if (GATEWAY_STATUSES.has(upstream.status)) {
 		// Passed through verbatim, but a 502/503/504 minted between hub and kernel

--- a/packages/api/src/shared.test.ts
+++ b/packages/api/src/shared.test.ts
@@ -253,12 +253,21 @@ describe('createApp defaultHook', () => {
 		expect(res.status).toBe(422);
 		const body = (await res.json()) as {
 			success: boolean;
-			error: { code: string; message: string };
+			error: {
+				code: string;
+				message: string;
+				details: { field: string; message: string }[];
+			};
 		};
 		expect(body.success).toBe(false);
 		expect(body.error.code).toBe('VALIDATION_ERROR');
-		// The hook flattens every zod issue into one "path: message" string.
-		expect(typeof body.error.message).toBe('string');
-		expect(body.error.message.length).toBeGreaterThan(0);
+		expect(body.error.message).toContain('n:');
+		expect(body.error.message).toContain('label:');
+		expect(body.error.details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ field: 'n' }),
+				expect.objectContaining({ field: 'label' }),
+			]),
+		);
 	});
 });

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -4,6 +4,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import {
 	canAct,
 	ASSIGNABLE_ROLES,
+	DOMAIN_ERROR_CODES,
 	effectiveRole,
 	ForbiddenError,
 	isSuperAdmin,
@@ -283,14 +284,19 @@ export function createApp() {
 	return new OpenAPIHono<HonoEnv>({
 		defaultHook: (result, c) => {
 			if (!result.success) {
-				// One `field: message` per failing field, deduped, so the caller can see
-				// exactly what to fix instead of one comma-run blob.
-				const seen = new Set<string>();
-				const message = result.error.issues
-					.map((i) => `${i.path.join('.') || '(body)'}: ${i.message}`)
-					.filter((m) => !seen.has(m) && (seen.add(m), true))
-					.join('; ');
-				return fail(c, 'VALIDATION_ERROR', message, 422);
+				const details = [
+					...new Map(
+						result.error.issues.map((issue) => {
+							const detail = {
+								field: issue.path.join('.') || '(body)',
+								message: issue.message,
+							};
+							return [`${detail.field}\u0000${detail.message}`, detail] as const;
+						}),
+					).values(),
+				];
+				const message = details.map((detail) => `${detail.field}: ${detail.message}`).join('; ');
+				return fail(c, 'VALIDATION_ERROR', message, 422, { details });
 			}
 		},
 	});
@@ -321,14 +327,30 @@ export function ok<T>(c: Context, data: T) {
 /** Backoff hint (seconds) for the retriable statuses, surfaced as `Retry-After`. */
 const RETRY_AFTER_SECONDS: Record<number, number> = { 429: 5, 503: 2 };
 
-export function fail(c: Context, code: string, message: string, status: number) {
+export interface ErrorDetail {
+	field: string;
+	message: string;
+}
+
+export function fail(
+	c: Context,
+	code: ErrorCode,
+	message: string,
+	status: number,
+	options: { details?: ErrorDetail[] } = {},
+) {
 	const retryAfter = RETRY_AFTER_SECONDS[status];
 	if (retryAfter !== undefined) c.header('Retry-After', String(retryAfter));
 	const requestId = (c.var as { requestId?: string }).requestId;
 	return c.json(
 		{
 			success: false as const,
-			error: { code, message, ...(requestId ? { request_id: requestId } : {}) },
+			error: {
+				code,
+				message,
+				...(options.details ? { details: options.details } : {}),
+				...(requestId ? { request_id: requestId } : {}),
+			},
 		},
 		status as ContentfulStatusCode,
 	);
@@ -445,19 +467,11 @@ export const SessionIdParam = NotebookIdParam.extend({
  * layer emits directly (auth, validation, body-limit, proxy, the catch-all).
  */
 export const ERROR_CODES = [
-	'BAD_REQUEST',
+	...DOMAIN_ERROR_CODES,
 	'UNAUTHORIZED',
-	'FORBIDDEN',
-	'NOT_FOUND',
-	'CONFLICT',
 	'GONE',
-	'PRECONDITION_FAILED',
 	'PAYLOAD_TOO_LARGE',
-	'VALIDATION_ERROR',
-	'RESOURCE_EXHAUSTED',
-	'NOT_INITIALIZED',
 	'NO_HTML_SNAPSHOT',
-	'SERVICE_UNAVAILABLE',
 	'INTERNAL_ERROR',
 ] as const;
 
@@ -469,6 +483,10 @@ export const ErrorResponseSchema = z
 		error: z.object({
 			code: z.enum(ERROR_CODES),
 			message: z.string(),
+			details: z
+				.array(z.object({ field: z.string(), message: z.string() }))
+				.optional()
+				.openapi({ description: 'Field-level validation failures.' }),
 			/** Correlation id (also on the `X-Request-Id` header) for support/tracing. */
 			request_id: z.string().optional(),
 		}),
@@ -495,6 +513,7 @@ const ERROR_DESCRIPTIONS: Record<number, string> = {
 	422: 'Validation error',
 	429: 'Resource limit reached',
 	503: 'Service unavailable',
+	500: 'Internal server error',
 };
 
 /** `Retry-After` header schema, documented on the retriable (429/503) responses. */
@@ -516,14 +535,14 @@ export function errorResponses(...codes: number[]) {
 
 /**
  * Errors reachable on any authenticated `/api/v1/*` route regardless of its
- * handler: 401 (the authN guard), 422 (request body / path-param validation via
- * the OpenAPIHono `defaultHook`), and 503 (a storage/compute dependency is
- * transiently unavailable). Spread into a route's `responses` alongside its
+ * handler: 401 (the authN guard), 413 (the body-size guard), 422 (request body /
+ * path-param validation via the OpenAPIHono `defaultHook`), 500 (the catch-all),
+ * and 503 (a transient storage/compute outage). Spread into a route's `responses` alongside its
  * handler-specific codes so the generated client models them too:
  *   responses: { 200: ..., ...commonErrors(), ...errorResponses(403, 404) }
  */
 export function commonErrors() {
-	return errorResponses(401, 422, 503);
+	return errorResponses(401, 413, 422, 500, 503);
 }
 
 // --- Domain response schemas for OpenAPI docs ---

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { SignJWT } from 'jose';
 import {
 	claimAtPointer,
@@ -1920,26 +1920,30 @@ describe('OIDC login discovery failure', () => {
 });
 
 describe('operational logging for swallowed verification failures', () => {
-	function spyOnOperationalLog() {
-		return vi.spyOn(console, 'error').mockImplementation(() => {});
-	}
-	const loggedEvents = (spy: ReturnType<typeof spyOnOperationalLog>) =>
+	const makeSpy = () => vi.spyOn(console, 'error').mockImplementation(() => {});
+	let spy: ReturnType<typeof makeSpy>;
+	beforeEach(() => {
+		spy = makeSpy();
+	});
+	// Guaranteed even when an assertion throws, so a silenced console.error can
+	// never leak into later tests in this file.
+	afterEach(() => {
+		spy.mockRestore();
+	});
+	const loggedEvents = () =>
 		spy.mock.calls.map(([line]) => String(line)).filter((line) => line.includes('oidc_'));
 
 	it('logs a session cookie that fails verification, without echoing the token', async () => {
-		const spy = spyOnOperationalLog();
 		const forged = await signSession({ sub: 'user-1', email: 'a@b.co', secret: 'x'.repeat(32) });
 
 		await expect(makeAuthenticator().authenticate(requestWithCookie(forged))).resolves.toBeNull();
 
-		const lines = loggedEvents(spy);
+		const lines = loggedEvents();
 		expect(lines.some((line) => line.includes('oidc_session_verify_failed'))).toBe(true);
 		expect(lines.some((line) => line.includes(forged))).toBe(false);
-		spy.mockRestore();
 	});
 
 	it('does not log routine session expiry', async () => {
-		const spy = spyOnOperationalLog();
 		const expired = await signSession({
 			sub: 'user-1',
 			email: 'a@b.co',
@@ -1948,12 +1952,10 @@ describe('operational logging for swallowed verification failures', () => {
 
 		await expect(makeAuthenticator().authenticate(requestWithCookie(expired))).resolves.toBeNull();
 
-		expect(loggedEvents(spy)).toEqual([]);
-		spy.mockRestore();
+		expect(loggedEvents()).toEqual([]);
 	});
 
 	it('logs an unverifiable transaction cookie on the callback path', async () => {
-		const spy = spyOnOperationalLog();
 		const { routes } = createOidcAuth(BASE_CONFIG);
 
 		const res = await routes.request('/api/auth/callback?code=abc&state=xyz', {
@@ -1962,18 +1964,67 @@ describe('operational logging for swallowed verification failures', () => {
 
 		expect(res.status).toBe(302);
 		expect(res.headers.get('location')).toBe('/?auth_error=session_expired');
-		expect(loggedEvents(spy).some((line) => line.includes('oidc_txn_cookie_invalid'))).toBe(true);
-		spy.mockRestore();
+		expect(loggedEvents().some((line) => line.includes('oidc_txn_cookie_invalid'))).toBe(true);
+	});
+
+	it('does not log an expired transaction cookie — a stale redirect is routine', async () => {
+		const { routes } = createOidcAuth(BASE_CONFIG);
+		const expiredTxn = await signSession({
+			typ: 'mh-oidc-txn+jwt',
+			expirationTime: Math.floor(Date.now() / 1000) - 60,
+		});
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=xyz', {
+			headers: { cookie: `${TXN_COOKIE}=${expiredTxn}` },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/?auth_error=session_expired');
+		expect(loggedEvents()).toEqual([]);
 	});
 
 	it('does not log a merely missing transaction cookie', async () => {
-		const spy = spyOnOperationalLog();
 		const { routes } = createOidcAuth(BASE_CONFIG);
 
 		const res = await routes.request('/api/auth/callback?code=abc&state=xyz');
 
 		expect(res.status).toBe(302);
-		expect(loggedEvents(spy)).toEqual([]);
-		spy.mockRestore();
+		expect(loggedEvents()).toEqual([]);
+	});
+
+	it('does not log a user declining consent at the IdP', async () => {
+		const { routes } = createOidcAuth(BASE_CONFIG);
+		const txnCookie = await beginOidcTransaction(routes);
+		oauthMock.validateAuthResponse.mockImplementation(() => {
+			throw Object.assign(new Error('authorization response error'), {
+				name: 'AuthorizationResponseError',
+				error: 'access_denied',
+			});
+		});
+
+		const res = await routes.request('/api/auth/callback?error=access_denied&state=state-1', {
+			headers: { cookie: txnCookie },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toContain('auth_error=auth_failed');
+		expect(loggedEvents()).toEqual([]);
+	});
+
+	it('still logs a genuine token-exchange failure', async () => {
+		const { routes } = createOidcAuth(BASE_CONFIG);
+		const txnCookie = await beginOidcTransaction(routes);
+		oauthMock.validateAuthResponse.mockImplementation(() => {
+			throw new Error('exchange blew up');
+		});
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txnCookie },
+		});
+
+		expect(res.status).toBe(302);
+		expect(loggedEvents().some((line) => line.includes('oidc_callback_exchange_failed'))).toBe(
+			true,
+		);
 	});
 });

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -1918,3 +1918,62 @@ describe('OIDC login discovery failure', () => {
 		expect(res.headers.get('location')).toBe('/signed-out');
 	});
 });
+
+describe('operational logging for swallowed verification failures', () => {
+	function spyOnOperationalLog() {
+		return vi.spyOn(console, 'error').mockImplementation(() => {});
+	}
+	const loggedEvents = (spy: ReturnType<typeof spyOnOperationalLog>) =>
+		spy.mock.calls.map(([line]) => String(line)).filter((line) => line.includes('oidc_'));
+
+	it('logs a session cookie that fails verification, without echoing the token', async () => {
+		const spy = spyOnOperationalLog();
+		const forged = await signSession({ sub: 'user-1', email: 'a@b.co', secret: 'x'.repeat(32) });
+
+		await expect(makeAuthenticator().authenticate(requestWithCookie(forged))).resolves.toBeNull();
+
+		const lines = loggedEvents(spy);
+		expect(lines.some((line) => line.includes('oidc_session_verify_failed'))).toBe(true);
+		expect(lines.some((line) => line.includes(forged))).toBe(false);
+		spy.mockRestore();
+	});
+
+	it('does not log routine session expiry', async () => {
+		const spy = spyOnOperationalLog();
+		const expired = await signSession({
+			sub: 'user-1',
+			email: 'a@b.co',
+			expirationTime: Math.floor(Date.now() / 1000) - 60,
+		});
+
+		await expect(makeAuthenticator().authenticate(requestWithCookie(expired))).resolves.toBeNull();
+
+		expect(loggedEvents(spy)).toEqual([]);
+		spy.mockRestore();
+	});
+
+	it('logs an unverifiable transaction cookie on the callback path', async () => {
+		const spy = spyOnOperationalLog();
+		const { routes } = createOidcAuth(BASE_CONFIG);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=xyz', {
+			headers: { cookie: `${TXN_COOKIE}=garbage` },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/?auth_error=session_expired');
+		expect(loggedEvents(spy).some((line) => line.includes('oidc_txn_cookie_invalid'))).toBe(true);
+		spy.mockRestore();
+	});
+
+	it('does not log a merely missing transaction cookie', async () => {
+		const spy = spyOnOperationalLog();
+		const { routes } = createOidcAuth(BASE_CONFIG);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=xyz');
+
+		expect(res.status).toBe(302);
+		expect(loggedEvents(spy)).toEqual([]);
+		spy.mockRestore();
+	});
+});

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -608,7 +608,12 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 			// the redirect below must hold even if the sanitizer or signing changes.
 			returnTo = sanitizeReturnTo(typeof payload.returnTo === 'string' ? payload.returnTo : null);
 		} catch (err) {
-			logOperationalError('oidc_txn_cookie_invalid', {}, err);
+			// The transaction cookie lives ~10 minutes; expiry (a stale redirect or
+			// slow IdP round-trip) is routine. Log only genuine signature/claim
+			// failures, mirroring the session-verify path above.
+			if ((err as { code?: string }).code !== 'ERR_JWT_EXPIRED') {
+				logOperationalError('oidc_txn_cookie_invalid', {}, err);
+			}
 			return callbackError(c, 'session_expired');
 		}
 
@@ -640,7 +645,17 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 				if (userInfo.sub !== claims.sub) throw new Error('userinfo subject mismatch');
 			}
 		} catch (err) {
-			logOperationalError('oidc_callback_exchange_failed', {}, err);
+			// A user declining consent at the IdP arrives as `error=access_denied` —
+			// a normal outcome, not an operational failure. Duck-typed (name, not
+			// instanceof) so the check holds even if the oauth4webapi class identity
+			// differs across bundling or test mocks.
+			const declined =
+				err instanceof Error &&
+				err.name === 'AuthorizationResponseError' &&
+				(err as { error?: string }).error === 'access_denied';
+			if (!declined) {
+				logOperationalError('oidc_callback_exchange_failed', {}, err);
+			}
 			return callbackError(c, 'auth_failed', returnTo);
 		}
 

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -20,7 +20,7 @@ import type { Context } from 'hono';
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
 import { jwtVerify, SignJWT } from 'jose';
 import * as oauth from 'oauth4webapi';
-import { ASSIGNABLE_ROLES, AUTH_ENTITLEMENTS, UserId } from '@marimo-hub/core';
+import { ASSIGNABLE_ROLES, AUTH_ENTITLEMENTS, logOperationalError, UserId } from '@marimo-hub/core';
 import type { AssignableRole, AuthEntitlement, Authenticator, AuthUser } from '@marimo-hub/core';
 
 export type EmailVerificationPolicy = 'required' | 'trusted-issuer';
@@ -544,7 +544,8 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		let url: URL | undefined;
 		try {
 			url = discoveredEndpoint(as, 'authorization_endpoint');
-		} catch {
+		} catch (err) {
+			logOperationalError('oidc_authorization_endpoint_invalid', {}, err);
 			return c.json(
 				{
 					success: false,
@@ -632,7 +633,8 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 				userInfo = await oauth.processUserInfoResponse(as, client, claims.sub, userInfoResponse);
 				if (userInfo.sub !== claims.sub) throw new Error('userinfo subject mismatch');
 			}
-		} catch {
+		} catch (err) {
+			logOperationalError('oidc_callback_exchange_failed', {}, err);
 			return callbackError(c, 'auth_failed', returnTo);
 		}
 
@@ -664,7 +666,8 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 			let groups: string[];
 			try {
 				groups = parseGroups(rawGroups, maxGroups) ?? [];
-			} catch {
+			} catch (err) {
+				logOperationalError('oidc_group_claim_invalid', {}, err);
 				return callbackError(c, 'auth_failed', returnTo);
 			}
 			if (
@@ -687,7 +690,8 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 				...(pictureUrl ? { pictureUrl } : {}),
 				...(config.groups ? { entitlements: entitlements ?? [] } : {}),
 			});
-		} catch {
+		} catch (err) {
+			logOperationalError('oidc_session_signing_failed', {}, err);
 			return callbackError(c, 'auth_failed', returnTo);
 		}
 		setCookie(c, SESSION_COOKIE, session, {
@@ -707,7 +711,8 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		let url: URL | undefined;
 		try {
 			url = discoveredEndpoint(as, 'end_session_endpoint');
-		} catch {
+		} catch (err) {
+			logOperationalError('oidc_end_session_endpoint_invalid', {}, err);
 			return c.redirect(postLoginRedirect);
 		}
 		if (url) {

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -475,7 +475,12 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 					...(entitlements?.length ? { entitlements } : {}),
 					...(entitlementsExpiresAt ? { entitlementsExpiresAt } : {}),
 				};
-			} catch {
+			} catch (err) {
+				// Expired sessions are routine (every request until re-auth); anything
+				// else — bad signature, malformed claims — is worth an operator trail.
+				if ((err as { code?: string }).code !== 'ERR_JWT_EXPIRED') {
+					logOperationalError('oidc_session_verify_failed', {}, err);
+				}
 				return null;
 			}
 		},
@@ -602,7 +607,8 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 			// Re-sanitize on the way out (defense in depth): the cookie is signed, but
 			// the redirect below must hold even if the sanitizer or signing changes.
 			returnTo = sanitizeReturnTo(typeof payload.returnTo === 'string' ? payload.returnTo : null);
-		} catch {
+		} catch (err) {
+			logOperationalError('oidc_txn_cookie_invalid', {}, err);
 			return callbackError(c, 'session_expired');
 		}
 

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -100,15 +100,29 @@ describe('apiData', () => {
 		expect(new Headers(init?.headers).get('content-type')).toBeNull();
 	});
 
-	it('throws ApiRequestError with the server code/message on { success: false }', async () => {
+	it('throws ApiRequestError with server error metadata on { success: false }', async () => {
 		stubFetch(async () =>
-			jsonResponse({ success: false, error: { code: 'FORBIDDEN', message: 'nope' } }, 403),
+			jsonResponse(
+				{
+					success: false,
+					error: {
+						code: 'FORBIDDEN',
+						message: 'nope',
+						request_id: 'req-123',
+						details: [{ field: 'role', message: 'Insufficient role' }],
+					},
+				},
+				403,
+			),
 		);
 
 		await expect(apiData(apiClient.GET('/api/v1/me'))).rejects.toMatchObject({
 			name: 'ApiRequestError',
 			code: 'FORBIDDEN',
 			message: 'nope',
+			status: 403,
+			requestId: 'req-123',
+			details: [{ field: 'role', message: 'Insufficient role' }],
 		});
 	});
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -52,6 +52,35 @@ export type ApiError = components['schemas']['ErrorResponse']['error'];
 export type ServerErrorCode = ApiError['code'];
 export type ApiRequestErrorCode = ServerErrorCode | 'NETWORK_ERROR' | 'PARSE_ERROR' | 'UNKNOWN';
 
+// A `satisfies Record<ServerErrorCode, true>` map, not a cast: a server can
+// emit codes this client build doesn't know (deploy skew), and the compiler
+// forces this list back in sync whenever the generated union grows.
+const KNOWN_SERVER_ERROR_CODES = {
+	BAD_REQUEST: true,
+	UNAUTHORIZED: true,
+	FORBIDDEN: true,
+	NOT_FOUND: true,
+	CONFLICT: true,
+	EDIT_SESSION_OWNED: true,
+	EDIT_SESSION_CHANGED: true,
+	TAKEOVER_IN_PROGRESS: true,
+	GONE: true,
+	PRECONDITION_FAILED: true,
+	PAYLOAD_TOO_LARGE: true,
+	VALIDATION_ERROR: true,
+	RESOURCE_EXHAUSTED: true,
+	NOT_INITIALIZED: true,
+	NO_HTML_SNAPSHOT: true,
+	SERVICE_UNAVAILABLE: true,
+	INTERNAL_ERROR: true,
+} satisfies Record<ServerErrorCode, true>;
+
+function knownServerErrorCode(value: unknown): ApiRequestErrorCode {
+	return typeof value === 'string' && Object.hasOwn(KNOWN_SERVER_ERROR_CODES, value)
+		? (value as ServerErrorCode)
+		: 'UNKNOWN';
+}
+
 export interface ApiResponse<T> {
 	success: boolean;
 	data?: T;
@@ -176,7 +205,7 @@ function unwrapEnvelope<T>(value: T, status: number): ApiData<T> {
 				)
 			: undefined;
 		throw new ApiRequestError(
-			typeof error?.code === 'string' ? (error.code as ServerErrorCode) : 'UNKNOWN',
+			knownServerErrorCode(error?.code),
 			typeof error?.message === 'string' ? error.message : 'Request failed',
 			{
 				status,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -48,10 +48,9 @@ export type AdminUser = components['schemas']['AdminUser'];
 /** Redacted deployment configuration from the super-admin `GET /api/v1/admin/config`. */
 export type DeploymentConfig = components['schemas']['DeploymentConfig'];
 
-export interface ApiError {
-	code: string;
-	message: string;
-}
+export type ApiError = components['schemas']['ErrorResponse']['error'];
+export type ServerErrorCode = ApiError['code'];
+export type ApiRequestErrorCode = ServerErrorCode | 'NETWORK_ERROR' | 'PARSE_ERROR' | 'UNKNOWN';
 
 export interface ApiResponse<T> {
 	success: boolean;
@@ -60,12 +59,22 @@ export interface ApiResponse<T> {
 }
 
 export class ApiRequestError extends Error {
-	code: string;
+	readonly code: ApiRequestErrorCode;
+	readonly status?: number;
+	readonly requestId?: string;
+	readonly details?: ApiError['details'];
 
-	constructor(code: string, message: string) {
+	constructor(
+		code: ApiRequestErrorCode,
+		message: string,
+		options: { status?: number; requestId?: string; details?: ApiError['details'] } = {},
+	) {
 		super(message);
 		this.name = 'ApiRequestError';
 		this.code = code;
+		this.status = options.status;
+		this.requestId = options.requestId;
+		this.details = options.details;
 	}
 }
 
@@ -148,7 +157,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function malformedResponse(status?: number): ApiRequestError {
 	const detail = status === undefined ? '' : `Server returned ${status} with a `;
-	return new ApiRequestError('PARSE_ERROR', `${detail}malformed response envelope`);
+	return new ApiRequestError('PARSE_ERROR', `${detail}malformed response envelope`, { status });
 }
 
 function unwrapEnvelope<T>(value: T, status: number): ApiData<T> {
@@ -158,9 +167,22 @@ function unwrapEnvelope<T>(value: T, status: number): ApiData<T> {
 
 	if (!value.success) {
 		const error = isRecord(value.error) ? value.error : undefined;
+		const details = Array.isArray(error?.details)
+			? error.details.filter(
+					(detail): detail is { field: string; message: string } =>
+						isRecord(detail) &&
+						typeof detail.field === 'string' &&
+						typeof detail.message === 'string',
+				)
+			: undefined;
 		throw new ApiRequestError(
-			typeof error?.code === 'string' ? error.code : 'UNKNOWN',
+			typeof error?.code === 'string' ? (error.code as ServerErrorCode) : 'UNKNOWN',
 			typeof error?.message === 'string' ? error.message : 'Request failed',
+			{
+				status,
+				requestId: typeof error?.request_id === 'string' ? error.request_id : undefined,
+				details,
+			},
 		);
 	}
 
@@ -199,4 +221,21 @@ export async function apiDataWithResponse<T>(
 /** Unwrap the API envelope and normalize API, transport, and parse failures. */
 export async function apiData<T>(request: Promise<FetchResult<T>>): Promise<ApiData<T>> {
 	return (await apiDataWithResponse(request)).data;
+}
+
+export async function apiErrorFromResponse(
+	response: Response,
+	fallbackMessage: string,
+): Promise<ApiRequestError> {
+	try {
+		const body: unknown = await response.clone().json();
+		try {
+			unwrapEnvelope(body, response.status);
+		} catch (err) {
+			if (err instanceof ApiRequestError) return err;
+		}
+	} catch {
+		// Raw-content endpoints and intermediaries may return non-JSON error bodies.
+	}
+	return new ApiRequestError('UNKNOWN', fallbackMessage, { status: response.status });
 }

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -205,8 +205,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -278,8 +296,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -358,8 +394,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -441,8 +495,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -540,8 +612,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -617,8 +707,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -717,8 +825,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -822,8 +948,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -904,8 +1048,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1001,8 +1163,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1096,8 +1276,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1177,8 +1375,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1258,8 +1474,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1350,8 +1584,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1454,8 +1706,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1587,8 +1857,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1686,8 +1974,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1823,8 +2129,35 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Conflict */
+				409: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1900,8 +2233,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -1984,8 +2335,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2080,6 +2449,15 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Conflict */
+				409: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Precondition failed (If-Match did not match the current version) */
 				412: {
 					headers: {
@@ -2089,8 +2467,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2166,8 +2562,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2259,8 +2673,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2344,8 +2776,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2424,8 +2874,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2505,8 +2973,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2598,8 +3084,35 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Conflict */
+				409: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2697,8 +3210,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2787,8 +3318,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2869,8 +3418,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -2943,8 +3510,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3030,8 +3615,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3140,8 +3743,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3258,6 +3879,15 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
 					headers: {
@@ -3272,6 +3902,15 @@ export interface paths {
 					headers: {
 						/** @description Seconds to wait before retrying. */
 						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
 						[name: string]: unknown;
 					};
 					content: {
@@ -3360,8 +3999,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3427,8 +4084,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3528,8 +4203,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3624,8 +4317,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3714,8 +4425,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3798,8 +4527,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3899,8 +4646,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3995,8 +4760,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -4090,8 +4873,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -4183,6 +4984,15 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
 					headers: {
@@ -4197,6 +5007,15 @@ export interface paths {
 					headers: {
 						/** @description Seconds to wait before retrying. */
 						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
 						[name: string]: unknown;
 					};
 					content: {
@@ -4291,8 +5110,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -4376,8 +5213,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -4465,8 +5320,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -4548,8 +5421,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -4648,8 +5539,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -4743,8 +5652,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -4836,6 +5763,15 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
 					headers: {
@@ -4850,6 +5786,15 @@ export interface paths {
 					headers: {
 						/** @description Seconds to wait before retrying. */
 						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
 						[name: string]: unknown;
 					};
 					content: {
@@ -5056,8 +6001,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -5135,6 +6098,15 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
 					headers: {
@@ -5149,6 +6121,15 @@ export interface paths {
 					headers: {
 						/** @description Seconds to wait before retrying. */
 						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
 						[name: string]: unknown;
 					};
 					content: {
@@ -5235,8 +6216,26 @@ export interface paths {
 						'application/json': components['schemas']['ErrorResponse'];
 					};
 				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
 				/** @description Validation error */
 				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -5282,20 +6281,28 @@ export interface components {
 				/** @enum {string} */
 				code:
 					| 'BAD_REQUEST'
-					| 'UNAUTHORIZED'
-					| 'FORBIDDEN'
+					| 'PRECONDITION_FAILED'
 					| 'NOT_FOUND'
 					| 'CONFLICT'
-					| 'GONE'
-					| 'PRECONDITION_FAILED'
-					| 'PAYLOAD_TOO_LARGE'
+					| 'EDIT_SESSION_OWNED'
+					| 'EDIT_SESSION_CHANGED'
+					| 'TAKEOVER_IN_PROGRESS'
+					| 'FORBIDDEN'
 					| 'VALIDATION_ERROR'
-					| 'RESOURCE_EXHAUSTED'
 					| 'NOT_INITIALIZED'
-					| 'NO_HTML_SNAPSHOT'
 					| 'SERVICE_UNAVAILABLE'
+					| 'RESOURCE_EXHAUSTED'
+					| 'UNAUTHORIZED'
+					| 'GONE'
+					| 'PAYLOAD_TOO_LARGE'
+					| 'NO_HTML_SNAPSHOT'
 					| 'INTERNAL_ERROR';
 				message: string;
+				/** @description Field-level validation failures. */
+				details?: {
+					field: string;
+					message: string;
+				}[];
 				request_id?: string;
 			};
 		};

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -77,9 +77,19 @@ describe('CloudflareSandboxProvider', () => {
 		});
 
 		it('surfaces success:false from the SDK exec result', async () => {
-			fakeSandbox.exec.mockResolvedValueOnce({ success: false, stdout: '', stderr: 'boom' });
+			fakeSandbox.exec.mockResolvedValueOnce({
+				success: false,
+				stdout: '',
+				stderr: 'boom',
+				error: { code: 'COMMAND_FAILED' },
+			});
 			const res = await makeProvider().create(SANDBOX_ID).exec('bad');
-			expect(res).toEqual({ success: false, stdout: '', stderr: 'boom' });
+			expect(res).toEqual({
+				success: false,
+				stdout: '',
+				stderr: 'boom',
+				error: { code: 'COMMAND_FAILED' },
+			});
 		});
 	});
 

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { SandboxId } from '@marimo-hub/core';
+import { listFilesFailure } from '@marimo-hub/core/ports';
 
 /**
  * Tests for the Cloudflare Containers compute adapter.
@@ -215,6 +216,10 @@ describe('CloudflareSandboxProvider', () => {
 	});
 
 	describe('instance.mountBucket()', () => {
+		it('advertises supportsBucketMount: true so mount failures are not hidden', () => {
+			expect(makeProvider().create(SANDBOX_ID).supportsBucketMount).toBe(true);
+		});
+
 		it('reshapes the options object into positional (name, path, {endpoint,prefix,credentials})', async () => {
 			// The single most error-prone line in the adapter: object → positional args.
 			fakeSandbox.mountBucket.mockResolvedValueOnce(undefined);
@@ -300,6 +305,12 @@ describe('CloudflareSandboxProvider', () => {
 	});
 
 	describe('instance.listFiles()', () => {
+		it('translates a vendor failure into the typed failure envelope', async () => {
+			fakeSandbox.listFiles.mockResolvedValueOnce({ success: false, files: [] });
+			const res = await makeProvider().create(SANDBOX_ID).listFiles('/w');
+			expect(res).toEqual(listFilesFailure());
+		});
+
 		it('projects each FileInfo field and forwards the options', async () => {
 			fakeSandbox.listFiles.mockResolvedValueOnce({
 				success: true,

--- a/packages/compute-cloudflare/src/index.ts
+++ b/packages/compute-cloudflare/src/index.ts
@@ -25,6 +25,7 @@ import type {
 	SetEnvVarsOptions,
 	StartProcessOptions,
 } from '@marimo-hub/core/ports';
+import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SandboxType = Sandbox<any>;
@@ -61,6 +62,7 @@ async function waitForTunnelReady(url: string): Promise<void> {
 }
 
 class CloudflareSandboxInstance implements SandboxInstance {
+	readonly supportsBucketMount = true;
 	private sandbox: SandboxType;
 	private useTunnel: boolean;
 	private envDefaults: Record<string, string> = {};
@@ -72,7 +74,7 @@ class CloudflareSandboxInstance implements SandboxInstance {
 
 	async exec(cmd: string): Promise<ExecResult> {
 		const res = await this.sandbox.exec(this.withDefaults(cmd));
-		return { success: res.success, stdout: res.stdout, stderr: res.stderr };
+		return execResult(res.success, res.stdout, res.stderr);
 	}
 
 	async execStream(cmd: string, options?: ExecStreamOptions): Promise<ReadableStream> {
@@ -83,13 +85,16 @@ class CloudflareSandboxInstance implements SandboxInstance {
 
 	async readFile(path: string): Promise<ReadFileResult> {
 		const res = await this.sandbox.readFile(path);
-		return { success: res.success, content: res.content, encoding: res.encoding };
+		return res.success
+			? { success: true, content: res.content, encoding: res.encoding }
+			: readFileFailure('READ_FAILED');
 	}
 
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {
 		const res = await this.sandbox.listFiles(path, options);
+		if (!res.success) return listFilesFailure();
 		return {
-			success: res.success,
+			success: true,
 			files: res.files.map((f) => ({
 				name: f.name,
 				absolutePath: f.absolutePath,

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { SandboxId } from '@marimo-hub/core';
+import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectListFilesResult } from '@marimo-hub/core/testing';
 import { computeContract } from '@marimo-hub/core/testing/compute-contract';
 import { DockerCompute, spawnDockerRunner } from './docker';
@@ -133,7 +134,11 @@ describe('DockerCompute', () => {
 		});
 		const res = await new DockerCompute({}, runner).create(SANDBOX_ID).readFile('/missing.py');
 
-		expect(res).toEqual({ success: false, content: '' });
+		expect(res).toEqual({
+			success: false,
+			content: '',
+			error: { code: 'READ_FAILED' },
+		});
 	});
 
 	it('execStream exposes stdout as a readable stream', async () => {
@@ -455,7 +460,7 @@ describe('DockerCompute', () => {
 			const { runner } = fakeRunner(onlyFind('', 1));
 			await expect(
 				new DockerCompute({}, runner).create(SANDBOX_ID).listFiles('/workspace'),
-			).resolves.toEqual({ success: false, files: [] });
+			).resolves.toEqual(listFilesFailure());
 		});
 	});
 

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -36,6 +36,7 @@ import type {
 	SetEnvVarsOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
+import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
 
 /** marimo's kernel port (matches SandboxProvisioner's MARIMO_PORT). */
 const KERNEL_PORT = 2718;
@@ -106,6 +107,7 @@ export function containerResourceArgs(resources: ComputeResources = {}): string[
 let procSeq = 0;
 
 class ContainerSandboxInstance implements SandboxInstance {
+	readonly supportsBucketMount = false;
 	private readonly name: string;
 	private env: Record<string, string> = {};
 	private envDefaults: Record<string, string> = {};
@@ -166,7 +168,7 @@ class ContainerSandboxInstance implements SandboxInstance {
 
 	async exec(cmd: string): Promise<ExecResult> {
 		const res = await this.dexec(cmd);
-		return { success: res.exitCode === 0, stdout: res.stdout, stderr: res.stderr };
+		return execResult(res.exitCode === 0, res.stdout, res.stderr);
 	}
 
 	async execStream(cmd: string, _options?: ExecStreamOptions): Promise<ReadableStream> {
@@ -182,13 +184,13 @@ class ContainerSandboxInstance implements SandboxInstance {
 
 	async readFile(path: string): Promise<ReadFileResult> {
 		const res = await this.dexec(`cat ${shellQuote(path)}`);
-		if (res.exitCode !== 0) return { success: false, content: '' };
+		if (res.exitCode !== 0) return readFileFailure('READ_FAILED');
 		return { success: true, content: res.stdout, encoding: 'utf-8' };
 	}
 
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {
 		const res = await this.dexec(buildFindFilesCommand(path, options));
-		if (res.exitCode !== 0) return { success: false, files: [] };
+		if (res.exitCode !== 0) return listFilesFailure();
 		return { success: true, files: parseFindFilesOutput(res.stdout, path, options) };
 	}
 

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -3,6 +3,7 @@ import { CWSandboxNotFoundError } from '@coreweave/cwsandbox';
 import type { SandboxInfo } from '@coreweave/cwsandbox';
 import type { SandboxId, SandboxProvider } from '@marimo-hub/core';
 import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
 import { coreWeaveProfileResources, CoreWeaveCompute, portWaitCommand } from './index';
 import type { CoreWeaveClient, CoreWeaveConfig } from './index';
@@ -703,7 +704,7 @@ describe('CoreWeaveCompute', () => {
 		it('returns success:false when the find command fails', async () => {
 			const world = makeWorld(onlyFind('', 1));
 			const res = await makeCompute(world).create(SANDBOX_ID).listFiles('/workspace');
-			expect(res).toEqual({ success: false, files: [] });
+			expect(res).toEqual(listFilesFailure());
 		});
 	});
 

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -83,6 +83,7 @@ import type {
 	StartProcessOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
+import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
 
 /** marimo's hardcoded kernel port (see `SandboxProvisioner`'s `MARIMO_PORT`). */
 const DEFAULT_KERNEL_PORT = 2718;
@@ -287,6 +288,7 @@ function isDeadStatus(status: SandboxInfo['status']): boolean {
 let PROC_SEQ = 0;
 
 class CoreWeaveSandboxInstance implements SandboxInstance {
+	readonly supportsBucketMount = false;
 	private readonly idTag: string;
 	private readonly kernelPort: number;
 	private sandbox?: CoreWeaveSandbox;
@@ -479,7 +481,7 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		const sandbox = await this.ensure();
 		this.execCount++;
 		const res = await sandbox.commands.run(['sh', '-lc', this.withEnv(cmd)]);
-		return { success: res.exitCode === 0, stdout: res.stdout, stderr: res.stderr };
+		return execResult(res.exitCode === 0, res.stdout, res.stderr);
 	}
 
 	async execStream(cmd: string, _options?: ExecStreamOptions): Promise<ReadableStream> {
@@ -494,7 +496,7 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 			const content = await sandbox.files.readText(path);
 			return { success: true, content, encoding: 'utf-8' };
 		} catch {
-			return { success: false, content: '' };
+			return readFileFailure('READ_FAILED');
 		}
 	}
 
@@ -525,10 +527,10 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		// PERSIST_WORKSPACE=workspace.
 		try {
 			const res = await this.exec(buildFindFilesCommand(path, options));
-			if (!res.success) return { success: false, files: [] };
+			if (!res.success) return listFilesFailure();
 			return { success: true, files: parseFindFilesOutput(res.stdout, path, options) };
 		} catch {
-			return { success: false, files: [] };
+			return listFilesFailure('BACKEND_ERROR');
 		}
 	}
 

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Seconds } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
+import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectListFilesResult } from '@marimo-hub/core/testing';
 import { computeContract } from '@marimo-hub/core/testing/compute-contract';
 import { createE2bClient, E2bCompute } from './index';
@@ -254,7 +255,11 @@ describe('E2bCompute', () => {
 			.create(SANDBOX_ID)
 			.readFile('/missing.py');
 
-		expect(res).toEqual({ success: false, content: '' });
+		expect(res).toEqual({
+			success: false,
+			content: '',
+			error: { code: 'READ_FAILED' },
+		});
 	});
 
 	it('exec reports success:false on a non-zero command result', async () => {
@@ -264,6 +269,7 @@ describe('E2bCompute', () => {
 			success: false,
 			stdout: '',
 			stderr: 'fatal',
+			error: { code: 'COMMAND_FAILED' },
 		});
 	});
 
@@ -381,7 +387,7 @@ describe('E2bCompute', () => {
 			});
 			await expect(
 				new E2bCompute(baseConfig, fake).create(SANDBOX_ID).listFiles('/workspace'),
-			).resolves.toEqual({ success: false, files: [] });
+			).resolves.toEqual(listFilesFailure());
 		});
 	});
 

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -45,6 +45,7 @@ import type {
 	StartProcessOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
+import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
 
 /** Sandbox metadata key carrying OUR SandboxId (E2B assigns its own ids). */
 const ID_META_KEY = 'mh-sandbox-id';
@@ -134,6 +135,7 @@ export interface E2bConfig {
 }
 
 class E2bSandboxInstance implements SandboxInstance {
+	readonly supportsBucketMount = false;
 	private handle?: E2bSandboxHandle;
 	private env: Record<string, string> = {};
 	private envDefaults: Record<string, string> = {};
@@ -169,7 +171,7 @@ class E2bSandboxInstance implements SandboxInstance {
 		// Forced vars ride the SDK's per-command `envs`; defaults can't (that channel
 		// always overwrites), so they go in as a guarded shell prefix instead.
 		const res = await sb.commands.run(this.withDefaults(cmd), { envs: this.env });
-		return { success: res.exitCode === 0, stdout: res.stdout, stderr: res.stderr };
+		return execResult(res.exitCode === 0, res.stdout, res.stderr);
 	}
 
 	async execStream(cmd: string, _options?: ExecStreamOptions): Promise<ReadableStream> {
@@ -188,7 +190,7 @@ class E2bSandboxInstance implements SandboxInstance {
 			const content = await sb.files.read(path);
 			return { success: true, content, encoding: 'utf-8' };
 		} catch {
-			return { success: false, content: '' };
+			return readFileFailure('READ_FAILED');
 		}
 	}
 
@@ -196,7 +198,7 @@ class E2bSandboxInstance implements SandboxInstance {
 		// The SDK filesystem API has no recursive list shape we rely on; shell out
 		// via `find` (not on the provision/teardown hot path).
 		const res = await this.exec(buildFindFilesCommand(path, options));
-		if (!res.success) return { success: false, files: [] };
+		if (!res.success) return listFilesFailure();
 		return { success: true, files: parseFindFilesOutput(res.stdout, path, options) };
 	}
 

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Millis } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
+import { listFilesFailure } from '@marimo-hub/core/ports';
 import { computeContract } from '@marimo-hub/core/testing/compute-contract';
 import {
 	expectExecResult,
@@ -362,19 +363,17 @@ describe('KubernetesCompute', () => {
 				execImpl: (cmd) =>
 					cmd[2].includes('find') ? { stdout: '', stderr: 'missing', exitCode: 1 } : undefined,
 			});
-			await expect(makeCompute(world).create(SANDBOX_ID).listFiles('/workspace')).resolves.toEqual({
-				success: false,
-				files: [],
-			});
+			await expect(makeCompute(world).create(SANDBOX_ID).listFiles('/workspace')).resolves.toEqual(
+				listFilesFailure(),
+			);
 		});
 
 		it('returns success:false when ensure or exec throws', async () => {
 			const world = makeWorld({ phase: 'Failed' });
 
-			await expect(makeCompute(world).create(SANDBOX_ID).listFiles('/workspace')).resolves.toEqual({
-				success: false,
-				files: [],
-			});
+			await expect(makeCompute(world).create(SANDBOX_ID).listFiles('/workspace')).resolves.toEqual(
+				listFilesFailure('BACKEND_ERROR'),
+			);
 		});
 	});
 

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -258,7 +258,11 @@ describe('KubernetesCompute', () => {
 			});
 			const res = await makeCompute(world).create(SANDBOX_ID).readFile('/workspace/missing.py');
 
-			expect(res).toEqual({ success: false, content: '' });
+			expect(res).toEqual({
+				success: false,
+				content: '',
+				error: { code: 'READ_FAILED' },
+			});
 		});
 
 		it('writeFile streams a large file via stdin, never into the exec argv (ARG_MAX)', async () => {

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -53,6 +53,7 @@ import { Millis } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
 import { createK8sClient } from './client';
 import type { K8sClient, KubernetesConfig } from './shared';
+import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
 export * from './shared';
 import type {
 	ActiveSandbox,
@@ -112,6 +113,7 @@ export function resourceName(id: SandboxId): string {
 let PROC_SEQ = 0;
 
 class KubernetesSandboxInstance implements SandboxInstance {
+	readonly supportsBucketMount = false;
 	private readonly name: string;
 	private readonly namespace: string;
 	private readonly image: string;
@@ -211,7 +213,7 @@ class KubernetesSandboxInstance implements SandboxInstance {
 	async exec(cmd: string): Promise<ExecResult> {
 		await this.ensure();
 		const res = await this.client.exec(this.name, ['sh', '-lc', this.withEnv(cmd)]);
-		return { success: res.exitCode === 0, stdout: res.stdout, stderr: res.stderr };
+		return execResult(res.exitCode === 0, res.stdout, res.stderr);
 	}
 
 	async execStream(cmd: string, _options?: ExecStreamOptions): Promise<ReadableStream> {
@@ -231,10 +233,10 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		try {
 			await this.ensure();
 			const res = await this.client.exec(this.name, ['sh', '-lc', `cat -- ${shellQuote(path)}`]);
-			if (res.exitCode !== 0) return { success: false, content: '' };
+			if (res.exitCode !== 0) return readFileFailure('READ_FAILED');
 			return { success: true, content: res.stdout, encoding: 'utf-8' };
 		} catch {
-			return { success: false, content: '' };
+			return readFileFailure('BACKEND_ERROR');
 		}
 	}
 
@@ -259,10 +261,10 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		// on teardown to enumerate the working dir under PERSIST_WORKSPACE=workspace.
 		try {
 			const res = await this.exec(buildFindFilesCommand(path, options));
-			if (!res.success) return { success: false, files: [] };
+			if (!res.success) return listFilesFailure();
 			return { success: true, files: parseFindFilesOutput(res.stdout, path, options) };
 		} catch {
-			return { success: false, files: [] };
+			return listFilesFailure('BACKEND_ERROR');
 		}
 	}
 

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { SandboxId } from '@marimo-hub/core';
 import { afterEach, describe, expect, it } from 'vitest';
+import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectFileResult } from '@marimo-hub/core/testing';
 import { LocalCompute, prepareMarimoCommand, rewriteWorkspace } from './index';
 
@@ -162,7 +163,7 @@ describe('LocalCompute file ops', () => {
 
 	it('returns success:false listing a missing directory', async () => {
 		const sb = newSandbox();
-		expect(await sb.listFiles('/workspace/does-not-exist')).toEqual({ success: false, files: [] });
+		expect(await sb.listFiles('/workspace/does-not-exist')).toEqual(listFilesFailure());
 	});
 
 	it('gitCheckout throws when the clone fails', async () => {

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -135,10 +135,10 @@ describe('LocalCompute file ops', () => {
 		expect(list.files.map((f) => f.name)).toContain('notebook.py');
 	});
 
-	it('returns success:false reading a missing file', async () => {
+	it('returns NOT_FOUND reading a missing file', async () => {
 		const sb = newSandbox();
 		const read = await sb.readFile('/workspace/nope.py');
-		expectFileResult(read, { success: false });
+		expectFileResult(read, { success: false, error: { code: 'NOT_FOUND' } });
 	});
 
 	it('rejects mountBucket so the provisioner falls back to copy', async () => {

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -52,6 +52,7 @@ import type {
 	StartProcessOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
+import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
 
 const WORKSPACE = '/workspace';
 
@@ -184,6 +185,7 @@ export interface LocalComputeOptions {
 }
 
 class LocalSandboxInstance implements SandboxInstance {
+	readonly supportsBucketMount = false;
 	private readonly root: string;
 	private readonly host: string;
 	private readonly bindHost: string;
@@ -254,8 +256,10 @@ class LocalSandboxInstance implements SandboxInstance {
 			let stderr = '';
 			child.stdout?.on('data', (d) => (stdout += d.toString()));
 			child.stderr?.on('data', (d) => (stderr += d.toString()));
-			child.on('error', (err) => resolve({ success: false, stdout, stderr: stderr + String(err) }));
-			child.on('close', (code) => resolve({ success: code === 0, stdout, stderr }));
+			child.on('error', (err) =>
+				resolve(execResult(false, stdout, stderr + String(err), 'SPAWN_FAILED')),
+			);
+			child.on('close', (code) => resolve(execResult(code === 0, stdout, stderr)));
 		});
 	}
 
@@ -269,8 +273,9 @@ class LocalSandboxInstance implements SandboxInstance {
 		try {
 			const content = await readFile(this.mapPath(p), 'utf-8');
 			return { success: true, content, encoding: 'utf-8' };
-		} catch {
-			return { success: false, content: '' };
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			return readFileFailure(code === 'ENOENT' || code === 'ENOTDIR' ? 'NOT_FOUND' : 'READ_FAILED');
 		}
 	}
 
@@ -304,7 +309,7 @@ class LocalSandboxInstance implements SandboxInstance {
 			}
 			return { success: true, files };
 		} catch {
-			return { success: false, files: [] };
+			return listFilesFailure();
 		}
 	}
 

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { NotFoundError } from 'modal';
 import type { SandboxId } from '@marimo-hub/core';
+import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
 import { modalProfileResources, ModalCompute } from './index';
 import type {
@@ -306,6 +307,19 @@ describe('ModalCompute', () => {
 			.listFiles('/workspace', { recursive: true });
 
 		expect(result.files.map((file) => file.relativePath)).toEqual(['a.py', 'sub', 'sub/b.py']);
+	});
+
+	it('returns BACKEND_ERROR when the SDK listing throws', async () => {
+		const world = makeWorld();
+		const sandbox = new FakeSandbox();
+		sandbox.filesystem.listFiles = async () => {
+			throw new Error('boom');
+		};
+		world.existing.set(SANDBOX_ID, sandbox);
+
+		await expect(makeCompute(world).create(SANDBOX_ID).listFiles('/workspace')).resolves.toEqual(
+			listFilesFailure('BACKEND_ERROR'),
+		);
 	});
 
 	it('exposes the SDK tunnel and terminates the named sandbox', async () => {

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { posix } from 'node:path';
-import { ModalClient, NotFoundError } from 'modal';
+import { ModalClient, NotFoundError as ModalNotFoundError } from 'modal';
 import {
 	buildGitCloneCommand,
 	mapWithConcurrency,
@@ -8,7 +8,7 @@ import {
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
-import { SandboxId } from '@marimo-hub/core';
+import { NotFoundError, SandboxId } from '@marimo-hub/core';
 import type {
 	ActiveSandbox,
 	ComputeResources,
@@ -17,6 +17,7 @@ import type {
 	ExecStreamOptions,
 	ExposePortOptions,
 	ExposePortResult,
+	FileInfo,
 	GitCheckoutOptions,
 	ListFilesOptions,
 	ListFilesResult,
@@ -30,6 +31,7 @@ import type {
 	StartProcessOptions,
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
+import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
 
 export interface ModalConfig {
 	tokenId: string;
@@ -125,7 +127,8 @@ export function modalProfileResources(resources: ComputeResources | undefined): 
 
 function isNotFound(error: unknown): boolean {
 	return (
-		error instanceof NotFoundError || (error instanceof Error && error.name === 'NotFoundError')
+		error instanceof ModalNotFoundError ||
+		(error instanceof Error && error.name === 'NotFoundError')
 	);
 }
 
@@ -167,7 +170,7 @@ async function runProcess(process: ModalProcessLike): Promise<ExecResult> {
 		readStream(process.stderr),
 		process.wait(),
 	]);
-	return { success: exitCode === 0, stdout, stderr };
+	return execResult(exitCode === 0, stdout, stderr);
 }
 
 function delay(ms: number): Promise<void> {
@@ -179,6 +182,7 @@ function delay(ms: number): Promise<void> {
 let processSequence = 0;
 
 class ModalSandboxInstance implements SandboxInstance {
+	readonly supportsBucketMount = false;
 	private sandboxPromise?: Promise<ModalSandboxLike>;
 	private env: Record<string, string> = {};
 	private envDefaults: Record<string, string> = {};
@@ -265,7 +269,7 @@ class ModalSandboxInstance implements SandboxInstance {
 			const content = await (await this.getSandbox()).filesystem.readText(path);
 			return { success: true, content, encoding: 'utf-8' };
 		} catch {
-			return { success: false, content: '' };
+			return readFileFailure('READ_FAILED');
 		}
 	}
 
@@ -284,7 +288,7 @@ class ModalSandboxInstance implements SandboxInstance {
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {
 		try {
 			const filesystem = (await this.getSandbox()).filesystem;
-			const files: ListFilesResult['files'] = [];
+			const files: FileInfo[] = [];
 			const visit = async (directory: string): Promise<void> => {
 				for (const file of await filesystem.listFiles(directory)) {
 					if (!options?.includeHidden && file.name.startsWith('.')) continue;
@@ -301,7 +305,7 @@ class ModalSandboxInstance implements SandboxInstance {
 			await visit(path);
 			return { success: true, files };
 		} catch {
-			return { success: false, files: [] };
+			return listFilesFailure('BACKEND_ERROR');
 		}
 	}
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -3,13 +3,30 @@
  * so the API's error handler is a single `instanceof DomainError` check instead
  * of a per-type if-ladder, and adding an error never touches the API layer.
  */
+export const DOMAIN_ERROR_CODES = [
+	'BAD_REQUEST',
+	'PRECONDITION_FAILED',
+	'NOT_FOUND',
+	'CONFLICT',
+	'EDIT_SESSION_OWNED',
+	'EDIT_SESSION_CHANGED',
+	'TAKEOVER_IN_PROGRESS',
+	'FORBIDDEN',
+	'VALIDATION_ERROR',
+	'NOT_INITIALIZED',
+	'SERVICE_UNAVAILABLE',
+	'RESOURCE_EXHAUSTED',
+] as const;
+
+export type DomainErrorCode = (typeof DOMAIN_ERROR_CODES)[number];
+
 export abstract class DomainError extends Error {
 	/** Stable, machine-readable code surfaced in the API error envelope. */
-	abstract readonly code: string;
+	abstract readonly code: DomainErrorCode;
 	/** HTTP status this error maps to. */
 	abstract readonly status: number;
-	constructor(message?: string) {
-		super(message);
+	constructor(message?: string, options?: ErrorOptions) {
+		super(message, options);
 		// Default; concrete subclasses override with their own name. Guarantees a
 		// non-`Error` name even if a subclass forgets to set one.
 		this.name = 'DomainError';
@@ -116,8 +133,8 @@ export class NotInitializedError extends DomainError {
 export class UnavailableError extends DomainError {
 	readonly code = 'SERVICE_UNAVAILABLE';
 	readonly status = 503;
-	constructor(message = 'Service unavailable') {
-		super(message);
+	constructor(message = 'Service unavailable', options?: ErrorOptions) {
+		super(message, options);
 		this.name = 'UnavailableError';
 	}
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from './constants';
 export * from './schema';
 export * from './ids';
 export * from './errors';
+export * from './operationalLog';
 export * from './paths';
 export * from './authz';
 export * from './identityMatch';

--- a/packages/core/src/integrations/syncedSource.ts
+++ b/packages/core/src/integrations/syncedSource.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { BadRequestError } from '../errors';
+import { BadRequestError, ConflictError } from '../errors';
 import { toBase64Url } from '../internal/base64url';
 import { toHex } from '../internal/hex';
 import type { GitSource, GitSourceConfig, Source } from '../schema';
@@ -208,7 +208,7 @@ export async function verifySyncTokenRecord(
 
 export function assertSyncedSource(source: Source): GitSource {
 	if (source.type !== 'git') {
-		throw new BadRequestError('Notebook is not backed by a synced source');
+		throw new ConflictError('Notebook is not backed by a synced source');
 	}
 	return source;
 }

--- a/packages/core/src/integrations/syncedSource.ts
+++ b/packages/core/src/integrations/syncedSource.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { BadRequestError, ConflictError } from '../errors';
+import { BadRequestError, ConflictError, ValidationError } from '../errors';
 import { toBase64Url } from '../internal/base64url';
 import { toHex } from '../internal/hex';
 import type { GitSource, GitSourceConfig, Source } from '../schema';
@@ -82,7 +82,7 @@ export function normalizeGitSourceConfig(input: {
 	}
 	const repo = normalizeRepo(input.repo);
 	if (repo === null) {
-		throw new BadRequestError(
+		throw new ValidationError(
 			'repo must be owner/repo (hosted on github.com) or a repository URL, e.g. acme/analytics or https://gitlab.example.com/group/project',
 		);
 	}
@@ -233,7 +233,7 @@ export function prepareSync(
 				`${header} received ${JSON.stringify(received)}, expected ${JSON.stringify(expected)}`,
 		);
 	if (mismatches.length > 0) {
-		throw new BadRequestError(
+		throw new ValidationError(
 			`Sync source mismatch: ${mismatches.join('; ')}. Update the request headers or the notebook's sync settings.`,
 		);
 	}
@@ -244,7 +244,7 @@ export function prepareSync(
 
 	const files = toSyncedWorkspaceFileMap(input.files);
 	if (!files.has(config.entry_notebook)) {
-		throw new BadRequestError(`entry_notebook not found in sync archive: ${config.entry_notebook}`);
+		throw new ValidationError(`entry_notebook not found in sync archive: ${config.entry_notebook}`);
 	}
 	return { commit, config, files };
 }

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -1,10 +1,24 @@
 import type { SandboxId } from '../ids';
 import type { Timings } from '../timing';
 
-export interface ExecResult {
-	success: boolean;
-	stdout: string;
-	stderr: string;
+export type ExecResult =
+	| { success: true; stdout: string; stderr: string }
+	| {
+			success: false;
+			stdout: string;
+			stderr: string;
+			error: { code: 'COMMAND_FAILED' | 'SPAWN_FAILED' | 'BACKEND_ERROR' };
+	  };
+
+export function execResult(
+	success: boolean,
+	stdout: string,
+	stderr: string,
+	failureCode: 'COMMAND_FAILED' | 'SPAWN_FAILED' | 'BACKEND_ERROR' = 'COMMAND_FAILED',
+): ExecResult {
+	return success
+		? { success: true, stdout, stderr }
+		: { success: false, stdout, stderr, error: { code: failureCode } };
 }
 
 export interface GitCheckoutOptions {
@@ -52,10 +66,18 @@ export interface SandboxProcess {
 	getLogs(): Promise<{ stdout: string; stderr: string }>;
 }
 
-export interface ReadFileResult {
-	success: boolean;
-	content: string;
-	encoding?: 'utf-8' | 'base64';
+export type ReadFileResult =
+	| { success: true; content: string; encoding?: 'utf-8' | 'base64' }
+	| {
+			success: false;
+			content: '';
+			error: { code: 'NOT_FOUND' | 'READ_FAILED' | 'BACKEND_ERROR' };
+	  };
+
+export function readFileFailure(
+	code: 'NOT_FOUND' | 'READ_FAILED' | 'BACKEND_ERROR' = 'READ_FAILED',
+): ReadFileResult {
+	return { success: false, content: '', error: { code } };
 }
 
 export interface FileInfo {
@@ -66,9 +88,14 @@ export interface FileInfo {
 	size: number;
 }
 
-export interface ListFilesResult {
-	success: boolean;
-	files: FileInfo[];
+export type ListFilesResult =
+	| { success: true; files: FileInfo[] }
+	| { success: false; files: []; error: { code: 'LIST_FAILED' | 'BACKEND_ERROR' } };
+
+export function listFilesFailure(
+	code: 'LIST_FAILED' | 'BACKEND_ERROR' = 'LIST_FAILED',
+): ListFilesResult {
+	return { success: false, files: [], error: { code } };
 }
 
 export interface ListFilesOptions {
@@ -102,6 +129,8 @@ export interface SetEnvVarsOptions {
 }
 
 export interface SandboxInstance {
+	/** Whether `mountBucket` is a real backend capability rather than a copy fallback signal. */
+	readonly supportsBucketMount?: boolean;
 	/**
 	 * Resolve the backing sandbox without running anything in it, so an adapter
 	 * that creates lazily pays its create here rather than inside whichever call

--- a/packages/core/src/ports/secrets.ts
+++ b/packages/core/src/ports/secrets.ts
@@ -6,6 +6,17 @@ export interface SecretRef {
 	locator: string;
 }
 
+export class SecretResolutionError extends Error {
+	constructor(
+		readonly reason: 'not_found' | 'invalid_value' | 'unavailable',
+		message: string,
+		options?: { cause?: unknown },
+	) {
+		super(message, options);
+		this.name = 'SecretResolutionError';
+	}
+}
+
 /** Dereferences one integration secret. Implemented by `packages/secrets-*` adapters. */
 export interface SecretResolver {
 	/** Matches `SecretRef.backend`. */

--- a/packages/core/src/ports/secrets.ts
+++ b/packages/core/src/ports/secrets.ts
@@ -8,7 +8,12 @@ export interface SecretRef {
 
 export class SecretResolutionError extends Error {
 	constructor(
-		readonly reason: 'not_found' | 'invalid_value' | 'unavailable',
+		/**
+		 * `forbidden` = the backend rejected our credentials/permissions — a
+		 * persistent configuration problem, never retriable. `unavailable` is
+		 * reserved for genuine transport/backend outages.
+		 */
+		readonly reason: 'not_found' | 'invalid_value' | 'forbidden' | 'unavailable',
 		message: string,
 		options?: { cause?: unknown },
 	) {

--- a/packages/core/src/schema.test.ts
+++ b/packages/core/src/schema.test.ts
@@ -74,7 +74,7 @@ describe('parseStored', () => {
 			expect.unreachable('should have thrown');
 		} catch (err) {
 			expect(err).toBeInstanceOf(Error);
-			expect((err as Error).message).toBe('Corrupted stored object: _system/catalog.json');
+			expect((err as Error).message).toBe('Stored data is temporarily unavailable');
 			expect(err).toMatchObject({
 				reason: 'schema_mismatch',
 				object: '_system/catalog.json',

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { DomainError } from './errors';
 import {
 	NOTEBOOK_STATUSES,
 	PROJECT_STATUSES,
@@ -65,7 +66,9 @@ const MAX_STORED_OBJECT_ISSUES = 20;
  * error. Diagnostics retain field paths and issue codes, but not stored values
  * or validator messages.
  */
-export class StoredObjectError extends Error {
+export class StoredObjectError extends DomainError {
+	readonly code = 'SERVICE_UNAVAILABLE';
+	readonly status = 503;
 	readonly reason: 'invalid_json' | 'schema_mismatch';
 	readonly object: string;
 	readonly issues?: { path: string; code: string }[];
@@ -76,7 +79,7 @@ export class StoredObjectError extends Error {
 		reason: 'invalid_json' | 'schema_mismatch',
 		options?: { issues?: { path: string; code: string }[]; causeName?: string },
 	) {
-		super(`Corrupted stored object: ${what}`);
+		super('Stored data is temporarily unavailable');
 		this.name = 'StoredObjectError';
 		this.object = what;
 		this.reason = reason;

--- a/packages/core/src/services/catalog/CatalogService.test.ts
+++ b/packages/core/src/services/catalog/CatalogService.test.ts
@@ -112,7 +112,9 @@ describe('CatalogService', () => {
 
 		it('throws a corrupted-object error on malformed catalog JSON', async () => {
 			await bucket.put(paths.catalog, JSON.stringify({ bad: true }));
-			await expect(catalog.getCurrentSnapshot()).rejects.toThrow(/Corrupted stored object/);
+			await expect(catalog.getCurrentSnapshot()).rejects.toThrow(
+				'Stored data is temporarily unavailable',
+			);
 		});
 	});
 
@@ -268,7 +270,7 @@ describe('CatalogService', () => {
 		it('throws a corrupted-object error on malformed catalog JSON', async () => {
 			await bucket.put(paths.catalog, JSON.stringify({ not: 'a catalog' }));
 			await expect(catalog.mutateSnapshot('test', ACTOR, (s) => s)).rejects.toThrow(
-				/Corrupted stored object/,
+				/Stored data is temporarily unavailable/,
 			);
 		});
 
@@ -276,7 +278,7 @@ describe('CatalogService', () => {
 			const current = await catalog.getCurrentSnapshot();
 			await bucket.put(paths.snapshot(current.snapshot_id), JSON.stringify({ nope: true }));
 			await expect(catalog.mutateSnapshot('test', ACTOR, (s) => s)).rejects.toThrow(
-				/Corrupted stored object/,
+				/Stored data is temporarily unavailable/,
 			);
 		});
 

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { MemoryBucket } from '../../testing';
-import { BadRequestError, DomainError, NotFoundError, PreconditionFailedError } from '../../errors';
+import {
+	BadRequestError,
+	ConflictError,
+	DomainError,
+	NotFoundError,
+	PreconditionFailedError,
+} from '../../errors';
 import { createNotebookId, createVersionId } from '../../ids';
 import type { NotebookId, ProjectId } from '../../ids';
 import { paths } from '../../paths';
@@ -534,10 +540,10 @@ describe('NotebookService', () => {
 
 			await expect(
 				notebooks.updateNotebook(projectId, meta.id, { code: 'hacked' }, ACTOR),
-			).rejects.toThrow(BadRequestError);
+			).rejects.toThrow(ConflictError);
 			await expect(
 				notebooks.updateNotebook(projectId, meta.id, { deps: 'hacked' }, ACTOR),
-			).rejects.toThrow(BadRequestError);
+			).rejects.toThrow(ConflictError);
 		});
 
 		it('updates metadata without creating a version when no code change', async () => {
@@ -806,7 +812,7 @@ describe('NotebookService', () => {
 	});
 
 	describe('restoreVersion', () => {
-		it('rejects a non-local (git) notebook with BadRequestError', async () => {
+		it('rejects a non-local (git) notebook with ConflictError', async () => {
 			const { meta } = await notebooks.synced.create(
 				projectId,
 				{
@@ -821,7 +827,7 @@ describe('NotebookService', () => {
 
 			await expect(
 				notebooks.restoreVersion(projectId, meta.id, createVersionId(), ACTOR),
-			).rejects.toThrow(BadRequestError);
+			).rejects.toThrow(ConflictError);
 		});
 
 		it('throws NotFoundError when the version folder does not exist', async () => {

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -6,6 +6,7 @@ import {
 	DomainError,
 	NotFoundError,
 	PreconditionFailedError,
+	ValidationError,
 } from '../../errors';
 import { createNotebookId, createVersionId } from '../../ids';
 import type { NotebookId, ProjectId } from '../../ids';
@@ -406,7 +407,7 @@ describe('NotebookService', () => {
 			const { meta } = await create();
 			await expect(
 				sync(meta.id, 'abc123', [{ path: 'other.py', bytes: enc('print(1)') }]),
-			).rejects.toThrow(BadRequestError);
+			).rejects.toThrow(ValidationError);
 		});
 
 		it('rotates and verifies sync tokens', async () => {

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -3,7 +3,7 @@ import type { Bucket } from '../../ports/bucket';
 import { mapWithConcurrency } from '../../concurrency';
 import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
 import { Millis } from '../../duration';
-import { assertVersionMatch, BadRequestError, NotFoundError } from '../../errors';
+import { assertVersionMatch, ConflictError, NotFoundError } from '../../errors';
 import { createNotebookId, createVersionId, SYSTEM_ACTOR, VersionId } from '../../ids';
 import { remoteWorkspaceEntry } from '../../integrations/remoteWorkspace';
 import type { NotebookId, ProjectId, UserId } from '../../ids';
@@ -368,7 +368,7 @@ export class NotebookService {
 		const { meta: existing, source } = detail;
 		assertVersionMatch(existing.updated_at, expectedVersion);
 		if (source.type !== 'local' && (input.code !== undefined || input.deps !== undefined)) {
-			throw new BadRequestError('Remote-backed notebook source is updated only by sync');
+			throw new ConflictError('Remote-backed notebook source is updated only by sync');
 		}
 		const now = new Date().toISOString();
 
@@ -462,7 +462,7 @@ export class NotebookService {
 	): Promise<NotebookMeta> {
 		const detail = await this.getNotebook(projectId, notebookId);
 		if (detail.source.type !== 'local') {
-			throw new BadRequestError('Cannot restore a version of a non-local notebook');
+			throw new ConflictError('Cannot restore a version of a non-local notebook');
 		}
 
 		const ver = paths.project(projectId).notebook(notebookId).version(versionId);

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -5,12 +5,14 @@ import {
 	NotFoundError,
 	PreconditionFailedError,
 	ResourceExhaustedError,
+	UnavailableError,
 	ValidationError,
 } from '../../errors';
 import { createIntegrationId, createProjectId, createSessionId } from '../../ids';
 import type { ProjectId, SessionId } from '../../ids';
 import { paths } from '../../paths';
 import type { Bucket, BucketListOptions } from '../../ports/bucket';
+import { SecretResolutionError } from '../../ports/secrets';
 import type { SecretResolver } from '../../ports/secrets';
 import { ACTOR, MemoryBucket } from '../../testing';
 import { AesGcmSecretCodec } from '../secrets/AesGcmSecretCodec';
@@ -261,7 +263,9 @@ describe('ProjectIntegrationsStore', () => {
 		const head = await (await bucket.get(key))!.json<Record<string, unknown>>();
 		await bucket.put(key, JSON.stringify({ ...head, current_version: 0 }));
 
-		await expect(makeStore(bucket).list(pid)).rejects.toThrow(/Corrupted stored object/);
+		await expect(makeStore(bucket).list(pid)).rejects.toThrow(
+			'Stored data is temporarily unavailable',
+		);
 	});
 
 	it('does not expose secret values thrown by an integration renderer', async () => {
@@ -695,8 +699,32 @@ describe('ProjectIntegrationsStore', () => {
 			expect(String(error)).not.toContain(locator);
 			expect(String(error)).not.toContain(providerMessage);
 			expect(String(error)).toContain('backend "vault"');
+			expect(error).toBeInstanceOf(UnavailableError);
 		}
 		expect(resolve).toHaveBeenCalledTimes(2);
+	});
+
+	it('reports an invalid secret reference as validation failure', async () => {
+		const resolve = vi.fn(async () => {
+			throw new SecretResolutionError('not_found', 'missing');
+		});
+		const store = makeStore(bucket, true, [{ ...vaultResolver, resolve }]);
+		const created = await store.create(
+			pid,
+			{
+				kind: 'echo',
+				name: 'prod',
+				config: {
+					token: {
+						$secret: { kind: 'reference', backend: 'vault', locator: 'missing' },
+					},
+				},
+			},
+			ACTOR,
+		);
+		await expect(store.test(pid, { source: 'stored', id: created.id })).rejects.toBeInstanceOf(
+			ValidationError,
+		);
 	});
 
 	it('resolves a stored reference before running its connection test', async () => {

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -7,6 +7,7 @@ import {
 	NotFoundError,
 	PreconditionFailedError,
 	ResourceExhaustedError,
+	UnavailableError,
 	ValidationError,
 } from '../../errors';
 import type { IntegrationId, ProjectId, UserId } from '../../ids';
@@ -35,6 +36,7 @@ import type {
 	UpdateIntegrationInput,
 } from '../../ports/integrations';
 import type { ManagedSecretCodec, SecretRef, SecretResolver } from '../../ports/secrets';
+import { SecretResolutionError } from '../../ports/secrets';
 import { metricsObserver, saga } from '../../saga';
 import {
 	CURRENT_INTEGRATION_CONFIG_VERSION,
@@ -1060,10 +1062,18 @@ class ScopedIntegrationsStore {
 		}
 		try {
 			return await resolver.resolve(ref);
-		} catch {
-			throw new ValidationError(
-				`Cannot resolve secret field "${at}" with backend "${ref.backend}".`,
+		} catch (err) {
+			if (err instanceof SecretResolutionError && err.reason !== 'unavailable') {
+				throw new ValidationError(
+					`Cannot resolve secret field "${at}" with backend "${ref.backend}".`,
+				);
+			}
+			logOperationalError(
+				'secret_resolution_failed',
+				{ operation: 'integration.secret.resolve', backend: ref.backend, field: at },
+				err,
 			);
+			throw new UnavailableError(`Secret backend "${ref.backend}" is temporarily unavailable.`);
 		}
 	}
 

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -1063,6 +1063,18 @@ class ScopedIntegrationsStore {
 		try {
 			return await resolver.resolve(ref);
 		} catch (err) {
+			if (err instanceof SecretResolutionError && err.reason === 'forbidden') {
+				// Persistent permission gap, not an outage: 422 so nobody retries it,
+				// plus an operator trail since the fix is backend-side (e.g. IAM).
+				logOperationalError(
+					'secret_resolution_forbidden',
+					{ operation: 'integration.secret.resolve', backend: ref.backend, field: at },
+					err,
+				);
+				throw new ValidationError(
+					`Secret backend "${ref.backend}" denied access to the secret for field "${at}". Check the deployment's secret-manager permissions.`,
+				);
+			}
 			if (err instanceof SecretResolutionError && err.reason !== 'unavailable') {
 				throw new ValidationError(
 					`Cannot resolve secret field "${at}" with backend "${ref.backend}".`,

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -318,6 +318,29 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess).toHaveLength(1);
 		});
 
+		it('never attempts the mount when the backend advertises supportsBucketMount: false', async () => {
+			const { instance: base, calls } = makeFakeSandbox({ failMount: true });
+			const instance = { ...base, supportsBucketMount: false };
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			const bucketHandle = new MemoryBucket();
+			const nb = paths.project(projectId).notebook(notebookId);
+			await bucketHandle.put(nb.code, 'import marimo as mo');
+			await bucketHandle.put(nb.deps, '[project]\nname = "nb"');
+
+			const result = await provisioner.provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				bucketHandle,
+			});
+
+			expect(result.usedFallback).toBe(true);
+			expect(calls.mountBucket).toHaveLength(0);
+		});
+
 		it('does not hide a mount failure when the backend advertises mount support', async () => {
 			const { instance: base, calls } = makeFakeSandbox({ failMount: true });
 			const instance = { ...base, supportsBucketMount: true };

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -318,6 +318,26 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess).toHaveLength(1);
 		});
 
+		it('does not hide a mount failure when the backend advertises mount support', async () => {
+			const { instance: base, calls } = makeFakeSandbox({ failMount: true });
+			const instance = { ...base, supportsBucketMount: true };
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			await expect(
+				provisioner.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					bucketHandle: new MemoryBucket(),
+				}),
+			).rejects.toThrow('Failed to start sandbox while mounting the notebook workspace');
+			expect(calls.mountBucket).toHaveLength(1);
+			expect(calls.writeFiles).toHaveLength(0);
+			expect(calls.startProcess).toHaveLength(0);
+		});
+
 		// A command round-trip is the dominant unit of startup cost on a remote
 		// backend (~220ms each on CoreWeave), so these lock in the count. Each was a
 		// measured regression: a duplicate mkdir, a reachability no-op, and a setup

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -164,9 +164,7 @@ function provisionFailure(step: string, err: unknown): UnavailableError {
 	// The vendor message is deliberately dropped: an SDK can echo the request it
 	// failed on, credentials included, and this string is shown to the caller and
 	// persisted on the session record.
-	const wrapped = new UnavailableError(parts.join(' '));
-	(wrapped as { cause?: unknown }).cause = err;
-	return wrapped;
+	return new UnavailableError(parts.join(' '), { cause: err });
 }
 
 /**
@@ -236,6 +234,7 @@ class MountOrCopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 	constructor(private copyFallback: WorkspaceLoadStrategy) {}
 
 	async load(ctx: WorkspaceLoadContext): Promise<WorkspaceLoadResult> {
+		if (ctx.sandbox.supportsBucketMount === false) return this.copyFallback.load(ctx);
 		try {
 			await ctx.sandbox.mountBucket({
 				bucketName: ctx.bucket.name,
@@ -246,6 +245,9 @@ class MountOrCopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 			});
 			return { usedFallback: false };
 		} catch (err) {
+			if (ctx.sandbox.supportsBucketMount) {
+				throw provisionFailure('mounting the notebook workspace into the sandbox', err);
+			}
 			if (!ctx.bucketHandle) {
 				throw provisionFailure('mounting the notebook workspace into the sandbox', err);
 			}
@@ -366,10 +368,7 @@ export class SandboxProvisioner {
 				await (sandbox.ready?.() ?? sandbox.exec('true'));
 			});
 		} catch (err) {
-			throw new UnavailableError(
-				`Sandbox compute backend is not available. ` +
-					`(${err instanceof Error ? err.message : String(err)})`,
-			);
+			throw new UnavailableError('Sandbox compute backend is not available', { cause: err });
 		}
 	}
 

--- a/packages/core/src/services/runtime/SessionRetirer.ts
+++ b/packages/core/src/services/runtime/SessionRetirer.ts
@@ -2,6 +2,7 @@ import type { Bucket } from '../../ports/bucket';
 import type { SandboxProvider } from '../../ports/sandbox';
 import type { Session } from '../../schema';
 import { Millis } from '../../duration';
+import { ConflictError } from '../../errors';
 import { logOperationalError } from '../../operationalLog';
 import { captureFilesystemSnapshot } from '../content/filesystemSnapshots';
 import type { NotebookService } from '../content/NotebookService';
@@ -22,11 +23,13 @@ export interface SessionRetirerDeps {
 
 export class TakeoverRetirementError extends Error {
 	readonly drainStarted: boolean;
+	override readonly cause: unknown;
 
 	constructor(cause: unknown, drainStarted: boolean) {
 		super(cause instanceof Error ? cause.message : 'Could not retire the editor for takeover');
 		this.name = 'TakeoverRetirementError';
 		this.drainStarted = drainStarted;
+		this.cause = cause;
 	}
 }
 
@@ -90,7 +93,7 @@ export class SessionRetirer {
 				},
 			);
 			if (!terminating.transitioned) {
-				throw new Error('Another request already started terminating the editor session');
+				throw new ConflictError('Another request already started terminating the editor session');
 			}
 			drainStarted = true;
 			await this.teardownForTakeover(terminating.session);
@@ -132,7 +135,7 @@ export class SessionRetirer {
 		const assertLease = async (): Promise<void> => {
 			if (leaseLost || !(await renewLease())) {
 				leaseLost = true;
-				throw new Error('The takeover drain lease is no longer owned by this request');
+				throw new ConflictError('The takeover drain lease is no longer owned by this request');
 			}
 		};
 		const advanceLease = async (stage: TakeoverDrainStage): Promise<void> => {
@@ -147,7 +150,7 @@ export class SessionRetirer {
 				))
 			) {
 				leaseLost = true;
-				throw new Error('The takeover drain lease is no longer owned by this request');
+				throw new ConflictError('The takeover drain lease is no longer owned by this request');
 			}
 		};
 		const renewalTimer = setInterval(() => {

--- a/packages/core/src/services/runtime/sandboxFiles.test.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.test.ts
@@ -9,6 +9,7 @@ import {
 	MemoryBucket,
 	RecordingBucket,
 } from '../../testing';
+import { listFilesFailure } from '../../ports/sandbox';
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
 
 // `makeFsSandbox`'s default root — every test mounts the notebook here.
@@ -382,7 +383,7 @@ describe('captureWorkspace', () => {
 			const { instance: base } = makeFsSandbox({ files: { 'data/keep.csv': 'precious' } });
 			const instance = {
 				...base,
-				listFiles: async () => ({ success: false, files: [] }),
+				listFiles: async () => listFilesFailure(),
 			} as unknown as typeof base;
 
 			await captureWorkspace(instance, bucket, projectId, notebookId, MOUNT, 'workspace');
@@ -400,7 +401,12 @@ describe('captureWorkspace', () => {
 				...base,
 				exec: async (cmd: string) =>
 					cmd.startsWith('base64 -w0') && cmd.includes('bad.txt')
-						? { success: false, stdout: '', stderr: 'io error' }
+						? {
+								success: false,
+								stdout: '',
+								stderr: 'io error',
+								error: { code: 'COMMAND_FAILED' },
+							}
 						: base.exec(cmd),
 			} as unknown as typeof base;
 

--- a/packages/core/src/services/runtime/sandboxFiles.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.ts
@@ -214,7 +214,9 @@ export async function captureWorkspace(
 			// to the mirror-delete below with an empty `present` set would treat every
 			// captured key as stale and delete it, wiping still-present workspace data
 			// on a transient listing failure.
-			console.warn(`captureWorkspace: listing ${workingDir} failed; skipping capture + cleanup`);
+			console.warn(
+				`captureWorkspace: listing ${workingDir} failed (${listing.error.code}); skipping capture + cleanup`,
+			);
 			return;
 		}
 		// Select the files to capture first — sequentially, since the count/byte caps

--- a/packages/core/src/services/runtime/sessionLifecycle.test.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createNotebookId, createProjectId, createSandboxId } from '../../ids';
 import { paths } from '../../paths';
 import type { SandboxInstance } from '../../ports/sandbox';
+import { listFilesFailure } from '../../ports/sandbox';
 import type { Session } from '../../schema';
 import {
 	fakeComputeFrom,
@@ -337,8 +338,12 @@ describe('SessionLifecycleService', () => {
 		it('does not stamp the reclaim marker when the destroy fails (retried next sweep)', async () => {
 			const failing = {
 				...makeFakeSandbox().instance,
-				readFile: async () => ({ success: false as const, content: '' }),
-				listFiles: async () => ({ success: false as const, files: [] }),
+				readFile: async () => ({
+					success: false as const,
+					content: '' as const,
+					error: { code: 'READ_FAILED' as const },
+				}),
+				listFiles: async () => listFilesFailure(),
 				destroy: async () => {
 					throw new Error('compute API down');
 				},
@@ -595,7 +600,12 @@ describe('kernelActiveConnections', () => {
 	});
 
 	it('returns null when the exec fails', async () => {
-		const sandbox = sandboxWith(async () => ({ success: false, stdout: '', stderr: 'boom' }));
+		const sandbox = sandboxWith(async () => ({
+			success: false,
+			stdout: '',
+			stderr: 'boom',
+			error: { code: 'COMMAND_FAILED' },
+		}));
 		expect(await kernelActiveConnections(sandbox)).toBeNull();
 	});
 

--- a/packages/core/src/testing/assertions.ts
+++ b/packages/core/src/testing/assertions.ts
@@ -54,6 +54,9 @@ export function expectExecResult(received: ExecResult, expected: Partial<ExecRes
 	expect(typeof received.success).toBe('boolean');
 	expect(typeof received.stdout).toBe('string');
 	expect(typeof received.stderr).toBe('string');
+	if (!received.success) {
+		expect(['COMMAND_FAILED', 'SPAWN_FAILED', 'BACKEND_ERROR']).toContain(received.error.code);
+	}
 	for (const key of Object.keys(expected) as (keyof ExecResult)[]) {
 		expect(received[key], key).toEqual(expected[key]);
 	}
@@ -61,8 +64,8 @@ export function expectExecResult(received: ExecResult, expected: Partial<ExecRes
 
 /**
  * Assert a `ReadFileResult` envelope ({ success, content, encoding? }) and match
- * the given fields. The provisioner's fallback contract hinges on the failure
- * shape `{ success: false, content: '' }`, so adapters assert this constantly.
+ * the given fields. The provisioner's fallback contract hinges on an empty
+ * failure result with a typed error code, so adapters assert this constantly.
  */
 export function expectFileResult(
 	received: ReadFileResult,
@@ -70,6 +73,9 @@ export function expectFileResult(
 ): void {
 	expect(typeof received.success).toBe('boolean');
 	expect(typeof received.content).toBe('string');
+	if (!received.success) {
+		expect(['NOT_FOUND', 'READ_FAILED', 'BACKEND_ERROR']).toContain(received.error.code);
+	}
 	for (const key of Object.keys(expected) as (keyof ReadFileResult)[]) {
 		expect(received[key], key).toEqual(expected[key]);
 	}
@@ -81,6 +87,9 @@ export function expectListFilesResult(
 ): void {
 	expect(typeof received.success).toBe('boolean');
 	expect(Array.isArray(received.files)).toBe(true);
+	if (!received.success) {
+		expect(['LIST_FAILED', 'BACKEND_ERROR']).toContain(received.error.code);
+	}
 	for (const file of received.files) {
 		expect(typeof file.name).toBe('string');
 		expect(typeof file.absolutePath).toBe('string');

--- a/packages/core/src/testing/computeContract.ts
+++ b/packages/core/src/testing/computeContract.ts
@@ -164,6 +164,10 @@ export function computeContract(
 					}),
 				).rejects.toThrow();
 			});
+
+			it('advertises supportsBucketMount: false so the provisioner skips the mount', () => {
+				expect(provider.create(CONTRACT_ID).supportsBucketMount).toBe(false);
+			});
 		}
 	});
 }

--- a/packages/core/src/testing/fakes.ts
+++ b/packages/core/src/testing/fakes.ts
@@ -15,6 +15,7 @@ import type {
 	SetEnvVarsOptions,
 	StartProcessOptions,
 } from '../ports/sandbox';
+import { execResult, listFilesFailure, readFileFailure } from '../ports/sandbox';
 
 /** URL the fake sandbox reports from `exposePort`. */
 export const EXPOSED_URL = 'https://sandbox.example/kernel';
@@ -96,7 +97,7 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 			calls.readFile.push(path);
 			const content = opts.files?.[path];
 			if (content === undefined) {
-				return { success: false, content: '' };
+				return readFileFailure('NOT_FOUND');
 			}
 			return { success: true, content };
 		},
@@ -217,7 +218,7 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 			if (capture) {
 				const rel = toRel(fsUnquote(capture[1]));
 				const bytes = fs.get(rel);
-				if (bytes === undefined) return { success: false, stdout: '', stderr: 'not found' };
+				if (bytes === undefined) return execResult(false, '', 'not found');
 				return { success: true, stdout: fsBase64Encode(bytes), stderr: '' };
 			}
 			// mkdir -p ... (and any other prep command): no-op success.
@@ -229,7 +230,7 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 		async readFile(path: string): Promise<ReadFileResult> {
 			calls.readFile.push(path);
 			const bytes = fs.get(toRel(path));
-			if (bytes === undefined) return { success: false, content: '' };
+			if (bytes === undefined) return readFileFailure('NOT_FOUND');
 			return { success: true, content: new TextDecoder().decode(bytes), encoding: 'utf-8' };
 		},
 		async listFiles(path: string): Promise<ListFilesResult> {
@@ -327,10 +328,10 @@ export class RecordingCompute implements SandboxProvider {
 		// with empty artifacts. `destroy()` records the teardown.
 		return {
 			async readFile() {
-				return { success: false as const };
+				return readFileFailure('NOT_FOUND');
 			},
 			async listFiles() {
-				return { success: false as const, files: [] };
+				return listFilesFailure();
 			},
 			async destroy() {
 				destroyed.push(id);

--- a/packages/secrets-aws/src/index.test.ts
+++ b/packages/secrets-aws/src/index.test.ts
@@ -74,9 +74,18 @@ describe('AwsSecretsManagerResolver', () => {
 		await expect(r.resolve(ref('gone'))).rejects.toMatchObject({ reason: 'not_found' });
 	});
 
-	it('classifies IAM and transport failures as backend outages', async () => {
+	it('classifies IAM denials as forbidden — persistent, never worth a retry', async () => {
 		const r = resolver(async () => {
 			throw Object.assign(new Error('denied'), { name: 'AccessDeniedException' });
+		});
+		const error = await r.resolve(ref('prod/key')).catch((err: unknown) => err);
+		expect(error).toBeInstanceOf(SecretResolutionError);
+		expect(error).toMatchObject({ reason: 'forbidden' });
+	});
+
+	it('classifies transport failures as backend outages', async () => {
+		const r = resolver(async () => {
+			throw Object.assign(new Error('reset'), { name: 'TimeoutError' });
 		});
 		const error = await r.resolve(ref('prod/key')).catch((err: unknown) => err);
 		expect(error).toBeInstanceOf(SecretResolutionError);

--- a/packages/secrets-aws/src/index.test.ts
+++ b/packages/secrets-aws/src/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { SecretResolutionError } from '@marimo-hub/core';
 import { AwsSecretsManagerResolver } from './index';
 import type { GetSecretValueResult, SecretFetcher } from './index';
 
@@ -60,7 +61,7 @@ describe('AwsSecretsManagerResolver', () => {
 		await expect(r.resolve(ref('bin'))).rejects.toThrow(/binary/);
 	});
 
-	it('maps a not-found/access-denied error without leaking the value', async () => {
+	it('maps a not-found error without leaking the value', async () => {
 		const err = Object.assign(new Error('secret value here should never surface'), {
 			name: 'ResourceNotFoundException',
 		});
@@ -70,6 +71,16 @@ describe('AwsSecretsManagerResolver', () => {
 		await expect(r.resolve(ref('gone'))).rejects.toThrow(/ResourceNotFoundException/);
 		await expect(r.resolve(ref('gone'))).rejects.not.toThrow(/gone/);
 		await expect(r.resolve(ref('gone'))).rejects.not.toThrow(/should never surface/);
+		await expect(r.resolve(ref('gone'))).rejects.toMatchObject({ reason: 'not_found' });
+	});
+
+	it('classifies IAM and transport failures as backend outages', async () => {
+		const r = resolver(async () => {
+			throw Object.assign(new Error('denied'), { name: 'AccessDeniedException' });
+		});
+		const error = await r.resolve(ref('prod/key')).catch((err: unknown) => err);
+		expect(error).toBeInstanceOf(SecretResolutionError);
+		expect(error).toMatchObject({ reason: 'unavailable' });
 	});
 
 	it('caches within the TTL and refetches after it', async () => {

--- a/packages/secrets-aws/src/index.ts
+++ b/packages/secrets-aws/src/index.ts
@@ -9,6 +9,7 @@
  */
 import { GetSecretValueCommand, SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import type { SecretsManagerClientConfig } from '@aws-sdk/client-secrets-manager';
+import { SecretResolutionError } from '@marimo-hub/core';
 import type { SecretRef, SecretResolver } from '@marimo-hub/core';
 
 /** The raw `GetSecretValue` result the resolver needs — the seam tests fake. */
@@ -58,9 +59,15 @@ export class AwsSecretsManagerResolver implements SecretResolver {
 
 		if (result.SecretString === undefined) {
 			if (result.SecretBinary !== undefined) {
-				throw new Error('AWS Secrets Manager returned a binary value; only strings are supported.');
+				throw new SecretResolutionError(
+					'invalid_value',
+					'AWS Secrets Manager returned a binary value; only strings are supported.',
+				);
 			}
-			throw new Error('AWS Secrets Manager returned no string value.');
+			throw new SecretResolutionError(
+				'invalid_value',
+				'AWS Secrets Manager returned no string value.',
+			);
 		}
 
 		return jsonKey === undefined
@@ -82,8 +89,11 @@ export class AwsSecretsManagerResolver implements SecretResolver {
 		try {
 			result = await this.fetch(secretId);
 		} catch (err) {
-			// SDK errors (ResourceNotFound / AccessDenied) carry no secret value.
-			throw new Error(`AWS Secrets Manager resolution failed: ${describeAwsError(err)}`);
+			const name = describeAwsError(err);
+			const reason = name === 'ResourceNotFoundException' ? 'not_found' : 'unavailable';
+			throw new SecretResolutionError(reason, `AWS Secrets Manager resolution failed: ${name}`, {
+				cause: err,
+			});
 		}
 		if (this.cacheTtlMs > 0) {
 			this.cache.set(secretId, { result, expires: this.now() + this.cacheTtlMs });
@@ -105,10 +115,16 @@ function selectJsonKey(secretString: string, key: string): string {
 	try {
 		parsed = JSON.parse(secretString);
 	} catch {
-		throw new Error('AWS Secrets Manager value is not valid JSON for the requested selection.');
+		throw new SecretResolutionError(
+			'invalid_value',
+			'AWS Secrets Manager value is not valid JSON for the requested selection.',
+		);
 	}
 	if (typeof parsed !== 'object' || parsed === null || !Object.hasOwn(parsed, key)) {
-		throw new Error('AWS Secrets Manager value does not contain the requested JSON key.');
+		throw new SecretResolutionError(
+			'invalid_value',
+			'AWS Secrets Manager value does not contain the requested JSON key.',
+		);
 	}
 	const value = (parsed as Record<string, unknown>)[key];
 	return typeof value === 'string' ? value : JSON.stringify(value);

--- a/packages/secrets-aws/src/index.ts
+++ b/packages/secrets-aws/src/index.ts
@@ -90,7 +90,12 @@ export class AwsSecretsManagerResolver implements SecretResolver {
 			result = await this.fetch(secretId);
 		} catch (err) {
 			const name = describeAwsError(err);
-			const reason = name === 'ResourceNotFoundException' ? 'not_found' : 'unavailable';
+			const reason =
+				name === 'ResourceNotFoundException'
+					? 'not_found'
+					: name === 'AccessDeniedException' || name === 'UnauthorizedException'
+						? 'forbidden'
+						: 'unavailable';
 			throw new SecretResolutionError(reason, `AWS Secrets Manager resolution failed: ${name}`, {
 				cause: err,
 			});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { ThemeProvider } from '@/context/ThemeContext';
 import { AuthProvider, useAuth } from '@/context/AuthContext';
 import { Header } from '@/components/Header/Header';
@@ -18,6 +19,28 @@ const AuditLogPage = lazy(() => import('@/components/AuditLog/AuditLogPage'));
 const AdminUsersPage = lazy(() => import('@/components/Admin/AdminUsersPage'));
 const AdminSettingsPage = lazy(() => import('@/components/Admin/AdminSettingsPage'));
 
+function AppErrorBoundary({ children }: { children: React.ReactNode }) {
+	return (
+		<QueryErrorResetBoundary>
+			{({ reset }) => <ErrorBoundary onRetry={reset}>{children}</ErrorBoundary>}
+		</QueryErrorResetBoundary>
+	);
+}
+
+function NotFoundPage() {
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center">
+			<h1 className="text-xl font-semibold">Page not found</h1>
+			<p className="text-sm text-muted-foreground">
+				The page may have moved, or you may not have access to it.
+			</p>
+			<Button variant="default" onPress={() => window.location.assign('/')}>
+				Back to projects
+			</Button>
+		</div>
+	);
+}
+
 function AuthGate({ children }: { children: React.ReactNode }) {
 	const { isPending, error, user, signIn, refetchUser } = useAuth();
 
@@ -34,7 +57,7 @@ function AuthGate({ children }: { children: React.ReactNode }) {
 		// Not signed in (401 from /api/v1/me) → show the sign-in screen. Any other
 		// failure (network, 5xx, forbidden) shows an error with retry + sign-in.
 		const isUnauthorized = error instanceof ApiRequestError && error.code === 'UNAUTHORIZED';
-		if (isUnauthorized) {
+		if (!error || isUnauthorized) {
 			return <SignIn />;
 		}
 
@@ -86,7 +109,7 @@ function StandardLayout() {
 		<div className="flex min-h-dvh flex-col">
 			<Header />
 			<main className="flex flex-1 overflow-hidden">
-				<ErrorBoundary>
+				<AppErrorBoundary>
 					<Suspense fallback={<PageFallback />}>
 						<Routes>
 							<Route path="/" element={<ProjectList />} />
@@ -97,10 +120,10 @@ function StandardLayout() {
 								<Route path="settings" element={<AdminSettingsPage />} />
 								<Route path="audit-logs" element={<AuditLogPage />} />
 							</Route>
-							<Route path="*" element={<Navigate to="/" replace />} />
+							<Route path="*" element={<NotFoundPage />} />
 						</Routes>
 					</Suspense>
-				</ErrorBoundary>
+				</AppErrorBoundary>
 			</main>
 			<Footer />
 		</div>
@@ -110,7 +133,7 @@ function StandardLayout() {
 function AppContent() {
 	return (
 		<>
-			<ErrorBoundary>
+			<AppErrorBoundary>
 				<Suspense fallback={<PageFallback />}>
 					<Routes>
 						<Route path="/projects/:pid/notebooks/:nid" element={<NotebookPage />} />
@@ -124,7 +147,7 @@ function AppContent() {
 						<Route path="*" element={<StandardLayout />} />
 					</Routes>
 				</Suspense>
-			</ErrorBoundary>
+			</AppErrorBoundary>
 
 			<Toaster />
 		</>
@@ -133,7 +156,7 @@ function AppContent() {
 
 function App() {
 	return (
-		<ErrorBoundary>
+		<AppErrorBoundary>
 			<BrowserRouter>
 				<ThemeProvider>
 					<AuthProvider>
@@ -143,7 +166,7 @@ function App() {
 					</AuthProvider>
 				</ThemeProvider>
 			</BrowserRouter>
-		</ErrorBoundary>
+		</AppErrorBoundary>
 	);
 }
 

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -1,2 +1,13 @@
-export { apiClient, apiData, apiDataWithResponse, ApiRequestError } from '@marimo-hub/client';
-export type { ApiError, ApiResponse } from '@marimo-hub/client';
+export {
+	apiClient,
+	apiData,
+	apiDataWithResponse,
+	apiErrorFromResponse,
+	ApiRequestError,
+} from '@marimo-hub/client';
+export type {
+	ApiError,
+	ApiResponse,
+	ApiRequestErrorCode,
+	ServerErrorCode,
+} from '@marimo-hub/client';

--- a/packages/web/src/api/hooks.test.tsx
+++ b/packages/web/src/api/hooks.test.tsx
@@ -550,16 +550,9 @@ describe('deployment-scoped queries', () => {
 	] as const)('%s does not retry a failure', async (_name, useHook) => {
 		const fetchMock = stubFetch(async () => jsonError('INTERNAL_ERROR', 'boom', 500));
 
-		const { result } = renderHookWithClient(() => useHook(), {
-			toaster: false,
-			errorBoundary: _name === 'useCapabilitiesQuery',
-		});
+		const { result } = renderHookWithClient(() => useHook(), { toaster: false });
 
-		if (_name !== 'useCapabilitiesQuery') {
-			await waitFor(() => expect(result.current.isError).toBe(true));
-		} else {
-			await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-		}
+		await waitFor(() => expect(result.current.isError).toBe(true));
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/web/src/api/hooks.test.tsx
+++ b/packages/web/src/api/hooks.test.tsx
@@ -213,7 +213,7 @@ describe('useNotebookHtmlQuery', () => {
 		});
 
 		await waitFor(() => expect(result.current.isError).toBe(true));
-		expect(result.current.error?.message).toBe('Notebook not found');
+		expect(result.current.error?.message).toBe('gone');
 	});
 
 	it('names the version, not the notebook, when a pinned snapshot 404s', async () => {
@@ -224,7 +224,7 @@ describe('useNotebookHtmlQuery', () => {
 		});
 
 		await waitFor(() => expect(result.current.isError).toBe(true));
-		expect(result.current.error?.message).toBe('Version not found');
+		expect(result.current.error?.message).toBe('gone');
 		expect(urlsOf(fetchMock)[0]).toBe(
 			`/api/v1/projects/${PID}/notebooks/${NID}/versions/ver-old/html`,
 		);
@@ -474,9 +474,16 @@ describe('deployment-scoped queries', () => {
 	] as const)('%s does not retry a failure', async (_name, useHook) => {
 		const fetchMock = stubFetch(async () => jsonError('INTERNAL_ERROR', 'boom', 500));
 
-		const { result } = renderHookWithClient(() => useHook(), { toaster: false });
+		const { result } = renderHookWithClient(() => useHook(), {
+			toaster: false,
+			errorBoundary: _name === 'useCapabilitiesQuery',
+		});
 
-		await waitFor(() => expect(result.current.isError).toBe(true));
+		if (_name !== 'useCapabilitiesQuery') {
+			await waitFor(() => expect(result.current.isError).toBe(true));
+		} else {
+			await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		}
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/web/src/api/hooks.test.tsx
+++ b/packages/web/src/api/hooks.test.tsx
@@ -11,7 +11,9 @@ import {
 	useRestartApp,
 	useRestartSession,
 	useStartSession,
+	useStopSession,
 	useUpdateGitSource,
+	useUpdateIntegration,
 	useUpdateNotebook,
 	useUpdateProject,
 	useUserQuery,
@@ -392,6 +394,80 @@ describe.each([
 
 		// A restart that half-ran (stopped, never started) is worse than one that failed.
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(spy).not.toHaveBeenCalled();
+	});
+});
+
+describe('session mutation toast suppression', () => {
+	// Start/stop failures on the notebook page render as the inline session
+	// panel; the meta flag is what keeps the global mutation-cache toast quiet.
+	it('useStartSession marks failures to skip the global error toast', async () => {
+		stubFetch(async () => jsonError('SERVICE_UNAVAILABLE', 'no capacity', 503));
+
+		const { result, client } = renderHookWithClient(() => useStartSession(PID, NID), {
+			toaster: false,
+		});
+		await act(async () => {
+			await result.current.mutateAsync().catch(() => {});
+		});
+
+		expect(client.getMutationCache().getAll().at(-1)?.meta).toEqual({ suppressErrorToast: true });
+	});
+
+	it('useStopSession suppresses the toast only when asked', async () => {
+		stubFetch(async () => jsonError('SERVICE_UNAVAILABLE', 'teardown failed', 503));
+
+		const { result, client } = renderHookWithClient(
+			() => ({
+				quiet: useStopSession(PID, NID, { suppressErrorToast: true }),
+				loud: useStopSession(PID, NID),
+			}),
+			{ toaster: false },
+		);
+		await act(async () => {
+			await result.current.quiet.mutateAsync('sess-1').catch(() => {});
+			await result.current.loud.mutateAsync('sess-2').catch(() => {});
+		});
+
+		const metas = client
+			.getMutationCache()
+			.getAll()
+			.map((mutation) => mutation.meta);
+		expect(metas).toEqual([{ suppressErrorToast: true }, undefined]);
+	});
+});
+
+describe('useUpdateIntegration conflict recovery', () => {
+	const scope = { pid: PID };
+
+	it('refetches the stale integration after a 412 so a retry gets a fresh ETag', async () => {
+		stubFetch(async () => jsonError('PRECONDITION_FAILED', 'stale etag', 412));
+
+		const { result, client } = renderHookWithClient(() => useUpdateIntegration(scope), {
+			toaster: false,
+		});
+		const spy = vi.spyOn(client, 'invalidateQueries');
+		await act(async () => {
+			await result.current.mutateAsync({ id: 'int-1', etag: 'W/"1"', name: 'n' }).catch(() => {});
+		});
+
+		expect(invalidatedKeys(spy)).toEqual([
+			projectKeys.integrations(PID),
+			projectKeys.integration(PID, 'int-1'),
+		]);
+	});
+
+	it('leaves the cache alone on non-conflict failures', async () => {
+		stubFetch(async () => jsonError('FORBIDDEN', 'no', 403));
+
+		const { result, client } = renderHookWithClient(() => useUpdateIntegration(scope), {
+			toaster: false,
+		});
+		const spy = vi.spyOn(client, 'invalidateQueries');
+		await act(async () => {
+			await result.current.mutateAsync({ id: 'int-1', etag: 'W/"1"', name: 'n' }).catch(() => {});
+		});
+
 		expect(spy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -6,7 +6,7 @@ import {
 	keepPreviousData,
 } from '@tanstack/react-query';
 import { apiClient, apiData, apiDataWithResponse, apiErrorFromResponse } from './client';
-import { useApiMutation } from './mutation';
+import { useApiMutation, useInvalidate } from './mutation';
 import { isApiErrorCode, isNotFoundError, notebookPath } from './request';
 import { sanitizeFilename, triggerDownload } from '../lib/download';
 import {
@@ -116,13 +116,16 @@ export function useVersionQuery() {
 	});
 }
 
-/** Deployment capability flags (e.g. whether WIF is configured). */
+/**
+ * Deployment capability flags (e.g. whether WIF is configured). Never throws
+ * into the error boundary: consumers (NotebookPage, Project) deliberately treat
+ * a failed probe as "grant nothing" rather than crashing the page.
+ */
 export function useCapabilitiesQuery(enabled = true) {
 	return useQuery({
 		queryKey: systemKeys.capabilities(),
 		queryFn: () => apiData(apiClient.GET('/api/v1/capabilities')),
 		enabled,
-		throwOnError: true,
 		...IMMUTABLE_QUERY,
 	});
 }
@@ -452,8 +455,9 @@ export function useCreateIntegration(scope: IntegrationsScope) {
 }
 
 export function useUpdateIntegration(scope: IntegrationsScope) {
-	return useApiMutation(
-		({
+	const invalidate = useInvalidate();
+	return useMutation({
+		mutationFn: ({
 			id,
 			etag,
 			...body
@@ -479,8 +483,15 @@ export function useUpdateIntegration(scope: IntegrationsScope) {
 							body,
 						}),
 			),
-		(variables) => integrationsInvalidations(scope, variables.id),
-	);
+		onSuccess: (_data, variables) => invalidate(...integrationsInvalidations(scope, variables.id)),
+		onError: (err, variables) => {
+			// A 412 means the cached ETag is stale. Refetch so the "reload and try
+			// again" guidance in the toast is a re-render away, not a re-open.
+			if (isApiErrorCode(err, 'PRECONDITION_FAILED')) {
+				invalidate(...integrationsInvalidations(scope, variables.id));
+			}
+		},
+	});
 }
 
 export function useDeleteIntegration(scope: IntegrationsScope) {
@@ -988,6 +999,8 @@ function useStartSessionRequest(
 ) {
 	return useMutation({
 		mutationFn: () => startSessionRequest(projectId, notebookId, mode, computeProfile, editIntent),
+		// useNotebookSession renders start failures as the inline session panel.
+		meta: { suppressErrorToast: true },
 	});
 }
 
@@ -1039,10 +1052,15 @@ export function useRestartSession(projectId: string) {
 	);
 }
 
-export function useStopSession(projectId: string, notebookId: string) {
+export function useStopSession(
+	projectId: string,
+	notebookId: string,
+	opts?: { suppressErrorToast?: boolean },
+) {
 	return useApiMutation(
 		(sessionId: string) => stopSessionRequest(projectId, notebookId, sessionId),
 		() => [sessionKeys.listByProject(projectId)],
+		opts?.suppressErrorToast ? { suppressErrorToast: true } : undefined,
 	);
 }
 

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -5,7 +5,7 @@ import {
 	useMutation,
 	keepPreviousData,
 } from '@tanstack/react-query';
-import { apiClient, apiData, apiDataWithResponse } from './client';
+import { apiClient, apiData, apiDataWithResponse, apiErrorFromResponse } from './client';
 import { useApiMutation } from './mutation';
 import { isApiErrorCode, isNotFoundError, notebookPath } from './request';
 import { sanitizeFilename, triggerDownload } from '../lib/download';
@@ -122,6 +122,7 @@ export function useCapabilitiesQuery(enabled = true) {
 		queryKey: systemKeys.capabilities(),
 		queryFn: () => apiData(apiClient.GET('/api/v1/capabilities')),
 		enabled,
+		throwOnError: true,
 		...IMMUTABLE_QUERY,
 	});
 }
@@ -832,15 +833,16 @@ async function fetchHtmlSnapshot(
 ): Promise<NotebookHtmlSnapshot | null> {
 	const res = await fetch(htmlSnapshotPath(projectId, notebookId, versionId));
 	if (res.status === 404) {
-		// Only "exists but never ran" is the empty state; a deleted/hidden
-		// notebook (code NOT_FOUND) must surface as an error, not "no outputs".
-		const body = (await res.json().catch(() => null)) as {
-			error?: { code?: string };
-		} | null;
-		if (body?.error?.code === 'NO_HTML_SNAPSHOT') return null;
-		throw new Error(versionId ? 'Version not found' : 'Notebook not found');
+		const error = await apiErrorFromResponse(
+			res,
+			versionId ? 'Version not found' : 'Notebook not found',
+		);
+		if (isApiErrorCode(error, 'NO_HTML_SNAPSHOT')) return null;
+		throw error;
 	}
-	if (!res.ok) throw new Error(`Failed to load notebook outputs (HTTP ${res.status})`);
+	if (!res.ok) {
+		throw await apiErrorFromResponse(res, `Failed to load notebook outputs (HTTP ${res.status})`);
+	}
 	return {
 		html: await res.text(),
 		capturedAt: res.headers.get('X-Marimohub-Captured-At'),

--- a/packages/web/src/api/mutation.ts
+++ b/packages/web/src/api/mutation.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import type { QueryKey } from '@tanstack/react-query';
+import type { MutationMeta, QueryKey } from '@tanstack/react-query';
 
 /** Keys are taken per call, so they may depend on a mutation's variables. */
 export function useInvalidate(): (...keys: readonly QueryKey[]) => void {
@@ -19,10 +19,12 @@ export function useInvalidate(): (...keys: readonly QueryKey[]) => void {
 export function useApiMutation<TData, TVariables = void>(
 	mutationFn: (variables: TVariables) => Promise<TData>,
 	invalidates?: (variables: TVariables, data: TData) => readonly QueryKey[],
+	meta?: MutationMeta,
 ) {
 	const invalidate = useInvalidate();
 	return useMutation({
 		mutationFn,
+		meta,
 		onSuccess: (data, variables) => {
 			if (invalidates) invalidate(...invalidates(variables, data));
 		},

--- a/packages/web/src/api/queryClient.test.ts
+++ b/packages/web/src/api/queryClient.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MutationObserver } from '@tanstack/react-query';
 import { ApiRequestError } from './client';
 import { createQueryClient, shouldRetryRequest } from './queryClient';
 import { userKeys } from './queryKeys';
+import { toastError } from '@/lib/errors';
+
+vi.mock('@/lib/errors', () => ({ toastError: vi.fn() }));
+
+beforeEach(() => {
+	vi.mocked(toastError).mockClear();
+});
 
 describe('shouldRetryRequest', () => {
 	it('does not retry client errors', () => {
@@ -31,5 +39,26 @@ describe('createQueryClient', () => {
 			}),
 		).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
 		expect(client.getQueryData(userKeys.me())).toBeNull();
+	});
+
+	it('toasts mutation failures by default', async () => {
+		const client = createQueryClient();
+		const observer = new MutationObserver(client, {
+			mutationFn: () => Promise.reject(new ApiRequestError('CONFLICT', 'nope', { status: 409 })),
+		});
+
+		await observer.mutate().catch(() => {});
+		expect(toastError).toHaveBeenCalledWith(expect.objectContaining({ code: 'CONFLICT' }));
+	});
+
+	it('meta.suppressErrorToast opts a mutation out of the default toast', async () => {
+		const client = createQueryClient();
+		const observer = new MutationObserver(client, {
+			mutationFn: () => Promise.reject(new ApiRequestError('CONFLICT', 'nope', { status: 409 })),
+			meta: { suppressErrorToast: true },
+		});
+
+		await observer.mutate().catch(() => {});
+		expect(toastError).not.toHaveBeenCalled();
 	});
 });

--- a/packages/web/src/api/queryClient.test.ts
+++ b/packages/web/src/api/queryClient.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { ApiRequestError } from './client';
+import { createQueryClient, shouldRetryRequest } from './queryClient';
+import { userKeys } from './queryKeys';
+
+describe('shouldRetryRequest', () => {
+	it('does not retry client errors', () => {
+		expect(shouldRetryRequest(0, new ApiRequestError('FORBIDDEN', 'no', { status: 403 }))).toBe(
+			false,
+		);
+	});
+
+	it('retries transient failures once', () => {
+		const unavailable = new ApiRequestError('SERVICE_UNAVAILABLE', 'later', { status: 503 });
+		expect(shouldRetryRequest(0, unavailable)).toBe(true);
+		expect(shouldRetryRequest(1, unavailable)).toBe(false);
+		expect(shouldRetryRequest(0, new ApiRequestError('NETWORK_ERROR', 'offline'))).toBe(true);
+	});
+});
+
+describe('createQueryClient', () => {
+	it('clears cached identity after an unauthorized query', async () => {
+		const client = createQueryClient();
+		client.setQueryData(userKeys.me(), { id: 'user-1' });
+
+		await expect(
+			client.fetchQuery({
+				queryKey: ['unauthorized-test'],
+				queryFn: () =>
+					Promise.reject(new ApiRequestError('UNAUTHORIZED', 'sign in', { status: 401 })),
+			}),
+		).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+		expect(client.getQueryData(userKeys.me())).toBeNull();
+	});
+});

--- a/packages/web/src/api/queryClient.ts
+++ b/packages/web/src/api/queryClient.ts
@@ -1,0 +1,49 @@
+import { MutationCache, QueryCache, QueryClient } from '@tanstack/react-query';
+import { ApiRequestError } from './client';
+import { userKeys } from './queryKeys';
+import { toastError } from '@/lib/errors';
+
+function isUnauthorized(error: unknown): boolean {
+	return (
+		error instanceof ApiRequestError && (error.status === 401 || error.code === 'UNAUTHORIZED')
+	);
+}
+
+export function shouldRetryRequest(failureCount: number, error: unknown): boolean {
+	if (failureCount >= 1) return false;
+	if (
+		error instanceof ApiRequestError &&
+		error.status !== undefined &&
+		error.status >= 400 &&
+		error.status < 500
+	) {
+		return false;
+	}
+	return true;
+}
+
+export function createQueryClient(): QueryClient {
+	const holder: { client?: QueryClient } = {};
+	const handleError = (error: unknown) => {
+		if (isUnauthorized(error)) holder.client?.setQueryData(userKeys.me(), null);
+	};
+	const client = new QueryClient({
+		queryCache: new QueryCache({ onError: handleError }),
+		mutationCache: new MutationCache({
+			onError: (error, _variables, _context, mutation) => {
+				handleError(error);
+				if (mutation.options.meta?.suppressErrorToast !== true) toastError(error);
+			},
+		}),
+		defaultOptions: {
+			queries: {
+				staleTime: 60_000,
+				retry: shouldRetryRequest,
+			},
+		},
+	});
+	holder.client = client;
+	return client;
+}
+
+export const queryClient = createQueryClient();

--- a/packages/web/src/api/request.ts
+++ b/packages/web/src/api/request.ts
@@ -1,10 +1,11 @@
 import { ApiRequestError } from './client';
+import type { ApiRequestErrorCode } from './client';
 
 export const projectPath = (projectId: string) => `/api/v1/projects/${projectId}`;
 export const notebookPath = (projectId: string, notebookId: string) =>
 	`${projectPath(projectId)}/notebooks/${notebookId}`;
 
-export function isApiErrorCode(err: unknown, code: string): boolean {
+export function isApiErrorCode(err: unknown, code: ApiRequestErrorCode): boolean {
 	return err instanceof ApiRequestError && err.code === code;
 }
 

--- a/packages/web/src/components/Account/ApiTokensDialog.test.tsx
+++ b/packages/web/src/components/Account/ApiTokensDialog.test.tsx
@@ -2,10 +2,11 @@ import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { ApiTokensDialog } from './ApiTokensDialog';
 import type { ApiToken } from '@/types';
+import { createTestQueryClient } from '@/test/render';
 
 const TOKEN_ID = '01HXY0S6GWMBASVAG3PZ7Y2K5T';
 const PLAINTEXT = `mhub_pat_${TOKEN_ID}_${'a'.repeat(32)}`;
@@ -52,7 +53,7 @@ function makeFetch(tokens: ApiToken[]) {
 function setup(tokens: ApiToken[] = []) {
 	const calls = makeFetch(tokens);
 	const onClose = vi.fn();
-	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const client = createTestQueryClient();
 	const wrapper = ({ children }: { children: ReactNode }) => (
 		<QueryClientProvider client={client}>
 			{children}
@@ -175,7 +176,7 @@ describe('ApiTokensDialog', () => {
 				);
 			}),
 		);
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const client = createTestQueryClient();
 		const wrapper = ({ children }: { children: ReactNode }) => (
 			<QueryClientProvider client={client}>
 				{children}

--- a/packages/web/src/components/Account/ApiTokensDialog.tsx
+++ b/packages/web/src/components/Account/ApiTokensDialog.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/components/ui';
 import { useApiTokensQuery, useCreateApiToken, useRevokeApiToken } from '@/api/hooks';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
-import { toastError } from '@/lib/errors';
 import { formatDuration, formatRelative } from '@/lib/time';
 import type { ApiToken, ApiTokenCreated } from '@/types';
 
@@ -67,8 +66,8 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 			setCreated(result);
 			setName('');
 			setExpiresInDays('');
-		} catch (err) {
-			toastError(err);
+		} catch {
+			return;
 		}
 	};
 
@@ -80,7 +79,6 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 				toast.success('Token revoked');
 				confirmRevoke.close();
 			},
-			onError: toastError,
 		});
 	};
 

--- a/packages/web/src/components/Notebook/ChangeBaseImageDialog.tsx
+++ b/packages/web/src/components/Notebook/ChangeBaseImageDialog.tsx
@@ -39,8 +39,8 @@ export function ChangeBaseImageDialog({
 						: `Base image set to "${imageLabel(choice)}"`,
 				);
 				onClose();
-			} catch (err) {
-				toast.error((err as Error).message);
+			} catch {
+				return;
 			}
 		},
 	});

--- a/packages/web/src/components/Notebook/ChangeComputeProfileDialog.tsx
+++ b/packages/web/src/components/Notebook/ChangeComputeProfileDialog.tsx
@@ -2,7 +2,6 @@ import { AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import { FormDialog, useAppForm, useSeedOnOpen } from '@/components/form';
 import { useCapabilitiesQuery, useNotebookQuery, useUpdateNotebook } from '@/api/hooks';
-import { toastError } from '@/lib/errors';
 import {
 	computeProfileOptions,
 	computeProfilePickerValue,
@@ -54,8 +53,8 @@ export function ChangeComputeProfileDialog({
 						: undefined,
 				);
 				onClose();
-			} catch (err) {
-				toastError(err);
+			} catch {
+				return;
 			}
 		},
 	});

--- a/packages/web/src/components/Notebook/RenameNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/RenameNotebookDialog.tsx
@@ -34,8 +34,8 @@ export function RenameNotebookDialog({
 				await updateNotebook.mutateAsync({ notebookId: notebook.id, title: name });
 				toast.success(`Renamed to "${name}"`);
 				onClose();
-			} catch (err) {
-				toast.error((err as Error).message);
+			} catch {
+				return;
 			}
 		},
 	});

--- a/packages/web/src/components/Notebook/SyncSettingsDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncSettingsDialog.tsx
@@ -104,8 +104,8 @@ export function SyncSettingsDialog({
 						: 'Sync settings saved',
 				);
 				onClose();
-			} catch (err) {
-				toast.error((err as Error).message);
+			} catch {
+				return;
 			}
 		},
 	});
@@ -253,7 +253,6 @@ export function SyncSettingsDialog({
 							setConfirmRotate(false);
 							toast.success(`Rotated sync token for "${title}"`);
 						},
-						onError: (err) => toast.error(err.message),
 					});
 				}}
 			/>

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
@@ -72,8 +72,8 @@ export function SyncedNotebookDialog({
 					syncUrl: data.sync_url,
 					token: data.sync_token,
 				});
-			} catch (err) {
-				toast.error((err as Error).message);
+			} catch {
+				return;
 			}
 		},
 	});

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
@@ -2,11 +2,12 @@ import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { VersionHistoryDialog } from './VersionHistoryDialog';
 import type { NotebookEntry, NotebookVersion } from '@/types';
+import { createTestQueryClient } from '@/test/render';
 
 // The real diff pane pulls in @pierre/diffs (shadow DOM + shiki), which cannot
 // run in jsdom. React.lazy's dynamic import resolves to this stub instead.
@@ -117,7 +118,7 @@ function renderDialog({
 	sourceType = 'local' as const,
 	canRestore = true,
 }: { sourceType?: 'local' | 'git'; canRestore?: boolean } = {}) {
-	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const client = createTestQueryClient();
 	const onClose = vi.fn();
 	const wrapper = ({ children }: { children: ReactNode }) => (
 		<MemoryRouter>

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
@@ -20,7 +20,6 @@ import {
 } from '@/api/hooks';
 import type { UserDirectory } from '@/api/hooks';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
-import { toastError } from '@/lib/errors';
 import { gitCommitUrl, gitCoords, shortCommit, versionCommit } from '@/lib/git';
 import { formatRelative } from '@/lib/time';
 import { cn } from '@/lib/utils';
@@ -230,7 +229,6 @@ export function VersionHistoryDialog({
 				setBaseId(null);
 				setCompareId(null);
 			},
-			onError: toastError,
 		});
 	};
 

--- a/packages/web/src/components/Notebook/baseImage.test.tsx
+++ b/packages/web/src/components/Notebook/baseImage.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { systemKeys } from '@/api/queryKeys';
 import { jsonError, jsonOk, renderHookWithClient } from '@/test/render';
 import {
@@ -115,17 +115,20 @@ describe('useSandboxImages', () => {
 		await waitFor(() => expect(result.current).toEqual(['img-a', 'img-b']));
 	});
 
-	it('returns an empty list when the capabilities query fails', async () => {
+	it('surfaces a capabilities failure through the error boundary', async () => {
 		vi.stubGlobal(
 			'fetch',
 			vi.fn(async () => jsonError('INTERNAL', 'capabilities unavailable', 500)),
 		);
 
-		const { result, client } = renderHookWithClient(() => useSandboxImages(), { toaster: false });
+		const { client } = renderHookWithClient(() => useSandboxImages(), {
+			toaster: false,
+			errorBoundary: true,
+		});
 
 		await waitFor(() =>
 			expect(client.getQueryState(systemKeys.capabilities())?.status).toBe('error'),
 		);
-		expect(result.current).toEqual([]);
+		expect(screen.getByText('Request failed')).toBeInTheDocument();
 	});
 });

--- a/packages/web/src/components/Notebook/baseImage.test.tsx
+++ b/packages/web/src/components/Notebook/baseImage.test.tsx
@@ -115,13 +115,13 @@ describe('useSandboxImages', () => {
 		await waitFor(() => expect(result.current).toEqual(['img-a', 'img-b']));
 	});
 
-	it('surfaces a capabilities failure through the error boundary', async () => {
+	it('falls back to no images on a capabilities failure instead of throwing', async () => {
 		vi.stubGlobal(
 			'fetch',
 			vi.fn(async () => jsonError('INTERNAL', 'capabilities unavailable', 500)),
 		);
 
-		const { client } = renderHookWithClient(() => useSandboxImages(), {
+		const { result, client } = renderHookWithClient(() => useSandboxImages(), {
 			toaster: false,
 			errorBoundary: true,
 		});
@@ -129,6 +129,9 @@ describe('useSandboxImages', () => {
 		await waitFor(() =>
 			expect(client.getQueryState(systemKeys.capabilities())?.status).toBe('error'),
 		);
-		expect(screen.getByText('Request failed')).toBeInTheDocument();
+		// The grant-nothing fallback: consumers render without profile choices
+		// rather than crashing the page into the boundary.
+		expect(screen.queryByText('Request failed')).not.toBeInTheDocument();
+		expect(result.current).toEqual([]);
 	});
 });

--- a/packages/web/src/components/Project/Project.test.tsx
+++ b/packages/web/src/components/Project/Project.test.tsx
@@ -605,6 +605,8 @@ describe('Project — Notebook Actions', () => {
 	it('duplicates a notebook from the overflow menu', async () => {
 		const user = userEvent.setup();
 		const calls = makeFetch();
+		const toastLoading = vi.spyOn(toast, 'loading');
+		const toastSuccess = vi.spyOn(toast, 'success');
 		await renderProject();
 
 		await chooseNotebookAction(user, 'Duplicate');
@@ -613,6 +615,13 @@ describe('Project — Notebook Actions', () => {
 			expect(
 				calls.some((c) => c.method === 'POST' && c.url.endsWith('/notebooks/nb-1/duplicate')),
 			).toBe(true),
+		);
+		// A slow duplicate shows progress, and the success toast replaces it in place.
+		expect(toastLoading).toHaveBeenCalledWith(expect.stringContaining('Duplicating'));
+		await waitFor(() =>
+			expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining('Duplicated'), {
+				id: toastLoading.mock.results[0]?.value,
+			}),
 		);
 	});
 
@@ -653,6 +662,7 @@ describe('Project — Notebook Actions', () => {
 		const user = userEvent.setup();
 		const calls = makeFetch();
 		const { createObjectURL } = installDownloadMocks();
+		const toastLoading = vi.spyOn(toast, 'loading');
 		await renderProject();
 
 		await chooseNotebookAction(user, 'Download workspace');
@@ -663,6 +673,7 @@ describe('Project — Notebook Actions', () => {
 			).toBe(true),
 		);
 		expect(createObjectURL).toHaveBeenCalledOnce();
+		expect(toastLoading).toHaveBeenCalledWith(expect.stringContaining('Preparing workspace'));
 	});
 
 	it('offers one unified sync settings action for a git-backed notebook', async () => {

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -92,7 +92,6 @@ import { VersionHistoryDialog } from '@/components/Notebook/VersionHistoryDialog
 import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { useSearchField } from '@/hooks/useSearchField';
-import { errorMessage, toastError } from '@/lib/errors';
 import { filterBySearch } from '@/lib/search';
 import { formatRelative } from '@/lib/time';
 import { syncUrl } from '@/lib/links';
@@ -200,8 +199,8 @@ export function Project() {
 				});
 				toast.success(`Updated project "${name}"`);
 				editProjectModal.close();
-			} catch (err) {
-				toastError(err);
+			} catch {
+				return;
 			}
 		},
 	});
@@ -222,8 +221,8 @@ export function Project() {
 				await deleteProject.mutateAsync(pid!);
 				toast.success(`Deleted "${project.name}"`);
 				void navigate('/');
-			} catch (err) {
-				toastError(err);
+			} catch {
+				return;
 			}
 		},
 	});
@@ -250,8 +249,8 @@ export function Project() {
 				});
 				toast.success(`Created "${name}"`);
 				closeCreateModal();
-			} catch (err) {
-				toastError(err);
+			} catch {
+				return;
 			}
 		},
 	});
@@ -262,13 +261,8 @@ export function Project() {
 	});
 
 	const handleSaveCloudAccess = async (enabled: boolean) => {
-		try {
-			await updateProject.mutateAsync({ projectId: pid!, federation: { enabled } });
-			toast.success(enabled ? 'Federated cloud access enabled' : 'Federated cloud access disabled');
-		} catch (error) {
-			toastError(error);
-			throw error;
-		}
+		await updateProject.mutateAsync({ projectId: pid!, federation: { enabled } });
+		toast.success(enabled ? 'Federated cloud access enabled' : 'Federated cloud access disabled');
 	};
 
 	// Map each notebook to its "most alive" session so a row shows the strongest state.
@@ -323,32 +317,29 @@ export function Project() {
 				toast.success(`Deleted "${nb.title}"`);
 				deleteModal.close();
 			},
-			onError: toastError,
 		});
 	};
 
 	const handleDuplicate = (nb: NotebookEntry) => {
-		toast.promise(duplicateNotebook.mutateAsync({ notebookId: nb.id }), {
-			loading: `Duplicating "${nb.title}"...`,
-			success: `Duplicated "${nb.title}"`,
-			error: (err: Error) => err.message,
-		});
+		duplicateNotebook.mutate(
+			{ notebookId: nb.id },
+			{ onSuccess: () => toast.success(`Duplicated "${nb.title}"`) },
+		);
 	};
 
 	const handleDownloadFile = (nb: NotebookEntry) => {
-		downloadNotebookFile.mutate({ notebookId: nb.id, title: nb.title }, { onError: toastError });
+		downloadNotebookFile.mutate({ notebookId: nb.id, title: nb.title });
 	};
 
 	const handleDownloadOutputs = (nb: NotebookEntry) => {
-		downloadOutputsHtml.mutate({ notebookId: nb.id, title: nb.title }, { onError: toastError });
+		downloadOutputsHtml.mutate({ notebookId: nb.id, title: nb.title });
 	};
 
 	const handleDownloadWorkspace = (nb: NotebookEntry) => {
-		toast.promise(downloadWorkspace.mutateAsync({ notebookId: nb.id, title: nb.title }), {
-			loading: `Preparing workspace for "${nb.title}"...`,
-			success: 'Workspace downloaded',
-			error: (err: Error) => err.message,
-		});
+		downloadWorkspace.mutate(
+			{ notebookId: nb.id, title: nb.title },
+			{ onSuccess: () => toast.success('Workspace downloaded') },
+		);
 	};
 
 	const handleStop = () => {
@@ -360,7 +351,6 @@ export function Project() {
 				toast.success(`Stopped "${stop.notebook.title}"`);
 				stopModal.close();
 			},
-			onError: toastError,
 		});
 	};
 
@@ -377,7 +367,6 @@ export function Project() {
 				);
 				appModal.close();
 			},
-			onError: toastError,
 		});
 	};
 
@@ -397,7 +386,7 @@ export function Project() {
 				sessionId: computeRestartSession.session_id,
 			})
 			.then(() => toast.success(`Restarted the session for "${computeTarget.title}"`))
-			.catch((error) => toast.error(errorMessage(error)));
+			.catch(() => {});
 	};
 
 	const handleSyncedCreated = (result: SyncedNotebookCreated) => {

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -321,9 +321,14 @@ export function Project() {
 	};
 
 	const handleDuplicate = (nb: NotebookEntry) => {
+		// Loading feedback only — the error toast comes from the global mutation cache.
+		const loadingToast = toast.loading(`Duplicating "${nb.title}"...`);
 		duplicateNotebook.mutate(
 			{ notebookId: nb.id },
-			{ onSuccess: () => toast.success(`Duplicated "${nb.title}"`) },
+			{
+				onSuccess: () => toast.success(`Duplicated "${nb.title}"`, { id: loadingToast }),
+				onError: () => toast.dismiss(loadingToast),
+			},
 		);
 	};
 
@@ -336,9 +341,13 @@ export function Project() {
 	};
 
 	const handleDownloadWorkspace = (nb: NotebookEntry) => {
+		const loadingToast = toast.loading(`Preparing workspace for "${nb.title}"...`);
 		downloadWorkspace.mutate(
 			{ notebookId: nb.id, title: nb.title },
-			{ onSuccess: () => toast.success('Workspace downloaded') },
+			{
+				onSuccess: () => toast.success('Workspace downloaded', { id: loadingToast }),
+				onError: () => toast.dismiss(loadingToast),
+			},
 		);
 	};
 

--- a/packages/web/src/components/Project/ProjectEnvironmentDialog.tsx
+++ b/packages/web/src/components/Project/ProjectEnvironmentDialog.tsx
@@ -127,7 +127,7 @@ function CloudAccessPanel({
 				await onSave(value.enabled);
 				form.reset({ enabled: value.enabled });
 			} catch {
-				// The parent reports the mutation error; keep this draft for retry.
+				// Keep the draft for retry; the global mutation handler reports the error.
 			}
 		},
 	});

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -2,10 +2,11 @@ import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { OrgIntegrationsDialog, ProjectIntegrationsPanel } from './ProjectIntegrationsDialog';
 import type { IntegrationDetail, IntegrationEntry, IntegrationKind, ProjectDetail } from '@/types';
+import { createTestQueryClient } from '@/test/render';
 
 const PID = 'p_1';
 
@@ -290,7 +291,7 @@ function setup(
 ) {
 	const calls = makeFetch(fetchOpts);
 	const onBack = vi.fn();
-	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const client = createTestQueryClient();
 	const wrapper = ({ children }: { children: ReactNode }) => (
 		<QueryClientProvider client={client}>
 			{children}
@@ -692,7 +693,7 @@ describe('ProjectIntegrationsPanel — inherited org integrations', () => {
 describe('OrgIntegrationsDialog', () => {
 	function setupOrg(fetchOpts: FetchOpts) {
 		const calls = makeFetch(fetchOpts);
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const client = createTestQueryClient();
 		const wrapper = ({ children }: { children: ReactNode }) => (
 			<QueryClientProvider client={client}>
 				{children}
@@ -827,7 +828,7 @@ describe('ProjectIntegrationsPanel — copy from another project', () => {
 	it('does not offer the copy entry point in the org dialog', async () => {
 		const user = userEvent.setup();
 		makeFetch({ kinds: [postgresKind], entries: [], orgEntries: [] });
-		const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+		const client = createTestQueryClient();
 		render(<OrgIntegrationsDialog isOpen onClose={vi.fn()} />, {
 			wrapper: ({ children }: { children: ReactNode }) => (
 				<QueryClientProvider client={client}>{children}</QueryClientProvider>

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
@@ -48,7 +48,6 @@ import {
 import type { IntegrationsScope } from '@/api/hooks';
 import { BRAND_ICONS } from './brandIcons';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
-import { toastError } from '@/lib/errors';
 import { canManageProject } from '@/lib/roles';
 import { filterBySearch } from '@/lib/search';
 import type { IntegrationEntry, IntegrationKind, ProjectDetail } from '@/types';
@@ -297,7 +296,6 @@ function ListView({
 			{
 				onSuccess: () =>
 					toast.success(entry.enabled ? `${entry.name} disabled` : `${entry.name} enabled`),
-				onError: toastError,
 			},
 		);
 	};
@@ -310,7 +308,6 @@ function ListView({
 				toast.success('Integration deleted');
 				confirmDelete.close();
 			},
-			onError: toastError,
 		});
 	};
 
@@ -659,8 +656,8 @@ function CopyView({
 			});
 			toast.success(`Copied ${trimmed}`);
 			onDone();
-		} catch (err) {
-			toastError(err);
+		} catch {
+			return;
 		}
 	};
 
@@ -861,8 +858,8 @@ function EditorForm({
 				toast.success('Integration added');
 			}
 			onDone();
-		} catch (err) {
-			toastError(err);
+		} catch {
+			return;
 		}
 	};
 
@@ -883,8 +880,8 @@ function EditorForm({
 			} else {
 				toast.error(`Connection failed${result.details ? ` — ${result.details}` : ''}`);
 			}
-		} catch (err) {
-			toastError(err);
+		} catch {
+			return;
 		}
 	};
 

--- a/packages/web/src/components/Project/ProjectMembersDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectMembersDialog.test.tsx
@@ -2,11 +2,12 @@ import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { ProjectMembersDialog } from './ProjectMembersDialog';
 import { AuthProvider } from '@/context/AuthContext';
 import { userKeys } from '@/api/queryKeys';
+import { createTestQueryClient } from '@/test/render';
 import type { Capabilities, ProjectDetail, ProjectMember, ResolvedUser, User } from '@/types';
 
 const PID = 'proj-1';
@@ -107,7 +108,7 @@ function makeFetch({
 }
 
 async function renderDialog(yourRole: ProjectDetail['your_role']) {
-	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	const client = createTestQueryClient();
 	client.setQueryData(userKeys.me(), currentTestUser);
 	const onClose = vi.fn();
 	const wrapper = ({ children }: { children: ReactNode }) => (

--- a/packages/web/src/components/Project/ProjectMembersDialog.tsx
+++ b/packages/web/src/components/Project/ProjectMembersDialog.tsx
@@ -25,7 +25,6 @@ import type { UserDirectory } from '@/api/hooks';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { useAuth } from '@/context/AuthContext';
-import { toastError } from '@/lib/errors';
 import {
 	ASSIGNABLE_ROLES,
 	canManageProject,
@@ -344,8 +343,7 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 			await addMember.mutateAsync({ ...choice, role });
 			toast.success('email' in choice ? 'Invite added' : 'Member added');
 			return true;
-		} catch (err) {
-			toastError(err);
+		} catch {
 			return false;
 		}
 	};
@@ -355,7 +353,6 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 			{ uid: memberKey(member), role },
 			{
 				onSuccess: () => toast.success('Role updated'),
-				onError: toastError,
 			},
 		);
 	};
@@ -368,7 +365,6 @@ export function ProjectMembersDialog({ isOpen, onClose, project }: ProjectMember
 				toast.success('Member removed');
 				confirmRemove.close();
 			},
-			onError: toastError,
 		});
 	};
 

--- a/packages/web/src/components/ProjectList/ProjectList.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.tsx
@@ -21,7 +21,6 @@ import {
 import { useProjectsQuery, useCreateProject } from '@/api/hooks';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { useSearchField } from '@/hooks/useSearchField';
-import { toastError } from '@/lib/errors';
 import { filterBySearch } from '@/lib/search';
 
 const projectSchema = z.object({
@@ -48,8 +47,8 @@ export function ProjectList() {
 				await createProject.mutateAsync({ name, description: description || name });
 				toast.success(`Created project "${name}"`);
 				createModal.close();
-			} catch (err) {
-				toastError(err);
+			} catch {
+				return;
 			}
 		},
 	});

--- a/packages/web/src/components/ui/ErrorBoundary.tsx
+++ b/packages/web/src/components/ui/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { Button } from './Button';
 interface ErrorBoundaryProps {
 	children: ReactNode;
 	fallback?: ReactNode;
+	onRetry?: () => void;
 }
 
 interface ErrorBoundaryState {
@@ -27,6 +28,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 	}
 
 	handleRetry = (): void => {
+		this.props.onRetry?.();
 		this.setState({ hasError: false, error: null });
 	};
 

--- a/packages/web/src/hooks/useNotebookSession.test.tsx
+++ b/packages/web/src/hooks/useNotebookSession.test.tsx
@@ -201,6 +201,43 @@ describe('useNotebookSession', () => {
 		expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(true);
 	});
 
+	it('stop() surfaces a failed stop inline — the toast is suppressed for this path', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) =>
+				init?.method === 'DELETE'
+					? jsonError('SERVICE_UNAVAILABLE', 'teardown failed', 503)
+					: jsonOk(makeSession()),
+			),
+		);
+
+		const { result } = renderHookWithClient(() => useNotebookSession(PID, NID), { toaster: false });
+		await waitFor(() => expect(result.current.session).not.toBeNull());
+
+		act(() => result.current.stop());
+
+		await waitFor(() => expect(result.current.error?.message).toBe('teardown failed'));
+		expect(result.current.session).toBeNull();
+	});
+
+	it('stop() treats an already-reaped (404) session as stopped, with no error', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) =>
+				init?.method === 'DELETE' ? jsonError('NOT_FOUND', 'gone', 404) : jsonOk(makeSession()),
+			),
+		);
+
+		const { result } = renderHookWithClient(() => useNotebookSession(PID, NID), { toaster: false });
+		await waitFor(() => expect(result.current.session).not.toBeNull());
+
+		act(() => result.current.stop());
+		await settleHook();
+
+		expect(result.current.session).toBeNull();
+		expect(result.current.error).toBeNull();
+	});
+
 	it('retry via start() recovers from an error', async () => {
 		let calls = 0;
 		vi.stubGlobal(

--- a/packages/web/src/hooks/useNotebookSession.ts
+++ b/packages/web/src/hooks/useNotebookSession.ts
@@ -180,9 +180,18 @@ export function useNotebookSession(
 	const stop = useCallback(() => {
 		const s = sessionRef.current;
 		if (s) {
-			generation.bump();
+			const gen = generation.bump();
 			setStarting(false);
-			stopSession.mutate(s.session_id);
+			// The global toast is suppressed for this mutation, so a failed stop must
+			// surface inline — otherwise the page shows no session AND no error.
+			stopSession.mutate(s.session_id, {
+				onError: (err) => {
+					if (!generation.isCurrent(gen)) return;
+					// Already gone (stopped/reaped underneath us): the stop succeeded in effect.
+					if (isNotFoundError(err)) return;
+					setError(toSessionError(err));
+				},
+			});
 			commitSession(null);
 		}
 	}, [stopSession, commitSession, generation]);

--- a/packages/web/src/hooks/useNotebookSession.ts
+++ b/packages/web/src/hooks/useNotebookSession.ts
@@ -95,7 +95,8 @@ export function useNotebookSession(
 	const startSession = useStartSession(projectId, notebookId, mode, editIntent);
 	const startPersistentSession = useStartSession(projectId, notebookId, mode);
 	const startDefaultSession = useStartSessionWithDefault(projectId, notebookId, mode, editIntent);
-	const stopSession = useStopSession(projectId, notebookId);
+	// Stop/restart failures render inline (session panel), never as a toast.
+	const stopSession = useStopSession(projectId, notebookId, { suppressErrorToast: true });
 
 	const [session, setSession] = useState<Session | null>(null);
 	const [error, setError] = useState<SessionError | null>(null);

--- a/packages/web/src/lib/errors.test.ts
+++ b/packages/web/src/lib/errors.test.ts
@@ -36,4 +36,10 @@ describe('toastError', () => {
 		toastError(new Error('could not save'));
 		expect(error).toHaveBeenCalledWith('could not save');
 	});
+
+	it('uses recovery guidance for stale writes', () => {
+		const error = vi.spyOn(toast, 'error').mockImplementation(() => '');
+		toastError(new ApiRequestError('PRECONDITION_FAILED', 'stale revision'));
+		expect(error).toHaveBeenCalledWith('Someone else changed this item. Reload it and try again.');
+	});
 });

--- a/packages/web/src/lib/errors.ts
+++ b/packages/web/src/lib/errors.ts
@@ -1,4 +1,5 @@
 import { toast } from 'sonner';
+import { ApiRequestError } from '@/api/client';
 
 /**
  * A displayable message for anything thrown. Rejections from the api hooks are
@@ -11,5 +12,9 @@ export function errorMessage(err: unknown): string {
 }
 
 export function toastError(err: unknown): void {
+	if (err instanceof ApiRequestError && err.code === 'PRECONDITION_FAILED') {
+		toast.error('Someone else changed this item. Reload it and try again.');
+		return;
+	}
 	toast.error(errorMessage(err));
 }

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,8 +1,9 @@
 import { lazy, StrictMode, Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import './index.css';
 import App from './App.tsx';
+import { queryClient } from './api/queryClient';
 
 // Dev-only: the React Query devtools are loaded via a dynamic import gated on
 // `import.meta.env.DEV`, so the production build tree-shakes the module out
@@ -14,15 +15,6 @@ const ReactQueryDevtools = import.meta.env.DEV
 			})),
 		)
 	: () => null;
-
-const queryClient = new QueryClient({
-	defaultOptions: {
-		queries: {
-			staleTime: 60_000,
-			retry: 1,
-		},
-	},
-});
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>

--- a/packages/web/src/test/render.tsx
+++ b/packages/web/src/test/render.tsx
@@ -12,7 +12,14 @@ import { createQueryClient } from '@/api/queryClient';
 
 export function createTestQueryClient(): QueryClient {
 	const client = createQueryClient();
-	client.setDefaultOptions({ queries: { retry: false }, mutations: { retry: false } });
+	// Merge, don't replace: tests must keep every production default (staleTime,
+	// future additions) and override only retry.
+	const defaults = client.getDefaultOptions();
+	client.setDefaultOptions({
+		...defaults,
+		queries: { ...defaults.queries, retry: false },
+		mutations: { ...defaults.mutations, retry: false },
+	});
 	return client;
 }
 

--- a/packages/web/src/test/render.tsx
+++ b/packages/web/src/test/render.tsx
@@ -2,15 +2,18 @@ import type { ReactElement, ReactNode } from 'react';
 import { Suspense } from 'react';
 import { render, renderHook } from '@testing-library/react';
 import type { RenderHookOptions, RenderOptions } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { QueryClient } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { Toaster } from 'sonner';
 import { vi } from 'vitest';
+import { ErrorBoundary } from '@/components/ui';
+import { createQueryClient } from '@/api/queryClient';
 
 export function createTestQueryClient(): QueryClient {
-	return new QueryClient({
-		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-	});
+	const client = createQueryClient();
+	client.setDefaultOptions({ queries: { retry: false }, mutations: { retry: false } });
+	return client;
 }
 
 interface ProviderOptions {
@@ -18,6 +21,7 @@ interface ProviderOptions {
 	route?: string | string[];
 	toaster?: boolean;
 	suspenseFallback?: ReactNode;
+	errorBoundary?: boolean;
 }
 
 function createWrapper({
@@ -25,11 +29,17 @@ function createWrapper({
 	route,
 	toaster = true,
 	suspenseFallback = null,
+	errorBoundary = false,
 }: ProviderOptions) {
 	return function TestWrapper({ children }: { children: ReactNode }) {
+		const content = errorBoundary ? (
+			<ErrorBoundary fallback={<div>Request failed</div>}>{children}</ErrorBoundary>
+		) : (
+			children
+		);
 		let tree = (
 			<QueryClientProvider client={client}>
-				<Suspense fallback={suspenseFallback}>{children}</Suspense>
+				<Suspense fallback={suspenseFallback}>{content}</Suspense>
 				{toaster && <Toaster />}
 			</QueryClientProvider>
 		);
@@ -51,13 +61,14 @@ export function renderWithClient(
 		route,
 		toaster,
 		suspenseFallback,
+		errorBoundary,
 		...renderOptions
 	} = options;
 	return {
 		client,
 		...render(ui, {
 			...renderOptions,
-			wrapper: createWrapper({ client, route, toaster, suspenseFallback }),
+			wrapper: createWrapper({ client, route, toaster, suspenseFallback, errorBoundary }),
 		}),
 	};
 }
@@ -71,13 +82,14 @@ export function renderHookWithClient<Result, Props>(
 		route,
 		toaster,
 		suspenseFallback,
+		errorBoundary,
 		...hookOptions
 	} = options;
 	return {
 		client,
 		...renderHook(callback, {
 			...hookOptions,
-			wrapper: createWrapper({ client, route, toaster, suspenseFallback }),
+			wrapper: createWrapper({ client, route, toaster, suspenseFallback, errorBoundary }),
 		}),
 	};
 }


### PR DESCRIPTION
Closes the FE/BE error contract and centralizes handling on both sides.

## Backend
- Domain error codes live in core and flow typed through `fail()`, the OpenAPI spec, and the client — drift is now a compile error. Adds the previously-emitted-but-undocumented takeover codes; documents 413/500 on every route.
- Structured validation payloads (`error.details: [{field, message}]`) from the zod hook.
- Status corrections: state conflicts 400→409, deployment policy 400→403, semantic rejections 400→422, corrupted stored objects 500→503, takeover lease losses 503→409.
- Vendor error shapes no longer cross port boundaries (compute results are discriminated unions with typed failure codes, `supportsBucketMount` disambiguates mount-unsupported vs mount-failed, secrets outages map to 503 instead of a user-blame 422).
- Swallowed OIDC verification failures and takeover-drain causes now log secret-safe operational events.

## Frontend
- `ApiRequestError` carries the generated code union plus `status`, `request_id`, and `details`.
- Shared QueryClient: global mutation toasts (opt-out via `meta.suppressErrorToast`), 401 wipes the cached identity so the app returns to sign-in, retry skips 4xx.
- 412 on integration saves refetches the stale ETag; 404 gets a real not-found page; error boundary resets query state.

## Notes for review
- oasdiff will flag the three new `error.code` enum values as a breaking response change — the runtime already emitted them, so this is a spec bug-fix needing acknowledgment.
- Runtime-visible behavior changes for pinned clients: the status corrections above and the sandbox-proxy 502 body switching from plain text to the JSON envelope.

All changes are pinned by regression tests (compute contract, provisioner mount paths, queryClient handlers, OIDC logging, tiered-compute flag forwarding).