### PR TITLE
feat: configurable sandbox startup timeout

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -13,6 +13,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_KUBERNETES_NAMESPACE=marimo-kernels
 MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE=https://{id}.{host}
 MARIMOHUB_COMPUTE_KUBERNETES_INGRESS_CLASS=traefik
@@ -59,6 +60,7 @@ exports[`config -> code generators > azure + kubernetes + oidc > compose 1`] = `
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_KUBERNETES_NAMESPACE: marimo-kernels
       MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE: https://{id}.{host}
       MARIMOHUB_COMPUTE_KUBERNETES_INGRESS_CLASS: traefik
@@ -94,6 +96,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_KUBERNETES_NAMESPACE: marimo-kernels
   MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE: https://{id}.{host}
   MARIMOHUB_COMPUTE_KUBERNETES_INGRESS_CLASS: traefik
@@ -194,6 +197,7 @@ MARIMOHUB_COMPUTE_IMAGE=_replace_me_  # e.g. ghcr.io/orgname/marimo-sandbox:late
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_MODAL_TOKEN_ID=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_APP_NAME=marimohub
@@ -236,6 +240,7 @@ exports[`config -> code generators > default-prod (s3 + modal + oidc) > compose 
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
@@ -266,6 +271,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
   MARIMOHUB_AUTH_BACKEND: oidc
   MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
@@ -349,6 +355,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_DOCKER_HOST=localhost
 MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=127.0.0.1
 MARIMOHUB_COMPUTE_DOCKER_NETWORK=marimohub
@@ -386,6 +393,7 @@ exports[`config -> code generators > fs + docker + oidc (single-box) > compose 1
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_DOCKER_HOST: localhost
       MARIMOHUB_COMPUTE_DOCKER_BIND_HOST: 127.0.0.1
       MARIMOHUB_COMPUTE_DOCKER_NETWORK: marimohub
@@ -413,6 +421,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_DOCKER_HOST: localhost
   MARIMOHUB_COMPUTE_DOCKER_BIND_HOST: 127.0.0.1
   MARIMOHUB_COMPUTE_DOCKER_NETWORK: marimohub
@@ -490,6 +499,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_PODMAN_HOST=localhost
 MARIMOHUB_COMPUTE_PODMAN_BIND_HOST=127.0.0.1
 MARIMOHUB_COMPUTE_PODMAN_NETWORK=marimohub
@@ -527,6 +537,7 @@ exports[`config -> code generators > fs + podman + oidc > compose 1`] = `
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_PODMAN_HOST: localhost
       MARIMOHUB_COMPUTE_PODMAN_BIND_HOST: 127.0.0.1
       MARIMOHUB_COMPUTE_PODMAN_NETWORK: marimohub
@@ -554,6 +565,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_PODMAN_HOST: localhost
   MARIMOHUB_COMPUTE_PODMAN_BIND_HOST: 127.0.0.1
   MARIMOHUB_COMPUTE_PODMAN_NETWORK: marimohub
@@ -635,6 +647,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_KUBERNETES_NAMESPACE=marimo-kernels
 MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE=https://{id}.{host}
 MARIMOHUB_COMPUTE_KUBERNETES_INGRESS_CLASS=traefik
@@ -682,6 +695,7 @@ exports[`config -> code generators > gcs + kubernetes + oidc, persist workspace 
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_KUBERNETES_NAMESPACE: marimo-kernels
       MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE: https://{id}.{host}
       MARIMOHUB_COMPUTE_KUBERNETES_INGRESS_CLASS: traefik
@@ -717,6 +731,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_KUBERNETES_NAMESPACE: marimo-kernels
   MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE: https://{id}.{host}
   MARIMOHUB_COMPUTE_KUBERNETES_INGRESS_CLASS: traefik
@@ -807,6 +822,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_LOCAL_HOST=localhost
 MARIMOHUB_COMPUTE_LOCAL_BIND_HOST=127.0.0.1
 MARIMOHUB_COMPUTE_LOCAL_PORTS=2718-2723
@@ -839,6 +855,7 @@ exports[`config -> code generators > memory + local + dev (all-local) > compose 
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_LOCAL_HOST: localhost
       MARIMOHUB_COMPUTE_LOCAL_BIND_HOST: 127.0.0.1
       MARIMOHUB_COMPUTE_LOCAL_PORTS: 2718-2723
@@ -861,6 +878,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_LOCAL_HOST: localhost
   MARIMOHUB_COMPUTE_LOCAL_BIND_HOST: 127.0.0.1
   MARIMOHUB_COMPUTE_LOCAL_PORTS: 2718-2723
@@ -933,6 +951,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/acme/marimo-sandbox:v1
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_COREWEAVE_API_KEY=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_COREWEAVE_BASE_URL=
 MARIMOHUB_COMPUTE_COREWEAVE_OWNER_TAG=marimohub
@@ -985,6 +1004,7 @@ exports[`config -> code generators > s3 + coreweave + oidc, custom image > compo
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_COREWEAVE_API_KEY: _replace_me_
       MARIMOHUB_COMPUTE_COREWEAVE_BASE_URL: ""
       MARIMOHUB_COMPUTE_COREWEAVE_OWNER_TAG: marimohub
@@ -1025,6 +1045,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_COREWEAVE_BASE_URL: ""
   MARIMOHUB_COMPUTE_COREWEAVE_OWNER_TAG: marimohub
   MARIMOHUB_COMPUTE_COREWEAVE_HOSTNAME_TEMPLATE: https://{sandboxId}-{port}.{host}
@@ -1121,6 +1142,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_DOCKER_HOST=localhost
 MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=127.0.0.1
 MARIMOHUB_COMPUTE_DOCKER_NETWORK=marimohub
@@ -1158,6 +1180,7 @@ exports[`config -> code generators > s3 + docker + dev > compose 1`] = `
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_DOCKER_HOST: localhost
       MARIMOHUB_COMPUTE_DOCKER_BIND_HOST: 127.0.0.1
       MARIMOHUB_COMPUTE_DOCKER_NETWORK: marimohub
@@ -1183,6 +1206,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_DOCKER_HOST: localhost
   MARIMOHUB_COMPUTE_DOCKER_BIND_HOST: 127.0.0.1
   MARIMOHUB_COMPUTE_DOCKER_NETWORK: marimohub
@@ -1262,6 +1286,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_E2B_API_KEY=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_E2B_TEMPLATE=marimo
 MARIMOHUB_COMPUTE_E2B_DOMAIN=
@@ -1306,6 +1331,7 @@ exports[`config -> code generators > s3 + e2b + oidc > compose 1`] = `
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_E2B_API_KEY: _replace_me_
       MARIMOHUB_COMPUTE_E2B_TEMPLATE: marimo
       MARIMOHUB_COMPUTE_E2B_DOMAIN: ""
@@ -1338,6 +1364,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_E2B_TEMPLATE: marimo
   MARIMOHUB_COMPUTE_E2B_DOMAIN: ""
   MARIMOHUB_COMPUTE_E2B_OWNER_TAG: marimohub
@@ -1426,6 +1453,7 @@ MARIMOHUB_COMPUTE_IMAGE=_replace_me_  # e.g. ghcr.io/orgname/marimo-sandbox:late
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_MODAL_TOKEN_ID=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_APP_NAME=marimohub
@@ -1476,6 +1504,7 @@ exports[`config -> code generators > s3 + modal + oidc, managed ai > compose 1`]
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
@@ -1514,6 +1543,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
   MARIMOHUB_AUTH_BACKEND: oidc
   MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
@@ -1618,6 +1648,7 @@ MARIMOHUB_COMPUTE_IMAGE=_replace_me_  # e.g. ghcr.io/orgname/marimo-sandbox:late
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_MODAL_TOKEN_ID=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_APP_NAME=marimohub
@@ -1660,6 +1691,7 @@ exports[`config -> code generators > s3 + modal + oidc, value overrides > compos
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
@@ -1690,6 +1722,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
   MARIMOHUB_AUTH_BACKEND: oidc
   MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
@@ -1778,6 +1811,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 
 # --- Auth ---
 MARIMOHUB_AUTH_BACKEND=dev
@@ -1812,6 +1846,7 @@ exports[`config -> code generators > s3 + none + dev > compose 1`] = `
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_AUTH_BACKEND: dev
       MARIMOHUB_AUTH_DEV_USER_ID: user
       MARIMOHUB_AUTH_DEV_EMAIL: "user@localhost"
@@ -1834,6 +1869,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_AUTH_BACKEND: dev
   MARIMOHUB_AUTH_DEV_USER_ID: user
   MARIMOHUB_AUTH_DEV_EMAIL: "user@localhost"
@@ -1912,6 +1948,7 @@ MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_WANDB_API_KEY=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_WANDB_ENTITY=my-team
 MARIMOHUB_COMPUTE_WANDB_PROJECT=sandbox
@@ -1957,6 +1994,7 @@ exports[`config -> code generators > s3 + wandb + oidc > compose 1`] = `
       MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_WANDB_API_KEY: _replace_me_
       MARIMOHUB_COMPUTE_WANDB_ENTITY: my-team
       MARIMOHUB_COMPUTE_WANDB_PROJECT: sandbox
@@ -1990,6 +2028,7 @@ config:
   MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
   MARIMOHUB_COMPUTE_WANDB_ENTITY: my-team
   MARIMOHUB_COMPUTE_WANDB_PROJECT: sandbox
   MARIMOHUB_COMPUTE_WANDB_BASE_URL: https://api.cwsandbox.com

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,7 +106,7 @@ Read regardless of the selected compute backend.
 | `MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME` | Public hostname used to expose kernel ports. | — | `'' (empty)` | `hub.example.com` |
 | `MARIMOHUB_COMPUTE_WORKDIR` | Working directory inside the sandbox where notebook files land and marimo runs. | — | `/workspace` | — |
 | `MARIMOHUB_COMPUTE_ASSET_URL` | Base URL for marimo frontend assets (e.g. a CDN). Omit to use the bundled assets. | — | — | `https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist` |
-| `MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS` | How long a session start waits for the marimo kernel to come up before failing. Generous by default because a cold sandbox may resolve + download the notebook environment on first boot. Served on `/api/v1/capabilities` so the client bounds its own startup wait with the same value. | — | `120` | `300` |
+| `MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS` | How long a session start waits for the marimo kernel to come up before failing. Generous by default because a cold sandbox may resolve + download the notebook environment on first boot. Served on `/api/v1/capabilities` so the client bounds its own startup wait with the same value. | — | `120` | — |
 
 ### CoreWeave Sandbox
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,7 @@ Read regardless of the selected compute backend.
 | `MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME` | Public hostname used to expose kernel ports. | — | `'' (empty)` | `hub.example.com` |
 | `MARIMOHUB_COMPUTE_WORKDIR` | Working directory inside the sandbox where notebook files land and marimo runs. | — | `/workspace` | — |
 | `MARIMOHUB_COMPUTE_ASSET_URL` | Base URL for marimo frontend assets (e.g. a CDN). Omit to use the bundled assets. | — | — | `https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist` |
+| `MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS` | How long a session start waits for the marimo kernel to come up before failing. Generous by default because a cold sandbox may resolve + download the notebook environment on first boot. Served on `/api/v1/capabilities` so the client bounds its own startup wait with the same value. | — | `120` | `300` |
 
 ### CoreWeave Sandbox
 

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -201,6 +201,8 @@ components:
           type: array
           items:
             type: string
+        sandbox_startup_timeout_seconds:
+          type: number
         compute_profiles:
           type: array
           items:
@@ -226,6 +228,7 @@ components:
         - default_role
         - limits
         - sandbox_images
+        - sandbox_startup_timeout_seconds
         - compute_profiles
         - compute_profile_override
     ComputeResources:

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -90,8 +90,9 @@ export interface SandboxConfig {
 	/**
 	 * How long a session provision waits for the marimo kernel to come up before
 	 * failing the start (config: MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS).
-	 * Undefined = the core default (2 minutes). Also served on `/capabilities`
-	 * so the client bounds its own startup wait with the same value.
+	 * Undefined = the core default (2 minutes). Also served on
+	 * `/api/v1/capabilities` so the client bounds its own startup wait with the
+	 * same value.
 	 */
 	startupTimeoutMs?: Millis;
 	/**

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -88,6 +88,13 @@ export interface SandboxConfig {
 	 */
 	assetUrl?: string;
 	/**
+	 * How long a session provision waits for the marimo kernel to come up before
+	 * failing the start (config: MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS).
+	 * Undefined = the core default (2 minutes). Also served on `/capabilities`
+	 * so the client bounds its own startup wait with the same value.
+	 */
+	startupTimeoutMs?: Millis;
+	/**
 	 * How kernels are surfaced to the browser (config: MARIMOHUB_SANDBOX_EXPOSURE):
 	 * `subdomain` (direct, isolated domain) or `proxy` (forwarded through the app at
 	 * `…/proxy/<token>/`), independent of the compute backend. Optional — `createApi`

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -149,6 +149,61 @@ describe('Session routes', () => {
 		expect(data.error).toBeUndefined();
 	});
 
+	it('passes the configured sandbox startup timeout through to the kernel port wait', async () => {
+		const sb = makeFakeSandbox();
+		const api = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: fakeComputeFrom(sb.instance),
+			deps: { sandbox: sandboxConfig({ startupTimeoutMs: Millis.seconds(300) }) },
+		}).request;
+		await expectOk<ApiSession>(await api('POST', sessionsPath()));
+		expect(sb.calls.waitForPortOptions).toEqual([{ timeout: 300_000 }]);
+	});
+
+	it('surfaces a startup timeout as a 503 naming the timeout, on the response AND the record', async () => {
+		const sb = makeFakeSandbox({
+			failWaitForPort: new Error('timed out'),
+			logs: { stdout: 'Resolved 42 packages', stderr: '' },
+		});
+		const api = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: fakeComputeFrom(sb.instance),
+			// 0ms: the fake's instant rejection has already consumed the window, so
+			// the provisioner classifies it as a timeout without a real 2-minute wait.
+			deps: { sandbox: sandboxConfig({ startupTimeoutMs: Millis.of(0) }) },
+		}).request;
+
+		const error = await expectError(await api('POST', sessionsPath()), 503, 'SERVICE_UNAVAILABLE');
+		expect(error.message).toContain('startup timeout');
+		expect(error.message).toContain('MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS');
+		expect(error.message).toContain('Resolved 42 packages');
+
+		// A client polling GET …/sessions/{sid} sees the same reason on the record.
+		const [record] = await createServices(bucket).sessions.listSessions(nid);
+		expect(record.status).toBe('failed');
+		expect(record.error?.message).toContain('startup timeout');
+	});
+
+	it('serves the sandbox startup timeout on /capabilities', async () => {
+		const defaults = await expectOk<{ sandbox_startup_timeout_seconds: number }>(
+			await owner('GET', '/capabilities'),
+		);
+		expect(defaults.sandbox_startup_timeout_seconds).toBe(120);
+
+		const configured = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: makeFakeCompute(),
+			deps: { sandbox: sandboxConfig({ startupTimeoutMs: Millis.seconds(300) }) },
+		}).request;
+		const overridden = await expectOk<{ sandbox_startup_timeout_seconds: number }>(
+			await configured('GET', '/capabilities'),
+		);
+		expect(overridden.sandbox_startup_timeout_seconds).toBe(300);
+	});
+
 	it('defaults to one shared edit sandbox across users', async () => {
 		const first = await expectOk<ApiSession>(await owner('POST', sessionsPath()));
 		const sharedOther = createTestApi({

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1200,6 +1200,7 @@ app.openapi(createSession, async (c) => {
 						bucketHandle,
 						workdir: sandbox.workdir,
 						assetUrl: sandbox.assetUrl,
+						startupTimeoutMs: sandbox.startupTimeoutMs,
 						baseUrl,
 						restoreFilesystemSnapshotId: restoreFilesystemSnapshot?.snapshot_id,
 						image,

--- a/packages/api/src/routes/system.ts
+++ b/packages/api/src/routes/system.ts
@@ -1,8 +1,10 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import {
+	DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS,
 	isSuperAdmin,
 	MAX_REQUEST_BYTES,
 	MAX_VERSIONS,
+	Millis,
 	viewerSessionModes,
 } from '@marimo-hub/core';
 import {
@@ -109,6 +111,9 @@ app.openapi(capabilitiesRoute, (c) => {
 			max_page_size: MAX_PAGE_SIZE,
 		},
 		sandbox_images: deps.sandbox.images ?? [],
+		sandbox_startup_timeout_seconds: Millis.toSeconds(
+			deps.sandbox.startupTimeoutMs ?? DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS,
+		),
 		compute_profiles: (deps.sandbox.computeProfiles ?? []).map((profile) => ({
 			name: profile.name,
 			...toComputeResourcesResponse(profile.resources),

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -972,6 +972,12 @@ export const CapabilitiesResponseSchema = z
 		 * the deployment offers no image choice (single image or imageless backend).
 		 */
 		sandbox_images: z.array(z.string()),
+		/**
+		 * How long the server waits for a kernel to come up before failing a
+		 * session start (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS). Clients bound
+		 * their own "still starting" waits with it instead of hardcoding a copy.
+		 */
+		sandbox_startup_timeout_seconds: z.number(),
 		compute_profiles: z.array(
 			ComputeResourcesResponseSchema.extend({
 				name: z.string(),

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -6332,6 +6332,7 @@ export interface components {
 				max_page_size: number;
 			};
 			sandbox_images: string[];
+			sandbox_startup_timeout_seconds: number;
 			compute_profiles: (components['schemas']['ComputeResources'] & {
 				name: string;
 			})[];

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -80,6 +80,21 @@ describe('createFromEnv auth backend selection', () => {
 		expect(deps.sandbox.computeProfileOverride).toBe('editors');
 	});
 
+	it('parses the sandbox startup timeout into ms, defaulting to unset (core default)', () => {
+		const devEnv = { ...baseEnv, MARIMOHUB_AUTH_BACKEND: 'dev' };
+		expect(createFromEnv({ ...devEnv }).sandbox.startupTimeoutMs).toBeUndefined();
+		expect(
+			createFromEnv({ ...devEnv, MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: '300' }).sandbox
+				.startupTimeoutMs,
+		).toBe(300_000);
+		expect(() =>
+			createFromEnv({ ...devEnv, MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: '0' }),
+		).toThrow(/MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS/);
+		expect(() =>
+			createFromEnv({ ...devEnv, MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 'soon' }),
+		).toThrow(/MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS/);
+	});
+
 	it('rejects an invalid compute profile override policy', () => {
 		expect(() =>
 			createFromEnv({

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -112,22 +112,45 @@ const DEFAULT_SESSION_LIFETIME_EXTENSION_S = 1800; // 30m slide while editors co
 const DEFAULT_SESSION_SWEEP_INTERVAL_S = 60;
 
 /**
+ * An integer-seconds env var as `Millis`. `dflt` fills in when unset (omitted:
+ * unset stays undefined). Below the floor — 1, or 0 with `allowZero` — throws,
+ * so every seconds-valued knob validates and words its error identically.
+ */
+function parseSecondsEnv(
+	env: Env,
+	key: string,
+	opts: { dflt: number; allowZero?: boolean },
+): Millis;
+function parseSecondsEnv(
+	env: Env,
+	key: string,
+	opts?: { dflt?: number; allowZero?: boolean },
+): Millis | undefined;
+function parseSecondsEnv(
+	env: Env,
+	key: string,
+	opts?: { dflt?: number; allowZero?: boolean },
+): Millis | undefined {
+	const n = parseIntEnv(env, key) ?? opts?.dflt;
+	if (n === undefined) return undefined;
+	const min = opts?.allowZero ? 0 : 1;
+	if (n < min) {
+		throw new ConfigError(`Invalid ${key}: ${n} (expected an integer >= ${min})`, {
+			variable: key,
+		});
+	}
+	return Millis.seconds(n);
+}
+
+/**
  * Parse the marimohub-owned session lifetime policy: the graceful TTL enforced
  * by the lifecycle sweep, the idle timeout, the periodic snapshot cadence, and
  * connection-awareness. All optional with safe defaults; snapshot interval `0`
  * disables periodic snapshots.
  */
 function parseSessionLifetime(env: Env): SessionLifetimeConfig {
-	const seconds = (key: string, dflt: number, opts?: { allowZero?: boolean }) => {
-		const n = parseIntEnv(env, key) ?? dflt;
-		const min = opts?.allowZero ? 0 : 1;
-		if (n < min) {
-			throw new ConfigError(`Invalid ${key}: ${n} (expected an integer >= ${min})`, {
-				variable: key,
-			});
-		}
-		return Millis.seconds(n);
-	};
+	const seconds = (key: string, dflt: number, opts?: { allowZero?: boolean }) =>
+		parseSecondsEnv(env, key, { dflt, ...opts });
 	return {
 		maxLifetimeMs: seconds(
 			'MARIMOHUB_SESSION_MAX_LIFETIME_SECONDS',
@@ -152,24 +175,6 @@ function parseSessionLifetime(env: Env): SessionLifetimeConfig {
 			DEFAULT_SESSION_SWEEP_INTERVAL_S,
 		),
 	};
-}
-
-/**
- * How long a session provision waits for the marimo kernel to come up before
- * failing the start. Undefined defers to the core default (2 minutes); the
- * value is also served on `/api/v1/capabilities` so the client bounds its own
- * startup wait with it.
- */
-function parseSandboxStartupTimeout(env: Env): Millis | undefined {
-	const key = 'MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS';
-	const seconds = parseIntEnv(env, key);
-	if (seconds === undefined) return undefined;
-	if (seconds < 1) {
-		throw new ConfigError(`Invalid ${key}: ${seconds} (expected an integer >= 1)`, {
-			variable: key,
-		});
-	}
-	return Millis.seconds(seconds);
 }
 
 /**
@@ -357,7 +362,8 @@ export function createFromEnv(
 			hostname: env.MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME ?? '',
 			workdir: env.MARIMOHUB_COMPUTE_WORKDIR ?? '/workspace',
 			assetUrl: env.MARIMOHUB_COMPUTE_ASSET_URL,
-			startupTimeoutMs: parseSandboxStartupTimeout(env),
+			// Unset defers to the core default (2 min); served on /api/v1/capabilities.
+			startupTimeoutMs: parseSecondsEnv(env, 'MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS'),
 			exposure,
 			appBaseUrl: env.MARIMOHUB_APP_BASE_URL,
 			persistWorkspace: parsePersistWorkspace(env),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -155,6 +155,24 @@ function parseSessionLifetime(env: Env): SessionLifetimeConfig {
 }
 
 /**
+ * How long a session provision waits for the marimo kernel to come up before
+ * failing the start. Undefined defers to the core default (2 minutes); the
+ * value is also served on `/api/v1/capabilities` so the client bounds its own
+ * startup wait with it.
+ */
+function parseSandboxStartupTimeout(env: Env): Millis | undefined {
+	const key = 'MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS';
+	const seconds = parseIntEnv(env, key);
+	if (seconds === undefined) return undefined;
+	if (seconds < 1) {
+		throw new ConfigError(`Invalid ${key}: ${seconds} (expected an integer >= 1)`, {
+			variable: key,
+		});
+	}
+	return Millis.seconds(seconds);
+}
+
+/**
  * The fallback role granted to any logged-in user who is not the project owner
  * or an explicit member. Defaults to `editor` so a logged-in user can edit
  * notebooks out of the box; set `none` (or `viewer`) to keep writes
@@ -339,6 +357,7 @@ export function createFromEnv(
 			hostname: env.MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME ?? '',
 			workdir: env.MARIMOHUB_COMPUTE_WORKDIR ?? '/workspace',
 			assetUrl: env.MARIMOHUB_COMPUTE_ASSET_URL,
+			startupTimeoutMs: parseSandboxStartupTimeout(env),
 			exposure,
 			appBaseUrl: env.MARIMOHUB_APP_BASE_URL,
 			persistWorkspace: parsePersistWorkspace(env),

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -270,6 +270,14 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 							'Base URL for marimo frontend assets (e.g. a CDN). Omit to use the bundled assets.',
 						example: 'https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist',
 					},
+					{
+						id: 'MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS',
+						name: 'Sandbox startup timeout (seconds)',
+						description:
+							'How long a session start waits for the marimo kernel to come up before failing. Generous by default because a cold sandbox may resolve + download the notebook environment on first boot. Served on `/api/v1/capabilities` so the client bounds its own startup wait with the same value.',
+						default: '120',
+						example: '300',
+					},
 				],
 			},
 			{

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -276,7 +276,6 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						description:
 							'How long a session start waits for the marimo kernel to come up before failing. Generous by default because a cold sandbox may resolve + download the notebook environment on first boot. Served on `/api/v1/capabilities` so the client bounds its own startup wait with the same value.',
 						default: '120',
-						example: '300',
 					},
 				],
 			},

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -97,7 +97,11 @@ export type { CreatedToken, CreateTokenInput } from './tokens/TokenService';
 export { composeAuthenticators } from './tokens/composeAuthenticators';
 export { listAllKeys } from './catalog/storage';
 export { mutateObject, withCasRetry, type CasRetryOptions } from './catalog/cas';
-export { createWorkspaceLoadStrategies, SandboxProvisioner } from './runtime/SandboxProvisioner';
+export {
+	createWorkspaceLoadStrategies,
+	DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS,
+	SandboxProvisioner,
+} from './runtime/SandboxProvisioner';
 export type {
 	BucketConfig,
 	ProvisionOptions,

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -255,6 +255,27 @@ describe('SandboxProvisioner', () => {
 			);
 		});
 
+		it('classifies on the attribution line only — appended output echoing "before port" stays a timeout', async () => {
+			const { instance } = makeFakeSandbox({
+				// An adapter timeout error whose appended process-output tail happens
+				// to contain the crash phrase.
+				failWaitForPort: new Error(
+					'timed out waiting for port 2718 after 0ms.\n' +
+						'earlier attempt: process exited (code 1) before port 2718 was ready.',
+				),
+			});
+			await expect(
+				new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					startupTimeoutMs: Millis.of(0),
+				}),
+			).rejects.toThrow(/startup timeout \(MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS\)/);
+		});
+
 		it('reads an adapter-attributed crash as a crash even at the deadline', async () => {
 			const { instance } = makeFakeSandbox({
 				failWaitForPort: new Error('process exited (code 1) before port 2718 was ready.'),

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -255,6 +255,27 @@ describe('SandboxProvisioner', () => {
 			);
 		});
 
+		it('reads an adapter-attributed crash as a crash even at the deadline', async () => {
+			const { instance } = makeFakeSandbox({
+				failWaitForPort: new Error('process exited (code 1) before port 2718 was ready.'),
+				logs: { stdout: '', stderr: 'boom' },
+			});
+			const failure = await new SandboxProvisioner(fakeComputeFrom(instance))
+				.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					// 0ms: the whole window is consumed, so only the adapter's "before
+					// port" attribution keeps this from reading as a timeout.
+					startupTimeoutMs: Millis.of(0),
+				})
+				.catch((err: Error) => err);
+			expect((failure as Error).message).not.toContain('startup timeout');
+			expect((failure as Error).message).toContain('boom');
+		});
+
 		it('keeps a pre-deadline kernel crash distinct from a startup timeout', async () => {
 			const { instance } = makeFakeSandbox({
 				failWaitForPort: new Error('process exited before the port opened'),

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { Millis } from '../../duration';
 import { createNotebookId, createProjectId, createSandboxId } from '../../ids';
 import { paths } from '../../paths';
 import {
@@ -206,6 +207,74 @@ describe('SandboxProvisioner', () => {
 			});
 
 			expect(calls.startProcess[0].cmd).toContain(`--asset-url="${assetUrl}"`);
+		});
+
+		it('waits for the kernel port with the configured startup timeout (default 2 minutes)', async () => {
+			const defaulted = makeFakeSandbox();
+			await new SandboxProvisioner(fakeComputeFrom(defaulted.instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+			});
+			expect(defaulted.calls.waitForPortOptions).toEqual([{ timeout: 120_000 }]);
+
+			const configured = makeFakeSandbox();
+			await new SandboxProvisioner(fakeComputeFrom(configured.instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				startupTimeoutMs: Millis.seconds(300),
+			});
+			expect(configured.calls.waitForPortOptions).toEqual([{ timeout: 300_000 }]);
+		});
+
+		it('names the startup timeout (and the config var) when the port wait consumes the full window', async () => {
+			const { instance } = makeFakeSandbox({
+				failWaitForPort: new Error('timed out after 0ms'),
+				logs: { stdout: 'Resolved 42 packages', stderr: '' },
+			});
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			// A 0ms window means the (instant) rejection has already consumed it, so
+			// the deadline classification triggers without waiting out a real timeout.
+			await expect(
+				provisioner.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					startupTimeoutMs: Millis.of(0),
+				}),
+			).rejects.toThrow(
+				/not ready within the 0s startup timeout \(MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS\)[\s\S]*Resolved 42 packages/,
+			);
+		});
+
+		it('keeps a pre-deadline kernel crash distinct from a startup timeout', async () => {
+			const { instance } = makeFakeSandbox({
+				failWaitForPort: new Error('process exited before the port opened'),
+				logs: { stdout: '', stderr: 'ModuleNotFoundError: no module named marimo' },
+			});
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			const failure = await provisioner
+				.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				})
+				.catch((err: Error) => err);
+			expect(failure).toBeInstanceOf(Error);
+			expect((failure as Error).message).toContain('starting the marimo kernel');
+			expect((failure as Error).message).toContain('ModuleNotFoundError');
+			expect((failure as Error).message).not.toContain('startup timeout');
 		});
 
 		it('injects sessionEnv (files + env) BEFORE starting the kernel', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -476,10 +476,14 @@ export class SandboxProvisioner {
 			// `provisionFailure` drops the adapter's message, so a deadline-shaped
 			// failure must be classified here or the caller can't tell "kernel took
 			// too long" (raise the timeout) from "kernel crashed" (read the logs).
-			// A wait that consumed the full window is a timeout; a probe error (e.g.
-			// the process exited) propagates well before the deadline.
+			// A wait that consumed the full window is a timeout — unless the adapter
+			// already attributed the failure to the process ("… before port N …",
+			// the shared wording of the exited-early errors): crash detection can
+			// land arbitrarily close to the deadline, and elapsed time alone would
+			// then tell the operator to raise the timeout for a crash.
+			const crashed = err instanceof Error && /before port \d+/.test(err.message);
 			const timedOut =
-				portWaitStart !== undefined && Date.now() - portWaitStart >= startupTimeoutMs;
+				!crashed && portWaitStart !== undefined && Date.now() - portWaitStart >= startupTimeoutMs;
 			const step = timedOut
 				? `starting the marimo kernel: not ready within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`
 				: 'starting the marimo kernel';

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -2,6 +2,7 @@ import { all, allSettled } from 'better-all';
 import type { Bucket } from '../../ports/bucket';
 import { MARIMO_PORT } from '../../constants';
 import type { SessionMode } from '../../constants';
+import { Millis } from '../../duration';
 import { UnavailableError } from '../../errors';
 import type { NotebookId, ProjectId, SandboxId, UserId } from '../../ids';
 import { workspaceSourcePolicy } from '../../integrations/remoteWorkspace';
@@ -24,11 +25,13 @@ import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sand
 import type { WorkspaceRestoreStats } from './sandboxFiles';
 
 /**
- * How long to wait for marimo to bind its port. Generous because a cold sandbox
- * may build its uv venv from scratch (e.g. the `uv-sandbox` launch strategy
- * resolves + downloads the notebook's deps on first boot). See marimoLaunch.ts.
+ * Default wait for marimo to bind its port (override per deployment via
+ * `startupTimeoutMs`, config: MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS).
+ * Generous because a cold sandbox may build its uv venv from scratch (e.g. the
+ * `uv-sandbox` launch strategy resolves + downloads the notebook's deps on
+ * first boot). See marimoLaunch.ts.
  */
-const MARIMO_PORT_TIMEOUT_MS = 120_000; // 2 minutes
+export const DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS = Millis.minutes(2);
 /**
  * Default sandbox working directory. Override per-deployment via the `workdir`
  * option (config: MARIMOHUB_COMPUTE_WORKDIR) when the sandbox image's user can't
@@ -115,6 +118,12 @@ export interface ProvisionOptions {
 	sessionEnv?: SessionEnv | Promise<SessionEnv | undefined>;
 	/** Workspace-relative notebook file marimo should open. Defaults to `notebook.py`. */
 	entryNotebook?: string;
+	/**
+	 * How long to wait for the marimo kernel to bind its port before failing the
+	 * provision. Covers setup too (a cold env may install/build first). Defaults
+	 * to `DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS`.
+	 */
+	startupTimeoutMs?: Millis;
 	/**
 	 * Session mode driving the marimo subcommand (see `LAUNCH_MODES`). `app`
 	 * sandboxes must also pass `workspaceLoadMode: 'copy-only'` — a mounted
@@ -435,7 +444,9 @@ export class SandboxProvisioner {
 			assetUrl: options.assetUrl,
 			baseUrl: options.baseUrl,
 		});
+		const startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS;
 		let process: SandboxProcess | undefined;
+		let portWaitStart: number | undefined;
 		try {
 			// Setup rides the kernel command instead of spending its own exec, and
 			// failures still surface through the process log read below. `&&` so a
@@ -444,10 +455,9 @@ export class SandboxProvisioner {
 			const command = [...launch.setup, launch.start].join(' && ');
 			const proc = await sw.time('start', () => sandbox.startProcess(command, { cwd: mountPath }));
 			process = proc;
+			portWaitStart = Date.now();
 			// Covers setup as well, so a slow kernel env (install/build) shows up here.
-			await sw.time('waitport', () =>
-				proc.waitForPort(MARIMO_PORT, { timeout: MARIMO_PORT_TIMEOUT_MS }),
-			);
+			await sw.time('waitport', () => proc.waitForPort(MARIMO_PORT, { timeout: startupTimeoutMs }));
 		} catch (err) {
 			// Surface the kernel's own output so a startup crash isn't an opaque
 			// "exited before ready". Best-effort.
@@ -463,12 +473,17 @@ export class SandboxProvisioner {
 					// getLogs can fail once the process/sandbox is gone — ignore.
 				}
 			}
-			throw provisionFailure(
-				kernelLogs
-					? `starting the marimo kernel; kernel output:\n${kernelLogs}`
-					: 'starting the marimo kernel',
-				err,
-			);
+			// `provisionFailure` drops the adapter's message, so a deadline-shaped
+			// failure must be classified here or the caller can't tell "kernel took
+			// too long" (raise the timeout) from "kernel crashed" (read the logs).
+			// A wait that consumed the full window is a timeout; a probe error (e.g.
+			// the process exited) propagates well before the deadline.
+			const timedOut =
+				portWaitStart !== undefined && Date.now() - portWaitStart >= startupTimeoutMs;
+			const step = timedOut
+				? `starting the marimo kernel: not ready within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`
+				: 'starting the marimo kernel';
+			throw provisionFailure(kernelLogs ? `${step}; kernel output:\n${kernelLogs}` : step, err);
 		}
 	}
 

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -480,8 +480,12 @@ export class SandboxProvisioner {
 			// already attributed the failure to the process ("… before port N …",
 			// the shared wording of the exited-early errors): crash detection can
 			// land arbitrarily close to the deadline, and elapsed time alone would
-			// then tell the operator to raise the timeout for a crash.
-			const crashed = err instanceof Error && /before port \d+/.test(err.message);
+			// then tell the operator to raise the timeout for a crash. Only the
+			// FIRST line is the adapter's attribution — the rest is appended
+			// process output, which can echo a "before port" phrase into a genuine
+			// timeout message.
+			const attribution = err instanceof Error ? err.message.split('\n', 1)[0] : '';
+			const crashed = /before port \d+/.test(attribution);
 			const timedOut =
 				!crashed && portWaitStart !== undefined && Date.now() - portWaitStart >= startupTimeoutMs;
 			const step = timedOut

--- a/packages/core/src/testing/fakes.ts
+++ b/packages/core/src/testing/fakes.ts
@@ -14,6 +14,7 @@ import type {
 	SandboxProvider,
 	SetEnvVarsOptions,
 	StartProcessOptions,
+	WaitForPortOptions,
 } from '../ports/sandbox';
 import { execResult, listFilesFailure, readFileFailure } from '../ports/sandbox';
 
@@ -35,6 +36,8 @@ export interface SandboxCalls {
 	setEnvDefaults: Record<string, string>[];
 	readFile: string[];
 	waitForPort: number[];
+	/** Options of each `waitForPort` call, index-aligned with `waitForPort`. */
+	waitForPortOptions: (WaitForPortOptions | undefined)[];
 	destroy: number;
 	/** Method names in call order (for the methods that record), for ordering assertions. */
 	sequence: string[];
@@ -45,6 +48,10 @@ export interface FakeSandboxOptions {
 	failExec?: string;
 	/** When true, `mountBucket` rejects (forcing the manual-copy fallback path). */
 	failMount?: boolean;
+	/** When set, `waitForPort` rejects with this error (the kernel never came up). */
+	failWaitForPort?: Error;
+	/** What `getLogs` returns — the kernel output surfaced on a startup failure. */
+	logs?: { stdout: string; stderr: string };
 	/** Files the sandbox reports as present when `readFile` is called. */
 	files?: Record<string, string>;
 }
@@ -70,6 +77,7 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 		setEnvDefaults: [],
 		readFile: [],
 		waitForPort: [],
+		waitForPortOptions: [],
 		destroy: 0,
 		sequence: [],
 	};
@@ -78,10 +86,12 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 		id: 'proc_1',
 		command: 'uv run marimo edit',
 		kill: async () => {},
-		waitForPort: async (port: number) => {
+		waitForPort: async (port: number, options?: WaitForPortOptions) => {
 			calls.waitForPort.push(port);
+			calls.waitForPortOptions.push(options);
+			if (opts.failWaitForPort) throw opts.failWaitForPort;
 		},
-		getLogs: async () => ({ stdout: '', stderr: '' }),
+		getLogs: async () => opts.logs ?? { stdout: '', stderr: '' },
 	};
 
 	const instance: SandboxInstance = {
@@ -202,6 +212,7 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 		setEnvDefaults: [],
 		readFile: [],
 		waitForPort: [],
+		waitForPortOptions: [],
 		destroy: 0,
 		sequence: [],
 	};

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -184,6 +184,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 			(!showEditorChoice || editIntent === 'temporary'),
 		mode: isApp ? 'app' : 'edit',
 		editIntent,
+		startupTimeoutSeconds: capabilities?.sandbox_startup_timeout_seconds,
 	});
 
 	// Freeze the theme when the URL is first established, not on every toggle:

--- a/packages/web/src/hooks/useNotebookSession.test.tsx
+++ b/packages/web/src/hooks/useNotebookSession.test.tsx
@@ -353,6 +353,116 @@ describe('useNotebookSession', () => {
 		expect(result.current.session).toBeNull();
 	});
 
+	it('fails a session stuck in starting once the startup timeout (plus grace) elapses', async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+				if (init?.method === 'POST' || String(url).endsWith('/sessions/sess-1')) {
+					return jsonOk(makeSession({ status: 'starting', sandbox_url: undefined }));
+				}
+				throw new Error(`unexpected fetch: ${String(url)}`);
+			}),
+		);
+
+		const { result } = renderHookWithClient(
+			() => useNotebookSession(PID, NID, { startupTimeoutSeconds: 1 }),
+			{ toaster: false },
+		);
+		await settleHook();
+		expect(result.current.session?.status).toBe('starting');
+
+		// Inside the 1s timeout + 30s grace: still polling, no error.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(2_000);
+		});
+		expect(result.current.error).toBeNull();
+		expect(result.current.session?.status).toBe('starting');
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(31_000);
+		});
+		expect(result.current.error).toEqual({
+			code: 'STARTUP_TIMEOUT',
+			message: 'The kernel did not start within 31 seconds.',
+			kind: 'startup',
+		});
+		expect(result.current.session).toBeNull();
+	});
+
+	it('falls back to the 120s server default when no capability timeout is provided', async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+				if (init?.method === 'POST' || String(url).endsWith('/sessions/sess-1')) {
+					return jsonOk(makeSession({ status: 'starting', sandbox_url: undefined }));
+				}
+				throw new Error(`unexpected fetch: ${String(url)}`);
+			}),
+		);
+
+		const { result } = renderHookWithClient(() => useNotebookSession(PID, NID), { toaster: false });
+		await settleHook();
+
+		// 120s default + 30s grace = 150s deadline.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(149_000);
+		});
+		expect(result.current.error).toBeNull();
+		expect(result.current.session?.status).toBe('starting');
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(4_000);
+		});
+		expect(result.current.error).toEqual({
+			code: 'STARTUP_TIMEOUT',
+			message: 'The kernel did not start within 150 seconds.',
+			kind: 'startup',
+		});
+	});
+
+	it('says "The app" for app-mode startup timeouts, and a retry recovers', async () => {
+		vi.useFakeTimers();
+		let posts = 0;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+				if (init?.method === 'POST') {
+					posts += 1;
+					// First start wedges in `starting`; the retry comes up immediately.
+					return posts === 1
+						? jsonOk(makeSession({ status: 'starting', sandbox_url: undefined }))
+						: jsonOk(makeSession());
+				}
+				if (String(url).endsWith('/sessions/sess-1')) {
+					return jsonOk(makeSession({ status: 'starting', sandbox_url: undefined }));
+				}
+				throw new Error(`unexpected fetch: ${String(url)}`);
+			}),
+		);
+
+		const { result } = renderHookWithClient(
+			() => useNotebookSession(PID, NID, { mode: 'app', startupTimeoutSeconds: 1 }),
+			{ toaster: false },
+		);
+		await settleHook();
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(33_000);
+		});
+		expect(result.current.error).toEqual({
+			code: 'STARTUP_TIMEOUT',
+			message: 'The app did not start within 31 seconds.',
+			kind: 'startup',
+		});
+
+		act(() => result.current.start());
+		await settleHook();
+		expect(result.current.error).toBeNull();
+		expect(result.current.isRunning).toBe(true);
+	});
+
 	it('posts heartbeats while running and ignores heartbeat failures', async () => {
 		vi.useFakeTimers();
 		const fetchMock = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/web/src/hooks/useNotebookSession.test.tsx
+++ b/packages/web/src/hooks/useNotebookSession.test.tsx
@@ -384,7 +384,7 @@ describe('useNotebookSession', () => {
 		});
 		expect(result.current.error).toEqual({
 			code: 'STARTUP_TIMEOUT',
-			message: 'The kernel did not start within 31 seconds.',
+			message: 'The kernel did not start within 1s.',
 			kind: 'startup',
 		});
 		expect(result.current.session).toBeNull();
@@ -417,7 +417,7 @@ describe('useNotebookSession', () => {
 		});
 		expect(result.current.error).toEqual({
 			code: 'STARTUP_TIMEOUT',
-			message: 'The kernel did not start within 150 seconds.',
+			message: 'The kernel did not start within 120s.',
 			kind: 'startup',
 		});
 	});
@@ -453,7 +453,7 @@ describe('useNotebookSession', () => {
 		});
 		expect(result.current.error).toEqual({
 			code: 'STARTUP_TIMEOUT',
-			message: 'The app did not start within 31 seconds.',
+			message: 'The app did not start within 1s.',
 			kind: 'startup',
 		});
 
@@ -461,6 +461,110 @@ describe('useNotebookSession', () => {
 		await settleHook();
 		expect(result.current.error).toBeNull();
 		expect(result.current.isRunning).toBe(true);
+	});
+
+	it('arms the startup clock for a starting app adopted as a replacement', async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+				const path = String(url);
+				if (init?.method === 'POST') return jsonOk(makeSession());
+				// The watched app ends underneath the page…
+				if (path.endsWith('/sessions/sess-1')) {
+					return jsonOk(makeSession({ status: 'terminated', sandbox_url: undefined }));
+				}
+				// …and the replacement scan finds someone else's restart, still starting.
+				if (path.endsWith(`/projects/${PID}/sessions`)) {
+					return jsonOk({
+						items: [
+							makeSession({
+								session_id: 'sess-2',
+								status: 'starting',
+								sandbox_url: undefined,
+								mode: 'app',
+							}),
+						],
+					});
+				}
+				if (path.endsWith('/sessions/sess-2')) {
+					return jsonOk(
+						makeSession({ session_id: 'sess-2', status: 'starting', sandbox_url: undefined }),
+					);
+				}
+				throw new Error(`unexpected fetch: ${path}`);
+			}),
+		);
+
+		const { result } = renderHookWithClient(
+			() => useNotebookSession(PID, NID, { mode: 'app', startupTimeoutSeconds: 1 }),
+			{ toaster: false },
+		);
+		await settleHook();
+		expect(result.current.isRunning).toBe(true);
+
+		// Run-watch tick adopts the starting replacement.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(10_000);
+		});
+		await settleHook();
+		expect(result.current.session?.session_id).toBe('sess-2');
+		expect(result.current.session?.status).toBe('starting');
+
+		// The adopted watch gets its own full timeout window — then fails.
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(2_000);
+		});
+		expect(result.current.error).toBeNull();
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(31_000);
+		});
+		expect(result.current.error?.code).toBe('STARTUP_TIMEOUT');
+	});
+
+	it('a late poll response cannot resurrect a session after the startup timeout', async () => {
+		vi.useFakeTimers();
+		let releasePoll!: (response: Response) => void;
+		const held = new Promise<Response>((resolve) => {
+			releasePoll = resolve;
+		});
+		let polls = 0;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+				if (init?.method === 'POST') {
+					return jsonOk(makeSession({ status: 'starting', sandbox_url: undefined }));
+				}
+				if (String(url).endsWith('/sessions/sess-1')) {
+					polls += 1;
+					// The first poll hangs until after the timeout has concluded.
+					return polls === 1
+						? held
+						: jsonOk(makeSession({ status: 'starting', sandbox_url: undefined }));
+				}
+				throw new Error(`unexpected fetch: ${String(url)}`);
+			}),
+		);
+
+		const { result } = renderHookWithClient(
+			() => useNotebookSession(PID, NID, { startupTimeoutSeconds: 1 }),
+			{ toaster: false },
+		);
+		await settleHook();
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(33_000);
+		});
+		expect(result.current.error?.code).toBe('STARTUP_TIMEOUT');
+
+		// The stale in-flight poll finally answers `running` — and must be ignored.
+		await act(async () => {
+			releasePoll(jsonOk(makeSession()));
+			await Promise.resolve();
+		});
+		await settleHook();
+		expect(result.current.session).toBeNull();
+		expect(result.current.error?.code).toBe('STARTUP_TIMEOUT');
 	});
 
 	it('posts heartbeats while running and ignores heartbeat failures', async () => {

--- a/packages/web/src/hooks/useNotebookSession.ts
+++ b/packages/web/src/hooks/useNotebookSession.ts
@@ -145,6 +145,18 @@ export function useNotebookSession(
 	// under an older render read, so a `setSession` without it re-arms a session
 	// the user has already left behind.
 	const commitSession = useCallback((next: Session | null) => {
+		// The startup clock follows whichever `starting` session is committed —
+		// this is the only commit point, so a start AND an adopted replacement app
+		// both arm it. Kept across re-commits of the same session, cleared
+		// otherwise so a stale timestamp can't instantly fail the next watch.
+		if (next?.status !== 'starting') {
+			startingSinceRef.current = null;
+		} else if (
+			startingSinceRef.current === null ||
+			sessionRef.current?.session_id !== next.session_id
+		) {
+			startingSinceRef.current = Date.now();
+		}
 		sessionRef.current = next;
 		setSession(next);
 	}, []);
@@ -179,7 +191,6 @@ export function useNotebookSession(
 						concludeAccessLost();
 						return;
 					}
-					startingSinceRef.current = data.status === 'starting' ? Date.now() : null;
 					commitSession(data);
 				},
 				(err) => {
@@ -273,6 +284,9 @@ export function useNotebookSession(
 
 	const failStart = useCallback(
 		(failure?: Session['error'], code?: string) => {
+			// Terminal: invalidate in-flight polls so a late `running` response
+			// cannot resurrect the session after the failure is shown.
+			generation.bump();
 			setError(
 				failure
 					? { message: failure.message, code: failure.code, kind: 'startup' }
@@ -285,7 +299,7 @@ export function useNotebookSession(
 			);
 			commitSession(null);
 		},
-		[startFailedMessage, commitSession],
+		[startFailedMessage, commitSession, generation],
 	);
 
 	/**
@@ -322,13 +336,15 @@ export function useNotebookSession(
 			if (session?.status !== 'starting') return;
 			// Watched longer than the deployment's startup timeout (plus grace) means
 			// whichever request was provisioning has died without failing the record —
-			// give up instead of polling forever.
-			const deadlineMs =
-				(startupTimeoutSeconds ?? DEFAULT_STARTUP_TIMEOUT_S) * 1000 + STARTUP_TIMEOUT_GRACE_MS;
+			// give up instead of polling forever. The message names the CONFIGURED
+			// timeout, matching the server's own timeout error; the grace is an
+			// implementation detail.
+			const timeoutSeconds = startupTimeoutSeconds ?? DEFAULT_STARTUP_TIMEOUT_S;
+			const deadlineMs = timeoutSeconds * 1000 + STARTUP_TIMEOUT_GRACE_MS;
 			if (startingSinceRef.current !== null && Date.now() - startingSinceRef.current > deadlineMs) {
 				failStart({
 					code: 'STARTUP_TIMEOUT',
-					message: `${mode === 'app' ? 'The app' : 'The kernel'} did not start within ${Math.round(deadlineMs / 1000)} seconds.`,
+					message: `${mode === 'app' ? 'The app' : 'The kernel'} did not start within ${timeoutSeconds}s.`,
 				});
 				return;
 			}

--- a/packages/web/src/hooks/useNotebookSession.ts
+++ b/packages/web/src/hooks/useNotebookSession.ts
@@ -12,6 +12,17 @@ const HEARTBEAT_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
 /** How often to poll a still-`starting` session until it is running, in ms. */
 const START_POLL_INTERVAL_MS = 2_000;
 
+/** Startup-timeout fallback when capabilities are unavailable (server default). */
+const DEFAULT_STARTUP_TIMEOUT_S = 120;
+
+/**
+ * Slack past the server's startup timeout before the client fails a
+ * still-`starting` session itself. The server enforces the timeout on the
+ * kernel wait and returns a richer error, so this only catches a start nothing
+ * else concludes (e.g. the provisioning replica died mid-start).
+ */
+const STARTUP_TIMEOUT_GRACE_MS = 30_000;
+
 /**
  * How often a running page re-checks its session. This surfaces app stops and
  * exclusive-editor takeovers as terminal UI instead of leaving a dead iframe.
@@ -90,7 +101,18 @@ export function useNotebookSession(
 		enabled = true,
 		mode = 'edit',
 		editIntent,
-	}: { enabled?: boolean; mode?: 'edit' | 'app'; editIntent?: 'temporary' } = {},
+		startupTimeoutSeconds,
+	}: {
+		enabled?: boolean;
+		mode?: 'edit' | 'app';
+		editIntent?: 'temporary';
+		/**
+		 * The deployment's sandbox-startup timeout
+		 * (`capabilities.sandbox_startup_timeout_seconds`); a still-`starting`
+		 * session older than this (plus grace) is failed instead of polled forever.
+		 */
+		startupTimeoutSeconds?: number;
+	} = {},
 ): NotebookSession {
 	const startSession = useStartSession(projectId, notebookId, mode, editIntent);
 	const startPersistentSession = useStartSession(projectId, notebookId, mode);
@@ -115,6 +137,9 @@ export function useNotebookSession(
 	// Bumped by every start/stop/restart: a poll issued before one still lands
 	// afterwards, re-arming the dying session or failing the fresh one.
 	const generation = useGeneration();
+	// When this client began watching a still-`starting` session (client clock, so
+	// server/client skew can't fail a fresh start). Null while nothing is starting.
+	const startingSinceRef = useRef<number | null>(null);
 
 	// The state and the ref must move together: the ref is what handlers entered
 	// under an older render read, so a `setSession` without it re-arms a session
@@ -154,6 +179,7 @@ export function useNotebookSession(
 						concludeAccessLost();
 						return;
 					}
+					startingSinceRef.current = data.status === 'starting' ? Date.now() : null;
 					commitSession(data);
 				},
 				(err) => {
@@ -294,6 +320,18 @@ export function useNotebookSession(
 	useInterval(
 		() => {
 			if (session?.status !== 'starting') return;
+			// Watched longer than the deployment's startup timeout (plus grace) means
+			// whichever request was provisioning has died without failing the record —
+			// give up instead of polling forever.
+			const deadlineMs =
+				(startupTimeoutSeconds ?? DEFAULT_STARTUP_TIMEOUT_S) * 1000 + STARTUP_TIMEOUT_GRACE_MS;
+			if (startingSinceRef.current !== null && Date.now() - startingSinceRef.current > deadlineMs) {
+				failStart({
+					code: 'STARTUP_TIMEOUT',
+					message: `${mode === 'app' ? 'The app' : 'The kernel'} did not start within ${Math.round(deadlineMs / 1000)} seconds.`,
+				});
+				return;
+			}
 			pollSession(
 				session.session_id,
 				(next) => {


### PR DESCRIPTION
Adds `MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS` (default 120, the previously hardcoded 2 min) controlling how long a session start waits for the marimo kernel.

- **Backend:** `SandboxProvisioner` takes `startupTimeoutMs` for the kernel port wait; a timed-out start now fails with a message naming the timeout and the config var (still with kernel logs attached), distinct from a pre-deadline crash. Reason lands on the 503 and the failed session record.
- **Frontend:** the value is served on `GET /api/v1/capabilities` as `sandbox_startup_timeout_seconds`; `useNotebookSession` fails a stuck `starting` session after timeout + 30s grace (client-clock anchored) instead of polling forever.

Tests: provisioner timeout pass-through + timeout-vs-crash messages, config parsing, route→provision wiring, capabilities values, 503/record message end-to-end, and hook timeout/default/app-wording/retry-recovery.