### PR TITLE
fix(compute-modal): pin an idle main process so the image entrypoint cannot boot marimo

### DIFF
--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -185,6 +185,12 @@ describe('ModalCompute', () => {
 		expect(world.created[0].sandbox.execCalls[0].command).toEqual(['sh', '-lc', 'true']);
 	});
 
+	it('pins an idle main process so the image entrypoint cannot boot its own marimo', async () => {
+		const world = makeWorld();
+		await makeCompute(world).create(SANDBOX_ID, { reuse: false }).exec('true');
+		expect(world.created[0].options.command).toEqual(['sleep', 'infinity']);
+	});
+
 	it('keeps unset resources as an exact create-options no-op', async () => {
 		expect(modalProfileResources(undefined)).toEqual({});
 		expect(modalProfileResources({ cpu: 0.5, memoryBytes: 512 * 1024 ** 2 })).toEqual({

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -92,6 +92,7 @@ export interface ModalClientLike {
 			image: unknown,
 			options: {
 				name: string;
+				command: string[];
 				tags: Record<string, string>;
 				encryptedPorts: number[];
 				timeoutMs: number;
@@ -196,6 +197,11 @@ class ModalSandboxInstance implements SandboxInstance {
 		return this.client.apps.fromName(appName, { createIfMissing: true }).then((app) =>
 			this.client.sandboxes.create(app, this.client.images.fromRegistry(this.config.image), {
 				name: this.id,
+				// Pin an idle main process. With no command the SDK sends empty
+				// entrypointArgs and Modal boots the image's ENTRYPOINT — a marimo
+				// that grabs the kernel port before the provisioner's `setup && start`
+				// exec, which then rewrites /opt/venv under the live server (#103).
+				command: ['sleep', 'infinity'],
 				tags: {
 					[OWNER_TAG]: appName,
 					[SANDBOX_ID_TAG]: this.id,


### PR DESCRIPTION
On the Modal backend, `createSandbox` passed no `command`, and the SDK
sends `entrypointArgs: params.command ?? []` — with empty args Modal
boots the image's default ENTRYPOINT/CMD. For the marimo-sandbox image
that is `dumb-init -- uv run --no-sync marimo edit notebook.py`, so a
boot-time marimo grabbed port 2718 before the provisioner's
`setup && start` exec ever ran. The exec's `uv sync` then rewrote
`/opt/venv` underneath that live server (poisoning loaded
`anyio`/`starlette` bytecode → `Can't instantiate abstract class
TaskGroup` 500s on every request), and its own marimo died on the port
conflict. `waitForPort` saw the *wrong* marimo holding the port, so the
session reported `running` while serving only 500s.

Every other container-image backend already neutralizes the entrypoint:
kubernetes sets `command: ['sh', '-c', 'sleep infinity']`, the container
adapter appends `sleep infinity` after the image, and the CoreWeave SDK
runs its own keep-alive as the main process. Modal was the only adapter
that let the image entrypoint run.

Fixes #103. Fixes #102.
