### PR TITLE
fix(auth-oidc): retry OIDC discovery after a failed attempt

### DIFF
--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -547,6 +547,19 @@ describe('OIDC routes', () => {
 		expect(setCookie).toContain('Secure');
 	});
 
+	it('re-discovers after a failed discovery instead of caching the rejection', async () => {
+		oauthMock.discoveryRequest.mockRejectedValueOnce(new Error('getaddrinfo ENOTFOUND issuer'));
+		const { routes } = makeOidc();
+
+		const first = await routes.request('/api/auth/login');
+		expect(first.status).toBe(500);
+
+		// Same adapter instance: the retry must re-discover, not replay the rejection.
+		const second = await routes.request('/api/auth/login');
+		expect(second.status).toBe(302);
+		expect(oauthMock.discoveryRequest).toHaveBeenCalledTimes(2);
+	});
+
 	it('defaults prompt to select_account, forcing the account chooser', async () => {
 		const { routes } = makeOidc({});
 

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -387,12 +387,18 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 	const clientAuth = oauth.ClientSecretPost(config.clientSecret);
 
 	// Discovery is cached for the lifetime of the adapter (one fetch per process).
+	// A rejected discovery must not stay cached: null the slot so the next request
+	// re-discovers instead of replaying a transient DNS/IdP failure forever.
 	let asPromise: Promise<oauth.AuthorizationServer> | null = null;
 	function authServer(): Promise<oauth.AuthorizationServer> {
 		if (!asPromise) {
 			asPromise = oauth
 				.discoveryRequest(issuerUrl, { algorithm: 'oidc' })
-				.then((res) => oauth.processDiscoveryResponse(issuerUrl, res));
+				.then((res) => oauth.processDiscoveryResponse(issuerUrl, res))
+				.catch((err: unknown) => {
+					asPromise = null;
+					throw err;
+				});
 		}
 		return asPromise;
 	}


### PR DESCRIPTION
The OIDC adapter caches its provider-discovery promise for the adapter's lifetime — including a **rejected** one. If the first login after a replica boots hits a transient failure (DNS blip, IdP maintenance), that rejection is cached forever: every later login, callback, and logout on that replica fails until the pod restarts. It's silent to operators (existing sessions verify locally, health checks pass), but no new user can sign in.

**Fix:** null the cache slot when discovery rejects, then re-throw — the failing request still surfaces its error, but the next request re-discovers instead of replaying the stale failure.

**Test:** first login rejects → 500; second login on the *same* adapter → 302, with `discoveryRequest` called twice (proves the cache cleared, not bypassed). Verified failing without the fix.