### PR TITLE
fix(core): grace mid-provision starting sessions in reconciliation Rule 2

### DIFF
--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -236,6 +236,34 @@ describe('ReconciliationService', () => {
 		expect(stored.status).toBe('failed');
 	});
 
+	it('Rule 2: leaves a fresh starting record alone while its provision is in flight', async () => {
+		// The saga writes the record before creating the sandbox, so a fresh
+		// `starting` record with no live sandbox is a provision, not a corpse.
+		const session = await createSession(goneId);
+		compute.active = [];
+
+		const result = await reconciler.reconcile();
+
+		expect(result.markedDead).toBe(0);
+		const stored = await sessions.getSession(projectId, session.session_id);
+		expect(stored.status).toBe('starting');
+	});
+
+	it('Rule 2: fails a starting record once past the provision grace', async () => {
+		const session = await putSession({
+			status: 'starting',
+			sandbox_id: goneId,
+			started_at: iso(-20 * 60_000), // past RECLAIM_PROVISION_GRACE_MS (15m)
+		});
+		compute.active = [];
+
+		const result = await reconciler.reconcile();
+
+		expect(result.markedDead).toBe(1);
+		const stored = await sessions.getSession(projectId, session.session_id);
+		expect(stored.status).toBe('failed');
+	});
+
 	it('leaves a healthy running session untouched', async () => {
 		const session = await createSession(healthyId);
 		await sessions.heartbeat(projectId, session.session_id); // -> running
@@ -429,6 +457,17 @@ describe('ReconciliationService', () => {
 			const stored = await sessions.getSession(projectId, session.session_id);
 			expect(stored.status).toBe('failed');
 			expect(await claim()).toBeNull();
+		});
+
+		it('Rule 2: keeps the app claim while a fresh starting app is still provisioning', async () => {
+			const session = await createApp(goneId);
+			compute.active = [];
+
+			const result = await reconciler.reconcile();
+
+			expect(result.markedDead).toBe(0);
+			expect((await sessions.getSession(projectId, session.session_id)).status).toBe('starting');
+			expect(await claim()).toBe(session.session_id);
 		});
 	});
 });

--- a/packages/core/src/services/runtime/ReconciliationService.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.ts
@@ -149,6 +149,19 @@ export class ReconciliationService {
 				// Rule 2 — live record, sandbox gone (crashed / idle-timed-out). The
 				// kernel URL is dead; mark the record failed (it didn't stop cleanly) so it
 				// stops being served and gets reaped on schedule.
+
+				// A fresh `starting` record legitimately has no live sandbox yet: the saga
+				// writes the record (with sandbox_id) BEFORE creating the sandbox, and a
+				// cold provision can take minutes. Failing it here would strand the caller
+				// on a terminal record (setRunning no-ops) with a live sandbox behind it,
+				// and release the app claim mid-provision. Aged `starting` records still
+				// fall through: a provision that died must eventually be marked failed.
+				if (
+					session.status === 'starting' &&
+					now - Date.parse(session.started_at) < RECLAIM_PROVISION_GRACE_MS
+				) {
+					continue;
+				}
 				try {
 					await this.sessions.markFailed(session.project_id, session.session_id);
 					markedDead++;


### PR DESCRIPTION
Reconciliation Rule 2 had no age guard, so a maintenance sweep landing during a legitimate provisioning window would flip a `starting` session to `failed`.

The saga writes the session record (with `sandbox_id`) **before** creating the sandbox at the provider, so there's a window (minutes on a cold provision) where a `starting` record's sandbox isn't in `listActive()`. Rule 2 would mark it `failed` (terminal — the saga's later `setRunning` no-ops), hand the caller a `failed` record with a live billing sandbox behind it, and release the app claim mid-provision. Rule 1 and Rule 3 already guard this same window; Rule 2 was the outlier.

## Fix
Skip Rule 2 for a `starting` record younger than `RECLAIM_PROVISION_GRACE_MS` (15m), *before* both `markFailed` and `releaseAppFor`. Aged `starting` records still fall through, so a genuinely dead provision is eventually marked failed.

## Tests
3 new Rule-2 tests: fresh `starting` left alone; `starting` past grace marked `failed`; fresh `starting` app keeps its claim. Existing `running`-vanished tests unchanged.