### PR TITLE
test: guard dependency rule against adapter deps in manifests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,11 @@ Dependencies point **inward only**. `core` and `api` never import an adapter;
 adapters depend on `core`'s port interfaces. `config` (and the entrypoints) are
 the only places concrete adapters are imported. **Reject PRs that violate this**
 — e.g. an `@marimo-hub/storage-*` / `compute-*` / `auth-*` import appearing in
-`packages/core` or `packages/api`.
+`packages/core` or `packages/api`. The rule is enforced mechanically: a
+`no-restricted-imports` override in `vite.config.ts` (files `packages/core/**`,
+`packages/api/**`) bans `@marimo-hub/{storage,compute,auth,credentials,secrets}-*`
+imports, and a colocated `package-dependencies.test.ts` in each of `core` and
+`api` fails if an adapter appears in their `package.json`.
 
 ## Conventions
 

--- a/packages/api/src/package-dependencies.test.ts
+++ b/packages/api/src/package-dependencies.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { expect, it } from 'vitest';
+
+// The lint ban in vite.config.ts only catches import statements; this guards
+// the other half of the dependency rule — an adapter sneaking into the
+// manifest without any import (see AGENTS.md "The dependency rule").
+const ADAPTER_PATTERN = /^@marimo-hub\/(storage|compute|auth|credentials|secrets)-/;
+
+const DEPENDENCY_FIELDS = [
+	'dependencies',
+	'devDependencies',
+	'peerDependencies',
+	'optionalDependencies',
+] as const;
+
+it('declares no adapter packages in any dependency field', () => {
+	const pkg = JSON.parse(
+		readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+	) as Partial<Record<(typeof DEPENDENCY_FIELDS)[number], Record<string, string>>>;
+	for (const field of DEPENDENCY_FIELDS) {
+		const names = Object.keys(pkg[field] ?? {});
+		expect(names.filter((name) => ADAPTER_PATTERN.test(name))).toEqual([]);
+	}
+});

--- a/packages/core/src/package-dependencies.test.ts
+++ b/packages/core/src/package-dependencies.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { expect, it } from 'vitest';
+
+// The lint ban in vite.config.ts only catches import statements; this guards
+// the other half of the dependency rule — an adapter sneaking into the
+// manifest without any import (see AGENTS.md "The dependency rule").
+const ADAPTER_PATTERN = /^@marimo-hub\/(storage|compute|auth|credentials|secrets)-/;
+
+const DEPENDENCY_FIELDS = [
+	'dependencies',
+	'devDependencies',
+	'peerDependencies',
+	'optionalDependencies',
+] as const;
+
+it('declares no adapter packages in any dependency field', () => {
+	const pkg = JSON.parse(
+		readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+	) as Partial<Record<(typeof DEPENDENCY_FIELDS)[number], Record<string, string>>>;
+	for (const field of DEPENDENCY_FIELDS) {
+		const names = Object.keys(pkg[field] ?? {});
+		expect(names.filter((name) => ADAPTER_PATTERN.test(name))).toEqual([]);
+	}
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -321,6 +321,7 @@ export default defineConfig({
 								'@marimo-hub/compute-*',
 								'@marimo-hub/auth-*',
 								'@marimo-hub/credentials-*',
+								'@marimo-hub/secrets-*',
 							],
 						},
 					],


### PR DESCRIPTION
Adds a colocated `package-dependencies.test.ts` to `core` and `api` that fails if an adapter package (`@marimo-hub/{storage,compute,auth,credentials,secrets}-*`) appears in any dependency field of the package manifest.

This covers the half of the dependency rule the `no-restricted-imports` lint can't: an adapter landing in `package.json` without an import statement. Also bans `@marimo-hub/secrets-*` in the lint override and documents the mechanical enforcement in AGENTS.md.