### PR TITLE
fix(runtime): don't snapshot a sandbox whose capture failed

### DIFF
--- a/packages/core/src/services/runtime/SessionRetirer.test.ts
+++ b/packages/core/src/services/runtime/SessionRetirer.test.ts
@@ -130,6 +130,65 @@ describe('SessionRetirer', () => {
 		});
 	});
 
+	it('does not snapshot or advance the restore pointer when the capture fails', async () => {
+		const { instance } = makeFakeSandbox();
+		const compute = snapshotProvider(instance);
+		const captureSnapshot = vi.spyOn(compute, 'captureSnapshot');
+		const deleteSnapshot = vi.spyOn(compute, 'deleteSnapshot');
+		await notebooks.setFsSnapshot(projectId, notebookId, {
+			snapshot_id: 'known-good',
+			captured_at: new Date().toISOString(),
+		});
+		vi.spyOn(SandboxProvisioner.prototype, 'captureSession').mockRejectedValue(
+			new Error('bucket unavailable'),
+		);
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const session = await persistentSession();
+		await sessions.beginTerminating(projectId, session.session_id);
+
+		await retirer(compute).retire(session);
+
+		expect(captureSnapshot).not.toHaveBeenCalled();
+		expect(deleteSnapshot).not.toHaveBeenCalled();
+		expect(await notebooks.getFsSnapshot(projectId, notebookId)).toMatchObject({
+			snapshot_id: 'known-good',
+		});
+		expect((await sessions.getSession(projectId, session.session_id)).status).toBe('terminated');
+	});
+
+	it('snapshots and GCs the previous snapshot after a successful capture', async () => {
+		const { instance } = makeFakeSandbox();
+		const compute = snapshotProvider(instance);
+		const deleteSnapshot = vi.spyOn(compute, 'deleteSnapshot');
+		await notebooks.setFsSnapshot(projectId, notebookId, {
+			snapshot_id: 'previous',
+			captured_at: new Date().toISOString(),
+		});
+		vi.spyOn(SandboxProvisioner.prototype, 'captureSession').mockResolvedValue(true);
+		const session = await persistentSession();
+		await sessions.beginTerminating(projectId, session.session_id);
+
+		await retirer(compute).retire(session);
+
+		expect(await notebooks.getFsSnapshot(projectId, notebookId)).toMatchObject({
+			snapshot_id: 'snapshot-after-takeover',
+		});
+		expect(deleteSnapshot).toHaveBeenCalledWith('previous');
+	});
+
+	it('does not snapshot when the capture reports nothing persisted', async () => {
+		const { instance } = makeFakeSandbox();
+		const compute = snapshotProvider(instance);
+		const captureSnapshot = vi.spyOn(compute, 'captureSnapshot');
+		vi.spyOn(SandboxProvisioner.prototype, 'captureSession').mockResolvedValue(false);
+		const session = await persistentSession();
+		await sessions.beginTerminating(projectId, session.session_id);
+
+		await retirer(compute).retire(session);
+
+		expect(captureSnapshot).not.toHaveBeenCalled();
+	});
+
 	it('captures an owner-scoped filesystem snapshot during takeover', async () => {
 		const { instance, calls } = makeFakeSandbox();
 		const compute = snapshotProvider(instance);

--- a/packages/core/src/services/runtime/SessionRetirer.ts
+++ b/packages/core/src/services/runtime/SessionRetirer.ts
@@ -281,7 +281,6 @@ export class SessionRetirer {
 			try {
 				const persistEdits =
 					sessionPersistsEdits(session) && (await this.deps.sessions.ownsEditorClaim(session));
-				persisted = persistEdits;
 				persisted = await this.provisioner.captureSession(
 					sandbox,
 					this.deps.notebooks,
@@ -294,6 +293,8 @@ export class SessionRetirer {
 					{ persistEdits },
 				);
 			} catch (err) {
+				// A failed capture means this sandbox's state was not committed as a version.
+				// Snapshotting it would point restores at unsaved state and delete the last good snapshot.
 				logOperationalError(
 					'session_capture_failed',
 					{


### PR DESCRIPTION
## What

A failed `captureSession` during session retirement no longer leaves `persisted = true`. Previously the dead assignment `persisted = persistEdits` set the flag before the capture ran, so a capture that threw could still trigger a filesystem snapshot.

## Why

Snapshotting a sandbox whose capture failed points restores at uncommitted state and GCs the last good snapshot. Now a failed capture skips the snapshot entirely and leaves the existing restore pointer intact.

## Tests

Added `SessionRetirer` cases: no snapshot / no GC on capture failure, snapshot + previous-snapshot GC on success, and no snapshot when capture reports nothing persisted.