### PR TITLE
ci(docs): typecheck apps/docs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
             vite-task-${{ runner.os }}-${{ runner.arch }}-
 
       - run: vp check
+      - run: vp run -r typecheck
       - run: vp run audit:prod
 
       # Build resolves packages from source, not dist, so it's independent of the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,20 +5,20 @@ TypeScript monorepo for marimohub). Read this before making changes.
 
 ## Build / test / lint commands
 
-| Purpose                | Command                          | Expected on success |
-| ---------------------- | -------------------------------- | ------------------- |
-| Install                | `pnpm install --frozen-lockfile` | exit 0              |
-| Check (typecheck+lint) | `pnpm check`                     | exit 0, no errors   |
-| Typecheck (+lint)      | `pnpm typecheck`                 | exit 0, no errors   |
-| Tests                  | `pnpm test`                      | all pass            |
-| Coverage               | `pnpm test:coverage`             | report (v8)         |
-| Build                  | `pnpm build`                     | exit 0              |
+| Purpose          | Command                          | Expected on success |
+| ---------------- | -------------------------------- | ------------------- |
+| Install          | `pnpm install --frozen-lockfile` | exit 0              |
+| Check (fmt+lint) | `pnpm check`                     | exit 0, no errors   |
+| Typecheck        | `pnpm typecheck`                 | exit 0, no errors   |
+| Tests            | `pnpm test`                      | all pass            |
+| Coverage         | `pnpm test:coverage`             | report (v8)         |
+| Build            | `pnpm build`                     | exit 0              |
 
 The toolchain is **vite-plus** (`vp`). `pnpm check` runs `vp check`
-(typecheck + lint); `pnpm typecheck` is an alias for the same (vite-plus does
-not expose a type-only command). `pnpm test` runs each package's `test` script
-(vitest); `pnpm build` builds every package. Use these as the done-criteria for
-any change.
+(format + lint; it does not run the TypeScript compiler). `pnpm typecheck` runs
+`vp run -r typecheck` — each package's `tsc --noEmit`. CI runs both. `pnpm test`
+runs each package's `test` script (vitest); `pnpm build` builds every package.
+Use these as the done-criteria for any change.
 
 ## Architecture (5 bullets)
 

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -1,13 +1,14 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitepress';
+import type { Plugin } from 'vitepress';
 import llmstxt from 'vitepress-plugin-llms';
 
 const REPO = 'https://github.com/marimo-team/marimohub';
 const SITE = 'https://marimohub.docs.marimo.io';
 const OPENAPI_PATH = fileURLToPath(new URL('../../../packages/api/openapi.yaml', import.meta.url));
 
-const openApiArtifact = {
+const openApiArtifact: Plugin = {
 	name: 'marimohub-openapi-artifact',
 	apply: 'build' as const,
 	generateBundle() {
@@ -32,6 +33,7 @@ export default defineConfig({
 	vite: {
 		plugins: [
 			openApiArtifact,
+			// The plugin is compiled against Vite 8; VitePress 1 supplies the compatible Vite 5 API.
 			// Emits llms.txt, llms-full.txt, and a raw-markdown twin next to every page.
 			llmstxt({
 				domain: SITE,
@@ -41,7 +43,7 @@ export default defineConfig({
 				ignoreFilesPerOutput: { llmsTxt: ['index.md'] },
 				// Mirrors srcExclude: setup/** and partials/** are @include-d into pages.
 				ignoreFiles: ['README.md', 'setup/**', 'partials/**'],
-			}),
+			}) as unknown as Plugin[],
 		],
 	},
 

--- a/apps/docs/.vitepress/vue-shim.d.ts
+++ b/apps/docs/.vitepress/vue-shim.d.ts
@@ -1,0 +1,17 @@
+// Plain `tsc` cannot resolve Vue SFC imports; type them as generic components so
+// surrounding TypeScript files are still checked.
+declare module '*.vue' {
+	import type { DefineComponent } from 'vue';
+	const component: DefineComponent;
+	export default component;
+}
+
+declare module '*.css';
+
+// VitePress does not make Vite's client globals available to this standalone tsc run.
+interface ImportMeta {
+	glob(
+		pattern: string | string[],
+		options: { eager?: boolean; import?: string; query?: string },
+	): Record<string, unknown>;
+}

--- a/apps/docs/.vitepress/wizard/markdown.ts
+++ b/apps/docs/.vitepress/wizard/markdown.ts
@@ -11,9 +11,11 @@ import container from 'markdown-it-container';
 const CONTAINERS = ['tip', 'warning', 'info', 'danger'] as const;
 
 const md = new MarkdownIt({ html: false, linkify: true });
+// The container typings depend on a distinct MarkdownIt declaration from the one this package uses.
+const markdownItContainer = container as unknown as Parameters<typeof md.use>[0];
 
 for (const type of CONTAINERS) {
-	md.use(container, type, {
+	md.use(markdownItContainer, type, {
 		render(tokens: { nesting: number; info: string }[], idx: number) {
 			const token = tokens[idx];
 			if (token.nesting === 1) {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,6 +9,7 @@
 		"build": "vitepress build",
 		"preview": "vitepress preview",
 		"test": "vp test",
+		"typecheck": "tsc --noEmit",
 		"integrations:generate": "UPDATE_INTEGRATION_DOCS=1 vp test integrations-docs/generate"
 	},
 	"devDependencies": {

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "@marimo-hub/tsconfig/base.json",
-	"include": [".vitepress"]
+	"include": [".vitepress/**/*.ts", ".vitepress/**/*.mts", "middleware.ts"]
 }


### PR DESCRIPTION
`pnpm typecheck` (`vp run -r typecheck`) previously skipped `apps/docs` — the package had no `typecheck` script, so type errors in the VitePress config and wizard shipped unchecked.

- Add a `typecheck` script (`tsc --noEmit`) to `apps/docs`, widen its tsconfig `include`, and add a `vue-shim.d.ts` so standalone `tsc` resolves `.vue`/`.css` imports and `import.meta.glob`.
- Fix the type errors this surfaced (plugin/container casts).
- Run `vp run -r typecheck` in CI so this stays green.
- Correct AGENTS.md: `vp check` is format+lint, not typecheck.