### PR TITLE
ci(storage): run bucket contract against live emulators

### DIFF
--- a/.github/workflows/storage-conformance.yml
+++ b/.github/workflows/storage-conformance.yml
@@ -28,19 +28,17 @@ jobs:
             - args: ['--frozen-lockfile']
 
       # Started with `docker run` (not `services:`) because GitHub service
-      # containers cannot override the image command, and minio/fake-gcs-server
-      # both need one.
+      # containers cannot override the image command used by these emulators.
+      # fake-gcs-server does not enforce the generation and delimiter-page
+      # semantics this contract protects, so GCS remains hermetic-only here.
       - name: Start storage emulators
         run: |
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-04-22T22-12-26Z server /data
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           docker run -d --name azurite -p 10000:10000 \
-            mcr.microsoft.com/azure-storage/azurite:3.34.0 \
-            azurite-blob --blobHost 0.0.0.0
-          docker run -d --name fake-gcs -p 4443:4443 \
-            fsouza/fake-gcs-server:1.52.2 \
-            -scheme http -backend memory
+            mcr.microsoft.com/azure-storage/azurite:3.36.0 \
+            azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
 
       - name: Wait for emulators
         run: |
@@ -53,10 +51,6 @@ jobs:
             [ "$code" != "000" ] && break
             sleep 1; [ "$i" = 30 ] && exit 1
           done
-          for i in $(seq 1 30); do
-            curl -fsS "http://127.0.0.1:4443/storage/v1/b?project=test" && break
-            sleep 1; [ "$i" = 30 ] && exit 1
-          done
 
       - name: Create test buckets
         env:
@@ -67,9 +61,7 @@ jobs:
         run: |
           aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://marimohub-test
           az storage container create --name marimohub-test \
-            --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IiFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
-          curl -fsS -X POST "http://127.0.0.1:4443/storage/v1/b?project=test" \
-            -H 'Content-Type: application/json' -d '{"name":"marimohub-test"}'
+            --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
 
       - name: S3 contract against MinIO
         env:
@@ -83,11 +75,5 @@ jobs:
       - name: Azure contract against Azurite
         env:
           MARIMOHUB_TEST_AZURE_CONTAINER: marimohub-test
-          MARIMOHUB_TEST_AZURE_CONNECTION_STRING: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IiFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+          MARIMOHUB_TEST_AZURE_CONNECTION_STRING: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
         run: pnpm --filter @marimo-hub/storage-azure test
-
-      - name: GCS contract against fake-gcs-server
-        env:
-          MARIMOHUB_TEST_GCS_BUCKET: marimohub-test
-          MARIMOHUB_TEST_GCS_ENDPOINT: http://127.0.0.1:4443
-        run: pnpm --filter @marimo-hub/storage-gcs test

--- a/.github/workflows/storage-conformance.yml
+++ b/.github/workflows/storage-conformance.yml
@@ -70,10 +70,10 @@ jobs:
           MARIMOHUB_TEST_S3_REGION: us-east-1
           MARIMOHUB_TEST_S3_KEY: minioadmin
           MARIMOHUB_TEST_S3_SECRET: minioadmin
-        run: pnpm --filter @marimo-hub/storage-s3 test
+        run: vp run --filter @marimo-hub/storage-s3 --fail-if-no-match test
 
       - name: Azure contract against Azurite
         env:
           MARIMOHUB_TEST_AZURE_CONTAINER: marimohub-test
           MARIMOHUB_TEST_AZURE_CONNECTION_STRING: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
-        run: pnpm --filter @marimo-hub/storage-azure test
+        run: vp run --filter @marimo-hub/storage-azure --fail-if-no-match test

--- a/.github/workflows/storage-conformance.yml
+++ b/.github/workflows/storage-conformance.yml
@@ -16,6 +16,8 @@ jobs:
   storage-conformance:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      AZURITE_CONNECTION_STRING: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
@@ -47,8 +49,8 @@ jobs:
             sleep 1; [ "$i" = 30 ] && exit 1
           done
           for i in $(seq 1 30); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:10000/devstoreaccount1 || true)
-            [ "$code" != "000" ] && break
+            az storage container list --connection-string "$AZURITE_CONNECTION_STRING" \
+              --num-results 1 --only-show-errors --output none && break
             sleep 1; [ "$i" = 30 ] && exit 1
           done
 
@@ -60,8 +62,12 @@ jobs:
           AWS_EC2_METADATA_DISABLED: 'true'
         run: |
           aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://marimohub-test
-          az storage container create --name marimohub-test \
-            --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+          for i in $(seq 1 10); do
+            az storage container create --name marimohub-test \
+              --connection-string "$AZURITE_CONNECTION_STRING" \
+              --only-show-errors --output none && break
+            sleep 1; [ "$i" = 10 ] && exit 1
+          done
 
       - name: S3 contract against MinIO
         env:
@@ -70,10 +76,10 @@ jobs:
           MARIMOHUB_TEST_S3_REGION: us-east-1
           MARIMOHUB_TEST_S3_KEY: minioadmin
           MARIMOHUB_TEST_S3_SECRET: minioadmin
-        run: vp run --filter @marimo-hub/storage-s3 --fail-if-no-match test
+        run: vp run --no-cache --filter @marimo-hub/storage-s3 --fail-if-no-match test
 
       - name: Azure contract against Azurite
         env:
           MARIMOHUB_TEST_AZURE_CONTAINER: marimohub-test
-          MARIMOHUB_TEST_AZURE_CONNECTION_STRING: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
-        run: vp run --filter @marimo-hub/storage-azure --fail-if-no-match test
+          MARIMOHUB_TEST_AZURE_CONNECTION_STRING: ${{ env.AZURITE_CONNECTION_STRING }}
+        run: vp run --no-cache --filter @marimo-hub/storage-azure --fail-if-no-match test

--- a/.github/workflows/storage-conformance.yml
+++ b/.github/workflows/storage-conformance.yml
@@ -1,0 +1,93 @@
+name: Storage conformance
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  storage-conformance:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+        with:
+          version: 0.1.24
+          node-version-file: '.node-version'
+          sfw: true
+          cache: true
+          run-install: |
+            - args: ['--frozen-lockfile']
+
+      # Started with `docker run` (not `services:`) because GitHub service
+      # containers cannot override the image command, and minio/fake-gcs-server
+      # both need one.
+      - name: Start storage emulators
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:RELEASE.2025-04-22T22-12-26Z server /data
+          docker run -d --name azurite -p 10000:10000 \
+            mcr.microsoft.com/azure-storage/azurite:3.34.0 \
+            azurite-blob --blobHost 0.0.0.0
+          docker run -d --name fake-gcs -p 4443:4443 \
+            fsouza/fake-gcs-server:1.52.2 \
+            -scheme http -backend memory
+
+      - name: Wait for emulators
+        run: |
+          for i in $(seq 1 30); do
+            curl -fsS http://127.0.0.1:9000/minio/health/live && break
+            sleep 1; [ "$i" = 30 ] && exit 1
+          done
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:10000/devstoreaccount1 || true)
+            [ "$code" != "000" ] && break
+            sleep 1; [ "$i" = 30 ] && exit 1
+          done
+          for i in $(seq 1 30); do
+            curl -fsS "http://127.0.0.1:4443/storage/v1/b?project=test" && break
+            sleep 1; [ "$i" = 30 ] && exit 1
+          done
+
+      - name: Create test buckets
+        env:
+          AWS_ACCESS_KEY_ID: minioadmin
+          AWS_SECRET_ACCESS_KEY: minioadmin
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_EC2_METADATA_DISABLED: 'true'
+        run: |
+          aws --endpoint-url http://127.0.0.1:9000 s3 mb s3://marimohub-test
+          az storage container create --name marimohub-test \
+            --connection-string 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IiFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+          curl -fsS -X POST "http://127.0.0.1:4443/storage/v1/b?project=test" \
+            -H 'Content-Type: application/json' -d '{"name":"marimohub-test"}'
+
+      - name: S3 contract against MinIO
+        env:
+          MARIMOHUB_TEST_S3_ENDPOINT: http://127.0.0.1:9000
+          MARIMOHUB_TEST_S3_BUCKET: marimohub-test
+          MARIMOHUB_TEST_S3_REGION: us-east-1
+          MARIMOHUB_TEST_S3_KEY: minioadmin
+          MARIMOHUB_TEST_S3_SECRET: minioadmin
+        run: pnpm --filter @marimo-hub/storage-s3 test
+
+      - name: Azure contract against Azurite
+        env:
+          MARIMOHUB_TEST_AZURE_CONTAINER: marimohub-test
+          MARIMOHUB_TEST_AZURE_CONNECTION_STRING: 'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IiFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;'
+        run: pnpm --filter @marimo-hub/storage-azure test
+
+      - name: GCS contract against fake-gcs-server
+        env:
+          MARIMOHUB_TEST_GCS_BUCKET: marimohub-test
+          MARIMOHUB_TEST_GCS_ENDPOINT: http://127.0.0.1:4443
+        run: pnpm --filter @marimo-hub/storage-gcs test

--- a/packages/core/src/ports/bucket.ts
+++ b/packages/core/src/ports/bucket.ts
@@ -14,16 +14,22 @@ export interface BucketObjectBody extends BucketObject {
 
 export interface BucketListResult {
 	objects: BucketObject[];
+	/** Whether more objects or delimited prefixes remain after this page. */
 	truncated: boolean;
+	/** Resume token, present if and only if `truncated` is true. */
 	cursor?: string;
+	/** Rolled-up prefixes count toward the page's `limit`. */
 	delimitedPrefixes: string[];
 }
 
 export interface BucketListOptions {
 	prefix?: string;
 	delimiter?: string;
+	/** Opaque resume token from a truncated result. Takes precedence over `startAfter`. */
 	cursor?: string;
+	/** Maximum combined object and delimited-prefix entries returned in one page. */
 	limit?: number;
+	/** Exclusive lower bound on object keys. */
 	startAfter?: string;
 }
 

--- a/packages/core/src/ports/bucket.ts
+++ b/packages/core/src/ports/bucket.ts
@@ -27,10 +27,16 @@ export interface BucketListOptions {
 	delimiter?: string;
 	/** Opaque resume token from a truncated result. Takes precedence over `startAfter`. */
 	cursor?: string;
-	/** Maximum combined object and delimited-prefix entries returned in one page. */
+	/** Positive integer maximum for combined object and delimited-prefix entries in one page. */
 	limit?: number;
 	/** Exclusive lower bound on object keys. */
 	startAfter?: string;
+}
+
+export function assertValidBucketListLimit(limit: number | undefined): void {
+	if (limit !== undefined && (!Number.isInteger(limit) || limit <= 0)) {
+		throw new RangeError('Bucket list limit must be a positive integer');
+	}
 }
 
 export interface BucketPutOptions {

--- a/packages/core/src/services/catalog/MaintenanceService.test.ts
+++ b/packages/core/src/services/catalog/MaintenanceService.test.ts
@@ -146,6 +146,22 @@ describe('MaintenanceService', () => {
 	});
 
 	describe('pruneEvents', () => {
+		it('deletes old day folders across every listing page', async () => {
+			clock.set(Date.parse('2025-06-17T00:00:00.000Z'));
+			for (let day = 1; day <= 5; day++) {
+				await bucket.put(paths.event(`2020-01-0${day}`, 'e1'), '{}');
+			}
+			const originalList = bucket.list.bind(bucket);
+			bucket.list = (options) => originalList({ ...options, limit: 2 });
+
+			const deleted = await maintenance.pruneEvents({ retentionMs: 90 * DAY_MS });
+
+			expect(deleted).toBe(5);
+			for (let day = 1; day <= 5; day++) {
+				expect(await bucket.get(paths.event(`2020-01-0${day}`, 'e1'))).toBeNull();
+			}
+		});
+
 		it('deletes day folders past retention and keeps recent ones', async () => {
 			clock.set(Date.parse('2025-06-17T00:00:00.000Z'));
 			await bucket.put(paths.event('2020-01-01', 'e1'), '{}');

--- a/packages/core/src/services/catalog/MaintenanceService.ts
+++ b/packages/core/src/services/catalog/MaintenanceService.ts
@@ -4,7 +4,7 @@ import { noopMetrics } from '../../ports/metrics';
 import type { Metrics } from '../../ports/metrics';
 import { paths } from '../../paths';
 import { CatalogSchema, readStored } from '../../schema';
-import { listAllObjects } from './storage';
+import { listAllObjects, listAllPrefixes } from './storage';
 
 // Every commit writes a new catalog snapshot; at ~20 writes/day that is
 // thousands of accumulating objects per year. The event log grows the same way
@@ -98,10 +98,7 @@ export class MaintenanceService {
 		const retentionMs = opts?.retentionMs ?? DEFAULT_EVENT_RETENTION_MS;
 		const cutoff = Date.now() - retentionMs;
 
-		const { delimitedPrefixes } = await this.bucket.list({
-			prefix: paths.eventsPrefix,
-			delimiter: '/',
-		});
+		const delimitedPrefixes = await listAllPrefixes(this.bucket, paths.eventsPrefix);
 
 		let deleted = 0;
 		for (const dayPrefix of delimitedPrefixes) {

--- a/packages/core/src/services/catalog/storage.test.ts
+++ b/packages/core/src/services/catalog/storage.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { MemoryBucket } from '../../testing';
 import type { BucketListOptions } from '../../ports/bucket';
-import { deleteByPrefix, listAllKeys, listAllObjects } from './storage';
+import { deleteByPrefix, listAllKeys, listAllObjects, listAllPrefixes } from './storage';
 
 /**
  * MemoryBucket pages at `limit` (default 1000). These helpers never pass a
@@ -92,6 +92,19 @@ describe('listAllKeys', () => {
 
 		const got = await listAllKeys(bucket, 'projects/p/');
 		expect(got.sort()).toEqual([...keys].sort());
+	});
+});
+
+describe('listAllPrefixes', () => {
+	it('returns every sorted prefix across multiple pages', async () => {
+		const bucket = new SmallPageBucket(2);
+		await seed(bucket, ['p/e/1', 'p/c/1', 'p/a/1', 'p/b/1', 'p/d/1', 'p/a/2']);
+
+		expect(await listAllPrefixes(bucket, 'p/')).toEqual(['p/a/', 'p/b/', 'p/c/', 'p/d/', 'p/e/']);
+	});
+
+	it('returns an empty array when no prefixes match', async () => {
+		expect(await listAllPrefixes(new MemoryBucket(), 'p/')).toEqual([]);
 	});
 });
 

--- a/packages/core/src/services/catalog/storage.ts
+++ b/packages/core/src/services/catalog/storage.ts
@@ -37,6 +37,24 @@ export async function listAllKeys(bucket: Bucket, prefix: string): Promise<strin
 	return keys;
 }
 
+/** Collect every rolled-up prefix because remote stores paginate delimiter listings. */
+export async function listAllPrefixes(
+	bucket: Bucket,
+	prefix: string,
+	delimiter = '/',
+): Promise<string[]> {
+	const prefixes = new Set<string>();
+	let cursor: string | undefined;
+	do {
+		const result = await bucket.list({ prefix, delimiter, cursor });
+		for (const delimitedPrefix of result.delimitedPrefixes) {
+			prefixes.add(delimitedPrefix);
+		}
+		cursor = result.truncated ? result.cursor : undefined;
+	} while (cursor);
+	return [...prefixes].sort();
+}
+
 /**
  * Recursively delete every object under a prefix (the paginated list + batch
  * delete used by the hard-delete paths). Returns the number of keys removed.

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -16,7 +16,7 @@ import type { CatalogService } from '../catalog/CatalogService';
 import { MAX_VERSIONS } from './NotebookService';
 import type { NotebookService } from './NotebookService';
 import type { ProjectService } from './ProjectService';
-import { listAllKeys } from '../catalog/storage';
+import { listAllKeys, listAllPrefixes } from '../catalog/storage';
 
 const enc = (s: string) => new TextEncoder().encode(s);
 
@@ -27,8 +27,7 @@ async function countVersionFolders(
 	notebookId: NotebookId,
 ): Promise<number> {
 	const nb = paths.project(projectId).notebook(notebookId);
-	const res = await bucket.list({ prefix: `${nb.base}/versions/`, delimiter: '/' });
-	return res.delimitedPrefixes.length;
+	return (await listAllPrefixes(bucket, `${nb.base}/versions/`)).length;
 }
 
 describe('NotebookService', () => {
@@ -742,19 +741,23 @@ describe('NotebookService', () => {
 			// Save MAX_VERSIONS + 5 more times (well over the cap).
 			const extraSaves = MAX_VERSIONS + 5;
 			let currentVid = oldestVid;
-			for (let i = 1; i <= extraSaves; i++) {
-				const updated = await notebooks.updateNotebook(
-					projectId,
-					created.id,
-					{ code: `v${i}`, message: `save ${i}` },
-					ACTOR,
-				);
-				// Track the live current version id via the source file.
-				const source = await (await bucket.get(
-					paths.project(projectId).notebook(created.id).source,
-				))!.json<{ current_version_id: string }>();
-				currentVid = source.current_version_id as typeof currentVid;
-				void updated;
+			const originalList = bucket.list.bind(bucket);
+			bucket.list = (options) => originalList({ ...options, limit: 2 });
+			try {
+				for (let i = 1; i <= extraSaves; i++) {
+					await notebooks.updateNotebook(
+						projectId,
+						created.id,
+						{ code: `v${i}`, message: `save ${i}` },
+						ACTOR,
+					);
+					const source = await (await bucket.get(
+						paths.project(projectId).notebook(created.id).source,
+					))!.json<{ current_version_id: string }>();
+					currentVid = source.current_version_id as typeof currentVid;
+				}
+			} finally {
+				bucket.list = originalList;
 			}
 
 			// The right things were deleted: version-folder count is bounded.
@@ -949,6 +952,21 @@ describe('NotebookService', () => {
 	});
 
 	describe('listVersions / getVersion', () => {
+		it('returns versions across every listing page', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			for (let version = 2; version <= 4; version++) {
+				await notebooks.updateNotebook(projectId, created.id, { code: `v${version}` }, ACTOR);
+			}
+			const originalList = bucket.list.bind(bucket);
+			bucket.list = (options) => originalList({ ...options, limit: 2 });
+
+			expect(await notebooks.listVersions(projectId, created.id)).toHaveLength(4);
+		});
+
 		it('returns all versions in order of creation', async () => {
 			const created = await notebooks.createNotebook(
 				projectId,

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -34,7 +34,7 @@ import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject } from '../catalog/cas';
 import { buildNotebookEntry, buildNotebookMeta, buildVersion, localSource } from './notebookMeta';
 import { SyncedNotebookService } from './SyncedNotebookService';
-import { deleteByPrefix, listAllKeys, listAllObjects } from '../catalog/storage';
+import { deleteByPrefix, listAllKeys, listAllObjects, listAllPrefixes } from '../catalog/storage';
 
 /**
  * Maximum number of immutable version folders to retain per notebook. Older
@@ -696,10 +696,10 @@ export class NotebookService {
 
 	async listVersions(projectId: ProjectId, notebookId: NotebookId): Promise<Version[]> {
 		const nb = paths.project(projectId).notebook(notebookId);
-		const result = await this.bucket.list({ prefix: `${nb.base}/versions/`, delimiter: '/' });
+		const versionPrefixes = await listAllPrefixes(this.bucket, `${nb.base}/versions/`);
 
 		const fetched = await mapWithConcurrency(
-			result.delimitedPrefixes,
+			versionPrefixes,
 			BUCKET_SCAN_CONCURRENCY,
 			async (pfx) => {
 				const key = `${pfx}version.json`;
@@ -838,11 +838,10 @@ export class NotebookService {
 		try {
 			const nb = paths.project(projectId).notebook(notebookId);
 			const versionsRoot = `${nb.base}/versions/`;
-			const listing = await this.bucket.list({ prefix: versionsRoot, delimiter: '/' });
 
 			// Each delimited prefix is `.../versions/{vid}/`; sort ascending so the
 			// newest (largest ULID) sort last.
-			const versionPrefixes = [...listing.delimitedPrefixes].sort();
+			const versionPrefixes = await listAllPrefixes(this.bucket, versionsRoot);
 			if (versionPrefixes.length <= max) {
 				return;
 			}

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -82,20 +82,9 @@ function pagedDelimiterBucket(inner: Bucket, pageSize: number): Bucket {
 		head: (key) => inner.head(key),
 		put: (key, value, options) => inner.put(key, value, options),
 		delete: (key) => inner.delete(key),
-		async list(options: BucketListOptions = {}) {
+		list(options: BucketListOptions = {}) {
 			if (!options.delimiter) return inner.list(options);
-			const { cursor, ...firstPage } = options;
-			const complete = await inner.list(firstPage);
-			const offset = cursor === undefined ? 0 : Number(cursor.slice('test-page:'.length));
-			const delimitedPrefixes = complete.delimitedPrefixes.slice(offset, offset + pageSize);
-			const next = offset + delimitedPrefixes.length;
-			const truncated = next < complete.delimitedPrefixes.length;
-			return {
-				objects: [],
-				delimitedPrefixes,
-				truncated,
-				...(truncated ? { cursor: `test-page:${next}` } : {}),
-			};
+			return inner.list({ ...options, limit: pageSize });
 		},
 	};
 }

--- a/packages/core/src/testing/MemoryBucket.test.ts
+++ b/packages/core/src/testing/MemoryBucket.test.ts
@@ -185,15 +185,18 @@ describe('MemoryBucket', () => {
 			expect(keys.size).toBe(1500);
 		});
 
-		it('delimited listings still return all prefixes in one shot (no pagination)', async () => {
+		it('paginates delimited prefixes', async () => {
 			for (let i = 0; i < 1500; i++) {
 				await bucket.put(`p/${String(i).padStart(4, '0')}/data`, '{}');
 			}
 
-			// With a delimiter, should return all 1500 collapsed prefixes in one call
-			const result = await bucket.list({ prefix: 'p/', delimiter: '/' });
-			expect(result.truncated).toBe(false);
-			expect(result.delimitedPrefixes).toHaveLength(1500);
+			const first = await bucket.list({ prefix: 'p/', delimiter: '/' });
+			expect(first.truncated).toBe(true);
+			expect(first.delimitedPrefixes).toHaveLength(1000);
+
+			const second = await bucket.list({ prefix: 'p/', delimiter: '/', cursor: first.cursor });
+			expect(second.truncated).toBe(false);
+			expect(second.delimitedPrefixes).toHaveLength(500);
 		});
 	});
 });

--- a/packages/core/src/testing/MemoryBucket.ts
+++ b/packages/core/src/testing/MemoryBucket.ts
@@ -1,4 +1,5 @@
 import { PreconditionFailedError } from '../errors';
+import { assertValidBucketListLimit } from '../ports/bucket';
 import type {
 	Bucket,
 	BucketListOptions,
@@ -87,6 +88,7 @@ export class MemoryBucket implements Bucket {
 	}
 
 	async list(options?: BucketListOptions): Promise<BucketListResult> {
+		assertValidBucketListLimit(options?.limit);
 		const prefix = options?.prefix ?? '';
 		const delimiter = options?.delimiter;
 		const limit = options?.limit ?? 1000;

--- a/packages/core/src/testing/MemoryBucket.ts
+++ b/packages/core/src/testing/MemoryBucket.ts
@@ -101,25 +101,40 @@ export class MemoryBucket implements Bucket {
 
 		const prefixes = new Set<string>();
 		const objectKeys: string[] = [];
+		let emitted = 0;
+		let lastConsumed: string | undefined;
+		let truncated = false;
 		for (const key of sorted) {
 			if (after && key <= after) continue;
 			if (delimiter) {
 				const rest = key.slice(prefix.length);
 				const idx = rest.indexOf(delimiter);
 				if (idx !== -1) {
-					prefixes.add(prefix + rest.slice(0, idx + delimiter.length));
+					const delimitedPrefix = prefix + rest.slice(0, idx + delimiter.length);
+					if (prefixes.has(delimitedPrefix)) {
+						lastConsumed = key;
+						continue;
+					}
+					if (emitted === limit) {
+						truncated = true;
+						break;
+					}
+					prefixes.add(delimitedPrefix);
+					emitted++;
+					lastConsumed = key;
 					continue;
 				}
 			}
+			if (emitted === limit) {
+				truncated = true;
+				break;
+			}
 			objectKeys.push(key);
+			emitted++;
+			lastConsumed = key;
 		}
 
-		// Emulate S3/R2 paging for object listings: at most `limit` per page, with a
-		// cursor to resume. Delimited (prefix-rollup) listings are returned whole.
-		const pageKeys = delimiter ? objectKeys : objectKeys.slice(0, limit);
-		const truncated = !delimiter && objectKeys.length > limit;
-
-		const objects: BucketObject[] = pageKeys.map((key) => {
+		const objects: BucketObject[] = objectKeys.map((key) => {
 			const stored = this.store.get(key)!;
 			return { key, etag: stored.etag, size: stored.body.length, uploaded: stored.uploaded };
 		});
@@ -127,7 +142,7 @@ export class MemoryBucket implements Bucket {
 		return {
 			objects,
 			truncated,
-			cursor: truncated ? pageKeys[pageKeys.length - 1] : undefined,
+			cursor: truncated ? lastConsumed : undefined,
 			delimitedPrefixes: [...prefixes].sort(),
 		};
 	}

--- a/packages/core/src/testing/bucketContract.ts
+++ b/packages/core/src/testing/bucketContract.ts
@@ -101,12 +101,18 @@ export function bucketContract(name: string, makeBucket: () => Bucket | Promise<
 			expect(new Set(seen).size).toBe(keys.length);
 		});
 
+		it.each([0, -1, 1.5])('rejects invalid list limit %s', async (limit) => {
+			await expect(bucket.list({ limit })).rejects.toThrow(
+				'Bucket list limit must be a positive integer',
+			);
+		});
+
 		it('treats startAfter as an exclusive lower bound', async () => {
 			await bucket.put('sa/a', '1');
 			await bucket.put('sa/b', '2');
 			await bucket.put('sa/c', '3');
 
-			const result = await bucket.list({ prefix: 'sa/', startAfter: 'sa/b' });
+			const result = await bucket.list({ prefix: 'sa/', limit: 1, startAfter: 'sa/b' });
 			expect(result.objects.map((object) => object.key)).toEqual(['sa/c']);
 		});
 

--- a/packages/core/src/testing/bucketContract.ts
+++ b/packages/core/src/testing/bucketContract.ts
@@ -81,6 +81,65 @@ export function bucketContract(name: string, makeBucket: () => Bucket | Promise<
 			expect(keys).toEqual(['p/1', 'p/2']);
 		});
 
+		it('paginates with limit and cursor to completion without duplicates or gaps', async () => {
+			const keys = Array.from({ length: 5 }, (_, i) => `pg/${i}`);
+			for (const key of keys) await bucket.put(key, 'x');
+
+			const seen: string[] = [];
+			let cursor: string | undefined;
+			let pages = 0;
+			do {
+				const result = await bucket.list({ prefix: 'pg/', limit: 2, cursor });
+				expect(result.objects.length).toBeLessThanOrEqual(2);
+				expect(Boolean(result.cursor)).toBe(result.truncated);
+				seen.push(...result.objects.map((object) => object.key));
+				cursor = result.truncated ? result.cursor : undefined;
+				expect(++pages).toBeLessThan(20);
+			} while (cursor);
+
+			expect([...seen].sort()).toEqual(keys);
+			expect(new Set(seen).size).toBe(keys.length);
+		});
+
+		it('treats startAfter as an exclusive lower bound', async () => {
+			await bucket.put('sa/a', '1');
+			await bucket.put('sa/b', '2');
+			await bucket.put('sa/c', '3');
+
+			const result = await bucket.list({ prefix: 'sa/', startAfter: 'sa/b' });
+			expect(result.objects.map((object) => object.key)).toEqual(['sa/c']);
+		});
+
+		it('paginates a delimited listing larger than the limit to completion', async () => {
+			for (const key of ['dp/a/1', 'dp/a/2', 'dp/b/1', 'dp/c/1', 'dp/d/1', 'dp/top']) {
+				await bucket.put(key, 'x');
+			}
+
+			const prefixes = new Set<string>();
+			const objects = new Set<string>();
+			let cursor: string | undefined;
+			let pages = 0;
+			do {
+				const result = await bucket.list({ prefix: 'dp/', delimiter: '/', limit: 2, cursor });
+				expect(result.objects.length + result.delimitedPrefixes.length).toBeLessThanOrEqual(2);
+				expect(Boolean(result.cursor)).toBe(result.truncated);
+				for (const prefix of result.delimitedPrefixes) prefixes.add(prefix);
+				for (const object of result.objects) objects.add(object.key);
+				cursor = result.truncated ? result.cursor : undefined;
+				expect(++pages).toBeLessThan(20);
+			} while (cursor);
+
+			expect([...prefixes].sort()).toEqual(['dp/a/', 'dp/b/', 'dp/c/', 'dp/d/']);
+			expect([...objects]).toEqual(['dp/top']);
+		});
+
+		it('omits the cursor from a non-truncated listing', async () => {
+			await bucket.put('nt/1', 'x');
+			const result = await bucket.list({ prefix: 'nt/' });
+			expect(result.truncated).toBe(false);
+			expect(result.cursor).toBeUndefined();
+		});
+
 		it('conditional put succeeds when the etag matches', async () => {
 			const first = await bucket.put('cas.json', '1');
 			const second = await bucket.put('cas.json', '2', { onlyIfEtagMatches: first.etag });

--- a/packages/storage-azure/src/index.test.ts
+++ b/packages/storage-azure/src/index.test.ts
@@ -294,6 +294,25 @@ describe('AzureStorage error handling', () => {
 		).rejects.toMatchObject({ statusCode: 403 });
 	});
 
+	it('maps BlobAlreadyExists for create-if-absent writes to PreconditionFailedError', async () => {
+		const client = {
+			getBlockBlobClient: () => ({
+				uploadData: async () => {
+					throw azureError(409, 'BlobAlreadyExists');
+				},
+			}),
+		} as unknown as ContainerClient;
+		const bucket = new AzureStorage({ containerClient: client });
+
+		await expect(bucket.put('k', 'v', { onlyIfNotExists: true })).rejects.toBeInstanceOf(
+			PreconditionFailedError,
+		);
+		await expect(bucket.put('k', 'v')).rejects.toMatchObject({
+			statusCode: 409,
+			code: 'BlobAlreadyExists',
+		});
+	});
+
 	it('propagates non-404 read failures', async () => {
 		const deniedClient = {
 			getBlobClient: () => ({

--- a/packages/storage-azure/src/index.test.ts
+++ b/packages/storage-azure/src/index.test.ts
@@ -243,9 +243,11 @@ describe('AzureStorage request mapping', () => {
 		const fake = makeFakeContainer();
 		const bucket = new AzureStorage({ containerClient: fake.client });
 
-		await expect(
-			bucket.put('missing', 'value', { onlyIfEtagMatches: 'bogus-etag' }),
-		).rejects.toBeInstanceOf(PreconditionFailedError);
+		const error = await bucket
+			.put('missing', 'value', { onlyIfEtagMatches: 'bogus-etag' })
+			.catch((cause) => cause);
+		expect(error).toBeInstanceOf(PreconditionFailedError);
+		expect(error.message).toBe('ETag mismatch for key "missing"');
 		expect(fake.calls.uploads[0]?.options?.conditions?.ifMatch).toBe('"bogus-etag"');
 	});
 
@@ -278,9 +280,11 @@ describe('AzureStorage error handling', () => {
 				},
 			}),
 		} as unknown as ContainerClient;
-		await expect(
-			new AzureStorage({ containerClient: client }).put('k', 'v'),
-		).rejects.toBeInstanceOf(PreconditionFailedError);
+		const error = await new AzureStorage({ containerClient: client })
+			.put('k', 'v')
+			.catch((cause) => cause);
+		expect(error).toBeInstanceOf(PreconditionFailedError);
+		expect(error.message).toBe('Precondition not met for key "k"');
 
 		const deniedClient = {
 			getBlockBlobClient: () => ({
@@ -304,9 +308,9 @@ describe('AzureStorage error handling', () => {
 		} as unknown as ContainerClient;
 		const bucket = new AzureStorage({ containerClient: client });
 
-		await expect(bucket.put('k', 'v', { onlyIfNotExists: true })).rejects.toBeInstanceOf(
-			PreconditionFailedError,
-		);
+		const error = await bucket.put('k', 'v', { onlyIfNotExists: true }).catch((cause) => cause);
+		expect(error).toBeInstanceOf(PreconditionFailedError);
+		expect(error.message).toBe('Key "k" already exists');
 		await expect(bucket.put('k', 'v')).rejects.toMatchObject({
 			statusCode: 409,
 			code: 'BlobAlreadyExists',

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -25,6 +25,7 @@ export type AzureStorageConfig =
 
 type AzureError = {
 	statusCode?: number;
+	code?: string;
 };
 
 function statusCode(err: unknown): number | undefined {
@@ -37,6 +38,11 @@ function isNotFound(err: unknown): boolean {
 
 function isPreconditionFailed(err: unknown): boolean {
 	return statusCode(err) === 412;
+}
+
+// Create-style conditional uploads can report the collision as BlobAlreadyExists.
+function isAlreadyExists(err: unknown): boolean {
+	return (err as AzureError)?.code === 'BlobAlreadyExists';
 }
 
 function conditionETag(etag: string): string {
@@ -194,7 +200,7 @@ export class AzureStorage implements Bucket {
 				uploaded: response.lastModified ?? new Date(),
 			};
 		} catch (err) {
-			if (isPreconditionFailed(err)) {
+			if (isPreconditionFailed(err) || (options?.onlyIfNotExists && isAlreadyExists(err))) {
 				throw new PreconditionFailedError(`ETag mismatch for key "${key}"`);
 			}
 			throw err;

--- a/packages/storage-azure/src/index.ts
+++ b/packages/storage-azure/src/index.ts
@@ -9,6 +9,7 @@ import type {
 } from '@azure/storage-blob';
 import type { TokenCredential } from '@azure/core-auth';
 import { PreconditionFailedError } from '@marimo-hub/core';
+import { assertValidBucketListLimit } from '@marimo-hub/core/ports';
 import type {
 	Bucket,
 	BucketListOptions,
@@ -200,8 +201,16 @@ export class AzureStorage implements Bucket {
 				uploaded: response.lastModified ?? new Date(),
 			};
 		} catch (err) {
-			if (isPreconditionFailed(err) || (options?.onlyIfNotExists && isAlreadyExists(err))) {
-				throw new PreconditionFailedError(`ETag mismatch for key "${key}"`);
+			if (options?.onlyIfNotExists && isAlreadyExists(err)) {
+				throw new PreconditionFailedError(`Key "${key}" already exists`);
+			}
+			if (isPreconditionFailed(err)) {
+				const message = options?.onlyIfNotExists
+					? `Key "${key}" already exists`
+					: options?.onlyIfEtagMatches !== undefined
+						? `ETag mismatch for key "${key}"`
+						: `Precondition not met for key "${key}"`;
+				throw new PreconditionFailedError(message);
 			}
 			throw err;
 		}
@@ -229,6 +238,7 @@ export class AzureStorage implements Bucket {
 	}
 
 	async list(options?: BucketListOptions): Promise<BucketListResult> {
+		assertValidBucketListLimit(options?.limit);
 		const iterable = options?.delimiter
 			? this.client.listBlobsByHierarchy(options.delimiter, { prefix: options.prefix })
 			: this.client.listBlobsFlat({ prefix: options?.prefix });

--- a/packages/storage-fs/src/index.test.ts
+++ b/packages/storage-fs/src/index.test.ts
@@ -213,12 +213,22 @@ describe('FsStorage', () => {
 			expect(both.objects.map((o) => o.key)).toEqual(['b/4.json']);
 		});
 
-		it('delimited listings are returned whole regardless of limit', async () => {
+		it('paginates delimited listings', async () => {
 			const bucket = new FsStorage({ root: makeRoot() });
 			for (let i = 0; i < 5; i++) await bucket.put(`p/${i}/data`, '{}');
-			const result = await bucket.list({ prefix: 'p/', delimiter: '/', limit: 2 });
-			expect(result.truncated).toBe(false);
-			expect(result.delimitedPrefixes).toHaveLength(5);
+
+			const first = await bucket.list({ prefix: 'p/', delimiter: '/', limit: 2 });
+			expect(first.truncated).toBe(true);
+			expect(first.delimitedPrefixes).toEqual(['p/0/', 'p/1/']);
+
+			const second = await bucket.list({
+				prefix: 'p/',
+				delimiter: '/',
+				limit: 2,
+				cursor: first.cursor,
+			});
+			expect(second.truncated).toBe(true);
+			expect(second.delimitedPrefixes).toEqual(['p/2/', 'p/3/']);
 		});
 	});
 

--- a/packages/storage-fs/src/index.ts
+++ b/packages/storage-fs/src/index.ts
@@ -302,26 +302,41 @@ export class FsStorage implements Bucket {
 
 		const prefixes = new Set<string>();
 		const objectKeys: string[] = [];
+		let emitted = 0;
+		let lastConsumed: string | undefined;
+		let truncated = false;
 		for (const key of sorted) {
 			if (after && key <= after) continue;
 			if (delimiter) {
 				const rest = key.slice(prefix.length);
 				const idx = rest.indexOf(delimiter);
 				if (idx !== -1) {
-					prefixes.add(prefix + rest.slice(0, idx + delimiter.length));
+					const delimitedPrefix = prefix + rest.slice(0, idx + delimiter.length);
+					if (prefixes.has(delimitedPrefix)) {
+						lastConsumed = key;
+						continue;
+					}
+					if (emitted === limit) {
+						truncated = true;
+						break;
+					}
+					prefixes.add(delimitedPrefix);
+					emitted++;
+					lastConsumed = key;
 					continue;
 				}
 			}
+			if (emitted === limit) {
+				truncated = true;
+				break;
+			}
 			objectKeys.push(key);
+			emitted++;
+			lastConsumed = key;
 		}
 
-		// Emulate S3/R2 paging for object listings: at most `limit` per page, with a
-		// cursor to resume. Delimited (prefix-rollup) listings are returned whole.
-		const pageKeys = delimiter ? objectKeys : objectKeys.slice(0, limit);
-		const truncated = !delimiter && objectKeys.length > limit;
-
 		const objects: BucketObject[] = [];
-		for (const key of pageKeys) {
+		for (const key of objectKeys) {
 			const read = await this.readObject(key);
 			// A file deleted between the walk and this read is silently skipped.
 			if (!read) continue;
@@ -336,7 +351,7 @@ export class FsStorage implements Bucket {
 		return {
 			objects,
 			truncated,
-			cursor: truncated ? pageKeys[pageKeys.length - 1] : undefined,
+			cursor: truncated ? lastConsumed : undefined,
 			delimitedPrefixes: [...prefixes].sort(),
 		};
 	}

--- a/packages/storage-fs/src/index.ts
+++ b/packages/storage-fs/src/index.ts
@@ -25,6 +25,7 @@ import { constants, mkdirSync, realpathSync } from 'node:fs';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import { PreconditionFailedError } from '@marimo-hub/core';
+import { assertValidBucketListLimit } from '@marimo-hub/core/ports';
 import type {
 	Bucket,
 	BucketListOptions,
@@ -288,6 +289,7 @@ export class FsStorage implements Bucket {
 	}
 
 	async list(options?: BucketListOptions): Promise<BucketListResult> {
+		assertValidBucketListLimit(options?.limit);
 		const prefix = options?.prefix ?? '';
 		const delimiter = options?.delimiter;
 		const limit = options?.limit ?? 1000;

--- a/packages/storage-gcs/src/index.test.ts
+++ b/packages/storage-gcs/src/index.test.ts
@@ -137,15 +137,57 @@ function makeFakeGcsFetch(): typeof fetch {
 		// List: GET /storage/v1/b/BUCKET/o?prefix=&delimiter=
 		if (method === 'GET' && oIndex === -1 && url.pathname.endsWith('/o')) {
 			const prefix = q.get('prefix') ?? '';
-			const items = [...store.entries()]
-				.filter(([k]) => k.startsWith(prefix))
-				.map(([k, v]) => ({
-					name: k,
-					generation: String(v.generation),
-					size: String(v.content.length),
-					updated: v.updated,
-				}));
-			return json({ items });
+			const delimiter = q.get('delimiter');
+			const limit = Number(q.get('maxResults') ?? 1000);
+			const cursor = q.get('pageToken');
+			const startOffset = q.get('startOffset');
+			const prefixes = new Set<string>();
+			const items: { name: string; generation: string; size: string; updated: string }[] = [];
+			let emitted = 0;
+			let lastConsumed: string | undefined;
+			let truncated = false;
+			for (const [name, value] of [...store.entries()].sort(([left], [right]) =>
+				left.localeCompare(right),
+			)) {
+				if (!name.startsWith(prefix) || (cursor && name <= cursor)) continue;
+				if (!cursor && startOffset && name < startOffset) continue;
+				if (delimiter) {
+					const rest = name.slice(prefix.length);
+					const index = rest.indexOf(delimiter);
+					if (index !== -1) {
+						const delimitedPrefix = prefix + rest.slice(0, index + delimiter.length);
+						if (prefixes.has(delimitedPrefix)) {
+							lastConsumed = name;
+							continue;
+						}
+						if (emitted === limit) {
+							truncated = true;
+							break;
+						}
+						prefixes.add(delimitedPrefix);
+						emitted++;
+						lastConsumed = name;
+						continue;
+					}
+				}
+				if (emitted === limit) {
+					truncated = true;
+					break;
+				}
+				items.push({
+					name,
+					generation: String(value.generation),
+					size: String(value.content.length),
+					updated: value.updated,
+				});
+				emitted++;
+				lastConsumed = name;
+			}
+			return json({
+				items,
+				prefixes: [...prefixes],
+				...(truncated ? { nextPageToken: lastConsumed } : {}),
+			});
 		}
 
 		if (key === undefined) return new Response('not found', { status: 404 });

--- a/packages/storage-gcs/src/index.test.ts
+++ b/packages/storage-gcs/src/index.test.ts
@@ -147,7 +147,7 @@ function makeFakeGcsFetch(): typeof fetch {
 			let lastConsumed: string | undefined;
 			let truncated = false;
 			for (const [name, value] of [...store.entries()].sort(([left], [right]) =>
-				left.localeCompare(right),
+				left < right ? -1 : left > right ? 1 : 0,
 			)) {
 				if (!name.startsWith(prefix) || (cursor && name <= cursor)) continue;
 				if (!cursor && startOffset && name < startOffset) continue;
@@ -454,7 +454,7 @@ describe('GcsStorage auth and request mapping', () => {
 		expect(seenUrl?.searchParams.get('delimiter')).toBe('/');
 		expect(seenUrl?.searchParams.get('maxResults')).toBe('25');
 		expect(seenUrl?.searchParams.get('pageToken')).toBe('cursor-1');
-		expect(seenUrl?.searchParams.get('startOffset')).toBe('runs/a.ipynb');
+		expect(seenUrl?.searchParams.get('startOffset')).toBeNull();
 		expect(result).toMatchObject({
 			objects: [{ key: 'runs/a.py', etag: '101', size: 9 }],
 			truncated: true,
@@ -485,6 +485,22 @@ describe('GcsStorage auth and request mapping', () => {
 });
 
 describe('GcsStorage error propagation and edge cases', () => {
+	it('paginates mixed-case and punctuation keys without duplicates or gaps', async () => {
+		const bucket = new GcsStorage({ bucket: 'test', fetchImpl: makeFakeGcsFetch() });
+		const keys = ['order/a', 'order/A', 'order/_', 'order/-'];
+		for (const key of keys) await bucket.put(key, key);
+
+		const seen: string[] = [];
+		let cursor: string | undefined;
+		do {
+			const result = await bucket.list({ prefix: 'order/', limit: 1, cursor });
+			seen.push(...result.objects.map((object) => object.key));
+			cursor = result.cursor;
+		} while (cursor);
+
+		expect(seen).toEqual([...keys].sort());
+	});
+
 	it('percent-encodes slashes in the object key path segment', async () => {
 		let seenUrl = '';
 		const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {

--- a/packages/storage-gcs/src/index.ts
+++ b/packages/storage-gcs/src/index.ts
@@ -23,6 +23,7 @@ import { importPKCS8, SignJWT } from 'jose';
 import { ofetch } from 'ofetch';
 import type { $Fetch } from 'ofetch';
 import { PreconditionFailedError } from '@marimo-hub/core';
+import { assertValidBucketListLimit } from '@marimo-hub/core/ports';
 import type {
 	Bucket,
 	BucketListOptions,
@@ -363,37 +364,52 @@ export class GcsStorage implements Bucket {
 	}
 
 	async list(options?: BucketListOptions): Promise<BucketListResult> {
-		const params = new URLSearchParams();
-		if (options?.prefix) params.set('prefix', options.prefix);
-		if (options?.delimiter) params.set('delimiter', options.delimiter);
-		if (options?.limit !== undefined) params.set('maxResults', String(options.limit));
-		if (options?.cursor) params.set('pageToken', options.cursor);
-		if (options?.startAfter) params.set('startOffset', options.startAfter);
+		assertValidBucketListLimit(options?.limit);
+		let pageToken = options?.cursor;
+		const startAfter = options?.cursor ? undefined : options?.startAfter;
 
-		const url = `${this.apiEndpoint}/storage/v1/b/${this.bucket}/o?${params}`;
-		const res = await this.client.raw(url, { headers: await this.authHeaders() });
-		if (!res.ok) return this.failNonOk(res, 'list', options?.prefix ?? '');
-		const json = (await res.json()) as {
-			items?: GcsObjectResource[];
-			prefixes?: string[];
-			nextPageToken?: string;
-		};
+		while (true) {
+			const params = new URLSearchParams();
+			if (options?.prefix) params.set('prefix', options.prefix);
+			if (options?.delimiter) params.set('delimiter', options.delimiter);
+			if (options?.limit !== undefined) params.set('maxResults', String(options.limit));
+			if (pageToken) params.set('pageToken', pageToken);
+			if (startAfter) params.set('startOffset', startAfter);
 
-		return {
-			objects: (json.items ?? [])
+			const url = `${this.apiEndpoint}/storage/v1/b/${this.bucket}/o?${params}`;
+			const res = await this.client.raw(url, { headers: await this.authHeaders() });
+			if (!res.ok) return this.failNonOk(res, 'list', options?.prefix ?? '');
+			const json = (await res.json()) as {
+				items?: GcsObjectResource[];
+				prefixes?: string[];
+				nextPageToken?: string;
+			};
+			const objects = (json.items ?? [])
 				.filter((o): o is GcsObjectResource & { name: string } => Boolean(o.name))
-				// GCS startOffset is inclusive; the Bucket port's startAfter is exclusive.
-				.filter((o) => options?.cursor || !options?.startAfter || o.name > options.startAfter)
+				.filter((o) => !startAfter || o.name > startAfter)
 				.map((o) => ({
 					key: o.name,
 					etag: o.generation ?? '',
 					size: Number(o.size ?? 0),
 					uploaded: o.updated ? new Date(o.updated) : new Date(),
-				})),
-			truncated: Boolean(json.nextPageToken),
-			cursor: json.nextPageToken,
-			delimitedPrefixes: json.prefixes ?? [],
-		};
+				}));
+			const delimitedPrefixes = json.prefixes ?? [];
+
+			if (
+				objects.length > 0 ||
+				delimitedPrefixes.length > 0 ||
+				!json.nextPageToken ||
+				!startAfter
+			) {
+				return {
+					objects,
+					truncated: Boolean(json.nextPageToken),
+					cursor: json.nextPageToken,
+					delimitedPrefixes,
+				};
+			}
+			pageToken = json.nextPageToken;
+		}
 	}
 
 	/**

--- a/packages/storage-gcs/src/index.ts
+++ b/packages/storage-gcs/src/index.ts
@@ -368,9 +368,6 @@ export class GcsStorage implements Bucket {
 		if (options?.delimiter) params.set('delimiter', options.delimiter);
 		if (options?.limit !== undefined) params.set('maxResults', String(options.limit));
 		if (options?.cursor) params.set('pageToken', options.cursor);
-		// NOTE: GCS `startOffset` is INCLUSIVE, whereas the port's `startAfter` is
-		// exclusive — they differ only at the exact boundary key. Pagination uses
-		// `cursor` (pageToken), so this matters only for direct `startAfter` callers.
 		if (options?.startAfter) params.set('startOffset', options.startAfter);
 
 		const url = `${this.apiEndpoint}/storage/v1/b/${this.bucket}/o?${params}`;
@@ -385,6 +382,8 @@ export class GcsStorage implements Bucket {
 		return {
 			objects: (json.items ?? [])
 				.filter((o): o is GcsObjectResource & { name: string } => Boolean(o.name))
+				// GCS startOffset is inclusive; the Bucket port's startAfter is exclusive.
+				.filter((o) => options?.cursor || !options?.startAfter || o.name > options.startAfter)
 				.map((o) => ({
 					key: o.name,
 					etag: o.generation ?? '',

--- a/packages/storage-r2/src/index.test.ts
+++ b/packages/storage-r2/src/index.test.ts
@@ -114,34 +114,50 @@ class FakeR2Bucket {
 
 		const sorted = [...this.store.keys()].filter((k) => k.startsWith(prefix)).sort();
 
-		const prefixes: string[] = [];
+		const prefixes = new Set<string>();
 		const objectKeys: string[] = [];
+		let emitted = 0;
+		let lastConsumed: string | undefined;
+		let truncated = false;
 		for (const key of sorted) {
 			if (after && key <= after) continue;
 			if (delimiter) {
 				const rest = key.slice(prefix.length);
 				const idx = rest.indexOf(delimiter);
 				if (idx !== -1) {
-					const pfx = prefix + rest.slice(0, idx + delimiter.length);
-					if (!prefixes.includes(pfx)) prefixes.push(pfx);
+					const delimitedPrefix = prefix + rest.slice(0, idx + delimiter.length);
+					if (prefixes.has(delimitedPrefix)) {
+						lastConsumed = key;
+						continue;
+					}
+					if (emitted === limit) {
+						truncated = true;
+						break;
+					}
+					prefixes.add(delimitedPrefix);
+					emitted++;
+					lastConsumed = key;
 					continue;
 				}
 			}
+			if (emitted === limit) {
+				truncated = true;
+				break;
+			}
 			objectKeys.push(key);
+			emitted++;
+			lastConsumed = key;
 		}
 
-		const pageKeys = delimiter ? objectKeys : objectKeys.slice(0, limit);
-		const truncated = !delimiter && objectKeys.length > limit;
-
-		const objects: R2Object[] = pageKeys.map((key) => {
+		const objects: R2Object[] = objectKeys.map((key) => {
 			return makeR2Object(key, this.store.get(key)!);
 		});
 
 		return {
 			objects,
 			truncated,
-			cursor: truncated ? pageKeys[pageKeys.length - 1] : undefined,
-			delimitedPrefixes: prefixes,
+			cursor: truncated ? lastConsumed : undefined,
+			delimitedPrefixes: [...prefixes],
 		} as unknown as R2Objects;
 	}
 }
@@ -278,5 +294,41 @@ describe('R2BucketAdapter list / put forwarding', () => {
 
 		expect(seen?.httpMetadata).toEqual({ contentType: 'text/x-python' });
 		expect(seen?.customMetadata).toEqual({ source: 'git' });
+	});
+});
+
+describe('R2BucketAdapter delete chunking', () => {
+	function recordingR2(): { r2: R2Bucket; batches: (string | string[])[] } {
+		const batches: (string | string[])[] = [];
+		const r2 = {
+			delete: async (keys: string | string[]) => {
+				batches.push(keys);
+			},
+		} as unknown as R2Bucket;
+		return { r2, batches };
+	}
+
+	it('chunks large deletes into batches of at most 1000 keys', async () => {
+		const { r2, batches } = recordingR2();
+		const keys = Array.from({ length: 2500 }, (_, index) => `k/${index}`);
+
+		await new R2BucketAdapter(r2).delete(keys);
+
+		expect(batches.map((batch) => (Array.isArray(batch) ? batch.length : 1))).toEqual([
+			1000, 1000, 500,
+		]);
+		expect(batches.flat()).toEqual(keys);
+	});
+
+	it('does not call the binding for an empty array', async () => {
+		const { r2, batches } = recordingR2();
+		await new R2BucketAdapter(r2).delete([]);
+		expect(batches).toHaveLength(0);
+	});
+
+	it('passes a single key through unchanged', async () => {
+		const { r2, batches } = recordingR2();
+		await new R2BucketAdapter(r2).delete('solo');
+		expect(batches).toEqual(['solo']);
 	});
 });

--- a/packages/storage-r2/src/index.ts
+++ b/packages/storage-r2/src/index.ts
@@ -1,4 +1,5 @@
 import { PreconditionFailedError } from '@marimo-hub/core';
+import { assertValidBucketListLimit } from '@marimo-hub/core/ports';
 import type {
 	Bucket,
 	BucketListOptions,
@@ -84,6 +85,7 @@ export class R2BucketAdapter implements Bucket {
 	}
 
 	async list(options?: BucketListOptions): Promise<BucketListResult> {
+		assertValidBucketListLimit(options?.limit);
 		const result = await this.r2.list({
 			prefix: options?.prefix,
 			delimiter: options?.delimiter,

--- a/packages/storage-r2/src/index.ts
+++ b/packages/storage-r2/src/index.ts
@@ -73,6 +73,13 @@ export class R2BucketAdapter implements Bucket {
 	}
 
 	async delete(key: string | string[]): Promise<void> {
+		if (Array.isArray(key)) {
+			// The Workers binding accepts at most 1000 keys per delete call.
+			for (let offset = 0; offset < key.length; offset += 1000) {
+				await this.r2.delete(key.slice(offset, offset + 1000));
+			}
+			return;
+		}
 		await this.r2.delete(key);
 	}
 

--- a/packages/storage-s3/src/index.test.ts
+++ b/packages/storage-s3/src/index.test.ts
@@ -113,22 +113,40 @@ function installFakeS3(opts: { ignoreIfMatch?: boolean } = {}) {
 					const sorted = [...store.map.keys()].filter((k) => k.startsWith(prefix)).sort();
 					const prefixes = new Set<string>();
 					const keys: string[] = [];
+					let emitted = 0;
+					let lastConsumed: string | undefined;
+					let truncated = false;
 					for (const key of sorted) {
 						if (after && key <= after) continue;
 						if (delimiter) {
 							const rest = key.slice(prefix.length);
 							const idx = rest.indexOf(delimiter);
 							if (idx !== -1) {
-								prefixes.add(prefix + rest.slice(0, idx + delimiter.length));
+								const delimitedPrefix = prefix + rest.slice(0, idx + delimiter.length);
+								if (prefixes.has(delimitedPrefix)) {
+									lastConsumed = key;
+									continue;
+								}
+								if (emitted === limit) {
+									truncated = true;
+									break;
+								}
+								prefixes.add(delimitedPrefix);
+								emitted++;
+								lastConsumed = key;
 								continue;
 							}
 						}
+						if (emitted === limit) {
+							truncated = true;
+							break;
+						}
 						keys.push(key);
+						emitted++;
+						lastConsumed = key;
 					}
-					const page = delimiter ? keys : keys.slice(0, limit);
-					const truncated = !delimiter && keys.length > limit;
 					return {
-						Contents: page.map((k) => {
+						Contents: keys.map((k) => {
 							const s = store.map.get(k)!;
 							return {
 								Key: k,
@@ -138,7 +156,7 @@ function installFakeS3(opts: { ignoreIfMatch?: boolean } = {}) {
 							};
 						}),
 						IsTruncated: truncated,
-						NextContinuationToken: truncated ? page[page.length - 1] : undefined,
+						NextContinuationToken: truncated ? lastConsumed : undefined,
 						CommonPrefixes: [...prefixes].sort().map((Prefix) => ({ Prefix })),
 					};
 				}
@@ -327,6 +345,51 @@ describe('S3Storage error classification', () => {
 		await expect(s3.put('k', 'v', { onlyIfEtagMatches: 'x' })).rejects.toBeInstanceOf(
 			PreconditionFailedError,
 		);
+	});
+
+	it('maps a conditional-write 409 to PreconditionFailedError', async () => {
+		vi.spyOn(S3Client.prototype, 'send').mockRejectedValue(
+			Object.assign(new Error('ConditionalRequestConflict'), {
+				name: 'ConditionalRequestConflict',
+				$metadata: { httpStatusCode: 409 },
+			}),
+		);
+		const s3 = new S3Storage(CFG);
+
+		await expect(s3.put('k', 'v', { onlyIfEtagMatches: 'e' })).rejects.toBeInstanceOf(
+			PreconditionFailedError,
+		);
+		await expect(s3.put('k2', 'v', { onlyIfNotExists: true })).rejects.toBeInstanceOf(
+			PreconditionFailedError,
+		);
+	});
+
+	it('maps a missing object on an If-Match put to PreconditionFailedError', async () => {
+		vi.spyOn(S3Client.prototype, 'send').mockRejectedValue(
+			Object.assign(new Error('NoSuchKey'), {
+				name: 'NoSuchKey',
+				$metadata: { httpStatusCode: 404 },
+			}),
+		);
+		const s3 = new S3Storage(CFG);
+
+		await expect(s3.put('k', 'v', { onlyIfEtagMatches: 'e' })).rejects.toBeInstanceOf(
+			PreconditionFailedError,
+		);
+	});
+
+	it('propagates an unconditional-put 409 unchanged', async () => {
+		vi.spyOn(S3Client.prototype, 'send').mockRejectedValue(
+			Object.assign(new Error('OperationAborted'), {
+				name: 'OperationAborted',
+				$metadata: { httpStatusCode: 409 },
+			}),
+		);
+		const s3 = new S3Storage(CFG);
+		const error = await s3.put('k', 'v').catch((cause) => cause);
+
+		expect(error).not.toBeInstanceOf(PreconditionFailedError);
+		expect(error.name).toBe('OperationAborted');
 	});
 });
 

--- a/packages/storage-s3/src/index.test.ts
+++ b/packages/storage-s3/src/index.test.ts
@@ -342,9 +342,24 @@ describe('S3Storage error classification', () => {
 			}),
 		);
 		const s3 = new S3Storage(CFG);
-		await expect(s3.put('k', 'v', { onlyIfEtagMatches: 'x' })).rejects.toBeInstanceOf(
-			PreconditionFailedError,
+		const error = await s3.put('k', 'v', { onlyIfEtagMatches: 'x' }).catch((cause) => cause);
+		expect(error).toBeInstanceOf(PreconditionFailedError);
+		expect(error.message).toBe('ETag mismatch for key "k"');
+	});
+
+	it('reports an existing key for a create-if-absent 412', async () => {
+		vi.spyOn(S3Client.prototype, 'send').mockRejectedValue(
+			Object.assign(new Error('PreconditionFailed'), {
+				name: 'PreconditionFailed',
+				$metadata: { httpStatusCode: 412 },
+			}),
 		);
+		const error = await new S3Storage(CFG)
+			.put('k', 'v', { onlyIfNotExists: true })
+			.catch((cause) => cause);
+
+		expect(error).toBeInstanceOf(PreconditionFailedError);
+		expect(error.message).toBe('Key "k" already exists');
 	});
 
 	it('maps a conditional-write 409 to PreconditionFailedError', async () => {
@@ -356,12 +371,14 @@ describe('S3Storage error classification', () => {
 		);
 		const s3 = new S3Storage(CFG);
 
-		await expect(s3.put('k', 'v', { onlyIfEtagMatches: 'e' })).rejects.toBeInstanceOf(
-			PreconditionFailedError,
-		);
-		await expect(s3.put('k2', 'v', { onlyIfNotExists: true })).rejects.toBeInstanceOf(
-			PreconditionFailedError,
-		);
+		for (const operation of [
+			() => s3.put('k', 'v', { onlyIfEtagMatches: 'e' }),
+			() => s3.put('k2', 'v', { onlyIfNotExists: true }),
+		]) {
+			const error = await operation().catch((cause) => cause);
+			expect(error).toBeInstanceOf(PreconditionFailedError);
+			expect(error.message).toMatch(/^Conditional request conflict for key "k2?"$/);
+		}
 	});
 
 	it('maps a missing object on an If-Match put to PreconditionFailedError', async () => {
@@ -373,12 +390,12 @@ describe('S3Storage error classification', () => {
 		);
 		const s3 = new S3Storage(CFG);
 
-		await expect(s3.put('k', 'v', { onlyIfEtagMatches: 'e' })).rejects.toBeInstanceOf(
-			PreconditionFailedError,
-		);
+		const error = await s3.put('k', 'v', { onlyIfEtagMatches: 'e' }).catch((cause) => cause);
+		expect(error).toBeInstanceOf(PreconditionFailedError);
+		expect(error.message).toBe('Key "k" does not exist');
 	});
 
-	it('propagates an unconditional-put 409 unchanged', async () => {
+	it('propagates an unrelated 409 unchanged for conditional and unconditional puts', async () => {
 		vi.spyOn(S3Client.prototype, 'send').mockRejectedValue(
 			Object.assign(new Error('OperationAborted'), {
 				name: 'OperationAborted',
@@ -386,10 +403,15 @@ describe('S3Storage error classification', () => {
 			}),
 		);
 		const s3 = new S3Storage(CFG);
-		const error = await s3.put('k', 'v').catch((cause) => cause);
-
-		expect(error).not.toBeInstanceOf(PreconditionFailedError);
-		expect(error.name).toBe('OperationAborted');
+		for (const operation of [
+			() => s3.put('plain', 'v'),
+			() => s3.put('cas', 'v', { onlyIfEtagMatches: 'e' }),
+			() => s3.put('create', 'v', { onlyIfNotExists: true }),
+		]) {
+			const error = await operation().catch((cause) => cause);
+			expect(error).not.toBeInstanceOf(PreconditionFailedError);
+			expect(error.name).toBe('OperationAborted');
+		}
 	});
 });
 

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -67,6 +67,12 @@ function isPreconditionFailed(err: unknown): boolean {
 	return name === 'PreconditionFailed' || httpStatus(err) === 412;
 }
 
+// S3 reports some losing conditional writes as retryable 409 conflicts instead of 412.
+function isConditionalRequestConflict(err: unknown): boolean {
+	const name = (err as { name?: string })?.name;
+	return name === 'ConditionalRequestConflict' || httpStatus(err) === 409;
+}
+
 function* chunk<T>(items: T[], size: number): Generator<T[]> {
 	for (let i = 0; i < items.length; i += size) {
 		yield items.slice(i, i + size);
@@ -144,6 +150,8 @@ export class S3Storage implements Bucket {
 			// if the key already exists), which `isPreconditionFailed` maps below.
 			input.IfNoneMatch = '*';
 		}
+		const matchesEtag = options?.onlyIfEtagMatches !== undefined;
+		const conditional = matchesEtag || options?.onlyIfNotExists === true;
 
 		try {
 			const res = await this.client.send(new PutObjectCommand(input));
@@ -154,7 +162,11 @@ export class S3Storage implements Bucket {
 				uploaded: new Date(),
 			};
 		} catch (err) {
-			if (isPreconditionFailed(err)) {
+			if (
+				isPreconditionFailed(err) ||
+				(conditional && isConditionalRequestConflict(err)) ||
+				(matchesEtag && isNotFound(err))
+			) {
 				throw new PreconditionFailedError(`ETag mismatch for key "${key}"`);
 			}
 			throw err;

--- a/packages/storage-s3/src/index.ts
+++ b/packages/storage-s3/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from '@aws-sdk/client-s3';
 import type { PutObjectCommandInput } from '@aws-sdk/client-s3';
 import { PreconditionFailedError } from '@marimo-hub/core';
+import { assertValidBucketListLimit } from '@marimo-hub/core/ports';
 import type {
 	Bucket,
 	BucketListOptions,
@@ -67,10 +68,8 @@ function isPreconditionFailed(err: unknown): boolean {
 	return name === 'PreconditionFailed' || httpStatus(err) === 412;
 }
 
-// S3 reports some losing conditional writes as retryable 409 conflicts instead of 412.
 function isConditionalRequestConflict(err: unknown): boolean {
-	const name = (err as { name?: string })?.name;
-	return name === 'ConditionalRequestConflict' || httpStatus(err) === 409;
+	return (err as { name?: string })?.name === 'ConditionalRequestConflict';
 }
 
 function* chunk<T>(items: T[], size: number): Generator<T[]> {
@@ -162,12 +161,19 @@ export class S3Storage implements Bucket {
 				uploaded: new Date(),
 			};
 		} catch (err) {
-			if (
-				isPreconditionFailed(err) ||
-				(conditional && isConditionalRequestConflict(err)) ||
-				(matchesEtag && isNotFound(err))
-			) {
-				throw new PreconditionFailedError(`ETag mismatch for key "${key}"`);
+			if (isPreconditionFailed(err)) {
+				const message = options?.onlyIfNotExists
+					? `Key "${key}" already exists`
+					: matchesEtag
+						? `ETag mismatch for key "${key}"`
+						: `Precondition not met for key "${key}"`;
+				throw new PreconditionFailedError(message);
+			}
+			if (conditional && isConditionalRequestConflict(err)) {
+				throw new PreconditionFailedError(`Conditional request conflict for key "${key}"`);
+			}
+			if (matchesEtag && isNotFound(err)) {
+				throw new PreconditionFailedError(`Key "${key}" does not exist`);
 			}
 			throw err;
 		}
@@ -203,6 +209,7 @@ export class S3Storage implements Bucket {
 	}
 
 	async list(options?: BucketListOptions): Promise<BucketListResult> {
+		assertValidBucketListLimit(options?.limit);
 		const res = await this.client.send(
 			new ListObjectsV2Command({
 				Bucket: this.bucket,


### PR DESCRIPTION
Adds storage conformance coverage and makes every supported adapter satisfy the shared bucket contract.

## Changes

- Run the S3 contract against MinIO and the Azure contract against Azurite on every PR.
- Keep GCS hermetic in CI because fake-gcs-server does not enforce generation preconditions or delimiter page bounds.
- Define and test bounded, cursor-based pagination for keys and delimiter groups.
- Update Memory, filesystem, S3, Azure, GCS, and R2 implementations and fakes to honor the pagination contract.
- Paginate every internal listing call site instead of assuming a single complete page.
- Normalize MinIO's missing-key conditional response and Azure's create conflict into the storage port errors.
- Chunk R2 bulk deletes to the provider's 1,000-key limit.

## Verification

- `pnpm check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- Live MinIO adapter suite: 67/67 passed locally and in CI
- Live Azurite adapter suite: 60/60 passed locally and in CI
