### PR TITLE
fix(runtime): heartbeat no longer revives starting sessions; skip terminal editor holders

### DIFF
--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -381,6 +381,19 @@ describe('Session routes', () => {
 		expect(discarded.status).toBe('terminated');
 	});
 
+	it('does not offer takeover when a claim names a terminal session', async () => {
+		const services = createServices(bucket);
+		const exclusiveOwner = exclusiveApi(ACTOR);
+		const exclusiveOther = exclusiveApi(STRANGER);
+		const persistent = await expectOk<ApiSession>(await exclusiveOwner('POST', sessionsPath()));
+		await services.sessions.terminate(pid, persistent.session_id as SessionId);
+
+		const state = await expectOk<EditorState>(await exclusiveOther('GET', editorSessionPath()));
+
+		expect(state.holder).toBeNull();
+		expect(state.can_take_over).toBe(false);
+	});
+
 	it('keeps the claim protected when the strict takeover save fails', async () => {
 		const exclusiveOwner = exclusiveApi(ACTOR);
 		const failing = makeFakeSandbox();

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -592,28 +592,32 @@ app.openapi(getEditorSession, async (c) => {
 	if (notebook.meta.status === 'deleted') throw new NotFoundError(`Notebook ${nid} not found`);
 	const claim = await deps.services.sessions.getEditorClaim(pid, nid);
 	const sharing = effectiveEditorSharing(claim, deps.policy.editorSandboxSharing);
-	const holder = claim?.session_id
+	const claimedSession = claim?.session_id
 		? await deps.services.sessions.getSession(pid, claim.session_id).catch(() => null)
 		: undefined;
-	const activity = holder ? await inspectEditorActivity(deps, holder) : undefined;
+	// A terminal session is a stale claim, not a holder eligible for takeover.
+	const holder =
+		claimedSession &&
+		(claimedSession.status === 'starting' ||
+			claimedSession.status === 'running' ||
+			claimedSession.status === 'terminating')
+			? { ...claimedSession, status: claimedSession.status }
+			: null;
+	const holderView = holder
+		? {
+				session_id: holder.session_id,
+				user_id: holder.user_id,
+				status: holder.status,
+				started_at: holder.started_at,
+				activity: await inspectEditorActivity(deps, holder),
+			}
+		: null;
 	return c.json(
 		{
 			success: true,
 			data: {
 				sharing,
-				holder:
-					holder &&
-					(holder.status === 'starting' ||
-						holder.status === 'running' ||
-						holder.status === 'terminating')
-						? {
-								session_id: holder.session_id,
-								user_id: holder.user_id,
-								status: holder.status,
-								started_at: holder.started_at,
-								activity: activity!,
-							}
-						: null,
+				holder: holderView,
 				can_take_over:
 					sharing === 'exclusive' && !!holder && holder.user_id !== user.id && !claim?.transfer,
 				...(claim?.transfer ? { transfer: { status: claim.transfer.phase } } : {}),

--- a/packages/core/src/integration.test.ts
+++ b/packages/core/src/integration.test.ts
@@ -135,7 +135,7 @@ describe('Integration: full service stack', () => {
 	});
 
 	describe('session lifecycle', () => {
-		it('create -> heartbeat -> terminate', async () => {
+		it('create -> run -> terminate', async () => {
 			const project = await services.projects.createProject({ name: 'P', description: 'd' }, ACTOR);
 			const nb = await services.notebooks.createNotebook(
 				project.id,
@@ -150,8 +150,12 @@ describe('Integration: full service stack', () => {
 			});
 			expect(session.status).toBe('starting');
 
-			const heartbeated = await services.sessions.heartbeat(project.id, session.session_id);
-			expect(heartbeated.status).toBe('running');
+			const running = await services.sessions.setRunning(
+				project.id,
+				session.session_id,
+				'https://sandbox.example',
+			);
+			expect(running.status).toBe('running');
 
 			const terminated = await services.sessions.terminate(project.id, session.session_id);
 			expect(terminated.status).toBe('terminated');

--- a/packages/core/src/services/runtime/ReconciliationService.test.ts
+++ b/packages/core/src/services/runtime/ReconciliationService.test.ts
@@ -136,7 +136,7 @@ describe('ReconciliationService', () => {
 		// workspace keys it created, and rewind the FS-snapshot pointer.
 		await putSession({ status: 'expired', sandbox_id: terminalId, started_at: iso(-60 * 60_000) });
 		const live = await createSession(healthyId);
-		await sessions.heartbeat(projectId, live.session_id); // -> running
+		await sessions.setRunning(projectId, live.session_id, 'https://kernel.example');
 		compute.active = [{ id: terminalId }, { id: healthyId }];
 
 		const result = await reconciler.reconcile();
@@ -225,7 +225,7 @@ describe('ReconciliationService', () => {
 
 	it('Rule 2: marks a record failed when its sandbox has vanished', async () => {
 		const session = await createSession(goneId);
-		await sessions.heartbeat(projectId, session.session_id); // -> running
+		await sessions.setRunning(projectId, session.session_id, 'https://kernel.example');
 		compute.active = []; // sandbox is no longer live
 
 		const result = await reconciler.reconcile();
@@ -266,7 +266,7 @@ describe('ReconciliationService', () => {
 
 	it('leaves a healthy running session untouched', async () => {
 		const session = await createSession(healthyId);
-		await sessions.heartbeat(projectId, session.session_id); // -> running
+		await sessions.setRunning(projectId, session.session_id, 'https://kernel.example');
 		compute.active = [{ id: healthyId }];
 
 		const result = await reconciler.reconcile();
@@ -389,7 +389,7 @@ describe('ReconciliationService', () => {
 
 	it('Rule 1: reclaims a lingering sandbox behind a terminating record', async () => {
 		const session = await createSession(goneId);
-		await sessions.heartbeat(projectId, session.session_id); // -> running
+		await sessions.setRunning(projectId, session.session_id, 'https://kernel.example');
 		await sessions.beginTerminating(projectId, session.session_id); // -> terminating
 		// Teardown stalled/crashed: the sandbox is still live and billing while the
 		// record sits in `terminating`. The provider-truth net must destroy it.
@@ -403,7 +403,7 @@ describe('ReconciliationService', () => {
 
 	it('Rule 2 does not misfire on a terminating record whose sandbox vanished', async () => {
 		const session = await createSession(healthyId);
-		await sessions.heartbeat(projectId, session.session_id); // -> running
+		await sessions.setRunning(projectId, session.session_id, 'https://kernel.example');
 		await sessions.beginTerminating(projectId, session.session_id); // -> terminating
 		compute.active = []; // sandbox already gone
 

--- a/packages/core/src/services/runtime/SessionService.countActive.test.ts
+++ b/packages/core/src/services/runtime/SessionService.countActive.test.ts
@@ -29,13 +29,13 @@ describe('SessionService.countActiveForUser', () => {
 		// ACTOR: one starting, one running, one terminated.
 		await create(ACTOR);
 		const running = await create(ACTOR);
-		await sessions.heartbeat(projectId, running.session_id); // -> running
+		await sessions.setRunning(projectId, running.session_id, 'https://sandbox.example');
 		const dead = await create(ACTOR);
 		await sessions.terminate(projectId, dead.session_id); // -> terminated (not counted)
 
 		// A different user's live session must not count toward ACTOR.
 		const other = await create(OTHER);
-		await sessions.heartbeat(projectId, other.session_id);
+		await sessions.setRunning(projectId, other.session_id, 'https://sandbox.example');
 
 		expect(await sessions.countActiveForUser(ACTOR)).toBe(2);
 		expect(await sessions.countActiveForUser(OTHER)).toBe(1);
@@ -46,14 +46,14 @@ describe('SessionService.countActiveForUser', () => {
 		// expired: reaped by the TTL sweep — terminal, must not count. Driven to
 		// `expired` first, in isolation, so the time-advance doesn't reap the others.
 		const gone = await create(ACTOR);
-		await sessions.heartbeat(projectId, gone.session_id); // -> running
+		await sessions.setRunning(projectId, gone.session_id, 'https://sandbox.example');
 		advanceTime(6 * 60 * 1000);
 		expect(await sessions.expireStale()).toBe(1); // -> expired
 		restoreClock();
 
 		// One genuinely-active session that must be counted.
 		const live = await create(ACTOR);
-		await sessions.heartbeat(projectId, live.session_id); // -> running
+		await sessions.setRunning(projectId, live.session_id, 'https://sandbox.example');
 
 		// terminating: on its way out — a stop should immediately free the slot.
 		const stopping = await create(ACTOR);

--- a/packages/core/src/services/runtime/SessionService.test.ts
+++ b/packages/core/src/services/runtime/SessionService.test.ts
@@ -1,14 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import {
-	ACTOR,
-	advanceTime,
-	expectHeartbeatAdvanced,
-	expectNotFound,
-	MemoryBucket,
-	restoreClock,
-	uid,
-	useFakeClock,
-} from '../../testing';
+import { ACTOR, advanceTime, expectNotFound, MemoryBucket, restoreClock, uid } from '../../testing';
+import { PreconditionFailedError } from '../../errors';
 import { createNotebookId, createProjectId } from '../../ids';
 import type { SessionId } from '../../ids';
 import { paths } from '../../paths';
@@ -64,16 +56,27 @@ describe('SessionService', () => {
 	});
 
 	describe('heartbeat', () => {
-		it('updates status to running and refreshes last_heartbeat', async () => {
+		it('does not promote a starting session', async () => {
 			const created = await sessions.createSession({
 				notebook_id: notebookId,
 				project_id: projectId,
 				user_id: ACTOR,
 			});
 
-			const updated = await sessions.heartbeat(projectId, created.session_id);
-			expect(updated.status).toBe('running');
-			expectHeartbeatAdvanced(updated, created);
+			const putSpy = vi.spyOn(bucket, 'put');
+			const result = await sessions.heartbeat(projectId, created.session_id);
+
+			expect(result.status).toBe('starting');
+			expect(result.last_heartbeat).toBe(created.last_heartbeat);
+			expect(putSpy).not.toHaveBeenCalled();
+			putSpy.mockRestore();
+
+			const running = await sessions.setRunning(
+				projectId,
+				created.session_id,
+				'https://sandbox.example',
+			);
+			expect(running.status).toBe('running');
 		});
 
 		it('throws NotFoundError for missing session', async () => {
@@ -88,21 +91,16 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
+			await sessions.setRunning(projectId, created.session_id, 'https://sandbox.example');
 
 			const putSpy = vi.spyOn(bucket, 'put');
 
-			// First heartbeat persists the `starting` → `running` transition.
 			await sessions.heartbeat(projectId, created.session_id);
-			expect(putSpy).toHaveBeenCalledTimes(1);
+			expect(putSpy).not.toHaveBeenCalled();
 
-			// Second heartbeat is already running and still fresh → coalesced.
-			await sessions.heartbeat(projectId, created.session_id);
-			expect(putSpy).toHaveBeenCalledTimes(1);
-
-			// Past the interval, it persists again.
 			advanceTime(61 * 1000);
 			await sessions.heartbeat(projectId, created.session_id);
-			expect(putSpy).toHaveBeenCalledTimes(2);
+			expect(putSpy).toHaveBeenCalledTimes(1);
 			restoreClock();
 
 			putSpy.mockRestore();
@@ -134,8 +132,7 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
-			// Drive the session to `expired` via the stale reaper.
-			await sessions.heartbeat(projectId, session.session_id);
+			await sessions.setRunning(projectId, session.session_id, 'https://sandbox.example');
 			advanceTime(6 * 60 * 1000);
 			expect(await sessions.expireStale()).toBe(1);
 			restoreClock();
@@ -151,25 +148,47 @@ describe('SessionService', () => {
 
 			putSpy.mockRestore();
 		});
+	});
 
-		it('promotes a starting session to running and updates last_heartbeat', async () => {
+	describe('releaseEditorFor', () => {
+		it('logs an operational error when the release fails for a non-CAS reason', async () => {
 			const created = await sessions.createSession({
 				notebook_id: notebookId,
 				project_id: projectId,
 				user_id: ACTOR,
 			});
-			expect(created.status).toBe('starting');
+			await sessions.claimEditor(projectId, notebookId, created.session_id, 'shared');
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const put = vi.spyOn(bucket, 'put').mockRejectedValue(new Error('bucket down'));
 
-			const clock = useFakeClock(new Date(created.last_heartbeat).getTime() + 1000);
+			await expect(sessions.releaseEditorFor(created)).resolves.toBeUndefined();
 
-			const updated = await sessions.heartbeat(projectId, created.session_id);
-			expect(updated.status).toBe('running');
-			expectHeartbeatAdvanced(updated, created, { strict: true });
+			const line = log.mock.calls.find((call) =>
+				String(call[0]).includes('editor_claim_release_failed'),
+			)?.[0] as string;
+			expect(line).toContain('session.editor_claim.release');
+			expect(line).toContain(created.session_id);
+			put.mockRestore();
+			log.mockRestore();
+		});
 
-			const stored = await sessions.getSession(projectId, created.session_id);
-			expect(stored.status).toBe('running');
+		it('stays silent when the release loses the CAS race', async () => {
+			const created = await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+			});
+			await sessions.claimEditor(projectId, notebookId, created.session_id, 'shared');
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const put = vi
+				.spyOn(bucket, 'put')
+				.mockRejectedValue(new PreconditionFailedError('etag mismatch'));
 
-			clock.restore();
+			await expect(sessions.releaseEditorFor(created)).resolves.toBeUndefined();
+
+			expect(log).not.toHaveBeenCalled();
+			put.mockRestore();
+			log.mockRestore();
 		});
 	});
 
@@ -180,6 +199,7 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
+			await sessions.setRunning(projectId, session.session_id, 'https://sandbox.example');
 			const key = paths.session(projectId, session.session_id);
 			const raw = await (await bucket.get(key))?.json<Record<string, unknown>>();
 			const pin = [{ id: 'intg-0000000000000000', name: 'prod', kind: 'postgres', version: 3 }];
@@ -188,7 +208,9 @@ describe('SessionService', () => {
 				JSON.stringify({ ...raw, integrations: pin, future_field: 'from-a-newer-replica' }),
 			);
 
+			advanceTime(61 * 1000);
 			await sessions.heartbeat(projectId, session.session_id);
+			restoreClock();
 
 			const rewritten = await (await bucket.get(key))?.json<Record<string, unknown>>();
 			expect(rewritten?.status).toBe('running');
@@ -265,7 +287,7 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
-			await sessions.heartbeat(projectId, session.session_id);
+			await sessions.setRunning(projectId, session.session_id, 'https://sandbox.example');
 			advanceTime(6 * 60 * 1000);
 			expect(await sessions.expireStale()).toBe(1);
 			restoreClock();
@@ -425,7 +447,7 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
-			await sessions.heartbeat(projectId, created.session_id);
+			await sessions.setRunning(projectId, created.session_id, 'https://sandbox.example');
 			advanceTime(6 * 60 * 1000);
 			expect(await sessions.expireStale()).toBe(1);
 			restoreClock();
@@ -760,9 +782,11 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
-			// A heartbeat promotes starting → running WITHOUT stamping a sandbox_url;
-			// there is no live kernel to reconnect to, so it must not be reused.
-			await sessions.heartbeat(projectId, created.session_id);
+			// Older replicas may have written this invalid intermediate state.
+			await bucket.put(
+				paths.session(projectId, created.session_id),
+				JSON.stringify({ ...created, status: 'running' }),
+			);
 
 			expect(await sessions.findReusable(projectId, notebookId, ACTOR)).toBeUndefined();
 		});
@@ -775,8 +799,7 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
-			// Set to running
-			await sessions.heartbeat(projectId, session.session_id);
+			await sessions.setRunning(projectId, session.session_id, 'https://sandbox.example');
 
 			// Move time forward past TTL (5 minutes)
 			advanceTime(6 * 60 * 1000);
@@ -796,7 +819,7 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
-			await sessions.heartbeat(projectId, session.session_id);
+			await sessions.setRunning(projectId, session.session_id, 'https://sandbox.example');
 
 			const expired = await sessions.expireStale();
 			expect(expired).toBe(0);
@@ -897,7 +920,7 @@ describe('SessionService', () => {
 				project_id: projectId,
 				user_id: ACTOR,
 			});
-			await sessions.heartbeat(projectId, session.session_id);
+			await sessions.setRunning(projectId, session.session_id, 'https://sandbox.example');
 
 			advanceTime(25 * 60 * 60 * 1000);
 

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -247,14 +247,16 @@ export class SessionService {
 		}));
 	}
 
-	/** Refresh a live session's heartbeat (keeps it off the TTL reaper). Coalesced
-	 * to ~1 write/60s; never revives a terminal/terminating session. */
+	/** Refresh a running session's heartbeat (keeps it off the TTL reaper).
+	 * Coalesced to ~1 write/60s; never revives a terminal/terminating session.
+	 * Provisioning owns the `starting` to `running` transition so a heartbeat
+	 * cannot create a claim-holding session without a sandbox URL. */
 	async heartbeat(projectId: ProjectId, id: SessionId): Promise<Session> {
 		return this.mutate(projectId, id, (session) => {
-			if (isTerminal(session.status) || session.status === 'terminating') return null;
+			if (session.status !== 'running') return null;
 			const ageMs = Date.now() - new Date(session.last_heartbeat).getTime();
-			if (session.status === 'running' && ageMs < HEARTBEAT_PERSIST_INTERVAL_MS) return null;
-			return { ...session, status: 'running', last_heartbeat: new Date().toISOString() };
+			if (ageMs < HEARTBEAT_PERSIST_INTERVAL_MS) return null;
+			return { ...session, last_heartbeat: new Date().toISOString() };
 		});
 	}
 
@@ -775,9 +777,19 @@ export class SessionService {
 				{ onlyIfEtagMatches: obj.etag },
 			);
 		} catch (err) {
-			if (!(err instanceof PreconditionFailedError)) {
-				this.metrics.increment('sessions.editor_claim.release_error');
-			}
+			// A losing CAS means another request changed the claim, so this release
+			// must not touch it. Other teardown failures are swallowed but logged.
+			if (err instanceof PreconditionFailedError) return;
+			this.metrics.increment('sessions.editor_claim.release_error');
+			logOperationalError(
+				'editor_claim_release_failed',
+				{
+					operation: 'session.editor_claim.release',
+					object: key,
+					session_id: session.session_id,
+				},
+				err,
+			);
 		}
 	}
 

--- a/packages/core/src/services/runtime/sessionState.test.ts
+++ b/packages/core/src/services/runtime/sessionState.test.ts
@@ -25,6 +25,7 @@ describe('sessionState', () => {
 	});
 
 	it('treats a no-op transition as null (skip the write)', () => {
+		expect(nextStatus('starting', 'heartbeat')).toBeNull(); // provisioning owns promotion
 		expect(nextStatus('running', 'running')).toBeNull(); // already running
 		expect(nextStatus('running', 'heartbeat')).toBeNull(); // status unchanged
 		expect(nextStatus('terminating', 'terminate')).toBeNull(); // already terminating

--- a/packages/core/src/services/runtime/sessionState.ts
+++ b/packages/core/src/services/runtime/sessionState.ts
@@ -30,7 +30,6 @@ const machine = createStateMachine<SessionStatus, SessionEvent>({
 	transitions: {
 		starting: {
 			running: 'running',
-			heartbeat: 'running',
 			terminate: 'terminating',
 			fail: 'failed',
 			expire: 'expired',


### PR DESCRIPTION
## Summary

Fixes two reported bugs in session runtime.

- **Heartbeat reviving `starting` sessions.** `heartbeat` now only refreshes a `running` session, and the `starting → running` heartbeat transition is removed from the state machine. Provisioning owns that transition, so a heartbeat can no longer create a claim-holding session that has no sandbox URL.
- **Terminal editor holders.** The editor-session view now treats a claimed session in a terminal state as a stale claim rather than a holder eligible for takeover.
- Editor-claim release failures are now logged (with operational context) instead of being silently swallowed.

## Test plan
- `pnpm test` (updated `SessionService`, `sessions` route, `sessionState`, reconciliation, and integration tests)
- `pnpm typecheck`