### PR TITLE
test(compute): behavioral contract cases + fix local/e2b hygiene races

### DIFF
--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
+import { computeContract } from '@marimo-hub/core/testing/compute-contract';
 
 /**
  * Tests for the Cloudflare Containers compute adapter.
@@ -428,3 +429,41 @@ describe('CloudflareSandboxProvider', () => {
 		});
 	});
 });
+
+function primeContractFakes() {
+	fakeSandbox.exec.mockImplementation(async (cmd: string) =>
+		cmd.includes('mh-contract-fail')
+			? {
+					success: false,
+					stdout: '',
+					stderr: 'scripted failure',
+					error: { code: 'COMMAND_FAILED' },
+				}
+			: { success: true, stdout: '', stderr: '' },
+	);
+	fakeSandbox.execStream.mockImplementation(async () => new ReadableStream());
+	fakeSandbox.readFile.mockImplementation(async () => ({ success: false }));
+	fakeSandbox.writeFile.mockResolvedValue(undefined);
+	fakeSandbox.listFiles.mockImplementation(async () => ({ success: true, files: [] }));
+	fakeSandbox.setEnvVars.mockResolvedValue(undefined);
+	fakeSandbox.mountBucket.mockResolvedValue(undefined);
+	fakeSandbox.unmountBucket.mockResolvedValue(undefined);
+	fakeSandbox.destroy.mockResolvedValue(undefined);
+	fakeSandbox.exposePort.mockImplementation(async () => ({ url: 'https://tunnel.example.com' }));
+	proxyToSandbox.mockResolvedValue(null);
+}
+
+computeContract(
+	'CloudflareSandboxProvider',
+	() => {
+		primeContractFakes();
+		return makeProvider();
+	},
+	{
+		semantics: {
+			failingCommand: 'mh-contract-fail',
+			// The SDK failure shape does not distinguish an absent file.
+			absentFile: { path: '/contract-absent.txt', code: 'READ_FAILED' },
+		},
+	},
+);

--- a/packages/compute-commons/package.json
+++ b/packages/compute-commons/package.json
@@ -9,6 +9,7 @@
 	"type": "module",
 	"exports": {
 		".": "./src/index.ts",
+		"./node": "./src/node.ts",
 		"./package.json": "./package.json"
 	},
 	"scripts": {

--- a/packages/compute-commons/src/node.test.ts
+++ b/packages/compute-commons/src/node.test.ts
@@ -16,4 +16,10 @@ describe('Utf8TailBuffer', () => {
 		buffer.append(Buffer.from([0xa9]));
 		expect(buffer.toString()).toBe('é');
 	});
+
+	it('does not retain half of an astral character at the truncation boundary', () => {
+		const buffer = new Utf8TailBuffer(2);
+		buffer.append(Buffer.from('a😀b'));
+		expect(buffer.toString()).toBe('b');
+	});
 });

--- a/packages/compute-commons/src/node.test.ts
+++ b/packages/compute-commons/src/node.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { Utf8TailBuffer } from './node';
+
+describe('Utf8TailBuffer', () => {
+	it('retains only the configured trailing characters', () => {
+		const buffer = new Utf8TailBuffer(5);
+		buffer.append(Buffer.from('abc'));
+		buffer.append(Buffer.from('defg'));
+		expect(buffer.toString()).toBe('cdefg');
+	});
+
+	it('decodes a UTF-8 character split across chunks', () => {
+		const buffer = new Utf8TailBuffer(10);
+		buffer.append(Buffer.from([0xc3]));
+		expect(buffer.toString()).toBe('');
+		buffer.append(Buffer.from([0xa9]));
+		expect(buffer.toString()).toBe('é');
+	});
+});

--- a/packages/compute-commons/src/node.ts
+++ b/packages/compute-commons/src/node.ts
@@ -10,7 +10,10 @@ export class Utf8TailBuffer {
 	append(chunk: Buffer): void {
 		this.text += this.decoder.write(chunk);
 		if (this.text.length > this.maxChars) {
-			this.text = this.text.slice(this.text.length - this.maxChars);
+			let start = this.text.length - this.maxChars;
+			const code = this.text.charCodeAt(start);
+			if (code >= 0xdc00 && code <= 0xdfff) start += 1;
+			this.text = this.text.slice(start);
 		}
 	}
 

--- a/packages/compute-commons/src/node.ts
+++ b/packages/compute-commons/src/node.ts
@@ -1,0 +1,20 @@
+import { StringDecoder } from 'node:string_decoder';
+
+/** Keeps the most recent decoded characters without breaking split UTF-8 sequences. */
+export class Utf8TailBuffer {
+	private text = '';
+	private readonly decoder = new StringDecoder('utf8');
+
+	constructor(private readonly maxChars: number) {}
+
+	append(chunk: Buffer): void {
+		this.text += this.decoder.write(chunk);
+		if (this.text.length > this.maxChars) {
+			this.text = this.text.slice(this.text.length - this.maxChars);
+		}
+	}
+
+	toString(): string {
+		return this.text;
+	}
+}

--- a/packages/compute-commons/vite.config.ts
+++ b/packages/compute-commons/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite-plus';
 export default defineConfig({
 	pack: {
 		dts: true,
+		entry: ['src/index.ts', 'src/node.ts'],
 	},
 	test: {
 		include: ['src/**/*.test.ts'],

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -328,7 +328,7 @@ describe('E2bCompute', () => {
 		expect(live[0].info.metadata?.['mh-owner']).toBe('marimohub');
 	});
 
-	it('a failed create is retryable (the rejected provision is not cached)', async () => {
+	it('shares a retry between the original instance and a fresh wrapper', async () => {
 		class FlakyCreateE2b extends FakeE2b {
 			failuresRemaining = 1;
 
@@ -338,10 +338,20 @@ describe('E2bCompute', () => {
 			}
 		}
 		const fake = new FlakyCreateE2b();
-		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+		const compute = new E2bCompute(baseConfig, fake);
+		const sb = compute.create(SANDBOX_ID);
 		await expect(sb.exec('true')).rejects.toThrow('provision failed');
-		await expect(sb.exec('true')).resolves.toMatchObject({ success: true });
+		await Promise.all([sb.exec('true'), compute.create(SANDBOX_ID).exec('true')]);
+		expect(fake.createCalls).toHaveLength(1);
 		expect(fake.sandboxes.size).toBe(1);
+	});
+
+	it('does not retain sandbox state strongly in the provider', async () => {
+		const compute = new E2bCompute(baseConfig, new FakeE2b());
+		await compute.create(SANDBOX_ID).exec('true');
+
+		const states = Reflect.get(compute, 'sandboxStates') as Map<SandboxId, unknown>;
+		expect(states.get(SANDBOX_ID)).toBeInstanceOf(WeakRef);
 	});
 
 	it('destroy kills every sandbox carrying our id, not just the first match', async () => {

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -46,6 +46,7 @@ class FakeE2b implements E2bClient {
 		cmd: string;
 		options?: { cwd?: string; envs?: Record<string, string> };
 	}[] = [];
+	readonly connectCalls: string[] = [];
 	killedBackgroundCommands = 0;
 	private seq = 0;
 
@@ -53,6 +54,7 @@ class FakeE2b implements E2bClient {
 		private readonly opts: {
 			failOn?: (cmd: string) => boolean;
 			runResult?: (cmd: string) => E2bExecResult | undefined;
+			beforeCreate?: () => Promise<void>;
 			beforeKill?: (sandbox: FakeSandbox) => Promise<void>;
 		} = {},
 	) {}
@@ -110,6 +112,7 @@ class FakeE2b implements E2bClient {
 		metadata?: Record<string, string>;
 		timeoutMs?: number;
 	}): Promise<E2bSandboxHandle> {
+		await this.opts.beforeCreate?.();
 		this.createCalls.push(options);
 		const sandboxId = `e2b-${++this.seq}`;
 		const sb: FakeSandbox = {
@@ -122,6 +125,7 @@ class FakeE2b implements E2bClient {
 	}
 
 	async connect(sandboxId: string): Promise<E2bSandboxHandle> {
+		this.connectCalls.push(sandboxId);
 		const sb = this.sandboxes.get(sandboxId);
 		if (!sb) throw new Error(`no sandbox ${sandboxId}`);
 		return this.makeHandle(sb);
@@ -130,6 +134,20 @@ class FakeE2b implements E2bClient {
 	async list(): Promise<E2bSandboxInfo[]> {
 		return [...this.sandboxes.values()].filter((s) => !s.killed).map((s) => s.info);
 	}
+}
+
+function stubClearedWeakRefs(): () => void {
+	vi.stubGlobal(
+		'WeakRef',
+		class {
+			constructor(_target: WeakKey) {}
+
+			deref(): undefined {
+				return undefined;
+			}
+		},
+	);
+	return () => vi.unstubAllGlobals();
 }
 
 describe('E2bCompute', () => {
@@ -300,32 +318,37 @@ describe('E2bCompute', () => {
 			releaseKill = resolve;
 		});
 		let pauseNextKill = true;
-		const fake = new FakeE2b({
-			beforeKill: async () => {
-				if (!pauseNextKill) return;
-				pauseNextKill = false;
-				signalKillStarted();
-				await killReleased;
-			},
-		});
-		const compute = new E2bCompute(baseConfig, fake);
-		const first = compute.create(SANDBOX_ID);
-		await first.exec('true');
+		const restoreWeakRefs = stubClearedWeakRefs();
+		try {
+			const fake = new FakeE2b({
+				beforeKill: async () => {
+					if (!pauseNextKill) return;
+					pauseNextKill = false;
+					signalKillStarted();
+					await killReleased;
+				},
+			});
+			const compute = new E2bCompute(baseConfig, fake);
+			await compute.create(SANDBOX_ID).exec('true');
 
-		const destroying = first.destroy();
-		await killStarted;
-		const replacing = compute.create(SANDBOX_ID).exec('true');
-		await Promise.resolve();
-		expect(fake.createCalls).toHaveLength(1);
+			const destroying = compute.create(SANDBOX_ID).destroy();
+			await killStarted;
+			const replacing = compute.create(SANDBOX_ID).exec('true');
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(fake.createCalls).toHaveLength(1);
 
-		releaseKill();
-		await destroying;
-		await replacing;
+			releaseKill();
+			await destroying;
+			await replacing;
 
-		expect(fake.createCalls).toHaveLength(2);
-		const live = [...fake.sandboxes.values()].filter((sandbox) => !sandbox.killed);
-		expect(live).toHaveLength(1);
-		expect(live[0].info.metadata?.['mh-owner']).toBe('marimohub');
+			expect(fake.createCalls).toHaveLength(2);
+			const live = [...fake.sandboxes.values()].filter((sandbox) => !sandbox.killed);
+			expect(live).toHaveLength(1);
+			expect(live[0].info.metadata?.['mh-owner']).toBe('marimohub');
+		} finally {
+			releaseKill();
+			restoreWeakRefs();
+		}
 	});
 
 	it('shares a retry between the original instance and a fresh wrapper', async () => {
@@ -346,12 +369,42 @@ describe('E2bCompute', () => {
 		expect(fake.sandboxes.size).toBe(1);
 	});
 
-	it('does not retain sandbox state strongly in the provider', async () => {
-		const compute = new E2bCompute(baseConfig, new FakeE2b());
-		await compute.create(SANDBOX_ID).exec('true');
+	it('retains pending provision state across temporary wrappers, then releases it', async () => {
+		let signalCreateStarted!: () => void;
+		let releaseCreate!: () => void;
+		const createStarted = new Promise<void>((resolve) => {
+			signalCreateStarted = resolve;
+		});
+		const createReleased = new Promise<void>((resolve) => {
+			releaseCreate = resolve;
+		});
+		let createAttempts = 0;
+		const restoreWeakRefs = stubClearedWeakRefs();
+		try {
+			const fake = new FakeE2b({
+				beforeCreate: async () => {
+					createAttempts += 1;
+					signalCreateStarted();
+					await createReleased;
+				},
+			});
+			const compute = new E2bCompute(baseConfig, fake);
+			const first = compute.create(SANDBOX_ID).exec('true');
+			await createStarted;
+			const second = compute.create(SANDBOX_ID).exec('true');
+			await new Promise<void>((resolve) => setImmediate(resolve));
+			expect(createAttempts).toBe(1);
 
-		const states = Reflect.get(compute, 'sandboxStates') as Map<SandboxId, unknown>;
-		expect(states.get(SANDBOX_ID)).toBeInstanceOf(WeakRef);
+			releaseCreate();
+			await Promise.all([first, second]);
+			expect(fake.createCalls).toHaveLength(1);
+
+			await compute.create(SANDBOX_ID).exec('true');
+			expect(fake.connectCalls).toHaveLength(1);
+		} finally {
+			releaseCreate();
+			restoreWeakRefs();
+		}
 	});
 
 	it('destroy kills every sandbox carrying our id, not just the first match', async () => {

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -53,6 +53,7 @@ class FakeE2b implements E2bClient {
 		private readonly opts: {
 			failOn?: (cmd: string) => boolean;
 			runResult?: (cmd: string) => E2bExecResult | undefined;
+			beforeKill?: (sandbox: FakeSandbox) => Promise<void>;
 		} = {},
 	) {}
 
@@ -97,7 +98,10 @@ class FakeE2b implements E2bClient {
 				},
 			},
 			getHost: (port) => `${port}-${sb.info.sandboxId}.e2b.app`,
-			kill: async () => void (sb.killed = true),
+			kill: async () => {
+				sb.killed = true;
+				await this.opts.beforeKill?.(sb);
+			},
 		};
 	}
 
@@ -169,6 +173,30 @@ describe('E2bCompute', () => {
 		const only = [...fake.sandboxes.values()][0];
 		expect(only.files.get('/a')).toBe('1');
 		expect(only.files.get('/b')).toBe('2');
+	});
+
+	it('does not reconnect to or destroy another owner sandbox with the same id', async () => {
+		const fake = new FakeE2b();
+		await fake.create({
+			metadata: { 'mh-sandbox-id': SANDBOX_ID, 'mh-owner': 'another-deployment' },
+		});
+		const compute = new E2bCompute(baseConfig, fake);
+		const sb = compute.create(SANDBOX_ID);
+
+		await sb.writeFiles([{ path: '/owned', content: 'yes' }]);
+		expect(fake.createCalls).toHaveLength(2);
+		const foreign = [...fake.sandboxes.values()].find(
+			(sandbox) => sandbox.info.metadata?.['mh-owner'] === 'another-deployment',
+		)!;
+		const owned = [...fake.sandboxes.values()].find(
+			(sandbox) => sandbox.info.metadata?.['mh-owner'] === 'marimohub',
+		)!;
+		expect(foreign.files.has('/owned')).toBe(false);
+		expect(owned.files.get('/owned')).toBe('yes');
+
+		await sb.destroy();
+		expect(foreign.killed).toBe(false);
+		expect(owned.killed).toBe(true);
 	});
 
 	it('destroy reconnects by metadata when the instance has no cached handle', async () => {
@@ -250,16 +278,54 @@ describe('E2bCompute', () => {
 		expect([...fake.sandboxes.values()][0].killed).toBe(true);
 	});
 
-	it('concurrent first calls provision exactly one sandbox', async () => {
+	it('concurrent calls through separate instances provision exactly one sandbox', async () => {
 		const fake = new FakeE2b();
-		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+		const compute = new E2bCompute(baseConfig, fake);
 		await Promise.all([
-			sb.exec('true'),
-			sb.writeFiles([{ path: '/a', content: '1' }]),
-			sb.exposePort(2718, { hostname: 'ignored' }),
+			compute.create(SANDBOX_ID).exec('true'),
+			compute.create(SANDBOX_ID).writeFiles([{ path: '/a', content: '1' }]),
+			compute.create(SANDBOX_ID).exposePort(2718, { hostname: 'ignored' }),
 		]);
 		expect(fake.createCalls).toHaveLength(1);
 		expect(fake.sandboxes.size).toBe(1);
+	});
+
+	it('waits for destroy before provisioning a replacement', async () => {
+		let signalKillStarted!: () => void;
+		let releaseKill!: () => void;
+		const killStarted = new Promise<void>((resolve) => {
+			signalKillStarted = resolve;
+		});
+		const killReleased = new Promise<void>((resolve) => {
+			releaseKill = resolve;
+		});
+		let pauseNextKill = true;
+		const fake = new FakeE2b({
+			beforeKill: async () => {
+				if (!pauseNextKill) return;
+				pauseNextKill = false;
+				signalKillStarted();
+				await killReleased;
+			},
+		});
+		const compute = new E2bCompute(baseConfig, fake);
+		const first = compute.create(SANDBOX_ID);
+		await first.exec('true');
+
+		const destroying = first.destroy();
+		await killStarted;
+		const replacing = compute.create(SANDBOX_ID).exec('true');
+		await Promise.resolve();
+		expect(fake.createCalls).toHaveLength(1);
+
+		releaseKill();
+		await destroying;
+		await replacing;
+
+		expect(fake.createCalls).toHaveLength(2);
+		const live = [...fake.sandboxes.values()].filter((sandbox) => !sandbox.killed);
+		expect(live).toHaveLength(1);
+		expect(live[0].info.metadata?.['mh-owner']).toBe('marimohub');
 	});
 
 	it('a failed create is retryable (the rejected provision is not cached)', async () => {

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -250,6 +250,48 @@ describe('E2bCompute', () => {
 		expect([...fake.sandboxes.values()][0].killed).toBe(true);
 	});
 
+	it('concurrent first calls provision exactly one sandbox', async () => {
+		const fake = new FakeE2b();
+		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+		await Promise.all([
+			sb.exec('true'),
+			sb.writeFiles([{ path: '/a', content: '1' }]),
+			sb.exposePort(2718, { hostname: 'ignored' }),
+		]);
+		expect(fake.createCalls).toHaveLength(1);
+		expect(fake.sandboxes.size).toBe(1);
+	});
+
+	it('a failed create is retryable (the rejected provision is not cached)', async () => {
+		class FlakyCreateE2b extends FakeE2b {
+			failuresRemaining = 1;
+
+			override async create(options: Parameters<FakeE2b['create']>[0]): Promise<E2bSandboxHandle> {
+				if (this.failuresRemaining-- > 0) throw new Error('provision failed');
+				return super.create(options);
+			}
+		}
+		const fake = new FlakyCreateE2b();
+		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+		await expect(sb.exec('true')).rejects.toThrow('provision failed');
+		await expect(sb.exec('true')).resolves.toMatchObject({ success: true });
+		expect(fake.sandboxes.size).toBe(1);
+	});
+
+	it('destroy kills every sandbox carrying our id, not just the first match', async () => {
+		const fake = new FakeE2b();
+		await fake.create({
+			metadata: { 'mh-sandbox-id': SANDBOX_ID, 'mh-owner': 'marimohub' },
+		});
+		await fake.create({
+			metadata: { 'mh-sandbox-id': SANDBOX_ID, 'mh-owner': 'marimohub' },
+		});
+
+		await new E2bCompute(baseConfig, fake).create(SANDBOX_ID).destroy();
+
+		expect([...fake.sandboxes.values()].every((sandbox) => sandbox.killed)).toBe(true);
+	});
+
 	it('readFile returns success:false when the SDK read throws', async () => {
 		const res = await new E2bCompute(baseConfig, new FakeE2b())
 			.create(SANDBOX_ID)
@@ -565,6 +607,16 @@ describe('createE2bClient', () => {
 	});
 });
 
-computeContract('E2bCompute', () => new E2bCompute(baseConfig, new FakeE2b()), {
-	mountFallsBack: true,
-});
+computeContract(
+	'E2bCompute',
+	() =>
+		new E2bCompute(baseConfig, new FakeE2b({ failOn: (cmd) => cmd.includes('mh-contract-fail') })),
+	{
+		mountFallsBack: true,
+		semantics: {
+			failingCommand: 'mh-contract-fail',
+			// The SDK does not distinguish a missing file from other read failures.
+			absentFile: { path: '/contract-absent.txt', code: 'READ_FAILED' },
+		},
+	},
+);

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -149,7 +149,6 @@ class E2bSandboxInstance implements SandboxInstance {
 		private readonly config: E2bConfig,
 		private readonly client: E2bClient,
 		private readonly state: E2bSandboxState,
-		private readonly releaseState: () => void,
 	) {}
 
 	private get ownerTag(): string {
@@ -181,7 +180,6 @@ class E2bSandboxInstance implements SandboxInstance {
 		this.state.handlePromise = promise;
 		promise.catch(() => {
 			if (this.state.handlePromise === promise) this.state.handlePromise = undefined;
-			this.releaseState();
 		});
 		return promise;
 	}
@@ -319,7 +317,6 @@ class E2bSandboxInstance implements SandboxInstance {
 		this.state.destroyPromise = promise;
 		const release = () => {
 			if (this.state.destroyPromise === promise) this.state.destroyPromise = undefined;
-			this.releaseState();
 		};
 		void promise.then(release, release);
 		return promise;
@@ -328,7 +325,13 @@ class E2bSandboxInstance implements SandboxInstance {
 
 export class E2bCompute implements SandboxProvider {
 	private client?: E2bClient;
-	private readonly sandboxStates = new Map<SandboxId, E2bSandboxState>();
+	private readonly sandboxStates = new Map<SandboxId, WeakRef<E2bSandboxState>>();
+	private readonly sandboxStateFinalizer = new FinalizationRegistry<{
+		id: SandboxId;
+		ref: WeakRef<E2bSandboxState>;
+	}>(({ id, ref }) => {
+		if (this.sandboxStates.get(id) === ref) this.sandboxStates.delete(id);
+	});
 
 	constructor(
 		private readonly config: E2bConfig,
@@ -345,21 +348,15 @@ export class E2bCompute implements SandboxProvider {
 	create(id: SandboxId, options?: CreateSandboxOptions): SandboxInstance {
 		// For E2B the selectable "image" is a template id.
 		const config = options?.image ? { ...this.config, template: options.image } : this.config;
-		let state = this.sandboxStates.get(id);
+		let ref = this.sandboxStates.get(id);
+		let state = ref?.deref();
 		if (!state) {
 			state = {};
-			this.sandboxStates.set(id, state);
+			ref = new WeakRef(state);
+			this.sandboxStates.set(id, ref);
+			this.sandboxStateFinalizer.register(state, { id, ref });
 		}
-		const sharedState = state;
-		return new E2bSandboxInstance(id, config, this.getClient(), sharedState, () => {
-			if (
-				this.sandboxStates.get(id) === sharedState &&
-				!sharedState.handlePromise &&
-				!sharedState.destroyPromise
-			) {
-				this.sandboxStates.delete(id);
-			}
-		});
+		return new E2bSandboxInstance(id, config, this.getClient(), state);
 	}
 
 	async proxy(_request: Request): Promise<Response | null> {

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -134,9 +134,13 @@ export interface E2bConfig {
 	maxLifetimeSeconds?: Seconds;
 }
 
+interface E2bSandboxState {
+	handlePromise?: Promise<E2bSandboxHandle>;
+	destroyPromise?: Promise<void>;
+}
+
 class E2bSandboxInstance implements SandboxInstance {
 	readonly supportsBucketMount = false;
-	private handlePromise?: Promise<E2bSandboxHandle>;
 	private env: Record<string, string> = {};
 	private envDefaults: Record<string, string> = {};
 
@@ -144,20 +148,27 @@ class E2bSandboxInstance implements SandboxInstance {
 		private readonly id: SandboxId,
 		private readonly config: E2bConfig,
 		private readonly client: E2bClient,
+		private readonly state: E2bSandboxState,
+		private readonly releaseState: () => void,
 	) {}
 
 	private get ownerTag(): string {
 		return this.config.ownerTag ?? DEFAULT_OWNER_TAG;
 	}
 
+	private isOwned(info: E2bSandboxInfo): boolean {
+		return (
+			info.metadata?.[ID_META_KEY] === this.id && info.metadata?.[OWNER_META_KEY] === this.ownerTag
+		);
+	}
+
 	/** Resolve the live E2B sandbox for our id: cached → reconnect-by-tag → create. */
 	private ensure(): Promise<E2bSandboxHandle> {
-		// Sharing the in-flight lookup closes the check-then-create race between callers.
-		if (this.handlePromise) return this.handlePromise;
+		if (this.state.handlePromise) return this.state.handlePromise;
+		const destroyPromise = this.state.destroyPromise;
 		const promise = (async () => {
-			const existing = (await this.client.list()).find(
-				(s) => s.metadata?.[ID_META_KEY] === this.id,
-			);
+			if (destroyPromise) await destroyPromise;
+			const existing = (await this.client.list()).find((sandbox) => this.isOwned(sandbox));
 			if (existing) return this.client.connect(existing.sandboxId);
 			return this.client.create({
 				template: this.config.template,
@@ -167,9 +178,10 @@ class E2bSandboxInstance implements SandboxInstance {
 					: {}),
 			});
 		})();
-		this.handlePromise = promise;
+		this.state.handlePromise = promise;
 		promise.catch(() => {
-			if (this.handlePromise === promise) this.handlePromise = undefined;
+			if (this.state.handlePromise === promise) this.state.handlePromise = undefined;
+			this.releaseState();
 		});
 		return promise;
 	}
@@ -287,24 +299,36 @@ class E2bSandboxInstance implements SandboxInstance {
 		return { url: `https://${sb.getHost(port)}` };
 	}
 
-	async destroy(): Promise<void> {
-		const pending = this.handlePromise;
-		this.handlePromise = undefined;
-		if (pending) {
-			const cached = await pending.catch(() => null);
-			if (cached) await cached.kill().catch(() => {});
-		}
-		// Sweep by tag to reap duplicates left by provisioning races from older instances.
-		const matches = (await this.client.list()).filter((s) => s.metadata?.[ID_META_KEY] === this.id);
-		for (const match of matches) {
-			const handle = await this.client.connect(match.sandboxId).catch(() => null);
-			if (handle) await handle.kill().catch(() => {});
-		}
+	destroy(): Promise<void> {
+		if (this.state.destroyPromise) return this.state.destroyPromise;
+
+		const pending = this.state.handlePromise;
+		this.state.handlePromise = undefined;
+		const promise = (async () => {
+			if (pending) {
+				const cached = await pending.catch(() => null);
+				if (cached) await cached.kill().catch(() => {});
+			}
+			// Reap duplicates left by provisioning races from older processes.
+			const matches = (await this.client.list()).filter((sandbox) => this.isOwned(sandbox));
+			for (const match of matches) {
+				const handle = await this.client.connect(match.sandboxId).catch(() => null);
+				if (handle) await handle.kill().catch(() => {});
+			}
+		})();
+		this.state.destroyPromise = promise;
+		const release = () => {
+			if (this.state.destroyPromise === promise) this.state.destroyPromise = undefined;
+			this.releaseState();
+		};
+		void promise.then(release, release);
+		return promise;
 	}
 }
 
 export class E2bCompute implements SandboxProvider {
 	private client?: E2bClient;
+	private readonly sandboxStates = new Map<SandboxId, E2bSandboxState>();
 
 	constructor(
 		private readonly config: E2bConfig,
@@ -321,7 +345,21 @@ export class E2bCompute implements SandboxProvider {
 	create(id: SandboxId, options?: CreateSandboxOptions): SandboxInstance {
 		// For E2B the selectable "image" is a template id.
 		const config = options?.image ? { ...this.config, template: options.image } : this.config;
-		return new E2bSandboxInstance(id, config, this.getClient());
+		let state = this.sandboxStates.get(id);
+		if (!state) {
+			state = {};
+			this.sandboxStates.set(id, state);
+		}
+		const sharedState = state;
+		return new E2bSandboxInstance(id, config, this.getClient(), sharedState, () => {
+			if (
+				this.sandboxStates.get(id) === sharedState &&
+				!sharedState.handlePromise &&
+				!sharedState.destroyPromise
+			) {
+				this.sandboxStates.delete(id);
+			}
+		});
 	}
 
 	async proxy(_request: Request): Promise<Response | null> {

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -136,7 +136,7 @@ export interface E2bConfig {
 
 class E2bSandboxInstance implements SandboxInstance {
 	readonly supportsBucketMount = false;
-	private handle?: E2bSandboxHandle;
+	private handlePromise?: Promise<E2bSandboxHandle>;
 	private env: Record<string, string> = {};
 	private envDefaults: Record<string, string> = {};
 
@@ -151,19 +151,27 @@ class E2bSandboxInstance implements SandboxInstance {
 	}
 
 	/** Resolve the live E2B sandbox for our id: cached → reconnect-by-tag → create. */
-	private async ensure(): Promise<E2bSandboxHandle> {
-		if (this.handle) return this.handle;
-		const existing = (await this.client.list()).find((s) => s.metadata?.[ID_META_KEY] === this.id);
-		this.handle = existing
-			? await this.client.connect(existing.sandboxId)
-			: await this.client.create({
-					template: this.config.template,
-					metadata: { [ID_META_KEY]: this.id, [OWNER_META_KEY]: this.ownerTag },
-					...(this.config.maxLifetimeSeconds
-						? { timeoutMs: Seconds.toMillis(this.config.maxLifetimeSeconds) }
-						: {}),
-				});
-		return this.handle;
+	private ensure(): Promise<E2bSandboxHandle> {
+		// Sharing the in-flight lookup closes the check-then-create race between callers.
+		if (this.handlePromise) return this.handlePromise;
+		const promise = (async () => {
+			const existing = (await this.client.list()).find(
+				(s) => s.metadata?.[ID_META_KEY] === this.id,
+			);
+			if (existing) return this.client.connect(existing.sandboxId);
+			return this.client.create({
+				template: this.config.template,
+				metadata: { [ID_META_KEY]: this.id, [OWNER_META_KEY]: this.ownerTag },
+				...(this.config.maxLifetimeSeconds
+					? { timeoutMs: Seconds.toMillis(this.config.maxLifetimeSeconds) }
+					: {}),
+			});
+		})();
+		this.handlePromise = promise;
+		promise.catch(() => {
+			if (this.handlePromise === promise) this.handlePromise = undefined;
+		});
+		return promise;
 	}
 
 	async exec(cmd: string): Promise<ExecResult> {
@@ -280,16 +288,17 @@ class E2bSandboxInstance implements SandboxInstance {
 	}
 
 	async destroy(): Promise<void> {
-		// Kill the cached handle if we have one; otherwise resolve-by-tag and kill.
-		if (this.handle) {
-			await this.handle.kill().catch(() => {});
-			this.handle = undefined;
-			return;
+		const pending = this.handlePromise;
+		this.handlePromise = undefined;
+		if (pending) {
+			const cached = await pending.catch(() => null);
+			if (cached) await cached.kill().catch(() => {});
 		}
-		const existing = (await this.client.list()).find((s) => s.metadata?.[ID_META_KEY] === this.id);
-		if (existing) {
-			const h = await this.client.connect(existing.sandboxId);
-			await h.kill().catch(() => {});
+		// Sweep by tag to reap duplicates left by provisioning races from older instances.
+		const matches = (await this.client.list()).filter((s) => s.metadata?.[ID_META_KEY] === this.id);
+		for (const match of matches) {
+			const handle = await this.client.connect(match.sandboxId).catch(() => null);
+			if (handle) await handle.kill().catch(() => {});
 		}
 	}
 }

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -139,6 +139,12 @@ interface E2bSandboxState {
 	destroyPromise?: Promise<void>;
 }
 
+interface E2bSandboxStateEntry {
+	ref: WeakRef<E2bSandboxState>;
+	retained?: E2bSandboxState;
+	retainCount: number;
+}
+
 class E2bSandboxInstance implements SandboxInstance {
 	readonly supportsBucketMount = false;
 	private env: Record<string, string> = {};
@@ -149,6 +155,7 @@ class E2bSandboxInstance implements SandboxInstance {
 		private readonly config: E2bConfig,
 		private readonly client: E2bClient,
 		private readonly state: E2bSandboxState,
+		private readonly retainState: () => () => void,
 	) {}
 
 	private get ownerTag(): string {
@@ -178,8 +185,10 @@ class E2bSandboxInstance implements SandboxInstance {
 			});
 		})();
 		this.state.handlePromise = promise;
-		promise.catch(() => {
+		const releaseState = this.retainState();
+		void promise.then(releaseState, () => {
 			if (this.state.handlePromise === promise) this.state.handlePromise = undefined;
+			releaseState();
 		});
 		return promise;
 	}
@@ -315,8 +324,10 @@ class E2bSandboxInstance implements SandboxInstance {
 			}
 		})();
 		this.state.destroyPromise = promise;
+		const releaseState = this.retainState();
 		const release = () => {
 			if (this.state.destroyPromise === promise) this.state.destroyPromise = undefined;
+			releaseState();
 		};
 		void promise.then(release, release);
 		return promise;
@@ -325,12 +336,12 @@ class E2bSandboxInstance implements SandboxInstance {
 
 export class E2bCompute implements SandboxProvider {
 	private client?: E2bClient;
-	private readonly sandboxStates = new Map<SandboxId, WeakRef<E2bSandboxState>>();
+	private readonly sandboxStates = new Map<SandboxId, E2bSandboxStateEntry>();
 	private readonly sandboxStateFinalizer = new FinalizationRegistry<{
 		id: SandboxId;
 		ref: WeakRef<E2bSandboxState>;
 	}>(({ id, ref }) => {
-		if (this.sandboxStates.get(id) === ref) this.sandboxStates.delete(id);
+		if (this.sandboxStates.get(id)?.ref === ref) this.sandboxStates.delete(id);
 	});
 
 	constructor(
@@ -345,18 +356,34 @@ export class E2bCompute implements SandboxProvider {
 		return this.client;
 	}
 
+	private retainSandboxState(entry: E2bSandboxStateEntry, state: E2bSandboxState): () => void {
+		entry.retainCount += 1;
+		entry.retained = state;
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			entry.retainCount -= 1;
+			if (entry.retainCount === 0) entry.retained = undefined;
+		};
+	}
+
 	create(id: SandboxId, options?: CreateSandboxOptions): SandboxInstance {
 		// For E2B the selectable "image" is a template id.
 		const config = options?.image ? { ...this.config, template: options.image } : this.config;
-		let ref = this.sandboxStates.get(id);
-		let state = ref?.deref();
-		if (!state) {
+		let entry = this.sandboxStates.get(id);
+		let state = entry?.retained ?? entry?.ref.deref();
+		if (!entry || !state) {
 			state = {};
-			ref = new WeakRef(state);
-			this.sandboxStates.set(id, ref);
+			const ref = new WeakRef(state);
+			entry = { ref, retainCount: 0 };
+			this.sandboxStates.set(id, entry);
 			this.sandboxStateFinalizer.register(state, { id, ref });
 		}
-		return new E2bSandboxInstance(id, config, this.getClient(), state);
+		const stateEntry = entry;
+		return new E2bSandboxInstance(id, config, this.getClient(), state, () =>
+			this.retainSandboxState(stateEntry, state),
+		);
 	}
 
 	async proxy(_request: Request): Promise<Response | null> {

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -3,9 +3,15 @@ import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import type { SandboxId } from '@marimo-hub/core';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
 import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectFileResult } from '@marimo-hub/core/testing';
+import {
+	computeContract,
+	CONTRACT_HIDDEN_FILE,
+	CONTRACT_SANDBOX_ID,
+	CONTRACT_VISIBLE_FILE,
+} from '@marimo-hub/core/testing/compute-contract';
 import { LocalCompute, prepareMarimoCommand, rewriteWorkspace } from './index';
 
 const compute = new LocalCompute();
@@ -397,4 +403,105 @@ describe('LocalCompute listActive', () => {
 		active = await compute.listActive();
 		expect(active.map((s) => s.id)).not.toContain(runningId);
 	});
+});
+
+describe('LocalCompute process hygiene', () => {
+	it('execStream does not deadlock when the command floods stderr', async () => {
+		const sb = newSandbox();
+		const stream = await sb.execStream(
+			`node -e "process.stderr.write('e'.repeat(256 * 1024)); process.stdout.write('done')"`,
+		);
+		expect(await new Response(stream).text()).toBe('done');
+	}, 15_000);
+
+	it('destroy kills a live execStream child', async () => {
+		const sb = newSandbox();
+		const stream = await sb.execStream('sleep 30');
+		const drained = new Response(stream).text();
+		await sb.destroy();
+		await expect(drained).resolves.toBe('');
+	}, 10_000);
+
+	it('cancelling an execStream kills the child', async () => {
+		const sb = newSandbox();
+		const stream = await sb.execStream('sleep 1 && echo alive > /workspace/alive.txt');
+		await stream.cancel();
+		await new Promise((resolve) => setTimeout(resolve, 1500));
+		const read = await sb.readFile('/workspace/alive.txt');
+		expect(read.success).toBe(false);
+	}, 10_000);
+
+	it('exec retains only the trailing output', async () => {
+		const sb = newSandbox();
+		const res = await sb.exec(`node -e "process.stdout.write('a'.repeat(300 * 1024))"`);
+		expect(res.success).toBe(true);
+		expect(res.stdout.length).toBeLessThanOrEqual(64 * 1024);
+		expect(res.stdout.endsWith('a')).toBe(true);
+	});
+
+	it('exec decodes multi-byte UTF-8 split across chunks', async () => {
+		const sb = newSandbox();
+		const res = await sb.exec(
+			`node -e "process.stdout.write(Buffer.from([0xc3])); setTimeout(() => process.stdout.write(Buffer.from([0xa9])), 100)"`,
+		);
+		expect(res.success).toBe(true);
+		expect(res.stdout).toBe('é');
+	});
+
+	it('startProcess logs are capped to the trailing output', async () => {
+		const sb = newSandbox();
+		const proc = await sb.startProcess(
+			`node -e "process.stdout.write('b'.repeat(300 * 1024)); setInterval(() => {}, 1000)"`,
+			{ cwd: '/workspace' },
+		);
+		let logs = { stdout: '', stderr: '' };
+		for (let i = 0; i < 50; i++) {
+			logs = await proc.getLogs();
+			if (logs.stdout.length > 0) break;
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		expect(logs.stdout.length).toBeGreaterThan(0);
+		expect(logs.stdout.length).toBeLessThanOrEqual(64 * 1024);
+		await proc.kill();
+	});
+
+	it('destroy evicts the instance so the id maps to a fresh one', async () => {
+		const id = `sb-evict-${Math.random().toString(36).slice(2, 10)}` as SandboxId;
+		created.push(id);
+		const sb = compute.create(id);
+		expect(compute.create(id)).toBe(sb);
+		await sb.destroy();
+		expect(compute.create(id)).not.toBe(sb);
+	});
+
+	it('a stale destroy does not evict a replacement instance', async () => {
+		const id = `sb-stale-${Math.random().toString(36).slice(2, 10)}` as SandboxId;
+		created.push(id);
+		const first = compute.create(id);
+		await first.destroy();
+		const second = compute.create(id);
+		await first.destroy();
+		expect(compute.create(id)).toBe(second);
+	});
+});
+
+computeContract('LocalCompute', () => new LocalCompute(), {
+	mountFallsBack: true,
+	semantics: {
+		failingCommand: 'false',
+		absentFile: { path: '/workspace/contract-absent.txt', code: 'NOT_FOUND' },
+		hiddenFiles: {
+			dir: '/workspace',
+			seed: (inst) =>
+				inst.writeFiles([
+					{ path: `/workspace/${CONTRACT_VISIBLE_FILE}`, content: 'v' },
+					{ path: `/workspace/${CONTRACT_HIDDEN_FILE}`, content: 'h' },
+				]),
+		},
+		envProbe: (name) => `printenv ${name}`,
+	},
+});
+
+afterAll(async () => {
+	await new LocalCompute().create(CONTRACT_SANDBOX_ID).destroy();
 });

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -424,10 +424,26 @@ describe('LocalCompute process hygiene', () => {
 
 	it('cancelling an execStream kills the child', async () => {
 		const sb = newSandbox();
+		await sb.writeFiles([{ path: '/workspace/.keep', content: '' }]);
 		const stream = await sb.execStream('sleep 1 && echo alive > /workspace/alive.txt');
 		await stream.cancel();
 		await new Promise((resolve) => setTimeout(resolve, 1500));
 		const read = await sb.readFile('/workspace/alive.txt');
+		expect(read.success).toBe(false);
+	}, 10_000);
+
+	it('cancelling an execStream reader kills the process group', async () => {
+		const sb = newSandbox();
+		await sb.writeFiles([{ path: '/workspace/.keep', content: '' }]);
+		const stream = await sb.execStream(
+			'(sleep 1; echo alive > /workspace/descendant.txt) & printf ready; wait',
+		);
+		const reader = stream.getReader();
+		const first = await reader.read();
+		expect(new TextDecoder().decode(first.value)).toBe('ready');
+		await reader.cancel();
+		await new Promise((resolve) => setTimeout(resolve, 1500));
+		const read = await sb.readFile('/workspace/descendant.txt');
 		expect(read.success).toBe(false);
 	}, 10_000);
 
@@ -499,6 +515,18 @@ computeContract('LocalCompute', () => new LocalCompute(), {
 				]),
 		},
 		envProbe: (name) => `printenv ${name}`,
+		preexistingEnv: {
+			name: 'MH_CONTRACT_ENV_PREEXISTING',
+			value: 'host',
+			setup: async () => {
+				const previous = process.env.MH_CONTRACT_ENV_PREEXISTING;
+				process.env.MH_CONTRACT_ENV_PREEXISTING = 'host';
+				return () => {
+					if (previous === undefined) delete process.env.MH_CONTRACT_ENV_PREEXISTING;
+					else process.env.MH_CONTRACT_ENV_PREEXISTING = previous;
+				};
+			},
+		},
 	},
 });
 

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { SandboxId } from '@marimo-hub/core';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import type { SandboxInstance } from '@marimo-hub/core/ports';
 import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectFileResult } from '@marimo-hub/core/testing';
 import {
@@ -21,6 +22,31 @@ function newSandbox() {
 	const id = `sb-${Math.random().toString(36).slice(2, 10)}` as SandboxId;
 	created.push(id);
 	return compute.create(id);
+}
+
+function processIsAlive(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ESRCH') return false;
+		throw error;
+	}
+}
+
+async function waitForPid(sandbox: SandboxInstance, path: string): Promise<number> {
+	let pid = 0;
+	await expect
+		.poll(
+			async () => {
+				const result = await sandbox.readFile(path);
+				if (result.success) pid = Number(result.content.trim());
+				return pid;
+			},
+			{ timeout: 5000, interval: 20 },
+		)
+		.toBeGreaterThan(0);
+	return pid;
 }
 
 afterEach(async () => {
@@ -424,27 +450,21 @@ describe('LocalCompute process hygiene', () => {
 
 	it('cancelling an execStream kills the child', async () => {
 		const sb = newSandbox();
-		await sb.writeFiles([{ path: '/workspace/.keep', content: '' }]);
-		const stream = await sb.execStream('sleep 1 && echo alive > /workspace/alive.txt');
+		const stream = await sb.execStream('echo $$ > direct.pid; sleep 30');
+		const pid = await waitForPid(sb, 'direct.pid');
+		expect(processIsAlive(pid)).toBe(true);
 		await stream.cancel();
-		await new Promise((resolve) => setTimeout(resolve, 1500));
-		const read = await sb.readFile('/workspace/alive.txt');
-		expect(read.success).toBe(false);
+		await expect.poll(() => processIsAlive(pid), { timeout: 5000, interval: 20 }).toBe(false);
 	}, 10_000);
 
 	it('cancelling an execStream reader kills the process group', async () => {
 		const sb = newSandbox();
-		await sb.writeFiles([{ path: '/workspace/.keep', content: '' }]);
-		const stream = await sb.execStream(
-			'(sleep 1; echo alive > /workspace/descendant.txt) & printf ready; wait',
-		);
+		const stream = await sb.execStream('sleep 30 & echo $! > descendant.pid; wait');
 		const reader = stream.getReader();
-		const first = await reader.read();
-		expect(new TextDecoder().decode(first.value)).toBe('ready');
+		const pid = await waitForPid(sb, 'descendant.pid');
+		expect(processIsAlive(pid)).toBe(true);
 		await reader.cancel();
-		await new Promise((resolve) => setTimeout(resolve, 1500));
-		const read = await sb.readFile('/workspace/descendant.txt');
-		expect(read.success).toBe(false);
+		await expect.poll(() => processIsAlive(pid), { timeout: 5000, interval: 20 }).toBe(false);
 	}, 10_000);
 
 	it('exec retains only the trailing output', async () => {

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -66,6 +66,18 @@ function captureOutput(child: ChildProcess) {
 	return { stdout, stderr };
 }
 
+function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+	if (!child.pid) {
+		child.kill(signal);
+		return;
+	}
+	try {
+		process.kill(-child.pid, signal);
+	} catch {
+		child.kill(signal);
+	}
+}
+
 const WORKSPACE = '/workspace';
 
 export interface PortRange {
@@ -291,20 +303,18 @@ class LocalSandboxInstance implements SandboxInstance {
 
 	async execStream(cmd: string, _options?: ExecStreamOptions): Promise<ReadableStream> {
 		await this.ensureRoot();
-		const child = this.spawnShell(this.rewriteCmd(cmd));
+		const child = this.spawnShell(this.rewriteCmd(cmd), { detached: true });
 		this.children.add(child);
 		// An undrained stderr pipe can fill and block the child before stdout completes.
 		child.stderr?.resume();
 		const forget = () => this.children.delete(child);
 		child.once('exit', forget);
 		child.once('error', forget);
-		const stream = Readable.toWeb(child.stdout ?? Readable.from([])) as ReadableStream;
-		const nodeCancel = stream.cancel.bind(stream);
-		stream.cancel = (reason?: unknown) => {
-			child.kill('SIGKILL');
-			return nodeCancel(reason);
-		};
-		return stream;
+		const stdout = child.stdout ?? Readable.from([]);
+		stdout.once('close', () => {
+			if (stdout.readableAborted) killProcessGroup(child, 'SIGKILL');
+		});
+		return Readable.toWeb(stdout) as ReadableStream;
 	}
 
 	async readFile(p: string): Promise<ReadFileResult> {
@@ -429,11 +439,7 @@ class LocalSandboxInstance implements SandboxInstance {
 			id,
 			command,
 			async kill(signal?: string) {
-				try {
-					if (child.pid) process.kill(-child.pid, (signal as NodeJS.Signals) ?? 'SIGTERM');
-				} catch {
-					child.kill((signal as NodeJS.Signals) ?? 'SIGTERM');
-				}
+				killProcessGroup(child, (signal as NodeJS.Signals) ?? 'SIGTERM');
 			},
 			async waitForPort(port: number, opts?: WaitForPortOptions) {
 				const real = portMap.get(port) ?? port;
@@ -471,11 +477,7 @@ class LocalSandboxInstance implements SandboxInstance {
 
 	async destroy(): Promise<void> {
 		for (const child of this.children) {
-			try {
-				if (child.pid) process.kill(-child.pid, 'SIGKILL');
-			} catch {
-				child.kill('SIGKILL');
-			}
+			killProcessGroup(child, 'SIGKILL');
 		}
 		this.children.clear();
 		this.portMap.clear();

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -31,6 +31,7 @@ import {
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
+import { Utf8TailBuffer } from '@marimo-hub/compute-commons/node';
 import type { SandboxId } from '@marimo-hub/core';
 import type {
 	ActiveSandbox,
@@ -53,6 +54,17 @@ import type {
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
 import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
+
+// Kernel processes can run for hours; diagnostics only need their recent output.
+const OUTPUT_TAIL_CHARS = 64 * 1024;
+
+function captureOutput(child: ChildProcess) {
+	const stdout = new Utf8TailBuffer(OUTPUT_TAIL_CHARS);
+	const stderr = new Utf8TailBuffer(OUTPUT_TAIL_CHARS);
+	child.stdout?.on('data', (chunk: Buffer) => stdout.append(chunk));
+	child.stderr?.on('data', (chunk: Buffer) => stderr.append(chunk));
+	return { stdout, stderr };
+}
 
 const WORKSPACE = '/workspace';
 
@@ -207,6 +219,7 @@ class LocalSandboxInstance implements SandboxInstance {
 		id: SandboxId,
 		opts: Required<Pick<LocalComputeOptions, 'host' | 'bindHost'>> &
 			Pick<LocalComputeOptions, 'ports'>,
+		private readonly onDestroyed?: () => void,
 	) {
 		this.root = path.join(os.tmpdir(), `marimohub-sandbox-${id}`);
 		this.host = opts.host;
@@ -248,25 +261,50 @@ class LocalSandboxInstance implements SandboxInstance {
 		await mkdir(this.root, { recursive: true });
 	}
 
+	private spawnShell(
+		command: string,
+		options: { cwd?: string; env?: NodeJS.ProcessEnv; detached?: boolean } = {},
+	): ChildProcess {
+		// Spawn env entries are forced; guarded defaults defer to the inherited host env.
+		return spawn('sh', ['-c', withEnvPrefix(command, {}, this.envDefaults)], {
+			cwd: options.cwd ?? this.root,
+			env: { ...process.env, ...this.env, ...options.env },
+			detached: options.detached,
+		});
+	}
+
 	async exec(cmd: string): Promise<ExecResult> {
 		await this.ensureRoot();
 		return new Promise((resolve) => {
-			const child = spawn('sh', ['-c', this.rewriteCmd(cmd)], { cwd: this.root });
-			let stdout = '';
-			let stderr = '';
-			child.stdout?.on('data', (d) => (stdout += d.toString()));
-			child.stderr?.on('data', (d) => (stderr += d.toString()));
+			const child = this.spawnShell(this.rewriteCmd(cmd));
+			const { stdout, stderr } = captureOutput(child);
 			child.on('error', (err) =>
-				resolve(execResult(false, stdout, stderr + String(err), 'SPAWN_FAILED')),
+				resolve(
+					execResult(false, stdout.toString(), stderr.toString() + String(err), 'SPAWN_FAILED'),
+				),
 			);
-			child.on('close', (code) => resolve(execResult(code === 0, stdout, stderr)));
+			child.on('close', (code) =>
+				resolve(execResult(code === 0, stdout.toString(), stderr.toString())),
+			);
 		});
 	}
 
 	async execStream(cmd: string, _options?: ExecStreamOptions): Promise<ReadableStream> {
 		await this.ensureRoot();
-		const child = spawn('sh', ['-c', this.rewriteCmd(cmd)], { cwd: this.root });
-		return Readable.toWeb(child.stdout ?? Readable.from([])) as ReadableStream;
+		const child = this.spawnShell(this.rewriteCmd(cmd));
+		this.children.add(child);
+		// An undrained stderr pipe can fill and block the child before stdout completes.
+		child.stderr?.resume();
+		const forget = () => this.children.delete(child);
+		child.once('exit', forget);
+		child.once('error', forget);
+		const stream = Readable.toWeb(child.stdout ?? Readable.from([])) as ReadableStream;
+		const nodeCancel = stream.cancel.bind(stream);
+		stream.cancel = (reason?: unknown) => {
+			child.kill('SIGKILL');
+			return nodeCancel(reason);
+		};
+		return stream;
 	}
 
 	async readFile(p: string): Promise<ReadFileResult> {
@@ -369,19 +407,14 @@ class LocalSandboxInstance implements SandboxInstance {
 		const cwd = options?.cwd ? this.mapPath(options.cwd) : this.root;
 		await mkdir(cwd, { recursive: true });
 
-		// Forced vars ride spawn's env; defaults can't (a spawn env entry always
-		// wins), so they go in as a guarded prefix that defers to the host env.
-		const child = spawn('sh', ['-c', withEnvPrefix(command, {}, this.envDefaults)], {
+		const child = this.spawnShell(command, {
 			cwd,
-			env: { ...process.env, ...this.env, ...options?.env },
+			env: options?.env,
 			detached: true,
 		});
 		this.children.add(child);
 
-		let stdout = '';
-		let stderr = '';
-		child.stdout?.on('data', (d) => (stdout += d.toString()));
-		child.stderr?.on('data', (d) => (stderr += d.toString()));
+		const { stdout, stderr } = captureOutput(child);
 
 		let exitInfo: { code: number | null; signal: NodeJS.Signals | null } | null = null;
 		child.on('exit', (code, signal) => {
@@ -411,7 +444,7 @@ class LocalSandboxInstance implements SandboxInstance {
 						// throw to abort the wait immediately (pollUntilReady won't retry).
 						if (exitInfo) {
 							throw new Error(
-								`process exited (code ${exitInfo.code}) before port ${port} was ready.\n${stderr || stdout}`,
+								`process exited (code ${exitInfo.code}) before port ${port} was ready.\n${stderr.toString() || stdout.toString()}`,
 							);
 						}
 						return tcpReady(real);
@@ -420,12 +453,12 @@ class LocalSandboxInstance implements SandboxInstance {
 						timeoutMs: timeout,
 						intervalMs: 200,
 						timeoutMessage: () =>
-							`timed out waiting for port ${port} after ${timeout}ms.\n${stderr || stdout}`,
+							`timed out waiting for port ${port} after ${timeout}ms.\n${stderr.toString() || stdout.toString()}`,
 					},
 				);
 			},
 			async getLogs() {
-				return { stdout, stderr };
+				return { stdout: stdout.toString(), stderr: stderr.toString() };
 			},
 		};
 		return proc;
@@ -447,6 +480,7 @@ class LocalSandboxInstance implements SandboxInstance {
 		this.children.clear();
 		this.portMap.clear();
 		await rm(this.root, { recursive: true, force: true });
+		this.onDestroyed?.();
 	}
 }
 
@@ -454,9 +488,8 @@ export class LocalCompute implements SandboxProvider {
 	private readonly host: string;
 	private readonly bindHost: string;
 	private readonly ports?: PortRange;
-	// The kernel child process lives in THIS Node process, so we must hand back
-	// the same instance when the (stateless) API re-resolves a sandbox by id for
-	// teardown — otherwise destroy() couldn't find the running kernel to kill it.
+	// Re-resolution must return the same live instance so teardown can find its
+	// child process; destroy evicts it so a later create gets fresh state.
 	private readonly instances = new Map<SandboxId, LocalSandboxInstance>();
 
 	constructor(options?: LocalComputeOptions) {
@@ -468,11 +501,18 @@ export class LocalCompute implements SandboxProvider {
 	create(id: SandboxId): SandboxInstance {
 		let instance = this.instances.get(id);
 		if (!instance) {
-			instance = new LocalSandboxInstance(id, {
-				host: this.host,
-				bindHost: this.bindHost,
-				ports: this.ports,
-			});
+			const next = new LocalSandboxInstance(
+				id,
+				{
+					host: this.host,
+					bindHost: this.bindHost,
+					ports: this.ports,
+				},
+				() => {
+					if (this.instances.get(id) === next) this.instances.delete(id);
+				},
+			);
+			instance = next;
 			this.instances.set(id, instance);
 		}
 		return instance;

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -3,6 +3,12 @@ import { NotFoundError } from 'modal';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
+import {
+	computeContract,
+	CONTRACT_HIDDEN_FILE,
+	CONTRACT_SANDBOX_ID,
+	CONTRACT_VISIBLE_FILE,
+} from '@marimo-hub/core/testing/compute-contract';
 import { modalProfileResources, ModalCompute } from './index';
 import type {
 	ModalClientLike,
@@ -431,3 +437,56 @@ describe('ModalCompute', () => {
 		expect(await compute.proxy(new Request('https://example.com'))).toBeNull();
 	});
 });
+
+function contractWorld() {
+	const world = makeWorld();
+	const create = world.client.sandboxes.create.bind(world.client.sandboxes);
+	world.client.sandboxes.create = async (app, image, options) => {
+		const sandbox = (await create(app, image, options)) as FakeSandbox;
+		sandbox.execImpl = (command) =>
+			command[2]?.includes('mh-contract-fail')
+				? processResult(1, '', 'scripted failure')
+				: processResult();
+		return sandbox;
+	};
+	return world;
+}
+
+let contractWorldRef: ReturnType<typeof makeWorld>;
+
+computeContract(
+	'ModalCompute',
+	() => {
+		contractWorldRef = contractWorld();
+		return makeCompute(contractWorldRef);
+	},
+	{
+		mountFallsBack: true,
+		semantics: {
+			failingCommand: 'mh-contract-fail',
+			// Modal maps every filesystem read exception to READ_FAILED.
+			absentFile: { path: '/workspace/contract-absent.txt', code: 'READ_FAILED' },
+			hiddenFiles: {
+				dir: '/workspace',
+				seed: async () => {
+					const sandbox = new FakeSandbox();
+					sandbox.directories.set('/workspace', [
+						{
+							name: CONTRACT_VISIBLE_FILE,
+							path: `/workspace/${CONTRACT_VISIBLE_FILE}`,
+							type: 'file',
+							size: 1,
+						},
+						{
+							name: CONTRACT_HIDDEN_FILE,
+							path: `/workspace/${CONTRACT_HIDDEN_FILE}`,
+							type: 'file',
+							size: 1,
+						},
+					]);
+					contractWorldRef.existing.set(CONTRACT_SANDBOX_ID, sandbox);
+				},
+			},
+		},
+	},
+);

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -6,7 +6,6 @@ import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
 import {
 	computeContract,
 	CONTRACT_HIDDEN_FILE,
-	CONTRACT_SANDBOX_ID,
 	CONTRACT_VISIBLE_FILE,
 } from '@marimo-hub/core/testing/compute-contract';
 import { modalProfileResources, ModalCompute } from './index';
@@ -69,6 +68,19 @@ class FakeSandbox implements ModalSandboxLike {
 		this.tags = tags;
 	}
 
+	private writeFile(path: string, content: string | Uint8Array): void {
+		this.files.set(path, content);
+		const separator = path.lastIndexOf('/');
+		const directory = separator === 0 ? '/' : path.slice(0, separator);
+		const name = path.slice(separator + 1);
+		const entries = this.directories.get(directory) ?? [];
+		const entry = { name, path, type: 'file' as const, size: content.length };
+		const existing = entries.findIndex((candidate) => candidate.path === path);
+		if (existing === -1) entries.push(entry);
+		else entries[existing] = entry;
+		this.directories.set(directory, entries);
+	}
+
 	filesystem = {
 		readText: async (path: string) => {
 			const value = this.files.get(path);
@@ -76,10 +88,10 @@ class FakeSandbox implements ModalSandboxLike {
 			return value;
 		},
 		writeText: async (content: string, path: string) => {
-			this.files.set(path, content);
+			this.writeFile(path, content);
 		},
 		writeBytes: async (content: Uint8Array, path: string) => {
-			this.files.set(path, content);
+			this.writeFile(path, content);
 		},
 		listFiles: async (path: string) => this.directories.get(path) ?? [],
 	};
@@ -452,41 +464,19 @@ function contractWorld() {
 	return world;
 }
 
-let contractWorldRef: ReturnType<typeof makeWorld>;
-
-computeContract(
-	'ModalCompute',
-	() => {
-		contractWorldRef = contractWorld();
-		return makeCompute(contractWorldRef);
-	},
-	{
-		mountFallsBack: true,
-		semantics: {
-			failingCommand: 'mh-contract-fail',
-			// Modal maps every filesystem read exception to READ_FAILED.
-			absentFile: { path: '/workspace/contract-absent.txt', code: 'READ_FAILED' },
-			hiddenFiles: {
-				dir: '/workspace',
-				seed: async () => {
-					const sandbox = new FakeSandbox();
-					sandbox.directories.set('/workspace', [
-						{
-							name: CONTRACT_VISIBLE_FILE,
-							path: `/workspace/${CONTRACT_VISIBLE_FILE}`,
-							type: 'file',
-							size: 1,
-						},
-						{
-							name: CONTRACT_HIDDEN_FILE,
-							path: `/workspace/${CONTRACT_HIDDEN_FILE}`,
-							type: 'file',
-							size: 1,
-						},
-					]);
-					contractWorldRef.existing.set(CONTRACT_SANDBOX_ID, sandbox);
-				},
-			},
+computeContract('ModalCompute', () => makeCompute(contractWorld()), {
+	mountFallsBack: true,
+	semantics: {
+		failingCommand: 'mh-contract-fail',
+		// Modal maps every filesystem read exception to READ_FAILED.
+		absentFile: { path: '/workspace/contract-absent.txt', code: 'READ_FAILED' },
+		hiddenFiles: {
+			dir: '/workspace',
+			seed: (inst) =>
+				inst.writeFiles([
+					{ path: `/workspace/${CONTRACT_VISIBLE_FILE}`, content: 'v' },
+					{ path: `/workspace/${CONTRACT_HIDDEN_FILE}`, content: 'h' },
+				]),
 		},
 	},
-);
+});

--- a/packages/core/src/testing/computeContract.test.ts
+++ b/packages/core/src/testing/computeContract.test.ts
@@ -1,5 +1,19 @@
+import { expectTypeOf, it } from 'vitest';
+import type { ComputeContractSemantics } from './computeContract';
 import { computeContract } from './computeContract';
 import { makeFakeCompute } from './fakes';
 
 // Validate the shared contract against the known-good in-memory fake provider.
 computeContract('makeFakeCompute', () => makeFakeCompute());
+
+it('requires envProbe when preexistingEnv is configured', () => {
+	type PreexistingEnvWithoutProbe = {
+		preexistingEnv: {
+			name: string;
+			value: string;
+			setup: () => Promise<() => void>;
+		};
+	};
+
+	expectTypeOf<PreexistingEnvWithoutProbe>().not.toExtend<ComputeContractSemantics>();
+});

--- a/packages/core/src/testing/computeContract.ts
+++ b/packages/core/src/testing/computeContract.ts
@@ -18,7 +18,6 @@ import type { SandboxInstance, SandboxProvider } from '../ports/sandbox';
 import { expectExecResult, expectFileResult, expectListFilesResult } from './assertions';
 
 export const CONTRACT_SANDBOX_ID = 'sb-aaaaaaaaaaaaaaaa' as SandboxId;
-/** Fixed names the hidden-file semantic case asserts on; seeds must create both. */
 export const CONTRACT_VISIBLE_FILE = 'contract-visible.txt';
 export const CONTRACT_HIDDEN_FILE = '.contract-hidden';
 
@@ -70,6 +69,12 @@ export interface ComputeContractSemantics {
 	hiddenFiles?: { dir: string; seed: (inst: SandboxInstance) => Promise<void> };
 	/** Command whose stdout is the value of the named environment variable. */
 	envProbe?: (name: string) => string;
+	/** Backend-defined environment value that an onlyIfUnset default must preserve. */
+	preexistingEnv?: {
+		name: string;
+		value: string;
+		setup: (inst: SandboxInstance) => Promise<() => void | Promise<void>>;
+	};
 }
 
 export function computeContract(
@@ -236,6 +241,21 @@ export function computeContract(
 				const res = await inst.exec(envProbe('MH_CONTRACT_ENV_UNSET'));
 				expect(res.stdout.trim()).toBe('default');
 			});
+
+			if (semantics.preexistingEnv !== undefined) {
+				const preexistingEnv = semantics.preexistingEnv;
+				it('setEnvVars onlyIfUnset preserves a backend-defined value', async () => {
+					const inst = provider.create(CONTRACT_ID);
+					const cleanup = await preexistingEnv.setup(inst);
+					try {
+						await inst.setEnvVars({ [preexistingEnv.name]: 'default' }, { onlyIfUnset: true });
+						const res = await inst.exec(envProbe(preexistingEnv.name));
+						expect(res.stdout.trim()).toBe(preexistingEnv.value);
+					} finally {
+						await cleanup();
+					}
+				});
+			}
 		}
 	});
 }

--- a/packages/core/src/testing/computeContract.ts
+++ b/packages/core/src/testing/computeContract.ts
@@ -56,26 +56,30 @@ export interface ComputeContractOptions {
 	semantics?: ComputeContractSemantics;
 }
 
-/**
- * Behavioral cases each backend/fake can opt into. Every field is optional:
- * a fake that cannot model a behavior omits the field and the case is skipped.
- */
-export interface ComputeContractSemantics {
+interface PreexistingEnvSemantics {
+	name: string;
+	value: string;
+	setup: (inst: SandboxInstance) => Promise<() => void | Promise<void>>;
+}
+
+type EnvironmentSemantics =
+	| { envProbe?: never; preexistingEnv?: never }
+	| {
+			/** Command whose stdout is the value of the named environment variable. */
+			envProbe: (name: string) => string;
+			/** Backend-defined value that an onlyIfUnset default must preserve. */
+			preexistingEnv?: PreexistingEnvSemantics;
+	  };
+
+/** Behavioral cases each backend fake can opt into when it can model them faithfully. */
+export type ComputeContractSemantics = {
 	/** Shell command guaranteed to exit non-zero in this backend/fake. */
 	failingCommand?: string;
 	/** A path guaranteed absent, plus the error code the adapter maps it to. */
 	absentFile?: { path: string; code: 'NOT_FOUND' | 'READ_FAILED' };
 	/** Directory listing whose seed creates the contract's visible and hidden fixtures. */
 	hiddenFiles?: { dir: string; seed: (inst: SandboxInstance) => Promise<void> };
-	/** Command whose stdout is the value of the named environment variable. */
-	envProbe?: (name: string) => string;
-	/** Backend-defined environment value that an onlyIfUnset default must preserve. */
-	preexistingEnv?: {
-		name: string;
-		value: string;
-		setup: (inst: SandboxInstance) => Promise<() => void | Promise<void>>;
-	};
-}
+} & EnvironmentSemantics;
 
 export function computeContract(
 	name: string,

--- a/packages/core/src/testing/computeContract.ts
+++ b/packages/core/src/testing/computeContract.ts
@@ -4,13 +4,10 @@
  * Compute adapters are translation layers: each maps the port onto a backend
  * SDK/HTTP/CLI and is mostly tested by asserting the calls it emits against a
  * backend-shaped fake. So unlike `bucketContract` (which verifies CAS behavior
- * against a faithful store), this contract pins only the fake-agnostic
- * invariants every adapter must honor regardless of backend — a fresh instance
- * exposes the full method surface, `exec` returns a well-formed `ExecResult`,
- * `exposePort` yields a parseable URL, `proxy` never throws, and `destroy`
- * resolves. Behavioral round-trips (writeFile/readFile, exit-code mapping,
- * lifecycle polling) stay in each adapter's own suite, where the fake models
- * that backend.
+ * against a faithful store), this contract pins the fake-agnostic invariants
+ * every adapter must honor regardless of backend. Behavioral invariants are
+ * opt-in through `semantics`; backend-specific translation details stay in each
+ * adapter's own suite, where the fake models that backend.
  *
  * Imports `vitest` — only invoke from a `*.test.ts`. Exposed at the
  * `@marimo-hub/core/testing/compute-contract` subpath so it never reaches runtime.
@@ -18,9 +15,14 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { SandboxId } from '../ids';
 import type { SandboxInstance, SandboxProvider } from '../ports/sandbox';
-import { expectListFilesResult } from './assertions';
+import { expectExecResult, expectFileResult, expectListFilesResult } from './assertions';
 
-const CONTRACT_ID = 'sb-aaaaaaaaaaaaaaaa' as SandboxId;
+export const CONTRACT_SANDBOX_ID = 'sb-aaaaaaaaaaaaaaaa' as SandboxId;
+/** Fixed names the hidden-file semantic case asserts on; seeds must create both. */
+export const CONTRACT_VISIBLE_FILE = 'contract-visible.txt';
+export const CONTRACT_HIDDEN_FILE = '.contract-hidden';
+
+const CONTRACT_ID = CONTRACT_SANDBOX_ID;
 
 const REQUIRED_METHODS: (keyof SandboxInstance)[] = [
 	'exec',
@@ -52,6 +54,22 @@ export interface ComputeContractOptions {
 	mountFallsBack?: boolean;
 	/** Hostname passed to `exposePort`; some adapters embed it in the URL. */
 	hostname?: string;
+	semantics?: ComputeContractSemantics;
+}
+
+/**
+ * Behavioral cases each backend/fake can opt into. Every field is optional:
+ * a fake that cannot model a behavior omits the field and the case is skipped.
+ */
+export interface ComputeContractSemantics {
+	/** Shell command guaranteed to exit non-zero in this backend/fake. */
+	failingCommand?: string;
+	/** A path guaranteed absent, plus the error code the adapter maps it to. */
+	absentFile?: { path: string; code: 'NOT_FOUND' | 'READ_FAILED' };
+	/** Directory listing whose seed creates the contract's visible and hidden fixtures. */
+	hiddenFiles?: { dir: string; seed: (inst: SandboxInstance) => Promise<void> };
+	/** Command whose stdout is the value of the named environment variable. */
+	envProbe?: (name: string) => string;
 }
 
 export function computeContract(
@@ -60,6 +78,7 @@ export function computeContract(
 	opts: ComputeContractOptions = {},
 ): void {
 	const hostname = opts.hostname ?? 'hub.example.com';
+	const semantics = opts.semantics ?? {};
 
 	describe(`Compute contract: ${name}`, () => {
 		let provider: SandboxProvider;
@@ -167,6 +186,55 @@ export function computeContract(
 
 			it('advertises supportsBucketMount: false so the provisioner skips the mount', () => {
 				expect(provider.create(CONTRACT_ID).supportsBucketMount).toBe(false);
+			});
+		}
+
+		if (semantics.failingCommand !== undefined) {
+			const failingCommand = semantics.failingCommand;
+			it('a nonzero-exit command maps to success:false with a typed error code', async () => {
+				const res = await provider.create(CONTRACT_ID).exec(failingCommand);
+				expectExecResult(res, { success: false });
+			});
+		}
+
+		if (semantics.absentFile !== undefined) {
+			const absentFile = semantics.absentFile;
+			it('readFile of an absent path returns a typed failure, not a throw', async () => {
+				const res = await provider.create(CONTRACT_ID).readFile(absentFile.path);
+				expectFileResult(res, { success: false, error: { code: absentFile.code } });
+			});
+		}
+
+		if (semantics.hiddenFiles !== undefined) {
+			const hiddenFiles = semantics.hiddenFiles;
+			it('listFiles hides dotfiles unless includeHidden is set', async () => {
+				const inst = provider.create(CONTRACT_ID);
+				await hiddenFiles.seed(inst);
+				const byDefault = await inst.listFiles(hiddenFiles.dir);
+				expectListFilesResult(byDefault, { success: true });
+				const defaultNames = byDefault.files.map((f) => f.name);
+				expect(defaultNames).toContain(CONTRACT_VISIBLE_FILE);
+				expect(defaultNames).not.toContain(CONTRACT_HIDDEN_FILE);
+				const withHidden = await inst.listFiles(hiddenFiles.dir, { includeHidden: true });
+				expect(withHidden.files.map((f) => f.name)).toContain(CONTRACT_HIDDEN_FILE);
+			});
+		}
+
+		if (semantics.envProbe !== undefined) {
+			const envProbe = semantics.envProbe;
+			it('setEnvVars onlyIfUnset defers to a var already set without onlyIfUnset', async () => {
+				const inst = provider.create(CONTRACT_ID);
+				await inst.setEnvVars({ MH_CONTRACT_ENV: 'forced' });
+				await inst.setEnvVars({ MH_CONTRACT_ENV: 'default' }, { onlyIfUnset: true });
+				const res = await inst.exec(envProbe('MH_CONTRACT_ENV'));
+				expect(res.stdout.trim()).toBe('forced');
+			});
+
+			it('setEnvVars onlyIfUnset applies when nothing else set the var', async () => {
+				const inst = provider.create(CONTRACT_ID);
+				await inst.setEnvVars({ MH_CONTRACT_ENV_UNSET: 'default' }, { onlyIfUnset: true });
+				const res = await inst.exec(envProbe('MH_CONTRACT_ENV_UNSET'));
+				expect(res.stdout.trim()).toBe('default');
 			});
 		}
 	});


### PR DESCRIPTION
## What

Extends the hermetic `computeContract` with opt-in **`semantics`** behavioral cases and wires them into every compute adapter suite (cloudflare, e2b, local, modal):

- nonzero-exit command → `success:false` with a typed error code
- `readFile` of an absent path → typed failure, not a throw
- `listFiles` hides dotfiles unless `includeHidden` is set
- `setEnvVars` `onlyIfUnset` semantics

## Fixes surfaced by the new cases

- **compute-e2b**: share the in-flight provision promise so concurrent first calls provision exactly one sandbox; drop the cached promise on failure so a rejected create is retryable; `destroy` sweeps *every* sandbox carrying our id (not just the first match).
- **compute-local**: cap `exec`/`startProcess` output to a trailing, UTF-8-safe buffer (new `@marimo-hub/compute-commons/node` `Utf8TailBuffer`) so long-running kernels don't grow output unbounded; drain stderr and kill children on `execStream` cancel/`destroy` to avoid pipe-fill deadlocks and orphaned processes; evict the instance on `destroy` so a later `create` gets fresh state (with a guard against a stale destroy evicting a replacement).

## Notes

- New `compute-commons/node` subpath entry (node-only helpers) added to `package.json` exports and vite `pack.entry`.
- `Utf8TailBuffer` has its own unit tests covering trailing-window and split-multibyte decoding.