### PR TITLE
test(e2e): session lifecycle spec + CI observability

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,7 @@
 name: E2E
 
 # Browser end-to-end tests (Playwright) driving the real SPA against a local
-# server wired to the in-memory / dev-auth / no-compute ports. No external deps.
+# server wired to in-memory storage and dev auth. Chromium also starts a local kernel.
 on:
   push:
     branches: [main]
@@ -18,7 +18,7 @@ jobs:
   e2e:
     name: e2e (${{ matrix.browser }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -37,14 +37,60 @@ jobs:
           cache: true
           run-install: |
             - args: ['--frozen-lockfile']
-      - run: pnpm --filter @marimo-hub/e2e exec playwright install --with-deps ${{ matrix.browser }}
+
+      # Forks must not read the shared cache; only main pushes can update it.
+      - name: Restore Vite Task cache
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        id: vite-task-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: node_modules/.vite/task-cache
+          key: vite-task-e2e-${{ matrix.browser }}-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            vite-task-e2e-${{ matrix.browser }}-${{ runner.os }}-${{ runner.arch }}-
+            vite-task-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-${{ matrix.browser }}-
+
+      - if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter @marimo-hub/e2e exec playwright install --with-deps ${{ matrix.browser }}
+      - if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter @marimo-hub/e2e exec playwright install-deps ${{ matrix.browser }}
+
+      - name: Install uv
+        if: matrix.browser == 'chromium'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+      - name: Pre-warm marimo
+        if: matrix.browser == 'chromium'
+        run: uv run --no-project --with marimo python -c "import marimo"
+
       - run: pnpm e2e
         env:
           E2E_BROWSER: ${{ matrix.browser }}
+
       - name: Upload report
-        if: failure()
+        if: '!cancelled()'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report-${{ matrix.browser }}
-          path: apps/e2e/playwright-report/
+          path: |
+            apps/e2e/playwright-report/
+            apps/e2e/test-results/
           retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Save Vite Task cache
+        if: success() && github.event_name == 'push'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: node_modules/.vite/task-cache
+          key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -23,7 +23,7 @@ for (const browser of browsers) {
 }
 
 // The lifecycle spec needs a real kernel through the local compute adapter, so
-// it runs only on Chromium and can be skipped on hosts without uv.
+// it runs only on Chromium. Set E2E_LIFECYCLE=0 on hosts without uv.
 const LIFECYCLE_SPEC = /session\.lifecycle\.spec\.ts$/;
 const runLifecycle = browsers.includes('chromium') && process.env.E2E_LIFECYCLE !== '0';
 
@@ -76,6 +76,8 @@ export default defineConfig({
 			PORT: String(PORT),
 			MARIMOHUB_STORAGE_BACKEND: 'memory',
 			MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: 'true',
+			// webServer is config-wide, so CRUD shares this backend when the lifecycle project runs.
+			// Those specs intentionally never open a notebook and therefore never start compute.
 			MARIMOHUB_COMPUTE_BACKEND: runLifecycle ? 'local' : 'none',
 			MARIMOHUB_AUTH_BACKEND: 'dev',
 			MARIMOHUB_STATIC_ROOT: 'packages/web/dist',

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -22,21 +22,47 @@ for (const browser of browsers) {
 	}
 }
 
-// Boots apps/server serving the prebuilt SPA, wired to the local ports (memory
-// storage, dev auth, no compute) for zero external deps. State is shared across
-// the single server process, so tests run serially with unique names.
+// The lifecycle spec needs a real kernel through the local compute adapter, so
+// it runs only on Chromium and can be skipped on hosts without uv.
+const LIFECYCLE_SPEC = /session\.lifecycle\.spec\.ts$/;
+const runLifecycle = browsers.includes('chromium') && process.env.E2E_LIFECYCLE !== '0';
+
+// Boots apps/server serving the prebuilt SPA with memory storage and dev auth.
+// State is shared across the single server process, so tests run serially with unique names.
 export default defineConfig({
 	testDir: './tests',
 	fullyParallel: false,
 	workers: 1,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 1 : 0,
-	reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+	reporter: process.env.CI
+		? [
+				['github'],
+				['junit', { outputFile: 'test-results/junit.xml' }],
+				['html', { open: 'never' }],
+				['list'],
+			]
+		: 'list',
 	use: {
 		baseURL: BASE_URL,
 		trace: 'on-first-retry',
+		screenshot: 'only-on-failure',
+		video: 'retain-on-failure',
 	},
-	projects: allProjects.filter((p) => browsers.includes(p.name)),
+	projects: [
+		...allProjects
+			.filter((p) => browsers.includes(p.name))
+			.map((p) => ({ ...p, testIgnore: LIFECYCLE_SPEC })),
+		...(runLifecycle
+			? [
+					{
+						name: 'lifecycle',
+						testMatch: LIFECYCLE_SPEC,
+						use: { ...devices['Desktop Chrome'] },
+					},
+				]
+			: []),
+	],
 	// Builds web + server (cached `vp run` tasks) and serves the SPA from
 	// packages/web/dist. A warm `e2e:serve` server is reused via reuseExistingServer.
 	webServer: {
@@ -50,7 +76,7 @@ export default defineConfig({
 			PORT: String(PORT),
 			MARIMOHUB_STORAGE_BACKEND: 'memory',
 			MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: 'true',
-			MARIMOHUB_COMPUTE_BACKEND: 'none',
+			MARIMOHUB_COMPUTE_BACKEND: runLifecycle ? 'local' : 'none',
 			MARIMOHUB_AUTH_BACKEND: 'dev',
 			MARIMOHUB_STATIC_ROOT: 'packages/web/dist',
 		},

--- a/apps/e2e/tests/helpers.ts
+++ b/apps/e2e/tests/helpers.ts
@@ -31,6 +31,15 @@ export async function openProject(page: Page, name: string): Promise<void> {
 	await expect(page.getByRole('heading', { name })).toBeVisible();
 }
 
+export async function createAndOpenProject(
+	page: Page,
+	name: string,
+	description?: string,
+): Promise<void> {
+	await createProject(page, name, description);
+	await openProject(page, name);
+}
+
 export async function editProjectName(page: Page, nextName: string): Promise<void> {
 	await page.getByRole('button', { name: 'Edit project' }).click();
 	await page.getByLabel('Project Name').fill(nextName);

--- a/apps/e2e/tests/notebooks.spec.ts
+++ b/apps/e2e/tests/notebooks.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from '@playwright/test';
 import {
-	createProject,
-	openProject,
+	createAndOpenProject,
 	createNotebook,
 	deleteNotebook,
 	notebookRow,
@@ -12,8 +11,7 @@ test('notebook lifecycle: create, list, delete', async ({ page }) => {
 	const project = uniqueName('proj');
 	const notebook = uniqueName('nb');
 
-	await createProject(page, project);
-	await openProject(page, project);
+	await createAndOpenProject(page, project);
 
 	// CRUD only — we don't open the notebook, since running a kernel needs compute.
 	await createNotebook(page, notebook);

--- a/apps/e2e/tests/projects.spec.ts
+++ b/apps/e2e/tests/projects.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import {
-	createProject,
+	createAndOpenProject,
 	openProject,
 	editProjectName,
 	deleteProject,
@@ -14,9 +14,7 @@ test('project lifecycle: create, list, edit, delete', async ({ page }) => {
 	// the old name is gone after the rename.
 	const renamed = uniqueName('proj-renamed');
 
-	await createProject(page, name, 'an e2e project');
-
-	await openProject(page, name);
+	await createAndOpenProject(page, name, 'an e2e project');
 	await editProjectName(page, renamed);
 
 	await page.goto('/');
@@ -42,8 +40,7 @@ test('create project: submit is disabled until a name is entered', async ({ page
 
 test('delete project: confirm is disabled until the exact name is typed', async ({ page }) => {
 	const name = uniqueName('proj');
-	await createProject(page, name);
-	await openProject(page, name);
+	await createAndOpenProject(page, name);
 
 	await page.getByRole('button', { name: 'Delete project' }).click();
 	const confirm = page.getByRole('button', { name: 'Delete', exact: true });

--- a/apps/e2e/tests/session.lifecycle.spec.ts
+++ b/apps/e2e/tests/session.lifecycle.spec.ts
@@ -20,10 +20,42 @@ async function listProjectSessions(page: Page, projectId: string): Promise<Sessi
 	return body.data?.items ?? [];
 }
 
+async function listProjectSessionsWithRetry(
+	page: Page,
+	projectId: string,
+): Promise<SessionSummary[]> {
+	let sessions: SessionSummary[] | undefined;
+	await expect(async () => {
+		sessions = await listProjectSessions(page, projectId);
+	}).toPass({ timeout: 10_000 });
+	if (!sessions) throw new Error('Session listing completed without a result');
+	return sessions;
+}
+
 async function expectNoProjectSessions(page: Page, projectId: string): Promise<void> {
-	await expect
-		.poll(async () => (await listProjectSessions(page, projectId)).length, { timeout: 120_000 })
-		.toBe(0);
+	await expect(async () => {
+		const sessions = await listProjectSessions(page, projectId);
+		expect(
+			sessions,
+			`Active project sessions: ${sessions.map((session) => `${session.session_id} (${session.status})`).join(', ')}`,
+		).toHaveLength(0);
+	}).toPass({ timeout: 120_000 });
+}
+
+async function deleteSessionForCleanup(
+	page: Page,
+	projectId: string,
+	session: SessionSummary,
+): Promise<void> {
+	const path = `/api/v1/projects/${projectId}/notebooks/${session.notebook_id}/sessions/${session.session_id}`;
+	const response = await page.request.delete(path).catch((error: unknown) => {
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new Error(`DELETE ${path} failed: ${detail}`);
+	});
+	if (!response.ok()) {
+		const body = (await response.text()).slice(0, 500);
+		throw new Error(`DELETE ${path} returned ${response.status()}${body ? `: ${body}` : ''}`);
+	}
 }
 
 test.describe('session lifecycle', () => {
@@ -33,17 +65,21 @@ test.describe('session lifecycle', () => {
 		const projectId = projectIdFromUrl(page.url());
 		if (!projectId) return;
 
-		const sessions = await listProjectSessions(page, projectId).catch(() => null);
-		if (!sessions) return;
-
-		for (const session of sessions) {
-			if (session.status === 'running' || session.status === 'starting') {
-				await page.request
-					.delete(
-						`/api/v1/projects/${projectId}/notebooks/${session.notebook_id}/sessions/${session.session_id}`,
-					)
-					.catch(() => {});
-			}
+		const sessions = await listProjectSessionsWithRetry(page, projectId);
+		const results = await Promise.allSettled(
+			sessions
+				.filter((session) => session.status === 'running' || session.status === 'starting')
+				.map((session) => deleteSessionForCleanup(page, projectId, session)),
+		);
+		const failures = results.flatMap((result) =>
+			result.status === 'rejected'
+				? [result.reason instanceof Error ? result.reason.message : String(result.reason)]
+				: [],
+		);
+		if (failures.length > 0) {
+			throw new Error(
+				`Session cleanup failed:\n${failures.map((failure) => `- ${failure}`).join('\n')}`,
+			);
 		}
 		// A terminating session already has a teardown owner; a duplicate DELETE
 		// skips sandbox destruction, so wait for the original teardown to finish.

--- a/apps/e2e/tests/session.lifecycle.spec.ts
+++ b/apps/e2e/tests/session.lifecycle.spec.ts
@@ -20,6 +20,12 @@ async function listProjectSessions(page: Page, projectId: string): Promise<Sessi
 	return body.data?.items ?? [];
 }
 
+async function expectNoProjectSessions(page: Page, projectId: string): Promise<void> {
+	await expect
+		.poll(async () => (await listProjectSessions(page, projectId)).length, { timeout: 120_000 })
+		.toBe(0);
+}
+
 test.describe('session lifecycle', () => {
 	test.setTimeout(420_000);
 
@@ -27,7 +33,9 @@ test.describe('session lifecycle', () => {
 		const projectId = projectIdFromUrl(page.url());
 		if (!projectId) return;
 
-		const sessions = await listProjectSessions(page, projectId).catch(() => []);
+		const sessions = await listProjectSessions(page, projectId).catch(() => null);
+		if (!sessions) return;
+
 		for (const session of sessions) {
 			if (session.status === 'running' || session.status === 'starting') {
 				await page.request
@@ -37,6 +45,9 @@ test.describe('session lifecycle', () => {
 					.catch(() => {});
 			}
 		}
+		// A terminating session already has a teardown owner; a duplicate DELETE
+		// skips sandbox destruction, so wait for the original teardown to finish.
+		await expectNoProjectSessions(page, projectId);
 	});
 
 	test('starts a session, sends a heartbeat, and stops the kernel', async ({ page }) => {
@@ -63,16 +74,6 @@ test.describe('session lifecycle', () => {
 		await page.getByRole('button', { name: 'Stop Sandbox' }).click();
 		await expect(page.getByRole('heading', { name: project })).toBeVisible();
 
-		await expect
-			.poll(
-				async () => {
-					const sessions = await listProjectSessions(page, projectId);
-					return sessions.filter((session) =>
-						['running', 'starting', 'terminating'].includes(session.status),
-					).length;
-				},
-				{ timeout: 120_000 },
-			)
-			.toBe(0);
+		await expectNoProjectSessions(page, projectId);
 	});
 });

--- a/apps/e2e/tests/session.lifecycle.spec.ts
+++ b/apps/e2e/tests/session.lifecycle.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { createAndOpenProject, createNotebook, notebookRow, uniqueName } from './helpers';
+
+interface SessionSummary {
+	session_id: string;
+	notebook_id: string;
+	status: string;
+}
+
+function projectIdFromUrl(url: string): string | undefined {
+	return url.match(/\/projects\/([^/]+)/)?.[1];
+}
+
+async function listProjectSessions(page: Page, projectId: string): Promise<SessionSummary[]> {
+	const response = await page.request.get(`/api/v1/projects/${projectId}/sessions`);
+	if (!response.ok()) throw new Error(`Failed to list project sessions: ${response.status()}`);
+
+	const body = (await response.json()) as { data?: { items?: SessionSummary[] } };
+	return body.data?.items ?? [];
+}
+
+test.describe('session lifecycle', () => {
+	test.setTimeout(420_000);
+
+	test.afterEach(async ({ page }) => {
+		const projectId = projectIdFromUrl(page.url());
+		if (!projectId) return;
+
+		const sessions = await listProjectSessions(page, projectId).catch(() => []);
+		for (const session of sessions) {
+			if (session.status === 'running' || session.status === 'starting') {
+				await page.request
+					.delete(
+						`/api/v1/projects/${projectId}/notebooks/${session.notebook_id}/sessions/${session.session_id}`,
+					)
+					.catch(() => {});
+			}
+		}
+	});
+
+	test('starts a session, sends a heartbeat, and stops the kernel', async ({ page }) => {
+		const project = uniqueName('proj');
+		const notebook = uniqueName('nb');
+
+		await createAndOpenProject(page, project);
+		await createNotebook(page, notebook);
+
+		await notebookRow(page, notebook).click();
+		await expect(page).toHaveURL(/\/projects\/[^/]+\/notebooks\/[^/]+$/);
+		const projectId = projectIdFromUrl(page.url())!;
+
+		const iframe = page.locator('iframe');
+		await expect(iframe).toBeVisible({ timeout: 240_000 });
+		await expect(iframe).toHaveAttribute('src', /^http:\/\/localhost:\d+\//);
+
+		await page.waitForRequest(
+			(request) => request.method() === 'POST' && request.url().includes('/heartbeat'),
+			{ timeout: 150_000 },
+		);
+
+		await page.getByRole('button', { name: 'Stop', exact: true }).click();
+		await page.getByRole('button', { name: 'Stop Sandbox' }).click();
+		await expect(page.getByRole('heading', { name: project })).toBeVisible();
+
+		await expect
+			.poll(
+				async () => {
+					const sessions = await listProjectSessions(page, projectId);
+					return sessions.filter((session) =>
+						['running', 'starting', 'terminating'].includes(session.status),
+					).length;
+				},
+				{ timeout: 120_000 },
+			)
+			.toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- Add a Chromium-only Playwright spec (`session.lifecycle.spec.ts`) that boots a real local kernel via the compute-local adapter, then verifies session start → heartbeat → stop and asserts the kernel is torn down.
- Run it as a dedicated `lifecycle` Playwright project so the memory/no-compute specs stay browser-matrixed; the e2e server switches to `MARIMOHUB_COMPUTE_BACKEND=local` only when the lifecycle run is active.
- CI: install `uv` + pre-warm marimo on Chromium, cache Vite task output and Playwright browsers, and add richer reporting (github/junit reporters, failure screenshots/videos, artifact upload on `!cancelled()`).
- Factor `createAndOpenProject` helper and adopt it in the existing specs.

## Test plan
- `pnpm e2e` (Chromium) runs the memory specs plus the lifecycle spec against a real local kernel.
- Other browsers ignore the lifecycle spec.