### PR TITLE
refactor(core): scope CAS retries to CasWriter conditional writes

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -63,8 +63,8 @@ export class NotFoundError extends DomainError {
 export class ConflictError extends DomainError {
 	readonly code = 'CONFLICT';
 	readonly status = 409;
-	constructor(message = 'Conflict') {
-		super(message);
+	constructor(message = 'Conflict', options?: ErrorOptions) {
+		super(message, options);
 		this.name = 'ConflictError';
 	}
 }

--- a/packages/core/src/services/catalog/CatalogService.test.ts
+++ b/packages/core/src/services/catalog/CatalogService.test.ts
@@ -9,13 +9,16 @@ import type { Snapshot } from '../../schema';
 import { CatalogService } from './CatalogService';
 import { EventService } from './EventService';
 
+// Exhaustion tests should not spend 750 ms in production backoff timers.
+const ZERO_BACKOFF = { backoffMs: () => 0 };
+
 describe('CatalogService', () => {
 	let bucket: MemoryBucket;
 	let catalog: CatalogService;
 
 	beforeEach(async () => {
 		bucket = new MemoryBucket();
-		catalog = new CatalogService(bucket);
+		catalog = new CatalogService(bucket, noopMetrics, undefined, ZERO_BACKOFF);
 	});
 
 	describe('initialize', () => {
@@ -343,7 +346,12 @@ describe('CatalogService', () => {
 	describe('metrics', () => {
 		it('emits CAS conflict + exhausted counters under contention', async () => {
 			const increment = vi.fn();
-			const instrumented = new CatalogService(bucket, { increment, gauge: vi.fn() });
+			const instrumented = new CatalogService(
+				bucket,
+				{ increment, gauge: vi.fn() },
+				undefined,
+				ZERO_BACKOFF,
+			);
 			await instrumented.initialize(ACTOR);
 
 			// Always fail the conditional catalog swap.

--- a/packages/core/src/services/catalog/CatalogService.test.ts
+++ b/packages/core/src/services/catalog/CatalogService.test.ts
@@ -150,6 +150,30 @@ describe('CatalogService', () => {
 			expect(result.projects[0].name).toBe('New');
 		});
 
+		it('awaits an asynchronous mutation', async () => {
+			const result = await catalog.mutateSnapshot('test.async', ACTOR, async (snapshot) => {
+				await Promise.resolve();
+				return {
+					...snapshot,
+					projects: [
+						{
+							id: 'proj-7h2k9qm4xz7rp3w8' as any,
+							name: 'Async',
+							description: '',
+							owner: ACTOR,
+							status: 'active',
+							created_at: new Date().toISOString(),
+							updated_at: new Date().toISOString(),
+							notebook_count: 0,
+							notebooks: [],
+						},
+					],
+				};
+			});
+
+			expect(result.projects[0].name).toBe('Async');
+		});
+
 		it('preserves snapshot chain — previous_snapshot_id is set', async () => {
 			const before = await catalog.getCurrentSnapshot();
 			await catalog.mutateSnapshot('test', ACTOR, (s) => s);

--- a/packages/core/src/services/catalog/CatalogService.test.ts
+++ b/packages/core/src/services/catalog/CatalogService.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ACTOR, makeCatalog, makeSnapshot, MemoryBucket, setupTestEnv } from '../../testing';
 import { ConflictError, NotInitializedError, PreconditionFailedError } from '../../errors';
-import { createSnapshotId } from '../../ids';
+import { createNotebookId, createSnapshotId } from '../../ids';
 import { paths } from '../../paths';
 import { noopMetrics } from '../../ports/metrics';
 import { EventSchema, SnapshotSchema } from '../../schema';
@@ -454,6 +454,73 @@ describe('CatalogService', () => {
 		it('writes no events when no EventService is injected', async () => {
 			await catalog.mutateSnapshot('project.update', ACTOR, (s) => s);
 			expect(await listEvents()).toHaveLength(0);
+		});
+	});
+
+	describe('updateNotebookEntry', () => {
+		async function setupEntry() {
+			const env = await setupTestEnv();
+			const project = await env.projects.createProject({ name: 'P', description: 'D' }, ACTOR);
+			const notebook = await env.notebooks.createNotebook(
+				project.id,
+				{ title: 'N', description: 'D', code: 'print(1)' },
+				ACTOR,
+			);
+			return { env, project, notebook };
+		}
+
+		it.each([
+			{
+				name: 'keeps a newer notebook timestamp over an older project patch',
+				notebookAt: '2099-01-01T00:00:00.000Z',
+				projectAt: '2000-01-01T00:00:00.000Z',
+				expected: '2099-01-01T00:00:00.000Z',
+			},
+			{
+				name: 'uses a newer explicit project timestamp',
+				notebookAt: '2099-01-01T00:00:00.000Z',
+				projectAt: '2100-01-01T00:00:00.000Z',
+				expected: '2100-01-01T00:00:00.000Z',
+			},
+		])('$name', async ({ notebookAt, projectAt, expected }) => {
+			const { env, project, notebook } = await setupEntry();
+
+			const snapshot = await env.catalog.updateNotebookEntry(
+				'test.notebook.patch',
+				ACTOR,
+				project.id,
+				notebook.id,
+				() => ({ updated_at: notebookAt }),
+				() => ({ updated_at: projectAt }),
+			);
+
+			expect(snapshot.projects[0].notebooks[0].updated_at).toBe(notebookAt);
+			expect(snapshot.projects[0].updated_at).toBe(expected);
+		});
+
+		it('skips the notebook patch when the entry is missing', async () => {
+			const { env, project } = await setupEntry();
+			const before = await env.catalog.getCurrentSnapshot();
+			const notebookPatch = vi.fn();
+			const projectPatch = vi.fn().mockReturnValue({
+				updated_at: '2000-01-01T00:00:00.000Z',
+				notebook_count: 7,
+			});
+
+			const snapshot = await env.catalog.updateNotebookEntry(
+				'test.notebook.missing',
+				ACTOR,
+				project.id,
+				createNotebookId(),
+				notebookPatch,
+				projectPatch,
+			);
+
+			expect(notebookPatch).not.toHaveBeenCalled();
+			expect(projectPatch).toHaveBeenCalledOnce();
+			expect(snapshot.projects[0].notebooks).toEqual(before.projects[0].notebooks);
+			expect(snapshot.projects[0].updated_at).toBe(before.projects[0].updated_at);
+			expect(snapshot.projects[0].notebook_count).toBe(7);
 		});
 	});
 

--- a/packages/core/src/services/catalog/CatalogService.ts
+++ b/packages/core/src/services/catalog/CatalogService.ts
@@ -8,6 +8,7 @@ import { paths } from '../../paths';
 import { CURRENT_SNAPSHOT_VERSION, CatalogSchema, readStored, SnapshotSchema } from '../../schema';
 import type { Catalog, Snapshot, SnapshotNotebookEntry, SnapshotProjectEntry } from '../../schema';
 import { withCasRetry } from './cas';
+import type { CasRetryOptions } from './cas';
 import type { EventService } from './EventService';
 
 /**
@@ -33,6 +34,8 @@ export class CatalogService {
 		private bucket: Bucket,
 		private metrics: Metrics = noopMetrics,
 		private events?: EventService,
+		/** Retry timing override; metrics hooks remain owned by this service. */
+		private casRetry?: Pick<CasRetryOptions, 'retries' | 'backoffMs'>,
 	) {}
 
 	async initialize(actor: UserId): Promise<Snapshot> {
@@ -115,7 +118,8 @@ export class CatalogService {
 		// snapshot, and conditionally swap the catalog pointer onto it. The retry
 		// loop / backoff / conflict accounting lives in `withCasRetry`.
 		const snapshot = await withCasRetry(
-			async () => {
+			this.bucket,
+			async (cas) => {
 				const catalogObj = await this.bucket.get(paths.catalog);
 				if (!catalogObj) {
 					throw new NotInitializedError('Catalog not found — call initialize() first');
@@ -163,7 +167,7 @@ export class CatalogService {
 				};
 
 				try {
-					await this.bucket.put(paths.catalog, JSON.stringify(newCatalog), {
+					await cas.put(paths.catalog, JSON.stringify(newCatalog), {
 						onlyIfEtagMatches: catalogEtag,
 					});
 					return newSnapshot;
@@ -171,7 +175,7 @@ export class CatalogService {
 					// The catalog swap failed (lost the race, or a transient error), so the
 					// snapshot we just wrote is unreferenced. Delete it (best-effort) so a
 					// failed attempt never leaves an orphan a prefix-listing could mistake
-					// for the head, then rethrow (withCasRetry retries a PreconditionFailed).
+					// for the head, then rethrow (the CAS writer marks a lost race for retry).
 					//
 					// INVARIANT (corruption safety): `newSnapshotId` was created in this
 					// attempt and the catalog never pointed at it, so this only ever deletes
@@ -181,6 +185,7 @@ export class CatalogService {
 				}
 			},
 			{
+				...this.casRetry,
 				onAttempt: () => this.metrics.increment('catalog.cas.attempt'),
 				onConflict: () => this.metrics.increment('catalog.cas.conflict'),
 				onExhausted: () => this.metrics.increment('catalog.cas.exhausted'),

--- a/packages/core/src/services/catalog/CatalogService.ts
+++ b/packages/core/src/services/catalog/CatalogService.ts
@@ -213,13 +213,14 @@ export class CatalogService {
 	 * CAS-mutate the snapshot to patch a single project's summary entry. `patch`
 	 * receives the matched entry and returns the fields to merge; a project that
 	 * doesn't match is left untouched (and if none matches, the snapshot is
-	 * rewritten unchanged). Async patches run again when the catalog CAS retries.
+	 * rewritten unchanged). Returning `undefined` applies no entry fields. Async
+	 * patches run again when the catalog CAS retries.
 	 */
 	updateProjectEntry(
 		operation: string,
 		actor: UserId,
 		projectId: ProjectId,
-		patch: (project: SnapshotProjectEntry) => Awaitable<Partial<SnapshotProjectEntry>>,
+		patch: (project: SnapshotProjectEntry) => Awaitable<Partial<SnapshotProjectEntry> | undefined>,
 		context: Record<string, unknown> = { project_id: projectId },
 	): Promise<Snapshot> {
 		return this.mutateSnapshot(
@@ -228,7 +229,7 @@ export class CatalogService {
 			async (snap) => {
 				const project = snap.projects.find((entry) => entry.id === projectId);
 				if (project === undefined) return snap;
-				const projectPatch = await patch(project);
+				const projectPatch = (await patch(project)) ?? {};
 				return {
 					...snap,
 					projects: snap.projects.map((entry) =>
@@ -269,15 +270,20 @@ export class CatalogService {
 	 * `patch` returns the notebook fields to merge; the optional `projectPatch`
 	 * merges other project-level fields (e.g. `notebook_count`) in the same write.
 	 * A patched notebook `updated_at` automatically advances the project's aggregate
-	 * timestamp. A notebook that doesn't match is left untouched.
+	 * timestamp. Returning `undefined` applies no notebook fields. A notebook that
+	 * doesn't match is left untouched.
 	 */
 	updateNotebookEntry(
 		operation: string,
 		actor: UserId,
 		projectId: ProjectId,
 		notebookId: NotebookId,
-		patch: (notebook: SnapshotNotebookEntry) => Awaitable<Partial<SnapshotNotebookEntry>>,
-		projectPatch?: (project: SnapshotProjectEntry) => Awaitable<Partial<SnapshotProjectEntry>>,
+		patch: (
+			notebook: SnapshotNotebookEntry,
+		) => Awaitable<Partial<SnapshotNotebookEntry> | undefined>,
+		projectPatch?: (
+			project: SnapshotProjectEntry,
+		) => Awaitable<Partial<SnapshotProjectEntry> | undefined>,
 	): Promise<Snapshot> {
 		return this.updateProjectEntry(
 			operation,
@@ -285,12 +291,15 @@ export class CatalogService {
 			projectId,
 			async (p) => {
 				const notebook = p.notebooks.find((entry) => entry.id === notebookId);
-				const notebookPatch = notebook === undefined ? undefined : await patch(notebook);
-				const updatedAt = notebookPatch?.updated_at;
+				const notebookPatch = notebook === undefined ? undefined : ((await patch(notebook)) ?? {});
+				const resolvedProjectPatch = (await projectPatch?.(p)) ?? {};
+				let updatedAt = p.updated_at;
+				for (const candidate of [notebookPatch?.updated_at, resolvedProjectPatch?.updated_at]) {
+					if (candidate !== undefined && candidate > updatedAt) updatedAt = candidate;
+				}
 				return {
-					updated_at:
-						updatedAt !== undefined && updatedAt > p.updated_at ? updatedAt : p.updated_at,
-					...(await projectPatch?.(p)),
+					...resolvedProjectPatch,
+					updated_at: updatedAt,
 					notebooks:
 						notebookPatch === undefined
 							? p.notebooks

--- a/packages/core/src/services/catalog/CatalogService.ts
+++ b/packages/core/src/services/catalog/CatalogService.ts
@@ -11,6 +11,8 @@ import { withCasRetry } from './cas';
 import type { CasRetryOptions } from './cas';
 import type { EventService } from './EventService';
 
+type Awaitable<T> = T | Promise<T>;
+
 /**
  * Lazy-migration seam for snapshots. The read schema is forward-tolerant (it
  * accepts any `schema_version`), so a snapshot written by a newer replica parses
@@ -108,10 +110,14 @@ export class CatalogService {
 		);
 	}
 
+	/**
+	 * `mutateFn` runs inside each catalog CAS attempt and may be asynchronous. It
+	 * must be safe to run again after a lost pointer race.
+	 */
 	async mutateSnapshot(
 		operation: string,
 		actor: UserId,
-		mutateFn: (snapshot: Snapshot) => Snapshot,
+		mutateFn: (snapshot: Snapshot) => Awaitable<Snapshot>,
 		context?: Record<string, unknown>,
 	): Promise<Snapshot> {
 		// One CAS attempt: read the catalog + its current snapshot, write a new
@@ -140,7 +146,7 @@ export class CatalogService {
 				const newSnapshotId = createSnapshotId();
 				const now = new Date().toISOString();
 
-				const mutated = mutateFn(currentSnapshot);
+				const mutated = await mutateFn(currentSnapshot);
 				const newSnapshot: Snapshot = {
 					...mutated,
 					snapshot_id: newSnapshotId,
@@ -207,22 +213,29 @@ export class CatalogService {
 	 * CAS-mutate the snapshot to patch a single project's summary entry. `patch`
 	 * receives the matched entry and returns the fields to merge; a project that
 	 * doesn't match is left untouched (and if none matches, the snapshot is
-	 * rewritten unchanged).
+	 * rewritten unchanged). Async patches run again when the catalog CAS retries.
 	 */
 	updateProjectEntry(
 		operation: string,
 		actor: UserId,
 		projectId: ProjectId,
-		patch: (project: SnapshotProjectEntry) => Partial<SnapshotProjectEntry>,
+		patch: (project: SnapshotProjectEntry) => Awaitable<Partial<SnapshotProjectEntry>>,
 		context: Record<string, unknown> = { project_id: projectId },
 	): Promise<Snapshot> {
 		return this.mutateSnapshot(
 			operation,
 			actor,
-			(snap) => ({
-				...snap,
-				projects: snap.projects.map((p) => (p.id === projectId ? { ...p, ...patch(p) } : p)),
-			}),
+			async (snap) => {
+				const project = snap.projects.find((entry) => entry.id === projectId);
+				if (project === undefined) return snap;
+				const projectPatch = await patch(project);
+				return {
+					...snap,
+					projects: snap.projects.map((entry) =>
+						entry.id === projectId ? { ...entry, ...projectPatch } : entry,
+					),
+				};
+			},
 			context,
 		);
 	}
@@ -254,25 +267,38 @@ export class CatalogService {
 	/**
 	 * CAS-mutate the snapshot to patch a single notebook entry within its project.
 	 * `patch` returns the notebook fields to merge; the optional `projectPatch`
-	 * merges project-level fields (e.g. `updated_at`, `notebook_count`) in the same
-	 * write. A notebook that doesn't match is left untouched.
+	 * merges other project-level fields (e.g. `notebook_count`) in the same write.
+	 * A patched notebook `updated_at` automatically advances the project's aggregate
+	 * timestamp. A notebook that doesn't match is left untouched.
 	 */
 	updateNotebookEntry(
 		operation: string,
 		actor: UserId,
 		projectId: ProjectId,
 		notebookId: NotebookId,
-		patch: (notebook: SnapshotNotebookEntry) => Partial<SnapshotNotebookEntry>,
-		projectPatch?: (project: SnapshotProjectEntry) => Partial<SnapshotProjectEntry>,
+		patch: (notebook: SnapshotNotebookEntry) => Awaitable<Partial<SnapshotNotebookEntry>>,
+		projectPatch?: (project: SnapshotProjectEntry) => Awaitable<Partial<SnapshotProjectEntry>>,
 	): Promise<Snapshot> {
 		return this.updateProjectEntry(
 			operation,
 			actor,
 			projectId,
-			(p) => ({
-				...projectPatch?.(p),
-				notebooks: p.notebooks.map((n) => (n.id === notebookId ? { ...n, ...patch(n) } : n)),
-			}),
+			async (p) => {
+				const notebook = p.notebooks.find((entry) => entry.id === notebookId);
+				const notebookPatch = notebook === undefined ? undefined : await patch(notebook);
+				const updatedAt = notebookPatch?.updated_at;
+				return {
+					updated_at:
+						updatedAt !== undefined && updatedAt > p.updated_at ? updatedAt : p.updated_at,
+					...(await projectPatch?.(p)),
+					notebooks:
+						notebookPatch === undefined
+							? p.notebooks
+							: p.notebooks.map((entry) =>
+									entry.id === notebookId ? { ...entry, ...notebookPatch } : entry,
+								),
+				};
+			},
 			{ project_id: projectId, notebook_id: notebookId },
 		);
 	}

--- a/packages/core/src/services/catalog/cas.test.ts
+++ b/packages/core/src/services/catalog/cas.test.ts
@@ -1,21 +1,38 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ConflictError, NotFoundError, PreconditionFailedError } from '../../errors';
+import {
+	assertVersionMatch,
+	ConflictError,
+	NotFoundError,
+	PreconditionFailedError,
+} from '../../errors';
 import { MemoryBucket } from '../../testing';
-import { acquireSingletonClaim, mutateObject, releaseSingletonClaim, withCasRetry } from './cas';
+import {
+	acquireSingletonClaim,
+	mutateObject,
+	mutateObjectWithOutcome,
+	releaseSingletonClaim,
+	withCasRetry,
+} from './cas';
 
 describe('withCasRetry', () => {
 	it('returns the first successful attempt', async () => {
+		const bucket = new MemoryBucket();
 		const attempt = vi.fn().mockResolvedValue('ok');
-		expect(await withCasRetry(attempt)).toBe('ok');
+		expect(await withCasRetry(bucket, attempt)).toBe('ok');
 		expect(attempt).toHaveBeenCalledTimes(1);
 	});
 
-	it('retries on PreconditionFailedError then succeeds', async () => {
+	it('retries a conditional-write conflict then succeeds', async () => {
+		const bucket = new MemoryBucket();
+		await bucket.put('k', 'seed');
 		const onConflict = vi.fn();
 		let n = 0;
 		const result = await withCasRetry(
-			async () => {
-				if (n++ < 2) throw new PreconditionFailedError('race');
+			bucket,
+			async (cas) => {
+				if (n++ < 2) {
+					await cas.put('k', 'loser', { onlyIfEtagMatches: 'stale' });
+				}
 				return 'won';
 			},
 			{ backoffMs: () => 0, onConflict },
@@ -25,11 +42,14 @@ describe('withCasRetry', () => {
 	});
 
 	it('throws ConflictError once retries are exhausted', async () => {
+		const bucket = new MemoryBucket();
+		await bucket.put('k', 'seed');
 		const onExhausted = vi.fn();
 		await expect(
 			withCasRetry(
-				async () => {
-					throw new PreconditionFailedError('race');
+				bucket,
+				async (cas) => {
+					return cas.put('k', 'loser', { onlyIfEtagMatches: 'stale' });
 				},
 				{
 					retries: 3,
@@ -42,14 +62,28 @@ describe('withCasRetry', () => {
 	});
 
 	it('propagates a non-precondition error immediately (no retry)', async () => {
+		const bucket = new MemoryBucket();
 		const attempt = vi.fn().mockRejectedValue(new TypeError('boom'));
-		await expect(withCasRetry(attempt, { backoffMs: () => 0 })).rejects.toBeInstanceOf(TypeError);
+		await expect(withCasRetry(bucket, attempt, { backoffMs: () => 0 })).rejects.toBeInstanceOf(
+			TypeError,
+		);
+		expect(attempt).toHaveBeenCalledTimes(1);
+	});
+
+	it('propagates a client precondition error immediately (no retry)', async () => {
+		const bucket = new MemoryBucket();
+		const precondition = new PreconditionFailedError('stale client version');
+		const attempt = vi.fn().mockRejectedValue(precondition);
+		await expect(withCasRetry(bucket, attempt, { backoffMs: () => 0 })).rejects.toBe(precondition);
 		expect(attempt).toHaveBeenCalledTimes(1);
 	});
 
 	it('throws ConflictError immediately when retries is 0 (attempt never runs)', async () => {
+		const bucket = new MemoryBucket();
 		const attempt = vi.fn();
-		await expect(withCasRetry(attempt, { retries: 0 })).rejects.toBeInstanceOf(ConflictError);
+		await expect(withCasRetry(bucket, attempt, { retries: 0 })).rejects.toBeInstanceOf(
+			ConflictError,
+		);
 		expect(attempt).not.toHaveBeenCalled();
 	});
 });
@@ -61,7 +95,7 @@ describe('mutateObject', () => {
 		const bucket = new MemoryBucket();
 		await bucket.put('k', JSON.stringify({ n: 1 }));
 		const result = await mutateObject(bucket, 'k', parse, (cur) => ({ n: cur.n + 1 }));
-		expect(result.n).toBe(2);
+		expect(result).toEqual({ n: 2 });
 		expect(JSON.parse(await (await bucket.get('k'))!.text())).toEqual({ n: 2 });
 	});
 
@@ -69,7 +103,7 @@ describe('mutateObject', () => {
 		const bucket = new MemoryBucket();
 		const before = await bucket.put('k', JSON.stringify({ n: 1 }));
 		const result = await mutateObject(bucket, 'k', parse, () => null);
-		expect(result.n).toBe(1);
+		expect(result).toEqual({ n: 1 });
 		// ETag unchanged → no write happened.
 		expect((await bucket.head('k'))!.etag).toBe(before.etag);
 	});
@@ -152,7 +186,58 @@ describe('mutateObject', () => {
 		);
 
 		expect(seen).toEqual([0, 99]); // applied to the stale value, then re-applied to fresh
-		expect(result.n).toBe(100);
+		expect(result).toEqual({ n: 100 });
+	});
+});
+
+describe('mutateObjectWithOutcome', () => {
+	const parse = (raw: unknown) => raw as { n: number };
+
+	it('reports a committed write', async () => {
+		const bucket = new MemoryBucket();
+		await bucket.put('k', JSON.stringify({ n: 1 }));
+
+		const result = await mutateObjectWithOutcome(bucket, 'k', parse, (current) => ({
+			n: current.n + 1,
+		}));
+
+		expect(result).toEqual({ value: { n: 2 }, written: true });
+	});
+
+	it('reports an unchanged value', async () => {
+		const bucket = new MemoryBucket();
+		await bucket.put('k', JSON.stringify({ n: 1 }));
+
+		const result = await mutateObjectWithOutcome(bucket, 'k', parse, () => null);
+
+		expect(result).toEqual({ value: { n: 1 }, written: false });
+	});
+});
+
+describe('mutateObject preconditions', () => {
+	it('does not retry a stale client precondition inside mutateObject', async () => {
+		const bucket = new MemoryBucket();
+		await bucket.put('k', JSON.stringify({ updated_at: 'v2' }));
+		const onAttempt = vi.fn();
+
+		await expect(
+			mutateObject(
+				bucket,
+				'k',
+				(raw) => raw as { updated_at: string },
+				(current) => {
+					assertVersionMatch(current.updated_at, 'v1');
+					return current;
+				},
+				{
+					onAttempt,
+					backoffMs: () => {
+						throw new Error('unexpected retry');
+					},
+				},
+			),
+		).rejects.toBeInstanceOf(PreconditionFailedError);
+		expect(onAttempt).toHaveBeenCalledTimes(1);
 	});
 });
 

--- a/packages/core/src/services/catalog/cas.test.ts
+++ b/packages/core/src/services/catalog/cas.test.ts
@@ -44,21 +44,67 @@ describe('withCasRetry', () => {
 	it('throws ConflictError once retries are exhausted', async () => {
 		const bucket = new MemoryBucket();
 		await bucket.put('k', 'seed');
+		const precondition = new PreconditionFailedError('lost race');
+		vi.spyOn(bucket, 'put').mockRejectedValue(precondition);
+		const onConflict = vi.fn();
 		const onExhausted = vi.fn();
+		const result = withCasRetry(
+			bucket,
+			async (cas) => {
+				return cas.put('k', 'loser', { onlyIfEtagMatches: 'stale' });
+			},
+			{
+				retries: 3,
+				backoffMs: () => 0,
+				onConflict,
+				onExhausted,
+			},
+		);
+		await expect(result).rejects.toMatchObject({
+			name: 'ConflictError',
+			cause: precondition,
+		});
+		expect(onConflict).toHaveBeenNthCalledWith(1, 0, precondition);
+		expect(onConflict).toHaveBeenNthCalledWith(2, 1, precondition);
+		expect(onConflict).toHaveBeenNthCalledWith(3, 2, precondition);
+		expect(onExhausted).toHaveBeenCalledOnce();
+		expect(onExhausted).toHaveBeenCalledWith(precondition);
+	});
+
+	it('does not attach a cause when zero retries run', async () => {
+		const bucket = new MemoryBucket();
+		const onExhausted = vi.fn();
+		const attempt = vi.fn();
+		const result = withCasRetry(bucket, attempt, { retries: 0, onExhausted });
+
+		await expect(result).rejects.toSatisfy(
+			(error: unknown) => error instanceof ConflictError && error.cause === undefined,
+		);
+		expect(attempt).not.toHaveBeenCalled();
+		expect(onExhausted).toHaveBeenCalledWith(undefined);
+	});
+
+	it('keeps callback-thrown preconditions out of conflict hooks', async () => {
+		const bucket = new MemoryBucket();
+		const precondition = new PreconditionFailedError('stale client version');
+		const onConflict = vi.fn();
+		const onExhausted = vi.fn();
+
 		await expect(
 			withCasRetry(
 				bucket,
-				async (cas) => {
-					return cas.put('k', 'loser', { onlyIfEtagMatches: 'stale' });
+				async () => {
+					throw precondition;
 				},
 				{
-					retries: 3,
 					backoffMs: () => 0,
+					onConflict,
 					onExhausted,
 				},
 			),
-		).rejects.toBeInstanceOf(ConflictError);
-		expect(onExhausted).toHaveBeenCalledTimes(1);
+		).rejects.toBe(precondition);
+		expect(onConflict).not.toHaveBeenCalled();
+		expect(onExhausted).not.toHaveBeenCalled();
 	});
 
 	it('propagates a non-precondition error immediately (no retry)', async () => {

--- a/packages/core/src/services/catalog/cas.ts
+++ b/packages/core/src/services/catalog/cas.ts
@@ -19,9 +19,9 @@ export interface CasRetryOptions {
 	/** Run at the start of each attempt (e.g. bump a metrics counter). */
 	onAttempt?: (attempt: number) => void;
 	/** Run when a conditional write through `CasWriter` loses the race. */
-	onConflict?: (attempt: number) => void;
+	onConflict?: (attempt: number, error: PreconditionFailedError) => void;
 	/** Run once when all attempts are exhausted, before throwing `ConflictError`. */
-	onExhausted?: () => void;
+	onExhausted?: (error: PreconditionFailedError | undefined) => void;
 }
 
 type CasPutOptions = Omit<BucketPutOptions, 'onlyIfEtagMatches' | 'onlyIfNotExists'> &
@@ -35,8 +35,8 @@ export interface CasWriter {
 }
 
 class CasWriteConflictError extends Error {
-	constructor(precondition: PreconditionFailedError) {
-		super(precondition.message);
+	constructor(readonly precondition: PreconditionFailedError) {
+		super(precondition.message, { cause: precondition });
 		this.name = 'CasWriteConflictError';
 	}
 }
@@ -69,21 +69,23 @@ export async function withCasRetry<T>(
 		onExhausted,
 	} = options;
 	const writer = casWriterFor(bucket);
+	let lastConflict: PreconditionFailedError | undefined;
 	for (let i = 0; i < retries; i++) {
 		onAttempt?.(i);
 		try {
 			return await attempt(writer);
 		} catch (err) {
 			if (err instanceof CasWriteConflictError) {
-				onConflict?.(i);
+				lastConflict = err.precondition;
+				onConflict?.(i, err.precondition);
 				await sleep(backoffMs(i));
 				continue;
 			}
 			throw err;
 		}
 	}
-	onExhausted?.();
-	throw new ConflictError('Write conflict: max retries exceeded');
+	onExhausted?.(lastConflict);
+	throw new ConflictError('Write conflict: max retries exceeded', { cause: lastConflict });
 }
 
 export interface SingletonClaimConfig {

--- a/packages/core/src/services/catalog/cas.ts
+++ b/packages/core/src/services/catalog/cas.ts
@@ -1,4 +1,4 @@
-import type { Bucket } from '../../ports/bucket';
+import type { Bucket, BucketObject, BucketPutOptions } from '../../ports/bucket';
 import { sleep } from '../../duration';
 import { ConflictError, NotFoundError, PreconditionFailedError } from '../../errors';
 import { logOperationalError } from '../../operationalLog';
@@ -18,19 +18,47 @@ export interface CasRetryOptions {
 	backoffMs?: (attempt: number) => number;
 	/** Run at the start of each attempt (e.g. bump a metrics counter). */
 	onAttempt?: (attempt: number) => void;
-	/** Run when an attempt loses the race (a `PreconditionFailedError`). */
+	/** Run when a conditional write through `CasWriter` loses the race. */
 	onConflict?: (attempt: number) => void;
 	/** Run once when all attempts are exhausted, before throwing `ConflictError`. */
 	onExhausted?: () => void;
 }
 
+type CasPutOptions = Omit<BucketPutOptions, 'onlyIfEtagMatches' | 'onlyIfNotExists'> &
+	(
+		| { onlyIfEtagMatches: string; onlyIfNotExists?: never }
+		| { onlyIfEtagMatches?: never; onlyIfNotExists: true }
+	);
+
+export interface CasWriter {
+	put(key: string, value: string | Uint8Array, options: CasPutOptions): Promise<BucketObject>;
+}
+
+class CasWriteConflictError extends Error {
+	constructor(precondition: PreconditionFailedError) {
+		super(precondition.message);
+		this.name = 'CasWriteConflictError';
+	}
+}
+
+const casWriterFor = (bucket: Bucket): CasWriter => ({
+	async put(key, value, options) {
+		try {
+			return await bucket.put(key, value, options);
+		} catch (err) {
+			if (err instanceof PreconditionFailedError) throw new CasWriteConflictError(err);
+			throw err;
+		}
+	},
+});
+
 /**
- * Retry a CAS `attempt` with backoff. `attempt` throws `PreconditionFailedError` to
- * signal a losing race (retried); any other error propagates. Throws
- * `ConflictError` once retries are exhausted.
+ * Retry conditional writes made through `CasWriter` with backoff. Errors thrown
+ * directly by the attempt propagate, including client-facing precondition errors.
  */
 export async function withCasRetry<T>(
-	attempt: () => Promise<T>,
+	bucket: Bucket,
+	attempt: (writer: CasWriter) => Promise<T>,
 	options: CasRetryOptions = {},
 ): Promise<T> {
 	const {
@@ -40,12 +68,13 @@ export async function withCasRetry<T>(
 		onConflict,
 		onExhausted,
 	} = options;
+	const writer = casWriterFor(bucket);
 	for (let i = 0; i < retries; i++) {
 		onAttempt?.(i);
 		try {
-			return await attempt();
+			return await attempt(writer);
 		} catch (err) {
-			if (err instanceof PreconditionFailedError) {
+			if (err instanceof CasWriteConflictError) {
 				onConflict?.(i);
 				await sleep(backoffMs(i));
 				continue;
@@ -92,31 +121,35 @@ export async function acquireSingletonClaim(
 	holder: string,
 ): Promise<{ acquired: boolean; holder: string }> {
 	const body = cfg.serialize(holder);
-	return withCasRetry(async () => {
-		const existing = await cfg.bucket.get(cfg.key);
-		if (!existing) {
-			await cfg.bucket.put(cfg.key, body, { onlyIfNotExists: true });
+	return withCasRetry(
+		cfg.bucket,
+		async (cas) => {
+			const existing = await cfg.bucket.get(cfg.key);
+			if (!existing) {
+				await cas.put(cfg.key, body, { onlyIfNotExists: true });
+				return { acquired: true, holder };
+			}
+			let current: string | null | undefined;
+			try {
+				current = cfg.parseHolder(await readStoredJson(existing, cfg.key));
+			} catch (err) {
+				logOperationalError(
+					'corrupt_singleton_claim_replaced',
+					{ operation: 'singleton_claim.acquire', object: cfg.key },
+					err,
+				);
+				// Corrupt claim — stale by definition; replaced below.
+			}
+			if (current === holder) return { acquired: true, holder };
+			if (current && (await cfg.isHolderLive(current))) {
+				return { acquired: false, holder: current };
+			}
+			// CAS the replacement so two concurrent stale-claim replacers can't both win.
+			await cas.put(cfg.key, body, { onlyIfEtagMatches: existing.etag });
 			return { acquired: true, holder };
-		}
-		let current: string | null | undefined;
-		try {
-			current = cfg.parseHolder(await readStoredJson(existing, cfg.key));
-		} catch (err) {
-			logOperationalError(
-				'corrupt_singleton_claim_replaced',
-				{ operation: 'singleton_claim.acquire', object: cfg.key },
-				err,
-			);
-			// Corrupt claim — stale by definition; replaced below.
-		}
-		if (current === holder) return { acquired: true, holder };
-		if (current && (await cfg.isHolderLive(current))) {
-			return { acquired: false, holder: current };
-		}
-		// CAS the replacement so two concurrent stale-claim replacers can't both win.
-		await cfg.bucket.put(cfg.key, body, { onlyIfEtagMatches: existing.etag });
-		return { acquired: true, holder };
-	}, cfg.retry);
+		},
+		cfg.retry,
+	);
 }
 
 /**
@@ -155,10 +188,37 @@ export async function releaseSingletonClaim(
 	}
 }
 
+export interface ObjectMutationOutcome<T> {
+	value: T;
+	written: boolean;
+}
+
+/** Use when a caller must distinguish a committed write from an unchanged value. */
+export async function mutateObjectWithOutcome<T>(
+	bucket: Bucket,
+	key: string,
+	parse: (raw: unknown) => T,
+	apply: (current: T) => T | null,
+	options: CasRetryOptions & { notFound?: () => Error } = {},
+): Promise<ObjectMutationOutcome<T>> {
+	return withCasRetry(
+		bucket,
+		async (cas) => {
+			const obj = await bucket.get(key);
+			if (!obj) throw options.notFound?.() ?? new NotFoundError(`Object ${key} not found`);
+			const current = parse(await readStoredJson(obj, key));
+			const next = apply(current);
+			if (next === null) return { value: current, written: false };
+			await cas.put(key, JSON.stringify(next), { onlyIfEtagMatches: obj.etag });
+			return { value: next, written: true };
+		},
+		options,
+	);
+}
+
 /**
- * Atomic read-modify-write of one JSON object via CAS. `apply` returns the next
- * value, or `null` to skip the write. On a losing race `apply` re-runs against the
- * fresh value (so it can no-op rather than clobber a concurrent writer).
+ * Atomic read-modify-write of one JSON object. On a losing race, `apply` re-runs
+ * against the fresh value and the committed or unchanged value is returned.
  */
 export async function mutateObject<T>(
 	bucket: Bucket,
@@ -167,13 +227,5 @@ export async function mutateObject<T>(
 	apply: (current: T) => T | null,
 	options: CasRetryOptions & { notFound?: () => Error } = {},
 ): Promise<T> {
-	return withCasRetry(async () => {
-		const obj = await bucket.get(key);
-		if (!obj) throw options.notFound?.() ?? new NotFoundError(`Object ${key} not found`);
-		const current = parse(await readStoredJson(obj, key));
-		const next = apply(current);
-		if (!next) return current;
-		await bucket.put(key, JSON.stringify(next), { onlyIfEtagMatches: obj.etag });
-		return next;
-	}, options);
+	return (await mutateObjectWithOutcome(bucket, key, parse, apply, options)).value;
 }

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -507,6 +507,109 @@ describe('NotebookService', () => {
 	});
 
 	describe('updateNotebook', () => {
+		it('merges a concurrent metadata update after retrying the CAS', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'Original', description: 'Original', code: 'v1' },
+				ACTOR,
+			);
+			const metaKey = paths.project(projectId).notebook(created.id).meta;
+			const realPut = bucket.put.bind(bucket);
+			let raced = false;
+			vi.spyOn(bucket, 'put').mockImplementation(async (key, value, options) => {
+				if (!raced && key === metaKey && options?.onlyIfEtagMatches) {
+					raced = true;
+					await notebooks.updateNotebook(projectId, created.id, { title: 'Racer' }, ACTOR);
+				}
+				return realPut(key, value, options);
+			});
+
+			await notebooks.updateNotebook(projectId, created.id, { description: 'Mine' }, ACTOR);
+
+			const stored = await (await bucket.get(metaKey))!.json<any>();
+			expect(raced).toBe(true);
+			expect(stored.title).toBe('Racer');
+			expect(stored.description).toBe('Mine');
+		});
+
+		it('returns 412 when If-Match becomes stale during the CAS', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'Original', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const metaKey = paths.project(projectId).notebook(created.id).meta;
+			const realPut = bucket.put.bind(bucket);
+			let raced = false;
+			vi.spyOn(bucket, 'put').mockImplementation(async (key, value, options) => {
+				if (!raced && key === metaKey && options?.onlyIfEtagMatches) {
+					raced = true;
+					const current = await (await bucket.get(metaKey))!.json<any>();
+					await realPut(
+						metaKey,
+						JSON.stringify({ ...current, title: 'Racer', updated_at: '2099-01-01T00:00:00.000Z' }),
+					);
+				}
+				return realPut(key, value, options);
+			});
+
+			await expect(
+				notebooks.updateNotebook(
+					projectId,
+					created.id,
+					{ description: 'Mine' },
+					ACTOR,
+					created.updated_at,
+				),
+			).rejects.toBeInstanceOf(PreconditionFailedError);
+
+			const stored = await (await bucket.get(metaKey))!.json<any>();
+			expect(stored.title).toBe('Racer');
+			expect(stored.description).toBe('D');
+		});
+
+		it('does not resurrect a notebook deleted during an update', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const metaKey = paths.project(projectId).notebook(created.id).meta;
+			const realPut = bucket.put.bind(bucket);
+			let raced = false;
+			vi.spyOn(bucket, 'put').mockImplementation(async (key, value, options) => {
+				if (!raced && key === metaKey && options?.onlyIfEtagMatches) {
+					raced = true;
+					await notebooks.deleteNotebook(projectId, created.id, ACTOR);
+				}
+				return realPut(key, value, options);
+			});
+
+			await expect(
+				notebooks.updateNotebook(projectId, created.id, { title: 'Resurrected' }, ACTOR),
+			).rejects.toBeInstanceOf(NotFoundError);
+
+			const stored = await (await bucket.get(metaKey))!.json<any>();
+			const snapshot = await catalog.getCurrentSnapshot();
+			const project = snapshot.projects.find((entry) => entry.id === projectId)!;
+			expect(stored.status).toBe('deleted');
+			expect(project.notebooks[0].status).toBe('deleted');
+			expect(project.notebook_count).toBe(0);
+		});
+
+		it('returns 404 when updating an already-deleted notebook', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'NB', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			await notebooks.deleteNotebook(projectId, created.id, ACTOR);
+
+			await expect(
+				notebooks.updateNotebook(projectId, created.id, { title: 'Resurrected' }, ACTOR),
+			).rejects.toBeInstanceOf(NotFoundError);
+		});
+
 		it('rejects a stale expectedVersion with PreconditionFailedError', async () => {
 			const created = await notebooks.createNotebook(
 				projectId,

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -507,6 +507,34 @@ describe('NotebookService', () => {
 	});
 
 	describe('updateNotebook', () => {
+		it('projects the latest metadata when catalog updates finish out of order', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'Original', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const realUpdateEntry = catalog.updateNotebookEntry.bind(catalog);
+			let raced = false;
+			vi.spyOn(catalog, 'updateNotebookEntry').mockImplementation(async (...args) => {
+				if (!raced && args[0] === 'notebook.update') {
+					raced = true;
+					await notebooks.updateNotebook(projectId, created.id, { title: 'Winner' }, ACTOR);
+				}
+				return realUpdateEntry(...args);
+			});
+
+			await notebooks.updateNotebook(projectId, created.id, { title: 'Delayed' }, ACTOR);
+
+			const stored = (await notebooks.getNotebook(projectId, created.id)).meta;
+			const snapshot = await catalog.getCurrentSnapshot();
+			const listed = snapshot.projects[0].notebooks[0];
+			expect(raced).toBe(true);
+			expect(stored.title).toBe('Winner');
+			expect(listed.title).toBe('Winner');
+			expect(listed.updated_at).toBe(stored.updated_at);
+			expect(snapshot.projects[0].updated_at).toBe(stored.updated_at);
+		});
+
 		it('merges a concurrent metadata update after retrying the CAS', async () => {
 			const created = await notebooks.createNotebook(
 				projectId,

--- a/packages/core/src/services/content/NotebookService.test.ts
+++ b/packages/core/src/services/content/NotebookService.test.ts
@@ -535,6 +535,37 @@ describe('NotebookService', () => {
 			expect(snapshot.projects[0].updated_at).toBe(stored.updated_at);
 		});
 
+		it('does not fail or resurrect a notebook purged after its metadata commit', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'Original', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const realUpdateEntry = catalog.updateNotebookEntry.bind(catalog);
+			let purged = false;
+			vi.spyOn(catalog, 'updateNotebookEntry').mockImplementation(async (...args) => {
+				if (!purged && args[0] === 'notebook.update') {
+					purged = true;
+					await notebooks.deleteNotebook(projectId, created.id, ACTOR);
+					await notebooks.hardDeleteNotebook(projectId, created.id);
+				}
+				return realUpdateEntry(...args);
+			});
+
+			const updated = await notebooks.updateNotebook(
+				projectId,
+				created.id,
+				{ title: 'Delayed' },
+				ACTOR,
+			);
+
+			const snapshot = await catalog.getCurrentSnapshot();
+			const project = snapshot.projects.find((entry) => entry.id === projectId)!;
+			expect(updated.title).toBe('Delayed');
+			expect(project.notebooks[0].status).toBe('deleted');
+			expect(project.notebook_count).toBe(0);
+		});
+
 		it('merges a concurrent metadata update after retrying the CAS', async () => {
 			const created = await notebooks.createNotebook(
 				projectId,
@@ -1009,6 +1040,31 @@ describe('NotebookService', () => {
 	});
 
 	describe('deleteNotebook', () => {
+		it('projects its tombstone when hard deletion wins before the catalog write', async () => {
+			const created = await notebooks.createNotebook(
+				projectId,
+				{ title: 'Doomed', description: 'D', code: 'v1' },
+				ACTOR,
+			);
+			const realUpdateEntry = catalog.updateNotebookEntry.bind(catalog);
+			let purged = false;
+			vi.spyOn(catalog, 'updateNotebookEntry').mockImplementation(async (...args) => {
+				if (!purged && args[0] === 'notebook.delete') {
+					purged = true;
+					await notebooks.hardDeleteNotebook(projectId, created.id);
+				}
+				return realUpdateEntry(...args);
+			});
+
+			await notebooks.deleteNotebook(projectId, created.id, ACTOR);
+
+			const snapshot = await catalog.getCurrentSnapshot();
+			const project = snapshot.projects.find((entry) => entry.id === projectId)!;
+			expect(purged).toBe(true);
+			expect(project.notebooks[0].status).toBe('deleted');
+			expect(project.notebook_count).toBe(0);
+		});
+
 		it('rejects a stale expectedVersion with PreconditionFailedError', async () => {
 			const created = await notebooks.createNotebook(
 				projectId,

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -32,7 +32,13 @@ import type {
 } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject, mutateObjectWithOutcome } from '../catalog/cas';
-import { buildNotebookEntry, buildNotebookMeta, buildVersion, localSource } from './notebookMeta';
+import {
+	buildNotebookEntry,
+	buildNotebookMeta,
+	buildVersion,
+	localSource,
+	notebookCatalogPatch,
+} from './notebookMeta';
 import { SyncedNotebookService } from './SyncedNotebookService';
 import { deleteByPrefix, listAllKeys, listAllObjects, listAllPrefixes } from '../catalog/storage';
 
@@ -142,6 +148,13 @@ export class NotebookService {
 		const readme = readmeObj ? await readmeObj.text() : null;
 
 		return { meta, readme, source };
+	}
+
+	private async loadNotebookCatalogPatch(projectId: ProjectId, notebookId: NotebookId) {
+		const key = paths.project(projectId).notebook(notebookId).meta;
+		const obj = await this.bucket.get(key);
+		if (!obj) throw new NotFoundError(`Notebook ${notebookId} not found`);
+		return notebookCatalogPatch(await readStored(NotebookMetaSchema, obj, key));
 	}
 
 	async getNotebookContent(projectId: ProjectId, notebookId: NotebookId): Promise<string> {
@@ -443,19 +456,8 @@ export class NotebookService {
 			await this.pruneVersions(projectId, notebookId, MAX_VERSIONS, versionId);
 		}
 
-		await this.catalog.updateNotebookEntry(
-			'notebook.update',
-			actor,
-			projectId,
-			notebookId,
-			() => ({
-				title: updated.title,
-				description: updated.description,
-				tags: updated.tags,
-				compute_profile: updated.compute_profile,
-				updated_at: now,
-			}),
-			() => ({ updated_at: now }),
+		await this.catalog.updateNotebookEntry('notebook.update', actor, projectId, notebookId, () =>
+			this.loadNotebookCatalogPatch(projectId, notebookId),
 		);
 
 		return updated;
@@ -670,7 +672,7 @@ export class NotebookService {
 		expectedVersion?: string,
 	): Promise<void> {
 		const nb = paths.project(projectId).notebook(notebookId);
-		const { value: updated, written } = await mutateObjectWithOutcome(
+		const { written } = await mutateObjectWithOutcome(
 			this.bucket,
 			nb.meta,
 			(raw) => parseStored(NotebookMetaSchema, raw, nb.meta),
@@ -686,7 +688,6 @@ export class NotebookService {
 			{ notFound: () => new NotFoundError(`Notebook ${notebookId} not found`) },
 		);
 		if (!written) return;
-		const now = updated.updated_at;
 
 		// Soft-delete in snapshot
 		await this.catalog.updateNotebookEntry(
@@ -694,8 +695,10 @@ export class NotebookService {
 			actor,
 			projectId,
 			notebookId,
-			() => ({ status: 'deleted' as const, updated_at: now }),
-			(p) => ({ updated_at: now, notebook_count: Math.max(0, p.notebook_count - 1) }),
+			() => this.loadNotebookCatalogPatch(projectId, notebookId),
+			(p) => ({
+				notebook_count: Math.max(0, p.notebook_count - 1),
+			}),
 		);
 
 		// Drop the app-singleton claim: a deleted notebook's id never recurs, so

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -31,7 +31,7 @@ import type {
 	Version,
 } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
-import { mutateObject } from '../catalog/cas';
+import { mutateObject, mutateObjectWithOutcome } from '../catalog/cas';
 import { buildNotebookEntry, buildNotebookMeta, buildVersion, localSource } from './notebookMeta';
 import { SyncedNotebookService } from './SyncedNotebookService';
 import { deleteByPrefix, listAllKeys, listAllObjects, listAllPrefixes } from '../catalog/storage';
@@ -366,30 +366,42 @@ export class NotebookService {
 		expectedVersion?: string,
 	): Promise<NotebookMeta> {
 		const { meta: existing, source } = detail;
+		// Preserve stale If-Match precedence for remote-source content updates; the CAS
+		// callback repeats the authoritative check against the latest metadata.
 		assertVersionMatch(existing.updated_at, expectedVersion);
 		if (source.type !== 'local' && (input.code !== undefined || input.deps !== undefined)) {
 			throw new ConflictError('Remote-backed notebook source is updated only by sync');
 		}
-		const now = new Date().toISOString();
 
-		const updated: NotebookMeta = {
-			...existing,
-			title: input.title ?? existing.title,
-			description: input.description ?? existing.description,
-			tags: input.tags ?? existing.tags,
-			// null clears back to the deployment default (the key is dropped from
-			// the written JSON); undefined leaves the stored choice as-is.
-			base_image: input.base_image === null ? undefined : (input.base_image ?? existing.base_image),
-			compute_profile:
-				input.compute_profile === null
-					? undefined
-					: (input.compute_profile ?? existing.compute_profile),
-			updated_at: now,
-		};
-
-		// Write updated meta
 		const nb = paths.project(projectId).notebook(notebookId);
-		await this.bucket.put(nb.meta, JSON.stringify(updated));
+		const updated = await mutateObject(
+			this.bucket,
+			nb.meta,
+			(raw) => parseStored(NotebookMetaSchema, raw, nb.meta),
+			(current) => {
+				assertVersionMatch(current.updated_at, expectedVersion);
+				if (current.status === 'deleted') {
+					throw new NotFoundError(`Notebook ${notebookId} not found`);
+				}
+				return {
+					...current,
+					title: input.title ?? current.title,
+					description: input.description ?? current.description,
+					tags: input.tags ?? current.tags,
+					// null clears back to the deployment default (the key is dropped from
+					// the written JSON); undefined leaves the stored choice as-is.
+					base_image:
+						input.base_image === null ? undefined : (input.base_image ?? current.base_image),
+					compute_profile:
+						input.compute_profile === null
+							? undefined
+							: (input.compute_profile ?? current.compute_profile),
+					updated_at: new Date().toISOString(),
+				};
+			},
+			{ notFound: () => new NotFoundError(`Notebook ${notebookId} not found`) },
+		);
+		const now = updated.updated_at;
 
 		if (input.readme !== undefined) {
 			await this.bucket.put(nb.readme, input.readme);
@@ -657,23 +669,24 @@ export class NotebookService {
 		actor: UserId,
 		expectedVersion?: string,
 	): Promise<void> {
-		const { meta } = await this.getNotebook(projectId, notebookId);
-		assertVersionMatch(meta.updated_at, expectedVersion);
-		// Idempotent: a notebook already soft-deleted is left untouched, so a repeated
-		// delete (retry / double-click) cannot decrement notebook_count twice.
-		if (meta.status === 'deleted') {
-			return;
-		}
-		const now = new Date().toISOString();
-
-		// Soft-delete: update status in meta.json
-		const updated: NotebookMeta = {
-			...meta,
-			status: 'deleted',
-			updated_at: now,
-		};
 		const nb = paths.project(projectId).notebook(notebookId);
-		await this.bucket.put(nb.meta, JSON.stringify(updated));
+		const { value: updated, written } = await mutateObjectWithOutcome(
+			this.bucket,
+			nb.meta,
+			(raw) => parseStored(NotebookMetaSchema, raw, nb.meta),
+			(current) => {
+				assertVersionMatch(current.updated_at, expectedVersion);
+				if (current.status === 'deleted') return null;
+				return {
+					...current,
+					status: 'deleted' as const,
+					updated_at: new Date().toISOString(),
+				};
+			},
+			{ notFound: () => new NotFoundError(`Notebook ${notebookId} not found`) },
+		);
+		if (!written) return;
+		const now = updated.updated_at;
 
 		// Soft-delete in snapshot
 		await this.catalog.updateNotebookEntry(

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -41,6 +41,7 @@ import {
 } from './notebookMeta';
 import { SyncedNotebookService } from './SyncedNotebookService';
 import { deleteByPrefix, listAllKeys, listAllObjects, listAllPrefixes } from '../catalog/storage';
+import { loadNotebookCatalogPatch } from './catalogProjection';
 
 /**
  * Maximum number of immutable version folders to retain per notebook. Older
@@ -148,13 +149,6 @@ export class NotebookService {
 		const readme = readmeObj ? await readmeObj.text() : null;
 
 		return { meta, readme, source };
-	}
-
-	private async loadNotebookCatalogPatch(projectId: ProjectId, notebookId: NotebookId) {
-		const key = paths.project(projectId).notebook(notebookId).meta;
-		const obj = await this.bucket.get(key);
-		if (!obj) throw new NotFoundError(`Notebook ${notebookId} not found`);
-		return notebookCatalogPatch(await readStored(NotebookMetaSchema, obj, key));
 	}
 
 	async getNotebookContent(projectId: ProjectId, notebookId: NotebookId): Promise<string> {
@@ -457,7 +451,7 @@ export class NotebookService {
 		}
 
 		await this.catalog.updateNotebookEntry('notebook.update', actor, projectId, notebookId, () =>
-			this.loadNotebookCatalogPatch(projectId, notebookId),
+			loadNotebookCatalogPatch(this.bucket, projectId, notebookId),
 		);
 
 		return updated;
@@ -672,7 +666,7 @@ export class NotebookService {
 		expectedVersion?: string,
 	): Promise<void> {
 		const nb = paths.project(projectId).notebook(notebookId);
-		const { written } = await mutateObjectWithOutcome(
+		const { value: updated, written } = await mutateObjectWithOutcome(
 			this.bucket,
 			nb.meta,
 			(raw) => parseStored(NotebookMetaSchema, raw, nb.meta),
@@ -695,7 +689,9 @@ export class NotebookService {
 			actor,
 			projectId,
 			notebookId,
-			() => this.loadNotebookCatalogPatch(projectId, notebookId),
+			async () =>
+				(await loadNotebookCatalogPatch(this.bucket, projectId, notebookId)) ??
+				notebookCatalogPatch(updated),
 			(p) => ({
 				notebook_count: Math.max(0, p.notebook_count - 1),
 			}),

--- a/packages/core/src/services/content/ProjectService.test.ts
+++ b/packages/core/src/services/content/ProjectService.test.ts
@@ -378,6 +378,26 @@ describe('ProjectService', () => {
 			expect(snapshot.projects[0].name).toBe('Winner');
 		});
 
+		it('does not fail or resurrect a project purged after its metadata commit', async () => {
+			const created = await projects.createProject({ name: 'Original', description: 'D' }, ACTOR);
+			const realUpdateEntry = catalog.updateProjectEntry.bind(catalog);
+			let purged = false;
+			vi.spyOn(catalog, 'updateProjectEntry').mockImplementation(async (...args) => {
+				if (!purged && args[0] === 'project.update') {
+					purged = true;
+					await projects.deleteProject(created.id, ACTOR);
+					await projects.hardDeleteProject(created.id);
+				}
+				return realUpdateEntry(...args);
+			});
+
+			const updated = await projects.updateProject(created.id, { name: 'Delayed' }, ACTOR);
+
+			const snapshot = await catalog.getCurrentSnapshot();
+			expect(updated.name).toBe('Delayed');
+			expect(snapshot.projects[0].status).toBe('deleted');
+		});
+
 		it('returns 412 when If-Match becomes stale during the CAS', async () => {
 			const created = await projects.createProject({ name: 'Original', description: 'D' }, ACTOR);
 			const metaKey = paths.project(created.id).meta;
@@ -503,6 +523,25 @@ describe('ProjectService', () => {
 	});
 
 	describe('deleteProject (soft-delete)', () => {
+		it('projects its tombstone when hard deletion wins before the catalog write', async () => {
+			const created = await projects.createProject({ name: 'Doomed', description: 'D' }, ACTOR);
+			const realUpdateEntry = catalog.updateProjectEntry.bind(catalog);
+			let purged = false;
+			vi.spyOn(catalog, 'updateProjectEntry').mockImplementation(async (...args) => {
+				if (!purged && args[0] === 'project.delete') {
+					purged = true;
+					await projects.hardDeleteProject(created.id);
+				}
+				return realUpdateEntry(...args);
+			});
+
+			await projects.deleteProject(created.id, ACTOR);
+
+			const snapshot = await catalog.getCurrentSnapshot();
+			expect(purged).toBe(true);
+			expect(snapshot.projects[0].status).toBe('deleted');
+		});
+
 		it('marks the project deleted but retains its bytes', async () => {
 			const created = await projects.createProject({ name: 'Doomed', description: 'D' }, ACTOR);
 

--- a/packages/core/src/services/content/ProjectService.test.ts
+++ b/packages/core/src/services/content/ProjectService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { NotFoundError, PreconditionFailedError } from '../../errors';
+import { ConflictError, NotFoundError, PreconditionFailedError } from '../../errors';
 import { UserId } from '../../ids';
 import type { ProjectId } from '../../ids';
 import { paths } from '../../paths';
@@ -208,6 +208,29 @@ describe('ProjectService', () => {
 	describe('membership', () => {
 		const MEMBER = UserId.parse('user_member');
 
+		it('detects a duplicate member added by a concurrent writer', async () => {
+			const project = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			const metaKey = paths.project(project.id).meta;
+			const realPut = bucket.put.bind(bucket);
+			let raced = false;
+			vi.spyOn(bucket, 'put').mockImplementation(async (key, value, options) => {
+				if (!raced && key === metaKey && options?.onlyIfEtagMatches) {
+					raced = true;
+					await projects.addMember(project.id, { email: 'racer@example.com' }, 'viewer', ACTOR);
+				}
+				return realPut(key, value, options);
+			});
+
+			await expect(
+				projects.addMember(project.id, { email: 'racer@example.com' }, 'editor', ACTOR),
+			).rejects.toBeInstanceOf(ConflictError);
+
+			const stored = await projects.getProject(project.id);
+			expect(stored.members.filter((member) => member.email === 'racer@example.com')).toHaveLength(
+				1,
+			);
+		});
+
 		it('adds a member by user id and denormalizes member_ids', async () => {
 			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
 			await projects.addMember(p.id, { user_id: MEMBER }, 'editor', ACTOR);
@@ -286,6 +309,55 @@ describe('ProjectService', () => {
 	});
 
 	describe('updateProject', () => {
+		it('returns 412 when If-Match becomes stale during the CAS', async () => {
+			const created = await projects.createProject({ name: 'Original', description: 'D' }, ACTOR);
+			const metaKey = paths.project(created.id).meta;
+			const realPut = bucket.put.bind(bucket);
+			let raced = false;
+			vi.spyOn(bucket, 'put').mockImplementation(async (key, value, options) => {
+				if (!raced && key === metaKey && options?.onlyIfEtagMatches) {
+					raced = true;
+					const current = await (await bucket.get(metaKey))!.json<any>();
+					await realPut(
+						metaKey,
+						JSON.stringify({ ...current, name: 'Racer', updated_at: '2099-01-01T00:00:00.000Z' }),
+					);
+				}
+				return realPut(key, value, options);
+			});
+
+			await expect(
+				projects.updateProject(created.id, { description: 'Mine' }, ACTOR, created.updated_at),
+			).rejects.toBeInstanceOf(PreconditionFailedError);
+
+			const stored = await projects.getProject(created.id);
+			expect(stored.name).toBe('Racer');
+			expect(stored.description).toBe('D');
+		});
+
+		it('does not resurrect a project deleted during an update', async () => {
+			const created = await projects.createProject({ name: 'Original', description: 'D' }, ACTOR);
+			const metaKey = paths.project(created.id).meta;
+			const realPut = bucket.put.bind(bucket);
+			let raced = false;
+			vi.spyOn(bucket, 'put').mockImplementation(async (key, value, options) => {
+				if (!raced && key === metaKey && options?.onlyIfEtagMatches) {
+					raced = true;
+					await projects.deleteProject(created.id, ACTOR);
+				}
+				return realPut(key, value, options);
+			});
+
+			await expect(
+				projects.updateProject(created.id, { name: 'Resurrected' }, ACTOR),
+			).rejects.toBeInstanceOf(NotFoundError);
+
+			const stored = await projects.getProject(created.id);
+			const snapshot = await catalog.getCurrentSnapshot();
+			expect(stored.status).toBe('deleted');
+			expect(snapshot.projects[0].status).toBe('deleted');
+		});
+
 		it('updates name and description', async () => {
 			const created = await projects.createProject({ name: 'Old', description: 'old desc' }, ACTOR);
 

--- a/packages/core/src/services/content/ProjectService.test.ts
+++ b/packages/core/src/services/content/ProjectService.test.ts
@@ -208,6 +208,32 @@ describe('ProjectService', () => {
 	describe('membership', () => {
 		const MEMBER = UserId.parse('user_member');
 
+		it('projects the latest roster when catalog updates finish out of order', async () => {
+			const project = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			const first = UserId.parse('first_member');
+			const second = UserId.parse('second_member');
+			const realUpdateEntry = catalog.updateProjectEntry.bind(catalog);
+			let raced = false;
+			vi.spyOn(catalog, 'updateProjectEntry').mockImplementation(async (...args) => {
+				if (!raced && args[0] === 'project.members') {
+					raced = true;
+					await projects.addMember(project.id, { user_id: second }, 'viewer', ACTOR);
+				}
+				return realUpdateEntry(...args);
+			});
+
+			await projects.addMember(project.id, { user_id: first }, 'editor', ACTOR);
+
+			const stored = await projects.getProject(project.id);
+			const snapshot = await catalog.getCurrentSnapshot();
+			expect(stored.members).toEqual([
+				{ user_id: ACTOR, role: 'admin' },
+				{ user_id: first, role: 'editor' },
+				{ user_id: second, role: 'viewer' },
+			]);
+			expect(snapshot.projects[0].member_ids).toEqual([ACTOR, first, second]);
+		});
+
 		it('detects a duplicate member added by a concurrent writer', async () => {
 			const project = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
 			const metaKey = paths.project(project.id).meta;
@@ -309,6 +335,49 @@ describe('ProjectService', () => {
 	});
 
 	describe('updateProject', () => {
+		it('uses the CAS read as the authoritative precondition check', async () => {
+			const created = await projects.createProject({ name: 'Original', description: 'D' }, ACTOR);
+			const metaKey = paths.project(created.id).meta;
+			const realGet = bucket.get.bind(bucket);
+			const realPut = bucket.put.bind(bucket);
+			let metaCommitted = false;
+			let readsBeforeCommit = 0;
+			vi.spyOn(bucket, 'get').mockImplementation(async (key) => {
+				if (key === metaKey && !metaCommitted) readsBeforeCommit++;
+				return realGet(key);
+			});
+			vi.spyOn(bucket, 'put').mockImplementation(async (key, value, options) => {
+				const result = await realPut(key, value, options);
+				if (key === metaKey && options?.onlyIfEtagMatches) metaCommitted = true;
+				return result;
+			});
+
+			await projects.updateProject(created.id, { name: 'Updated' }, ACTOR, created.updated_at);
+
+			expect(readsBeforeCommit).toBe(1);
+		});
+
+		it('projects the latest metadata when catalog updates finish out of order', async () => {
+			const created = await projects.createProject({ name: 'Original', description: 'D' }, ACTOR);
+			const realUpdateEntry = catalog.updateProjectEntry.bind(catalog);
+			let raced = false;
+			vi.spyOn(catalog, 'updateProjectEntry').mockImplementation(async (...args) => {
+				if (!raced && args[0] === 'project.update') {
+					raced = true;
+					await projects.updateProject(created.id, { name: 'Winner' }, ACTOR);
+				}
+				return realUpdateEntry(...args);
+			});
+
+			await projects.updateProject(created.id, { name: 'Delayed' }, ACTOR);
+
+			const stored = await projects.getProject(created.id);
+			const snapshot = await catalog.getCurrentSnapshot();
+			expect(raced).toBe(true);
+			expect(stored.name).toBe('Winner');
+			expect(snapshot.projects[0].name).toBe('Winner');
+		});
+
 		it('returns 412 when If-Match becomes stale during the CAS', async () => {
 			const created = await projects.createProject({ name: 'Original', description: 'D' }, ACTOR);
 			const metaKey = paths.project(created.id).meta;

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -20,11 +20,11 @@ import type {
 	ProjectMember,
 	PublicProjectEntry,
 	Snapshot,
-	SnapshotProjectEntry,
 } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject, mutateObjectWithOutcome } from '../catalog/cas';
 import { deleteByPrefix } from '../catalog/storage';
+import { loadProjectCatalogPatch, projectCatalogPatch } from './catalogProjection';
 
 /** Grace period before a soft-deleted project's storage is purged by the GC sweep. */
 export const DEFAULT_DELETED_PROJECT_RETENTION_MS = Millis.days(30);
@@ -101,25 +101,6 @@ export class ProjectService {
 			throw new NotFoundError(`Project ${id} not found`);
 		}
 		return readStored(ProjectSchema, obj, paths.project(id).meta);
-	}
-
-	private async loadProjectCatalogPatch(
-		id: ProjectId,
-		entry: SnapshotProjectEntry,
-	): Promise<Partial<SnapshotProjectEntry>> {
-		const project = await this.getProject(id);
-		return {
-			name: project.name,
-			description: project.description,
-			status: project.status,
-			updated_at: entry.updated_at >= project.updated_at ? entry.updated_at : project.updated_at,
-			member_ids: project.members.flatMap((member) =>
-				member.user_id !== undefined ? [member.user_id] : [],
-			),
-			member_emails: project.members.flatMap((member) =>
-				member.email !== undefined ? [member.email] : [],
-			),
-		};
 	}
 
 	async createProject(input: CreateProjectInput, actor: UserId): Promise<Project> {
@@ -211,7 +192,7 @@ export class ProjectService {
 		);
 
 		await this.catalog.updateProjectEntry('project.update', actor, id, (entry) =>
-			this.loadProjectCatalogPatch(id, entry),
+			loadProjectCatalogPatch(this.bucket, id, entry),
 		);
 
 		return updated;
@@ -325,7 +306,7 @@ export class ProjectService {
 			{ notFound: () => new NotFoundError(`Project ${id} not found`) },
 		);
 		await this.catalog.updateProjectEntry('project.members', actor, id, (entry) =>
-			this.loadProjectCatalogPatch(id, entry),
+			loadProjectCatalogPatch(this.bucket, id, entry),
 		);
 		return updated;
 	}
@@ -338,7 +319,7 @@ export class ProjectService {
 	 */
 	async deleteProject(id: ProjectId, actor: UserId, expectedVersion?: string): Promise<void> {
 		const key = paths.project(id).meta;
-		const { written } = await mutateObjectWithOutcome(
+		const { value: updated, written } = await mutateObjectWithOutcome(
 			this.bucket,
 			key,
 			(raw) => parseStored(ProjectSchema, raw, key),
@@ -358,8 +339,13 @@ export class ProjectService {
 		// Soft-delete in the snapshot: keep the entry (and its nested notebooks) so
 		// the GC sweep can find and purge it later, but mark it deleted so it drops
 		// out of listProjects immediately.
-		await this.catalog.updateProjectEntry('project.delete', actor, id, (entry) =>
-			this.loadProjectCatalogPatch(id, entry),
+		await this.catalog.updateProjectEntry(
+			'project.delete',
+			actor,
+			id,
+			async (entry) =>
+				(await loadProjectCatalogPatch(this.bucket, id, entry)) ??
+				projectCatalogPatch(updated, entry),
 		);
 	}
 

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -13,7 +13,7 @@ import { noopMetrics } from '../../ports/metrics';
 import type { Metrics } from '../../ports/metrics';
 import { paths } from '../../paths';
 import { metricsObserver, saga } from '../../saga';
-import { ProjectSchema, readStored, toPublicProjectEntry } from '../../schema';
+import { parseStored, ProjectSchema, readStored, toPublicProjectEntry } from '../../schema';
 import type {
 	Project,
 	ProjectFederation,
@@ -22,6 +22,7 @@ import type {
 	Snapshot,
 } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
+import { mutateObject, mutateObjectWithOutcome } from '../catalog/cas';
 import { deleteByPrefix } from '../catalog/storage';
 
 /** Grace period before a soft-deleted project's storage is purged by the GC sweep. */
@@ -168,18 +169,29 @@ export class ProjectService {
 	): Promise<Project> {
 		const existing = await this.getProject(id);
 		assertVersionMatch(existing.updated_at, expectedVersion);
-		const now = new Date().toISOString();
+		const key = paths.project(id).meta;
 
-		const updated: Project = {
-			...existing,
-			name: input.name ?? existing.name,
-			description: input.description ?? existing.description,
-			tags: input.tags ?? existing.tags,
-			federation: input.federation ?? existing.federation,
-			updated_at: now,
-		};
-
-		await this.bucket.put(paths.project(id).meta, JSON.stringify(updated));
+		const updated = await mutateObject(
+			this.bucket,
+			key,
+			(raw) => parseStored(ProjectSchema, raw, key),
+			(current) => {
+				assertVersionMatch(current.updated_at, expectedVersion);
+				if (current.status === 'deleted') {
+					throw new NotFoundError(`Project ${id} not found`);
+				}
+				return {
+					...current,
+					name: input.name ?? current.name,
+					description: input.description ?? current.description,
+					tags: input.tags ?? current.tags,
+					federation: input.federation ?? current.federation,
+					updated_at: new Date().toISOString(),
+				};
+			},
+			{ notFound: () => new NotFoundError(`Project ${id} not found`) },
+		);
+		const now = updated.updated_at;
 
 		await this.catalog.updateProjectEntry('project.update', actor, id, () => ({
 			name: updated.name,
@@ -201,20 +213,25 @@ export class ProjectService {
 		role: AssignableRole,
 		actor: UserId,
 	): Promise<Project> {
-		const existing = await this.getProject(id);
 		const userId = 'user_id' in member ? member.user_id : undefined;
 		const email = member.email !== undefined ? normalizeEmail(member.email) : undefined;
-		const duplicate = existing.members.some(
-			(m) =>
-				(userId !== undefined && m.user_id === userId) ||
-				(email !== undefined && m.email === email),
+		return this.writeMembers(
+			id,
+			(current) => {
+				const duplicate = current.members.some(
+					(m) =>
+						(userId !== undefined && m.user_id === userId) ||
+						(email !== undefined && m.email === email),
+				);
+				if (duplicate) {
+					throw new ConflictError(`${userId ?? email} is already a member of project ${id}`);
+				}
+				const row: ProjectMember =
+					userId !== undefined ? { user_id: userId, role } : { email: email as string, role };
+				return [...current.members, row];
+			},
+			actor,
 		);
-		if (duplicate) {
-			throw new ConflictError(`${userId ?? email} is already a member of project ${id}`);
-		}
-		const row: ProjectMember =
-			userId !== undefined ? { user_id: userId, role } : { email: email as string, role };
-		return this.writeMembers(existing, [...existing.members, row], actor);
 	}
 
 	/**
@@ -228,17 +245,21 @@ export class ProjectService {
 		role: AssignableRole,
 		actor: UserId,
 	): Promise<Project> {
-		const existing = await this.getProject(id);
-		if (selector === existing.owner) {
-			throw new ConflictError(`Cannot change the role of the project owner`);
-		}
-		if (!existing.members.some((m) => memberRefMatchesSelector(m, selector))) {
-			throw new NotFoundError(`${selector} is not a member of project ${id}`);
-		}
-		const members = existing.members.map((m) =>
-			memberRefMatchesSelector(m, selector) ? { ...m, role } : m,
+		return this.writeMembers(
+			id,
+			(current) => {
+				if (selector === current.owner) {
+					throw new ConflictError(`Cannot change the role of the project owner`);
+				}
+				if (!current.members.some((m) => memberRefMatchesSelector(m, selector))) {
+					throw new NotFoundError(`${selector} is not a member of project ${id}`);
+				}
+				return current.members.map((m) =>
+					memberRefMatchesSelector(m, selector) ? { ...m, role } : m,
+				);
+			},
+			actor,
 		);
-		return this.writeMembers(existing, members, actor);
 	}
 
 	/**
@@ -246,15 +267,19 @@ export class ProjectService {
 	 * be removed.
 	 */
 	async removeMember(id: ProjectId, selector: string, actor: UserId): Promise<Project> {
-		const existing = await this.getProject(id);
-		if (selector === existing.owner) {
-			throw new ConflictError(`Cannot remove the project owner`);
-		}
-		if (!existing.members.some((m) => memberRefMatchesSelector(m, selector))) {
-			throw new NotFoundError(`${selector} is not a member of project ${id}`);
-		}
-		const members = existing.members.filter((m) => !memberRefMatchesSelector(m, selector));
-		return this.writeMembers(existing, members, actor);
+		return this.writeMembers(
+			id,
+			(current) => {
+				if (selector === current.owner) {
+					throw new ConflictError(`Cannot remove the project owner`);
+				}
+				if (!current.members.some((m) => memberRefMatchesSelector(m, selector))) {
+					throw new NotFoundError(`${selector} is not a member of project ${id}`);
+				}
+				return current.members.filter((m) => !memberRefMatchesSelector(m, selector));
+			},
+			actor,
+		);
 	}
 
 	// The authoritative roster (with roles) lives on project.json; the snapshot
@@ -263,17 +288,32 @@ export class ProjectService {
 	// membership change rewrites the meta blob and, in the same catalog CAS, bumps
 	// `updated_at` and refreshes both rosters to match.
 	private async writeMembers(
-		existing: Project,
-		members: ProjectMember[],
+		id: ProjectId,
+		deriveMembers: (current: Project) => ProjectMember[],
 		actor: UserId,
 	): Promise<Project> {
-		const now = new Date().toISOString();
-		const updated: Project = { ...existing, members, updated_at: now };
-		await this.bucket.put(paths.project(existing.id).meta, JSON.stringify(updated));
-		await this.catalog.updateProjectEntry('project.members', actor, existing.id, () => ({
+		const key = paths.project(id).meta;
+		const updated = await mutateObject(
+			this.bucket,
+			key,
+			(raw) => parseStored(ProjectSchema, raw, key),
+			(current) => {
+				if (current.status === 'deleted') {
+					throw new NotFoundError(`Project ${id} not found`);
+				}
+				return {
+					...current,
+					members: deriveMembers(current),
+					updated_at: new Date().toISOString(),
+				};
+			},
+			{ notFound: () => new NotFoundError(`Project ${id} not found`) },
+		);
+		const now = updated.updated_at;
+		await this.catalog.updateProjectEntry('project.members', actor, id, () => ({
 			updated_at: now,
-			member_ids: members.flatMap((m) => (m.user_id !== undefined ? [m.user_id] : [])),
-			member_emails: members.flatMap((m) => (m.email !== undefined ? [m.email] : [])),
+			member_ids: updated.members.flatMap((m) => (m.user_id !== undefined ? [m.user_id] : [])),
+			member_emails: updated.members.flatMap((m) => (m.email !== undefined ? [m.email] : [])),
 		}));
 		return updated;
 	}
@@ -285,18 +325,24 @@ export class ProjectService {
 	 * Mirrors `NotebookService.deleteNotebook`.
 	 */
 	async deleteProject(id: ProjectId, actor: UserId, expectedVersion?: string): Promise<void> {
-		const existing = await this.getProject(id); // ensure exists (404 otherwise)
-		assertVersionMatch(existing.updated_at, expectedVersion);
-		// Idempotent: a project already soft-deleted is left untouched so a repeated
-		// delete (retry / double-click) is a no-op.
-		if (existing.status === 'deleted') {
-			return;
-		}
-		const now = new Date().toISOString();
-
-		// Soft-delete: tombstone the project.json (deletion time = updated_at).
-		const updated: Project = { ...existing, status: 'deleted', updated_at: now };
-		await this.bucket.put(paths.project(id).meta, JSON.stringify(updated));
+		const key = paths.project(id).meta;
+		const { value: updated, written } = await mutateObjectWithOutcome(
+			this.bucket,
+			key,
+			(raw) => parseStored(ProjectSchema, raw, key),
+			(current) => {
+				assertVersionMatch(current.updated_at, expectedVersion);
+				if (current.status === 'deleted') return null;
+				return {
+					...current,
+					status: 'deleted' as const,
+					updated_at: new Date().toISOString(),
+				};
+			},
+			{ notFound: () => new NotFoundError(`Project ${id} not found`) },
+		);
+		if (!written) return;
+		const now = updated.updated_at;
 
 		// Soft-delete in the snapshot: keep the entry (and its nested notebooks) so
 		// the GC sweep can find and purge it later, but mark it deleted so it drops

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -20,6 +20,7 @@ import type {
 	ProjectMember,
 	PublicProjectEntry,
 	Snapshot,
+	SnapshotProjectEntry,
 } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject, mutateObjectWithOutcome } from '../catalog/cas';
@@ -102,6 +103,25 @@ export class ProjectService {
 		return readStored(ProjectSchema, obj, paths.project(id).meta);
 	}
 
+	private async loadProjectCatalogPatch(
+		id: ProjectId,
+		entry: SnapshotProjectEntry,
+	): Promise<Partial<SnapshotProjectEntry>> {
+		const project = await this.getProject(id);
+		return {
+			name: project.name,
+			description: project.description,
+			status: project.status,
+			updated_at: entry.updated_at >= project.updated_at ? entry.updated_at : project.updated_at,
+			member_ids: project.members.flatMap((member) =>
+				member.user_id !== undefined ? [member.user_id] : [],
+			),
+			member_emails: project.members.flatMap((member) =>
+				member.email !== undefined ? [member.email] : [],
+			),
+		};
+	}
+
 	async createProject(input: CreateProjectInput, actor: UserId): Promise<Project> {
 		const id = createProjectId();
 		const now = new Date().toISOString();
@@ -167,8 +187,6 @@ export class ProjectService {
 		actor: UserId,
 		expectedVersion?: string,
 	): Promise<Project> {
-		const existing = await this.getProject(id);
-		assertVersionMatch(existing.updated_at, expectedVersion);
 		const key = paths.project(id).meta;
 
 		const updated = await mutateObject(
@@ -191,13 +209,10 @@ export class ProjectService {
 			},
 			{ notFound: () => new NotFoundError(`Project ${id} not found`) },
 		);
-		const now = updated.updated_at;
 
-		await this.catalog.updateProjectEntry('project.update', actor, id, () => ({
-			name: updated.name,
-			description: updated.description,
-			updated_at: now,
-		}));
+		await this.catalog.updateProjectEntry('project.update', actor, id, (entry) =>
+			this.loadProjectCatalogPatch(id, entry),
+		);
 
 		return updated;
 	}
@@ -309,12 +324,9 @@ export class ProjectService {
 			},
 			{ notFound: () => new NotFoundError(`Project ${id} not found`) },
 		);
-		const now = updated.updated_at;
-		await this.catalog.updateProjectEntry('project.members', actor, id, () => ({
-			updated_at: now,
-			member_ids: updated.members.flatMap((m) => (m.user_id !== undefined ? [m.user_id] : [])),
-			member_emails: updated.members.flatMap((m) => (m.email !== undefined ? [m.email] : [])),
-		}));
+		await this.catalog.updateProjectEntry('project.members', actor, id, (entry) =>
+			this.loadProjectCatalogPatch(id, entry),
+		);
 		return updated;
 	}
 
@@ -326,7 +338,7 @@ export class ProjectService {
 	 */
 	async deleteProject(id: ProjectId, actor: UserId, expectedVersion?: string): Promise<void> {
 		const key = paths.project(id).meta;
-		const { value: updated, written } = await mutateObjectWithOutcome(
+		const { written } = await mutateObjectWithOutcome(
 			this.bucket,
 			key,
 			(raw) => parseStored(ProjectSchema, raw, key),
@@ -342,15 +354,13 @@ export class ProjectService {
 			{ notFound: () => new NotFoundError(`Project ${id} not found`) },
 		);
 		if (!written) return;
-		const now = updated.updated_at;
 
 		// Soft-delete in the snapshot: keep the entry (and its nested notebooks) so
 		// the GC sweep can find and purge it later, but mark it deleted so it drops
 		// out of listProjects immediately.
-		await this.catalog.updateProjectEntry('project.delete', actor, id, () => ({
-			status: 'deleted' as const,
-			updated_at: now,
-		}));
+		await this.catalog.updateProjectEntry('project.delete', actor, id, (entry) =>
+			this.loadProjectCatalogPatch(id, entry),
+		);
 	}
 
 	/**

--- a/packages/core/src/services/content/SyncedNotebookService.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.ts
@@ -1,4 +1,5 @@
 import type { Bucket } from '../../ports/bucket';
+import { NotFoundError } from '../../errors';
 import { createNotebookId, createVersionId, SYSTEM_ACTOR } from '../../ids';
 import type { NotebookId, ProjectId, UserId, VersionId } from '../../ids';
 import {
@@ -28,7 +29,12 @@ import { compensableWrite, metricsObserver, saga } from '../../saga';
 import { NotebookMetaSchema, parseStored, readStored, SourceSchema } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject } from '../catalog/cas';
-import { buildNotebookEntry, buildNotebookMeta, buildVersion } from './notebookMeta';
+import {
+	buildNotebookEntry,
+	buildNotebookMeta,
+	buildVersion,
+	notebookCatalogPatch,
+} from './notebookMeta';
 import { listAllKeys } from '../catalog/storage';
 import type { GitSource, NotebookMeta, Source } from '../../schema';
 
@@ -54,6 +60,13 @@ export class SyncedNotebookService {
 		private metrics: Metrics,
 		private hooks: SyncedNotebookServiceHooks,
 	) {}
+
+	private async loadNotebookCatalogPatch(projectId: ProjectId, notebookId: NotebookId) {
+		const key = paths.project(projectId).notebook(notebookId).meta;
+		const obj = await this.bucket.get(key);
+		if (!obj) throw new NotFoundError(`Notebook ${notebookId} not found`);
+		return notebookCatalogPatch(await readStored(NotebookMetaSchema, obj, key));
+	}
 
 	async create(
 		projectId: ProjectId,
@@ -175,8 +188,7 @@ export class SyncedNotebookService {
 			actor,
 			projectId,
 			notebookId,
-			() => ({ updated_at: now }),
-			() => ({ updated_at: now }),
+			() => this.loadNotebookCatalogPatch(projectId, notebookId),
 		);
 		return source;
 	}
@@ -287,8 +299,7 @@ export class SyncedNotebookService {
 			actor,
 			projectId,
 			notebookId,
-			() => ({ status: updatedMeta.status, updated_at: now }),
-			() => ({ updated_at: now }),
+			() => this.loadNotebookCatalogPatch(projectId, notebookId),
 		);
 
 		await this.hooks.pruneVersions(projectId, notebookId, versionToKeep);

--- a/packages/core/src/services/content/SyncedNotebookService.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.ts
@@ -1,5 +1,4 @@
 import type { Bucket } from '../../ports/bucket';
-import { NotFoundError } from '../../errors';
 import { createNotebookId, createVersionId, SYSTEM_ACTOR } from '../../ids';
 import type { NotebookId, ProjectId, UserId, VersionId } from '../../ids';
 import {
@@ -29,14 +28,10 @@ import { compensableWrite, metricsObserver, saga } from '../../saga';
 import { NotebookMetaSchema, parseStored, readStored, SourceSchema } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject } from '../catalog/cas';
-import {
-	buildNotebookEntry,
-	buildNotebookMeta,
-	buildVersion,
-	notebookCatalogPatch,
-} from './notebookMeta';
+import { buildNotebookEntry, buildNotebookMeta, buildVersion } from './notebookMeta';
 import { listAllKeys } from '../catalog/storage';
 import type { GitSource, NotebookMeta, Source } from '../../schema';
+import { loadNotebookCatalogPatch } from './catalogProjection';
 
 interface SyncedNotebookServiceHooks {
 	getNotebook: (
@@ -60,13 +55,6 @@ export class SyncedNotebookService {
 		private metrics: Metrics,
 		private hooks: SyncedNotebookServiceHooks,
 	) {}
-
-	private async loadNotebookCatalogPatch(projectId: ProjectId, notebookId: NotebookId) {
-		const key = paths.project(projectId).notebook(notebookId).meta;
-		const obj = await this.bucket.get(key);
-		if (!obj) throw new NotFoundError(`Notebook ${notebookId} not found`);
-		return notebookCatalogPatch(await readStored(NotebookMetaSchema, obj, key));
-	}
 
 	async create(
 		projectId: ProjectId,
@@ -188,7 +176,7 @@ export class SyncedNotebookService {
 			actor,
 			projectId,
 			notebookId,
-			() => this.loadNotebookCatalogPatch(projectId, notebookId),
+			() => loadNotebookCatalogPatch(this.bucket, projectId, notebookId),
 		);
 		return source;
 	}
@@ -299,7 +287,7 @@ export class SyncedNotebookService {
 			actor,
 			projectId,
 			notebookId,
-			() => this.loadNotebookCatalogPatch(projectId, notebookId),
+			() => loadNotebookCatalogPatch(this.bucket, projectId, notebookId),
 		);
 
 		await this.hooks.pruneVersions(projectId, notebookId, versionToKeep);

--- a/packages/core/src/services/content/catalogProjection.ts
+++ b/packages/core/src/services/content/catalogProjection.ts
@@ -1,0 +1,53 @@
+import type { Bucket } from '../../ports/bucket';
+import type { NotebookId, ProjectId } from '../../ids';
+import { paths } from '../../paths';
+import { NotebookMetaSchema, ProjectSchema, readStored } from '../../schema';
+import type { Project, SnapshotNotebookEntry, SnapshotProjectEntry } from '../../schema';
+import { notebookCatalogPatch } from './notebookMeta';
+
+/**
+ * These reads run inside each catalog CAS attempt. Reading only before the first
+ * attempt is unsafe: a newer metadata writer can finish its catalog update first,
+ * letting a stale projection commit without losing the catalog CAS. A missing
+ * object means a hard-delete won. Active mutations leave the catalog unchanged;
+ * delete callers can still project their committed tombstone.
+ */
+export async function loadNotebookCatalogPatch(
+	bucket: Bucket,
+	projectId: ProjectId,
+	notebookId: NotebookId,
+): Promise<Partial<SnapshotNotebookEntry> | undefined> {
+	const key = paths.project(projectId).notebook(notebookId).meta;
+	const obj = await bucket.get(key);
+	if (!obj) return undefined;
+	return notebookCatalogPatch(await readStored(NotebookMetaSchema, obj, key));
+}
+
+export async function loadProjectCatalogPatch(
+	bucket: Bucket,
+	projectId: ProjectId,
+	entry: SnapshotProjectEntry,
+): Promise<Partial<SnapshotProjectEntry> | undefined> {
+	const key = paths.project(projectId).meta;
+	const obj = await bucket.get(key);
+	if (!obj) return undefined;
+	return projectCatalogPatch(await readStored(ProjectSchema, obj, key), entry);
+}
+
+export function projectCatalogPatch(
+	project: Project,
+	entry: SnapshotProjectEntry,
+): Partial<SnapshotProjectEntry> {
+	return {
+		name: project.name,
+		description: project.description,
+		status: project.status,
+		updated_at: entry.updated_at >= project.updated_at ? entry.updated_at : project.updated_at,
+		member_ids: project.members.flatMap((member) =>
+			member.user_id !== undefined ? [member.user_id] : [],
+		),
+		member_emails: project.members.flatMap((member) =>
+			member.email !== undefined ? [member.email] : [],
+		),
+	};
+}

--- a/packages/core/src/services/content/notebookMeta.ts
+++ b/packages/core/src/services/content/notebookMeta.ts
@@ -98,3 +98,20 @@ export function buildNotebookEntry(
 		key_prefix: keyPrefix,
 	};
 }
+
+export function notebookCatalogPatch(
+	meta: NotebookMeta,
+): Pick<
+	SnapshotNotebookEntry,
+	'title' | 'description' | 'status' | 'updated_at' | 'tags' | 'last_run_at' | 'compute_profile'
+> {
+	return {
+		title: meta.title,
+		description: meta.description,
+		status: meta.status,
+		updated_at: meta.updated_at,
+		tags: meta.tags,
+		last_run_at: meta.last_run_at,
+		compute_profile: meta.compute_profile,
+	};
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -96,7 +96,14 @@ export {
 export type { CreatedToken, CreateTokenInput } from './tokens/TokenService';
 export { composeAuthenticators } from './tokens/composeAuthenticators';
 export { listAllKeys } from './catalog/storage';
-export { mutateObject, withCasRetry, type CasRetryOptions } from './catalog/cas';
+export {
+	mutateObject,
+	mutateObjectWithOutcome,
+	withCasRetry,
+	type CasRetryOptions,
+	type CasWriter,
+	type ObjectMutationOutcome,
+} from './catalog/cas';
 export {
 	createWorkspaceLoadStrategies,
 	DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS,

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -5,7 +5,6 @@ import {
 	assertVersionMatch,
 	BadRequestError,
 	NotFoundError,
-	PreconditionFailedError,
 	ResourceExhaustedError,
 	UnavailableError,
 	ValidationError,
@@ -117,27 +116,6 @@ const ORG_SCOPE: IntegrationScope = {
 	nameClaim: paths.orgIntegrationNameClaim,
 	where: 'at the org level',
 };
-
-/**
- * A head that no longer matches the caller's `If-Match`, raised from inside a CAS
- * callback. `withCasRetry` reads a `PreconditionFailedError` as a lost race and
- * retries it, so the guard escapes the loop wrapped and `update` rethrows the 412.
- */
-class StaleHeadError extends Error {
-	constructor(readonly precondition: PreconditionFailedError) {
-		super(precondition.message);
-		this.name = 'StaleHeadError';
-	}
-}
-
-function assertHeadUnchanged(current: IntegrationRecord, expected: string | undefined): void {
-	try {
-		assertVersionMatch(current.updated_at, expected);
-	} catch (err) {
-		if (err instanceof PreconditionFailedError) throw new StaleHeadError(err);
-		throw err;
-	}
-}
 
 /**
  * A head carrying `deleted_at` is a tombstone: the terminal state a delete CAS's
@@ -367,7 +345,7 @@ class ScopedIntegrationsStore {
 							headPath,
 							parseHead,
 							(current) => {
-								assertHeadUnchanged(current, expected);
+								assertVersionMatch(current.updated_at, expected);
 								return {
 									...current,
 									name: newName,
@@ -413,7 +391,7 @@ class ScopedIntegrationsStore {
 				headPath,
 				parseHead,
 				(current) => {
-					assertHeadUnchanged(current, expected);
+					assertVersionMatch(current.updated_at, expected);
 					return {
 						...current,
 						...(input.enabled !== undefined ? { enabled: input.enabled } : {}),
@@ -428,12 +406,7 @@ class ScopedIntegrationsStore {
 				headNotFound,
 			);
 		});
-		try {
-			await transaction.run();
-		} catch (err) {
-			if (err instanceof StaleHeadError) throw err.precondition;
-			throw err;
-		}
+		await transaction.run();
 		if (newName !== undefined) await this.releaseName(scope, head.name, id);
 		const { version, config } = await this.loadCurrent(scope, updated!);
 		return this.toDetail(scope, updated!, version, config);
@@ -494,7 +467,6 @@ class ScopedIntegrationsStore {
 			name = await this.tombstoneHead(scope, id, expectedVersion);
 			existed = name !== undefined;
 		} catch (err) {
-			if (err instanceof StaleHeadError) throw err.precondition;
 			// A head that cannot be parsed has no version to check and nothing to
 			// tombstone, but must still be removable — sweep its objects unguarded.
 			if (!(err instanceof ValidationError || err instanceof StoredObjectError)) throw err;
@@ -528,7 +500,7 @@ class ScopedIntegrationsStore {
 		expectedVersion: string | undefined,
 	): Promise<string | undefined> {
 		const headPath = scope.integration(id).head;
-		return withCasRetry(async () => {
+		return withCasRetry(this.bucket, async (cas) => {
 			const existing = await this.bucket.get(headPath);
 			if (!existing) return;
 			const raw = await readStoredJson(existing, headPath);
@@ -538,8 +510,8 @@ class ScopedIntegrationsStore {
 				return parseStored(IntegrationRecordSchema, raw, `integration ${id}`).name;
 			}
 			const head = this.parseHead(scope, id, raw);
-			assertHeadUnchanged(head, expectedVersion);
-			await this.bucket.put(headPath, JSON.stringify({ ...head, deleted_at: this.now() }), {
+			assertVersionMatch(head.updated_at, expectedVersion);
+			await cas.put(headPath, JSON.stringify({ ...head, deleted_at: this.now() }), {
 				onlyIfEtagMatches: existing.etag,
 			});
 			return head.name;
@@ -853,21 +825,20 @@ class ScopedIntegrationsStore {
 	): Promise<number> {
 		let version = head.current_version + 1;
 		const integrationPaths = scope.integration(head.id);
-		return withCasRetry(async () => {
-			try {
-				await this.bucket.put(
-					integrationPaths.version(version),
-					JSON.stringify({ ...record, version }),
-					{
-						onlyIfNotExists: true,
-					},
-				);
+		return withCasRetry(
+			this.bucket,
+			async (cas) => {
+				await cas.put(integrationPaths.version(version), JSON.stringify({ ...record, version }), {
+					onlyIfNotExists: true,
+				});
 				return version;
-			} catch (err) {
-				if (err instanceof PreconditionFailedError) version += 1;
-				throw err;
-			}
-		});
+			},
+			{
+				onConflict: () => {
+					version += 1;
+				},
+			},
+		);
 	}
 
 	private async assertNameFree(scope: IntegrationScope, name: string): Promise<void> {

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -15,6 +15,7 @@ import {
 import {
 	acquireSingletonClaim,
 	mutateObject,
+	mutateObjectWithOutcome,
 	releaseSingletonClaim,
 	withCasRetry,
 } from '../catalog/cas';
@@ -107,12 +108,12 @@ export class SessionService {
 	 * heartbeat — its conditional write fails the ETag check, `apply` re-runs against
 	 * the fresh (terminal) state, and no-ops. See `mutateObject` in `./cas`.
 	 */
-	private mutate(
+	private async mutate(
 		projectId: ProjectId,
 		id: SessionId,
 		apply: (session: Session) => Session | null,
 	): Promise<Session> {
-		return mutateObject(
+		const value = await mutateObject(
 			this.bucket,
 			paths.session(projectId, id),
 			(raw) => parseStored(SessionSchema, raw, paths.session(projectId, id)),
@@ -123,6 +124,7 @@ export class SessionService {
 				onExhausted: () => this.metrics.increment('sessions.cas.exhausted'),
 			},
 		);
+		return value;
 	}
 
 	async createSession(input: CreateSessionInput): Promise<Session> {
@@ -677,7 +679,8 @@ export class SessionService {
 	): Promise<{ claimed: boolean; claim: EditorClaim }> {
 		const key = paths.editorClaim(projectId, notebookId);
 		return withCasRetry(
-			async () => {
+			this.bucket,
+			async (cas) => {
 				const obj = await this.bucket.get(key);
 				const next: EditorClaim = {
 					session_id: sessionId,
@@ -685,7 +688,7 @@ export class SessionService {
 					claimed_at: new Date().toISOString(),
 				};
 				if (!obj) {
-					await this.bucket.put(key, JSON.stringify(next), { onlyIfNotExists: true });
+					await cas.put(key, JSON.stringify(next), { onlyIfNotExists: true });
 					return { claimed: true, claim: next };
 				}
 				const current = await readStored(EditorClaimSchema, obj, key);
@@ -706,7 +709,7 @@ export class SessionService {
 						...current,
 						transfer: { ...current.transfer, replacement_session_id: sessionId },
 					};
-					await this.bucket.put(key, JSON.stringify(reservedClaim), {
+					await cas.put(key, JSON.stringify(reservedClaim), {
 						onlyIfEtagMatches: obj.etag,
 					});
 					return { claimed: true, claim: reservedClaim };
@@ -718,7 +721,9 @@ export class SessionService {
 					return { claimed: false, claim: current };
 				}
 				const replacement = { ...current, ...next, transfer: undefined };
-				await this.bucket.put(key, JSON.stringify(replacement), { onlyIfEtagMatches: obj.etag });
+				await cas.put(key, JSON.stringify(replacement), {
+					onlyIfEtagMatches: obj.etag,
+				});
 				return { claimed: true, claim: replacement };
 			},
 			{
@@ -803,7 +808,7 @@ export class SessionService {
 			expectedActivity: 'active' | 'idle' | 'unknown' | 'starting';
 		},
 	): Promise<EditorClaim> {
-		return mutateObject(
+		const value = await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
 			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
@@ -829,12 +834,13 @@ export class SessionService {
 						takeover_id: input.takeoverId,
 						requested_by: input.requestedBy,
 						expected_activity: input.expectedActivity,
-						phase: 'requested',
+						phase: 'requested' as const,
 						requested_at: new Date().toISOString(),
 					},
 				};
 			},
 		);
+		return value;
 	}
 
 	async setTakeoverPhase(
@@ -844,7 +850,7 @@ export class SessionService {
 		phase: 'draining' | 'ready',
 		replacementSessionId?: SessionId,
 	): Promise<EditorClaim> {
-		return mutateObject(
+		const value = await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
 			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
@@ -868,6 +874,7 @@ export class SessionService {
 				};
 			},
 		);
+		return value;
 	}
 
 	async acquireTakeoverDrainLease(
@@ -876,13 +883,11 @@ export class SessionService {
 		takeoverId: string,
 		leaseId: string,
 	): Promise<boolean> {
-		let acquired = false;
-		await mutateObject(
+		const claim = await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
 			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
-				acquired = false;
 				if (claim.transfer?.takeover_id !== takeoverId || claim.transfer.phase !== 'draining') {
 					throw new EditSessionChangedError();
 				}
@@ -891,7 +896,6 @@ export class SessionService {
 					claim.transfer.drain_lease_expires_at &&
 					Date.parse(claim.transfer.drain_lease_expires_at) > Date.now();
 				if (activeLease && claim.transfer.drain_lease_id !== leaseId) return null;
-				acquired = true;
 				if (activeLease) return null;
 				const now = Date.now();
 				return {
@@ -908,7 +912,10 @@ export class SessionService {
 				};
 			},
 		);
-		return acquired;
+		return (
+			claim.transfer?.drain_lease_id === leaseId &&
+			Date.parse(claim.transfer.drain_lease_expires_at ?? '') > Date.now()
+		);
 	}
 
 	async renewTakeoverDrainLease(
@@ -917,13 +924,11 @@ export class SessionService {
 		takeoverId: string,
 		leaseId: string,
 	): Promise<boolean> {
-		let renewed = false;
-		await mutateObject(
+		const { written } = await mutateObjectWithOutcome(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
 			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
-				renewed = false;
 				if (claim.transfer?.takeover_id !== takeoverId || claim.transfer.phase !== 'draining') {
 					throw new EditSessionChangedError();
 				}
@@ -943,7 +948,6 @@ export class SessionService {
 				) {
 					return null;
 				}
-				renewed = true;
 				return {
 					...claim,
 					transfer: {
@@ -955,7 +959,7 @@ export class SessionService {
 				};
 			},
 		);
-		return renewed;
+		return written;
 	}
 
 	async advanceTakeoverDrainLease(
@@ -965,13 +969,11 @@ export class SessionService {
 		leaseId: string,
 		stage: TakeoverDrainStage,
 	): Promise<boolean> {
-		let advanced = false;
-		await mutateObject(
+		const claim = await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
 			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
 			(claim) => {
-				advanced = false;
 				if (claim.transfer?.takeover_id !== takeoverId || claim.transfer.phase !== 'draining') {
 					throw new EditSessionChangedError();
 				}
@@ -989,10 +991,8 @@ export class SessionService {
 					currentStage &&
 					TAKEOVER_DRAIN_STAGE_ORDER[stage] <= TAKEOVER_DRAIN_STAGE_ORDER[currentStage]
 				) {
-					advanced = currentStage === stage;
 					return null;
 				}
-				advanced = true;
 				return {
 					...claim,
 					transfer: {
@@ -1006,7 +1006,11 @@ export class SessionService {
 				};
 			},
 		);
-		return advanced;
+		return (
+			claim.transfer?.drain_lease_id === leaseId &&
+			claim.transfer.drain_lease_stage === stage &&
+			Date.parse(claim.transfer.drain_lease_expires_at ?? '') > Date.now()
+		);
 	}
 
 	async finishTakeoverDrainLease(
@@ -1091,7 +1095,7 @@ export class SessionService {
 		takeoverId: string,
 		replacementSessionId: SessionId,
 	): Promise<EditorClaim> {
-		return mutateObject(
+		const value = await mutateObject(
 			this.bucket,
 			paths.editorClaim(projectId, notebookId),
 			(raw) => parseStored(EditorClaimSchema, raw, paths.editorClaim(projectId, notebookId)),
@@ -1106,12 +1110,13 @@ export class SessionService {
 				return {
 					...claim,
 					session_id: replacementSessionId,
-					sharing: 'exclusive',
+					sharing: 'exclusive' as const,
 					claimed_at: new Date().toISOString(),
 					transfer: undefined,
 				};
 			},
 		);
+		return value;
 	}
 
 	async cancelRequestedTakeover(


### PR DESCRIPTION
Route conditional writes through a CasWriter so only lost-race
PreconditionFailedErrors trigger retries; client-facing precondition
errors thrown directly by the attempt now propagate instead of being
swallowed as conflicts.
