### PR TITLE
refactor(server): extract testable bootstrap from entrypoint

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,7 +23,8 @@
 		"@opentelemetry/sdk-metrics": "catalog:",
 		"@opentelemetry/sdk-trace-base": "catalog:",
 		"@opentelemetry/sdk-trace-node": "catalog:",
-		"hono": "catalog:"
+		"hono": "catalog:",
+		"zod": "catalog:"
 	},
 	"devDependencies": {
 		"@marimo-hub/tsconfig": "workspace:*",

--- a/apps/server/src/bootstrap.test.ts
+++ b/apps/server/src/bootstrap.test.ts
@@ -1,0 +1,217 @@
+import type { ServerType } from '@hono/node-server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ApiDeps } from '@marimo-hub/api';
+import { createInitializedBucket, makeTestDeps } from '@marimo-hub/api/testing';
+import { ConfigError } from '@marimo-hub/config';
+import { bootstrap } from './bootstrap';
+import type { BootstrapOverrides } from './bootstrap';
+import { startMaintenance, startSessionLifecycle } from './cron';
+import type { OtelHandle } from './otel';
+
+vi.mock('./cron', () => ({
+	startMaintenance: vi.fn(() => vi.fn()),
+	startSessionLifecycle: vi.fn(() => vi.fn()),
+}));
+
+type Signal = 'SIGTERM' | 'SIGINT';
+type PreflightReport = Awaited<ReturnType<NonNullable<ApiDeps['preflight']>>>;
+
+const BASE_ENV = { MARIMOHUB_STATIC_ROOT: './public' };
+
+function fakeServer(closeImmediately = true) {
+	const close = vi.fn((callback?: () => void) => {
+		if (closeImmediately) callback?.();
+	});
+	const closeIdleConnections = vi.fn();
+	const on = vi.fn();
+	const server = { close, closeIdleConnections, on } as unknown as ServerType;
+	return { server, close, closeIdleConnections };
+}
+
+function makeHarness(
+	deps: ApiDeps,
+	options: { closeImmediately?: boolean; otel?: OtelHandle | null } = {},
+) {
+	const server = fakeServer(options.closeImmediately);
+	const createDeps = vi.fn(() => deps);
+	const serveFn = vi.fn(() => server.server);
+	const exit = vi.fn<(code: number) => void>();
+	const signals = new Map<Signal, () => void>();
+	const registerSignal = vi.fn((signal: Signal, handler: () => void) => {
+		signals.set(signal, handler);
+		return () => signals.delete(signal);
+	});
+	const startOtelFn = vi.fn(() => options.otel ?? null);
+	const overrides = {
+		createDeps,
+		serveFn,
+		exit,
+		registerSignal,
+		startOtelFn,
+	} satisfies BootstrapOverrides;
+	return { ...server, createDeps, serveFn, exit, signals, startOtelFn, overrides };
+}
+
+describe('bootstrap', () => {
+	let deps: ApiDeps;
+
+	beforeEach(async () => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		deps = makeTestDeps(await createInitializedBucket());
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.mocked(startMaintenance).mockImplementation(() => vi.fn());
+		vi.mocked(startSessionLifecycle).mockImplementation(() => vi.fn());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.useRealTimers();
+	});
+
+	it('exits on a fatal preflight result without serving', async () => {
+		const report: PreflightReport = {
+			ok: false,
+			fatal: true,
+			checks: [
+				{
+					name: 'storage',
+					status: 'fail',
+					fatal: true,
+					message: 'conditional writes ignored',
+				},
+			],
+		};
+		deps.preflight = async () => report;
+		const harness = makeHarness(deps);
+
+		await expect(bootstrap(BASE_ENV, harness.overrides)).resolves.toBeUndefined();
+		expect(harness.exit).toHaveBeenCalledWith(1);
+		expect(harness.serveFn).not.toHaveBeenCalled();
+	});
+
+	it('serves after a non-fatal preflight failure', async () => {
+		const report: PreflightReport = {
+			ok: false,
+			fatal: false,
+			checks: [
+				{
+					name: 'storage',
+					status: 'fail',
+					fatal: false,
+					message: 'storage unavailable',
+				},
+			],
+		};
+		deps.preflight = async () => report;
+		const harness = makeHarness(deps);
+
+		await expect(bootstrap(BASE_ENV, harness.overrides)).resolves.toBeDefined();
+		expect(harness.serveFn).toHaveBeenCalledOnce();
+		expect(harness.exit).not.toHaveBeenCalled();
+	});
+
+	it('registers both drain signals without OpenTelemetry', async () => {
+		const harness = makeHarness(deps);
+
+		await bootstrap(BASE_ENV, harness.overrides);
+
+		expect([...harness.signals.keys()]).toEqual(['SIGTERM', 'SIGINT']);
+	});
+
+	it('closes connections and exits at the drain deadline', async () => {
+		const harness = makeHarness(deps, { closeImmediately: false });
+		await bootstrap(BASE_ENV, harness.overrides);
+
+		harness.signals.get('SIGTERM')?.();
+
+		expect(harness.close).toHaveBeenCalledOnce();
+		expect(harness.closeIdleConnections).toHaveBeenCalledOnce();
+		expect(harness.exit).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(9_999);
+		expect(harness.exit).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+		expect(harness.exit).toHaveBeenCalledWith(0);
+	});
+
+	it('flushes OpenTelemetry during drain', async () => {
+		const shutdown = vi.fn().mockResolvedValue(undefined);
+		const harness = makeHarness(deps, {
+			otel: { tracing: false, metrics: false, shutdown },
+		});
+		await bootstrap(BASE_ENV, harness.overrides);
+
+		harness.signals.get('SIGTERM')?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(shutdown).toHaveBeenCalledOnce();
+		expect(harness.exit).toHaveBeenCalledWith(0);
+	});
+
+	it.each([
+		['starts', 'true', 1],
+		['does not start', undefined, 0],
+	] as const)('%s maintenance loops when enabled is %s', async (_label, enabled, calls) => {
+		const harness = makeHarness(deps);
+		await bootstrap({ ...BASE_ENV, MARIMOHUB_RUN_MAINTENANCE: enabled }, harness.overrides);
+
+		expect(startMaintenance).toHaveBeenCalledTimes(calls);
+		expect(startSessionLifecycle).toHaveBeenCalledTimes(calls);
+	});
+
+	it('cancels maintenance loops before draining connections', async () => {
+		const stopMaintenance = vi.fn();
+		const stopLifecycle = vi.fn();
+		vi.mocked(startMaintenance).mockReturnValueOnce(stopMaintenance);
+		vi.mocked(startSessionLifecycle).mockReturnValueOnce(stopLifecycle);
+		const harness = makeHarness(deps);
+		await bootstrap({ ...BASE_ENV, MARIMOHUB_RUN_MAINTENANCE: 'true' }, harness.overrides);
+
+		harness.signals.get('SIGTERM')?.();
+
+		expect(stopMaintenance).toHaveBeenCalledOnce();
+		expect(stopLifecycle).toHaveBeenCalledOnce();
+		expect(stopMaintenance.mock.invocationCallOrder[0]).toBeLessThan(
+			harness.close.mock.invocationCallOrder[0],
+		);
+	});
+
+	it('exits on a configuration error without serving', async () => {
+		const harness = makeHarness(deps);
+		harness.createDeps.mockImplementationOnce(() => {
+			throw new ConfigError('missing storage backend');
+		});
+
+		await expect(bootstrap(BASE_ENV, harness.overrides)).resolves.toBeUndefined();
+		expect(harness.exit).toHaveBeenCalledWith(1);
+		expect(harness.serveFn).not.toHaveBeenCalled();
+		expect(console.error).toHaveBeenCalledWith(
+			expect.stringContaining('Configuration error: missing storage backend'),
+		);
+	});
+
+	it('exits on invalid server-owned environment without creating adapters', async () => {
+		const harness = makeHarness(deps);
+
+		await expect(
+			bootstrap({ ...BASE_ENV, PORT: 'not-a-port' }, harness.overrides),
+		).resolves.toBeUndefined();
+		expect(harness.exit).toHaveBeenCalledWith(1);
+		expect(harness.createDeps).not.toHaveBeenCalled();
+		expect(harness.serveFn).not.toHaveBeenCalled();
+	});
+
+	it('can be drained with await using without exiting the process', async () => {
+		const harness = makeHarness(deps);
+
+		{
+			await using handle = await bootstrap(BASE_ENV, harness.overrides);
+			expect(handle?.server).toBe(harness.server);
+		}
+
+		expect(harness.close).toHaveBeenCalledOnce();
+		expect(harness.exit).not.toHaveBeenCalled();
+		expect(harness.signals.size).toBe(0);
+	});
+});

--- a/apps/server/src/bootstrap.test.ts
+++ b/apps/server/src/bootstrap.test.ts
@@ -135,6 +135,32 @@ describe('bootstrap', () => {
 		expect(harness.exit).toHaveBeenCalledWith(0);
 	});
 
+	it('logs a warning and still exits 0 when the drain times out', async () => {
+		const harness = makeHarness(deps, { closeImmediately: false });
+		await bootstrap(BASE_ENV, harness.overrides);
+
+		harness.signals.get('SIGTERM')?.();
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(harness.exit).toHaveBeenCalledWith(0);
+		expect(console.log).toHaveBeenCalledWith(expect.stringContaining('"event":"drain_timeout"'));
+	});
+
+	it('logs an error and exits non-zero when the drain rejects', async () => {
+		vi.mocked(startMaintenance).mockReturnValueOnce(() => {
+			throw new Error('stop failed');
+		});
+		const harness = makeHarness(deps);
+		await bootstrap({ ...BASE_ENV, MARIMOHUB_RUN_MAINTENANCE: 'true' }, harness.overrides);
+
+		harness.signals.get('SIGTERM')?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(console.log).toHaveBeenCalledWith(expect.stringContaining('"event":"drain_failed"'));
+		expect(harness.exit).toHaveBeenCalledWith(1);
+		expect(harness.exit).not.toHaveBeenCalledWith(0);
+	});
+
 	it('flushes OpenTelemetry during drain', async () => {
 		const shutdown = vi.fn().mockResolvedValue(undefined);
 		const harness = makeHarness(deps, {

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -1,0 +1,185 @@
+import { serve } from '@hono/node-server';
+import type { ServerType } from '@hono/node-server';
+import { httpInstrumentationMiddleware } from '@hono/otel';
+import { secureHeaders } from 'hono/secure-headers';
+import type { ApiDeps } from '@marimo-hub/api';
+import { createApi } from '@marimo-hub/api';
+import { createFromEnv, isConfigError } from '@marimo-hub/config';
+import { startMaintenance, startSessionLifecycle } from './cron';
+import { validateServerEnv } from './env';
+import { logEvent } from './log';
+import { fanoutMetrics, OtelMetrics, WideEventMetrics } from './metrics';
+import { startOtel } from './otel';
+import { settleAllWithin } from './promise';
+import { serveSpaFallback, serveStaticWithCache } from './staticCache';
+import { attachSandboxProxyUpgrade } from './sandboxProxyWs';
+
+const DRAIN_TIMEOUT_MS = 10_000;
+
+type Signal = 'SIGTERM' | 'SIGINT';
+
+export interface BootstrapOverrides {
+	createDeps?: typeof createFromEnv;
+	serveFn?: typeof serve;
+	startOtelFn?: typeof startOtel;
+	exit?: (code: number) => void;
+	registerSignal?: (signal: Signal, handler: () => void) => void | (() => void);
+}
+
+export interface BootstrapHandle extends AsyncDisposable {
+	server: ServerType;
+	drain(): Promise<void>;
+}
+
+export async function bootstrap(
+	env: Record<string, string | undefined>,
+	overrides: BootstrapOverrides = {},
+): Promise<BootstrapHandle | undefined> {
+	const createDeps = overrides.createDeps ?? createFromEnv;
+	const serveFn = overrides.serveFn ?? serve;
+	const startOtelFn = overrides.startOtelFn ?? startOtel;
+	const exit = overrides.exit ?? ((code) => process.exit(code));
+	const registerSignal =
+		overrides.registerSignal ??
+		((signal: Signal, handler: () => void) => {
+			process.once(signal, handler);
+			return () => process.off(signal, handler);
+		});
+
+	// Telemetry sink: services emit CAS/reaper/snapshot signals here; the maintenance
+	// loop flushes them as one wide event per cycle (and request-path CAS contention
+	// surfaces at the next flush).
+	const wideEvents = new WideEventMetrics();
+
+	// Tracing + metrics (standard OTEL_* env vars); the global providers must
+	// register before requests are served.
+	const otel = startOtelFn();
+
+	// Fan domain metrics out to OTEL when its metrics pillar is on; the maintenance
+	// loop below still flushes `wideEvents` directly.
+	const metrics = otel?.metrics ? fanoutMetrics(wideEvents, new OtelMetrics()) : wideEvents;
+
+	// Config errors are deterministic — a restart can't fix them — so print a readable
+	// remediation block to stderr and exit. (Transient backend problems go through the
+	// non-fatal preflight below instead, so they never crashloop a replica.)
+	let validatedEnv: Record<string, string | undefined>;
+	let deps: ApiDeps;
+	try {
+		validatedEnv = validateServerEnv(env);
+		deps = createDeps(validatedEnv, metrics, { tracing: otel?.tracing ?? false });
+	} catch (err) {
+		if (isConfigError(err)) {
+			console.error(`\n${err.format()}\n`);
+			exit(1);
+			return undefined;
+		}
+		throw err;
+	}
+	// Installed for metrics-only mode too: RED metrics still record, spans don't.
+	if (otel)
+		deps.tracingMiddleware = httpInstrumentationMiddleware({ disableTracing: !otel.tracing });
+	const app = createApi(deps);
+
+	// Boot preflight: probe downstream deps (storage conditional-writes, OIDC
+	// discovery, WIF key, compute). Log each non-ok check, but DO NOT exit on a
+	// connectivity failure — a transient blip must not crashloop the pod. Exit only on
+	// a `fatal` result: a deterministic, unsafe-to-run misconfiguration (e.g. a store
+	// that ignores conditional writes, which would corrupt the catalog).
+	const report = await deps.preflight?.();
+	if (report) {
+		for (const check of report.checks) {
+			if (check.status === 'ok' || check.status === 'skipped') continue;
+			logEvent({
+				level: check.status === 'fail' ? 'error' : 'warn',
+				event: 'preflight_check',
+				check: check.name,
+				status: check.status,
+				message: check.message,
+				remediation: check.remediation,
+				fatal: check.fatal ?? false,
+				latencyMs: check.latencyMs,
+			});
+		}
+		logEvent({ level: 'info', event: 'preflight_complete', ok: report.ok, fatal: report.fatal });
+		if (report.fatal) {
+			logEvent({ level: 'error', event: 'boot_failed', reason: 'preflight_fatal' });
+			exit(1);
+			return undefined;
+		}
+	}
+
+	// Security headers for the SPA/static responses: anti-clickjacking
+	// (X-Frame-Options: SAMEORIGIN), MIME-sniffing (nosniff), HSTS, Referrer-Policy,
+	// and cross-origin isolation defaults. Registered after createApi, so it wraps the
+	// fall-through static/HTML responses (the framing/XSS-delivery surface); the
+	// terminal /api/* JSON routes inside createApi are unaffected. No CSP is set here —
+	// a tuned CSP (allowing the font CDN + the sandbox iframe origin) is a follow-up.
+	app.use('*', secureHeaders());
+
+	// Serve the prebuilt SPA. API routes (registered inside createApi) are terminal,
+	// so they take precedence; everything else falls through to static assets, with
+	// a single-page-app fallback to index.html.
+	const staticRoot = validatedEnv.MARIMOHUB_STATIC_ROOT ?? './public';
+	app.use('/*', serveStaticWithCache({ root: staticRoot }));
+	app.get('*', serveSpaFallback(staticRoot));
+
+	// Maintenance + session-lifecycle loops — run on a single replica (the
+	// marimohub-maintenance Deployment). The bucket-CAS leases inside are
+	// defense-in-depth guards.
+	const stops: (() => void)[] = [];
+	if (validatedEnv.MARIMOHUB_RUN_MAINTENANCE === 'true') {
+		stops.push(startMaintenance(deps, wideEvents));
+		const stopLifecycle = startSessionLifecycle(deps);
+		if (stopLifecycle) stops.push(stopLifecycle);
+	}
+
+	const port = Number(validatedEnv.PORT ?? 3000);
+	const server = serveFn({ fetch: app.fetch, port }, (info) => {
+		console.log(`[marimohub] server listening on :${info.port}`);
+	});
+
+	// In `proxy` exposure mode, forward `…/proxy/<token>/` WebSocket upgrades to the
+	// kernel (the HTTP side is handled inside `app.fetch`). A no-op otherwise.
+	attachSandboxProxyUpgrade(server, deps);
+
+	const unregisterSignals: (() => void)[] = [];
+	let drainPromise: Promise<void> | undefined;
+	const drain = (): Promise<void> => {
+		drainPromise ??= (async () => {
+			for (const unregisterSignal of unregisterSignals.splice(0)) unregisterSignal();
+			// Cancel future ticks first. An in-flight sweep still has the remaining drain
+			// window to release its lease; the lease TTL is the fallback if it outlives it.
+			for (const stopLoop of stops) stopLoop();
+
+			const closed = new Promise<void>((resolve) => {
+				server.close(() => resolve());
+			});
+			if ('closeIdleConnections' in server) server.closeIdleConnections();
+
+			// Long-lived WebSockets can keep close pending indefinitely. Ten seconds stays
+			// below Kubernetes' default 30-second termination grace period.
+			await settleAllWithin(
+				[closed, ...(otel ? [Promise.resolve().then(() => otel.shutdown())] : [])],
+				DRAIN_TIMEOUT_MS,
+			);
+		})();
+		return drainPromise;
+	};
+
+	const handle: BootstrapHandle = {
+		server,
+		drain,
+		[Symbol.asyncDispose]: drain,
+	};
+	const drainAndExit = () => {
+		void drain().then(
+			() => exit(0),
+			() => exit(0),
+		);
+	};
+	for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+		const unregisterSignal = registerSignal(signal, drainAndExit);
+		if (unregisterSignal) unregisterSignals.push(unregisterSignal);
+	}
+	return handle;
+}

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -158,10 +158,14 @@ export async function bootstrap(
 
 			// Long-lived WebSockets can keep close pending indefinitely. Ten seconds stays
 			// below Kubernetes' default 30-second termination grace period.
-			await settleAllWithin(
+			const result = await settleAllWithin(
 				[closed, ...(otel ? [Promise.resolve().then(() => otel.shutdown())] : [])],
 				DRAIN_TIMEOUT_MS,
 			);
+			// A timed-out drain still resolves (settleAllWithin never rejects), so surface it
+			// here or the forced termination looks like a clean shutdown.
+			if (result === 'timed-out')
+				logEvent({ level: 'warn', event: 'drain_timeout', timeoutMs: DRAIN_TIMEOUT_MS });
 		})();
 		return drainPromise;
 	};
@@ -174,7 +178,14 @@ export async function bootstrap(
 	const drainAndExit = () => {
 		void drain().then(
 			() => exit(0),
-			() => exit(0),
+			(err: unknown) => {
+				logEvent({
+					level: 'error',
+					event: 'drain_failed',
+					message: err instanceof Error ? err.message : String(err),
+				});
+				exit(1);
+			},
 		);
 	};
 	for (const signal of ['SIGTERM', 'SIGINT'] as const) {

--- a/apps/server/src/env.test.ts
+++ b/apps/server/src/env.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { ConfigError } from '@marimo-hub/config';
+import { validateServerEnv } from './env';
+
+function getConfigError(run: () => unknown): ConfigError {
+	try {
+		run();
+	} catch (error) {
+		expect(error).toBeInstanceOf(ConfigError);
+		return error as ConfigError;
+	}
+	throw new Error('Expected ConfigError');
+}
+
+describe('validateServerEnv', () => {
+	it('preserves known and unknown variables unchanged', () => {
+		const env = {
+			PORT: '4321',
+			MARIMOHUB_STATIC_ROOT: './public',
+			MARIMOHUB_RUN_MAINTENANCE: 'false',
+			MARIMOHUB_STORAGE_BACKEND: 'memory',
+			OTEL_EXPORTER_OTLP_ENDPOINT: 'http://collector:4318',
+		};
+
+		expect(validateServerEnv(env)).toBe(env);
+	});
+
+	it.each([
+		['PORT', 'abc', 'expected an integer from 1 to 65535'],
+		['PORT', '0', 'expected an integer from 1 to 65535'],
+		['PORT', '65536', 'expected an integer from 1 to 65535'],
+		['MARIMOHUB_STATIC_ROOT', '   ', 'expected a non-empty path'],
+		['MARIMOHUB_RUN_MAINTENANCE', 'yes', 'expected true or false'],
+	] as const)('rejects invalid %s=%s', (variable, value, message) => {
+		const error = getConfigError(() => validateServerEnv({ [variable]: value }));
+
+		expect(error.opts.variable).toBe(variable);
+		expect(error.message).toContain(message);
+	});
+
+	it.each(['1', '65535'])('accepts PORT=%s', (value) => {
+		expect(validateServerEnv({ PORT: value })).toEqual({ PORT: value });
+	});
+});

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { ConfigError } from '@marimo-hub/config';
+
+export type ServerEnv = Record<string, string | undefined>;
+
+const port = z
+	.string()
+	.refine(
+		(value) => /^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 65_535,
+		'expected an integer from 1 to 65535',
+	);
+
+export const ServerEnvSchema = z.looseObject({
+	PORT: port.optional(),
+	MARIMOHUB_STATIC_ROOT: z
+		.string()
+		.refine((value) => value.trim().length > 0, 'expected a non-empty path')
+		.optional(),
+	MARIMOHUB_RUN_MAINTENANCE: z
+		.string()
+		.refine((value) => value === 'true' || value === 'false', 'expected true or false')
+		.optional(),
+});
+
+export function validateServerEnv(env: ServerEnv): ServerEnv {
+	const result = ServerEnvSchema.safeParse(env);
+	if (result.success) return env;
+
+	const issue = result.error.issues[0];
+	const variable = String(issue?.path[0] ?? 'server environment');
+	throw new ConfigError(`Invalid ${variable}: ${env[variable]} (${issue?.message})`, { variable });
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -6,18 +6,8 @@
  * prebuilt SPA, and runs session maintenance. The API tier is stateless — all
  * state lives in object storage + compute — so this scales horizontally.
  */
-import { serve } from '@hono/node-server';
-import { httpInstrumentationMiddleware } from '@hono/otel';
-import { secureHeaders } from 'hono/secure-headers';
-import type { ApiDeps } from '@marimo-hub/api';
-import { createApi } from '@marimo-hub/api';
-import { createFromEnv, isConfigError } from '@marimo-hub/config';
-import { startMaintenance, startSessionLifecycle } from './cron';
+import { bootstrap } from './bootstrap';
 import { logEvent } from './log';
-import { fanoutMetrics, OtelMetrics, WideEventMetrics } from './metrics';
-import { startOtel } from './otel';
-import { serveSpaFallback, serveStaticWithCache } from './staticCache';
-import { attachSandboxProxyUpgrade } from './sandboxProxyWs';
 
 // Process-level safety net. A rejected promise with no catch handler — e.g. a
 // transient CoreWeave sandbox gRPC stream reset (ECONNRESET) that surfaces after
@@ -47,112 +37,11 @@ process.on('uncaughtException', (err) => {
 	process.exit(1);
 });
 
-// Telemetry sink: services emit CAS/reaper/snapshot signals here; the maintenance
-// loop flushes them as one wide event per cycle (and request-path CAS contention
-// surfaces at the next flush).
-const wideEvents = new WideEventMetrics();
-
-// Tracing + metrics (standard OTEL_* env vars); the global providers must
-// register before requests are served.
-const otel = startOtel();
-
-// Fan domain metrics out to OTEL when its metrics pillar is on; the maintenance
-// loop below still flushes `wideEvents` directly.
-const metrics = otel?.metrics ? fanoutMetrics(wideEvents, new OtelMetrics()) : wideEvents;
-
-// Config errors are deterministic — a restart can't fix them — so print a readable
-// remediation block to stderr and exit. (Transient backend problems go through the
-// non-fatal preflight below instead, so they never crashloop a replica.)
-let deps: ApiDeps;
-try {
-	deps = createFromEnv(process.env, metrics, { tracing: otel?.tracing ?? false });
-} catch (err) {
-	if (isConfigError(err)) {
-		console.error(`\n${err.format()}\n`);
-		process.exit(1);
-	}
-	throw err;
-}
-// Installed for metrics-only mode too: RED metrics still record, spans don't.
-if (otel) deps.tracingMiddleware = httpInstrumentationMiddleware({ disableTracing: !otel.tracing });
-const app = createApi(deps);
-
-// Boot preflight: probe downstream deps (storage conditional-writes, OIDC
-// discovery, WIF key, compute). Log each non-ok check, but DO NOT exit on a
-// connectivity failure — a transient blip must not crashloop the pod. Exit only on
-// a `fatal` result: a deterministic, unsafe-to-run misconfiguration (e.g. a store
-// that ignores conditional writes, which would corrupt the catalog).
-const report = await deps.preflight?.();
-if (report) {
-	for (const check of report.checks) {
-		if (check.status === 'ok' || check.status === 'skipped') continue;
-		logEvent({
-			level: check.status === 'fail' ? 'error' : 'warn',
-			event: 'preflight_check',
-			check: check.name,
-			status: check.status,
-			message: check.message,
-			remediation: check.remediation,
-			fatal: check.fatal ?? false,
-			latencyMs: check.latencyMs,
-		});
-	}
-	logEvent({ level: 'info', event: 'preflight_complete', ok: report.ok, fatal: report.fatal });
-	if (report.fatal) {
-		logEvent({ level: 'error', event: 'boot_failed', reason: 'preflight_fatal' });
-		process.exit(1);
-	}
-}
-
-// Security headers for the SPA/static responses: anti-clickjacking
-// (X-Frame-Options: SAMEORIGIN), MIME-sniffing (nosniff), HSTS, Referrer-Policy,
-// and cross-origin isolation defaults. Registered after createApi, so it wraps the
-// fall-through static/HTML responses (the framing/XSS-delivery surface); the
-// terminal /api/* JSON routes inside createApi are unaffected. No CSP is set here —
-// a tuned CSP (allowing the font CDN + the sandbox iframe origin) is a follow-up.
-app.use('*', secureHeaders());
-
-// Serve the prebuilt SPA. API routes (registered inside createApi) are terminal,
-// so they take precedence; everything else falls through to static assets, with
-// a single-page-app fallback to index.html.
-const staticRoot = process.env.MARIMOHUB_STATIC_ROOT ?? './public';
-app.use('/*', serveStaticWithCache({ root: staticRoot }));
-app.get('*', serveSpaFallback(staticRoot));
-
-// Maintenance + session-lifecycle loops — run on a single replica (the
-// marimohub-maintenance Deployment). The bucket-CAS leases inside are
-// defense-in-depth guards.
-if (process.env.MARIMOHUB_RUN_MAINTENANCE === 'true') {
-	startMaintenance(deps, wideEvents);
-	startSessionLifecycle(deps);
-}
-
-const port = Number(process.env.PORT ?? 3000);
-const server = serve({ fetch: app.fetch, port }, (info) => {
-	console.log(`[marimohub] server listening on :${info.port}`);
+// Keep server-owned env reads at the process boundary, where the config registry
+// inventories them; adapter env remains opaque to this entrypoint.
+await bootstrap({
+	...process.env,
+	PORT: process.env.PORT,
+	MARIMOHUB_STATIC_ROOT: process.env.MARIMOHUB_STATIC_ROOT,
+	MARIMOHUB_RUN_MAINTENANCE: process.env.MARIMOHUB_RUN_MAINTENANCE,
 });
-
-// In `proxy` exposure mode, forward `…/proxy/<token>/` WebSocket upgrades to the
-// kernel (the HTTP side is handled inside `app.fetch`). A no-op otherwise.
-attachSandboxProxyUpgrade(server, deps);
-
-// Drain on shutdown: let in-flight requests finish and flush buffered spans and
-// metrics, bounded so long-lived sockets (WS kernel proxies) can't hold the pod
-// past its termination grace window. Registered only when telemetry is enabled
-// so the default signal semantics are unchanged otherwise.
-if (otel) {
-	const drain = () => {
-		const closed = new Promise<void>((resolve) => {
-			server.close(() => resolve());
-		});
-		if ('closeIdleConnections' in server) server.closeIdleConnections();
-		void Promise.race([
-			Promise.allSettled([closed, otel.shutdown()]),
-			new Promise((resolve) => {
-				setTimeout(resolve, 10_000);
-			}),
-		]).then(() => process.exit(0));
-	};
-	process.once('SIGTERM', drain);
-	process.once('SIGINT', drain);
-}

--- a/apps/server/src/promise.test.ts
+++ b/apps/server/src/promise.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { settleAllWithin } from './promise';
+
+describe('settleAllWithin', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('finishes when every promise settles and clears the deadline', async () => {
+		await expect(
+			settleAllWithin([Promise.resolve(), Promise.reject(new Error('ignored'))], 10_000),
+		).resolves.toBe('settled');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('finishes at the deadline when work remains pending', async () => {
+		const result = settleAllWithin([new Promise(() => {})], 10_000);
+		const resolved = vi.fn();
+		void result.then(resolved);
+
+		await vi.advanceTimersByTimeAsync(9_999);
+		expect(resolved).not.toHaveBeenCalled();
+		await vi.advanceTimersByTimeAsync(1);
+
+		await expect(result).resolves.toBe('timed-out');
+		expect(vi.getTimerCount()).toBe(0);
+	});
+});

--- a/apps/server/src/promise.ts
+++ b/apps/server/src/promise.ts
@@ -1,0 +1,18 @@
+export type SettleWithinResult = 'settled' | 'timed-out';
+
+export async function settleAllWithin(
+	promises: Iterable<PromiseLike<unknown>>,
+	timeoutMs: number,
+): Promise<SettleWithinResult> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timedOut = new Promise<'timed-out'>((resolve) => {
+		timer = setTimeout(() => resolve('timed-out'), timeoutMs);
+	});
+	const settled = Promise.allSettled(promises).then(() => 'settled' as const);
+
+	try {
+		return await Promise.race([settled, timedOut]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -301,6 +301,9 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.12.31
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@marimo-hub/tsconfig':
         specifier: workspace:*


### PR DESCRIPTION
Extracts server composition out of `apps/server/src/index.ts` into a `bootstrap()` function so boot ordering, preflight handling, and graceful drain are unit-testable via injected overrides (`createDeps`, `serveFn`, `startOtelFn`, `exit`, `registerSignal`).

- `bootstrap.ts` — composition + lifecycle, returns an `AsyncDisposable` handle with `drain()`.
- `env.ts` — zod validation of server-owned env (`PORT`, `MARIMOHUB_STATIC_ROOT`, `MARIMOHUB_RUN_MAINTENANCE`) at the process boundary; adapter env stays opaque.
- `promise.ts` — bounded `settleAllWithin` helper backing the drain timeout.
- `index.ts` — now just the process-level safety nets + a `bootstrap(process.env)` call.