### PR TITLE
feat(data-browser): raw S3 object browsing over integrations

### DIFF
--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -1254,6 +1254,13 @@ components:
           type: boolean
         supports_browse:
           type: boolean
+        browse_surfaces:
+          type: array
+          items:
+            type: string
+            enum:
+              - tables
+              - objects
         secret_sources:
           type: object
           properties:
@@ -1304,6 +1311,7 @@ components:
         - ui_hints
         - supports_test
         - supports_browse
+        - browse_surfaces
         - secret_sources
         - requirements
     IntegrationPage:
@@ -1479,6 +1487,49 @@ components:
     IntegrationBrowseCapability:
       type: object
       properties:
+        surfaces:
+          type: object
+          properties:
+            tables:
+              type: object
+              properties:
+                available:
+                  type: boolean
+                preview:
+                  type: boolean
+                reason:
+                  type: string
+              required:
+                - available
+                - preview
+            objects:
+              type: object
+              properties:
+                available:
+                  type: boolean
+                preview:
+                  type: boolean
+                download:
+                  type: boolean
+                search:
+                  type: string
+                  enum:
+                    - bounded-key-name
+                versions:
+                  type: boolean
+                preview_formats:
+                  type: array
+                  items:
+                    type: string
+                reason:
+                  type: string
+              required:
+                - available
+                - preview
+                - download
+                - search
+                - versions
+                - preview_formats
         metadata:
           type: boolean
         preview:
@@ -1486,6 +1537,7 @@ components:
         reason:
           type: string
       required:
+        - surfaces
         - metadata
         - preview
     IntegrationBrowseNamespacePage:

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -10,6 +10,7 @@ import {
 	UnavailableError,
 	zSecret,
 } from '@marimo-hub/core';
+import type { ObjectBrowser } from '@marimo-hub/core';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
 import { ACTOR, uid } from '@marimo-hub/core/testing';
 import { createInitializedBucket, createTestApi, expectError, expectOk } from '../testing';
@@ -74,13 +75,50 @@ const sandboxBrowsyKind = defineIntegration({
 	},
 });
 
+const objectBrowser: ObjectBrowser = {
+	capability: () => ({
+		available: true,
+		preview: false,
+		download: false,
+		search: 'bounded-key-name',
+		versions: true,
+		preview_formats: [],
+	}),
+	listBuckets: async () => ({ items: [], next_cursor: null }),
+	listObjects: async () => ({ items: [], next_cursor: null }),
+	searchObjects: async () => ({ items: [], next_cursor: null, scanned: 0, complete: true }),
+	headObject: async (_source, _context, request) => ({
+		...request,
+		size: 0,
+		checksums: [],
+		metadata: {},
+		tags_available: false,
+	}),
+	listVersions: async () => ({ items: [], next_cursor: null }),
+	previewObject: async () => ({
+		kind: 'unsupported',
+		reason: 'disabled',
+		total_bytes: 0,
+	}),
+	openObject: async () => {
+		throw new Error('not used');
+	},
+};
+
 function browserDeps(bucket: MemoryBucket) {
 	const registry = new IntegrationRegistry();
 	registry.register(browsyKind);
 	registry.register(sandboxBrowsyKind);
 	for (const def of defaultRegistry().list()) registry.register(def);
 	const stubProbe = { fetch: () => Promise.reject(new Error('no network in tests')) };
-	const options = { bucket, registry, codec, probe: stubProbe, browseProbe: stubProbe };
+	const options = {
+		bucket,
+		registry,
+		codec,
+		probe: stubProbe,
+		browseProbe: stubProbe,
+		objectBrowsers: { s3: objectBrowser },
+	};
 	return {
 		integrations: new ProjectIntegrationsStore(options),
 		orgIntegrations: new OrgIntegrationsStore(options),
@@ -136,7 +174,11 @@ describe('Data browser routes', () => {
 		const capability = await expectOk<Record<string, unknown>>(
 			await request('GET', `/projects/${pid}/integrations/${created.id}/browse`),
 		);
-		expect(capability).toEqual({ metadata: true, preview: false });
+		expect(capability).toEqual({
+			metadata: true,
+			preview: false,
+			surfaces: { tables: { available: true, preview: false } },
+		});
 
 		const closed = await expectOk<{ id: string }>(
 			await request('POST', `/projects/${pid}/integrations`, {
@@ -149,7 +191,39 @@ describe('Data browser routes', () => {
 		const closedCapability = await expectOk<Record<string, unknown>>(
 			await request('GET', `/projects/${pid}/integrations/${closed.id}/browse`),
 		);
-		expect(closedCapability).toEqual({ metadata: false, preview: false, reason: 'sandbox only' });
+		expect(closedCapability).toEqual({
+			metadata: false,
+			preview: false,
+			reason: 'sandbox only',
+			surfaces: { tables: { available: false, preview: false, reason: 'sandbox only' } },
+		});
+	});
+
+	it('does not advertise object-only instances until object routes are available', async () => {
+		const pid = await createProject();
+		const created = await expectOk<{ id: string }>(
+			await request('POST', `/projects/${pid}/integrations`, {
+				kind: 's3',
+				name: 'objects',
+				config: {
+					bucket: 'lake',
+					auth: {
+						method: 'static',
+						access_key_id: 'access',
+						secret_access_key: 'secret',
+					},
+				},
+			}),
+			201,
+		);
+		const capability = await expectOk<Record<string, unknown>>(
+			await request('GET', `/projects/${pid}/integrations/${created.id}/browse`),
+		);
+		expect(capability).toEqual({
+			metadata: false,
+			preview: false,
+			surfaces: {},
+		});
 	});
 
 	it('previews rows on demand with no-store and appends an audit event', async () => {
@@ -160,7 +234,11 @@ describe('Data browser routes', () => {
 		const capability = await expectOk<Record<string, unknown>>(
 			await request('GET', `/projects/${pid}/integrations/${created.id}/browse`),
 		);
-		expect(capability).toEqual({ metadata: true, preview: true });
+		expect(capability).toEqual({
+			metadata: true,
+			preview: true,
+			surfaces: { tables: { available: true, preview: true } },
+		});
 
 		const response = await request(
 			'POST',
@@ -277,9 +355,17 @@ describe('Data browser routes', () => {
 		}).request;
 		const url = `/projects/${pid}/integrations/${selected.id}/browse`;
 
-		expect(await expectOk(await full('GET', url))).toEqual({ metadata: true, preview: false });
+		expect(await expectOk(await full('GET', url))).toEqual({
+			metadata: true,
+			preview: false,
+			surfaces: { tables: { available: true, preview: false } },
+		});
 		ready = true;
-		expect(await expectOk(await full('GET', url))).toEqual({ metadata: true, preview: true });
+		expect(await expectOk(await full('GET', url))).toEqual({
+			metadata: true,
+			preview: true,
+			surfaces: { tables: { available: true, preview: true } },
+		});
 	});
 
 	it('injects project WIF credentials into sandbox previews', async () => {
@@ -626,7 +712,11 @@ describe('Data browser routes', () => {
 		const capability = await expectOk<Record<string, unknown>>(
 			await request('GET', `/projects/${pid}/integrations/${orgInstance.id}/browse`),
 		);
-		expect(capability).toEqual({ metadata: true, preview: false });
+		expect(capability).toEqual({
+			metadata: true,
+			preview: false,
+			surfaces: { tables: { available: true, preview: false } },
+		});
 
 		await createBrowsable(pid, 'shared-lake');
 		await expectError(

--- a/packages/api/src/routes/integrations.test.ts
+++ b/packages/api/src/routes/integrations.test.ts
@@ -78,7 +78,10 @@ describe('Integrations routes', () => {
 			category: 'database',
 			schema_version: 2,
 			json_schema: { type: 'object' },
+			browse_surfaces: [],
 		});
+		const s3 = kinds.find((k) => k.kind === 's3');
+		expect(s3).toMatchObject({ supports_browse: false, browse_surfaces: [] });
 	});
 
 	it('create → get returns a redacted config; the plaintext never appears anywhere', async () => {

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -93,6 +93,7 @@ const KindDescriptorSchema = z
 		),
 		supports_test: z.boolean(),
 		supports_browse: z.boolean(),
+		browse_surfaces: z.array(z.enum(['tables', 'objects'])),
 		secret_sources: z.object({
 			inline: z.boolean(),
 			references: z.array(
@@ -413,6 +414,26 @@ const BrowsePageQuery = z.object({
 
 const BrowseCapabilitySchema = z
 	.object({
+		surfaces: z.object({
+			tables: z
+				.object({
+					available: z.boolean(),
+					preview: z.boolean(),
+					reason: z.string().optional(),
+				})
+				.optional(),
+			objects: z
+				.object({
+					available: z.boolean(),
+					preview: z.boolean(),
+					download: z.boolean(),
+					search: z.literal('bounded-key-name'),
+					versions: z.boolean(),
+					preview_formats: z.array(z.string()),
+					reason: z.string().optional(),
+				})
+				.optional(),
+		}),
 		/** Whether namespace/table/schema browsing works for this instance. */
 		metadata: z.boolean(),
 		/** Whether row preview is available for this instance. */
@@ -841,7 +862,11 @@ const app = createApp();
 
 app.openapi(listKinds, (c) => {
 	const integrations = requireIntegrations(c.get('deps'));
-	return c.json({ success: true as const, data: integrations.listKinds() }, 200);
+	const data = integrations.listKinds().map((kind) => {
+		const browse_surfaces = kind.browse_surfaces.filter((surface) => surface === 'tables');
+		return { ...kind, browse_surfaces, supports_browse: browse_surfaces.length > 0 };
+	});
+	return c.json({ success: true as const, data }, 200);
 });
 
 app.openapi(listIntegrations, async (c) => {
@@ -1081,15 +1106,24 @@ app.openapi(browseCapability, async (c) => {
 	const { integrations, preview } = requireDataBrowser(deps);
 	await assertProjectRole(deps.services.projects, pid, user, 'editor', deps.policy);
 	const capability = await integrations.browseCapability(pid, iid);
+	const tablePreview =
+		preview &&
+		capability.metadata &&
+		(capability.hub_preview || deps.dataBrowser?.sandboxPreview?.available() === true);
 	return c.json(
 		{
 			success: true,
 			data: {
+				surfaces: capability.surfaces.tables
+					? {
+							tables: {
+								...capability.surfaces.tables,
+								preview: tablePreview,
+							},
+						}
+					: {},
 				metadata: capability.metadata,
-				preview:
-					preview &&
-					capability.metadata &&
-					(capability.hub_preview || deps.dataBrowser?.sandboxPreview?.available() === true),
+				preview: tablePreview,
 				...(capability.reason !== undefined ? { reason: capability.reason } : {}),
 			},
 		},

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -7732,6 +7732,7 @@ export interface components {
 			};
 			supports_test: boolean;
 			supports_browse: boolean;
+			browse_surfaces: ('tables' | 'objects')[];
 			secret_sources: {
 				inline: boolean;
 				references: {
@@ -7812,6 +7813,23 @@ export interface components {
 					id: string;
 			  };
 		IntegrationBrowseCapability: {
+			surfaces: {
+				tables?: {
+					available: boolean;
+					preview: boolean;
+					reason?: string;
+				};
+				objects?: {
+					available: boolean;
+					preview: boolean;
+					download: boolean;
+					/** @enum {string} */
+					search: 'bounded-key-name';
+					versions: boolean;
+					preview_formats: string[];
+					reason?: string;
+				};
+			};
 			metadata: boolean;
 			preview: boolean;
 			reason?: string;

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -36,6 +36,7 @@
 		"@marimo-hub/notify-slack": "workspace:*",
 		"@marimo-hub/notify-smtp": "workspace:*",
 		"@marimo-hub/notify-webhook": "workspace:*",
+		"@marimo-hub/object-browser-s3": "workspace:*",
 		"@marimo-hub/secrets-aws": "workspace:*",
 		"@marimo-hub/storage-azure": "workspace:*",
 		"@marimo-hub/storage-fs": "workspace:*",

--- a/packages/config/src/env.test.ts
+++ b/packages/config/src/env.test.ts
@@ -5,6 +5,7 @@ import {
 	parseEnumOr,
 	parseIntEnv,
 	parseList,
+	parseSecondsEnv,
 	readFolded,
 	required,
 	requiredVar,
@@ -74,6 +75,18 @@ describe('parseIntEnv', () => {
 
 	it.each(['1.5', 'abc', '10px'])('throws ConfigError on the non-integer %o', (value) => {
 		expect(() => parseIntEnv({ N: value }, 'N')).toThrow(ConfigError);
+	});
+});
+
+describe('parseSecondsEnv', () => {
+	it('uses a default and converts integer seconds to milliseconds', () => {
+		expect(parseSecondsEnv({}, 'TIMEOUT', { dflt: 30 })).toBe(30_000);
+		expect(parseSecondsEnv({ TIMEOUT: '2' }, 'TIMEOUT')).toBe(2_000);
+	});
+
+	it('supports an explicit zero only when allowed', () => {
+		expect(parseSecondsEnv({ TIMEOUT: '0' }, 'TIMEOUT', { allowZero: true })).toBe(0);
+		expect(() => parseSecondsEnv({ TIMEOUT: '0' }, 'TIMEOUT')).toThrow(ConfigError);
 	});
 });
 

--- a/packages/config/src/env.test.ts
+++ b/packages/config/src/env.test.ts
@@ -88,6 +88,15 @@ describe('parseSecondsEnv', () => {
 		expect(parseSecondsEnv({ TIMEOUT: '0' }, 'TIMEOUT', { allowZero: true })).toBe(0);
 		expect(() => parseSecondsEnv({ TIMEOUT: '0' }, 'TIMEOUT')).toThrow(ConfigError);
 	});
+
+	it.each(['9007199254740992', '9007199254741'])('rejects the unsafe duration %s', (value) => {
+		expect(() => parseSecondsEnv({ TIMEOUT: value }, 'TIMEOUT')).toThrow(/safe integer/);
+	});
+
+	it('enforces an optional upper bound', () => {
+		expect(parseSecondsEnv({ TIMEOUT: '60' }, 'TIMEOUT', { max: 60 })).toBe(60_000);
+		expect(() => parseSecondsEnv({ TIMEOUT: '61' }, 'TIMEOUT', { max: 60 })).toThrow(/<= 60/);
+	});
 });
 
 describe('readFolded', () => {

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -58,27 +58,37 @@ export function parseIntEnv(env: Env, key: string): number | undefined {
 export function parseSecondsEnv(
 	env: Env,
 	key: string,
-	opts: { dflt: number; allowZero?: boolean },
+	opts: { dflt: number; allowZero?: boolean; max?: number },
 ): Millis;
 export function parseSecondsEnv(
 	env: Env,
 	key: string,
-	opts?: { dflt?: number; allowZero?: boolean },
+	opts?: { dflt?: number; allowZero?: boolean; max?: number },
 ): Millis | undefined;
 export function parseSecondsEnv(
 	env: Env,
 	key: string,
-	opts?: { dflt?: number; allowZero?: boolean },
+	opts?: { dflt?: number; allowZero?: boolean; max?: number },
 ): Millis | undefined {
 	const seconds = parseIntEnv(env, key) ?? opts?.dflt;
 	if (seconds === undefined) return undefined;
 	const minimum = opts?.allowZero ? 0 : 1;
-	if (seconds < minimum) {
-		throw new ConfigError(`Invalid ${key}: ${seconds} (expected an integer >= ${minimum})`, {
-			variable: key,
-		});
+	const milliseconds = seconds * 1000;
+	if (
+		!Number.isSafeInteger(seconds) ||
+		!Number.isSafeInteger(milliseconds) ||
+		seconds < minimum ||
+		(opts?.max !== undefined && seconds > opts.max)
+	) {
+		const maximum = opts?.max === undefined ? '' : ` and <= ${opts.max}`;
+		throw new ConfigError(
+			`Invalid ${key}: ${seconds} (expected a safe integer >= ${minimum}${maximum})`,
+			{
+				variable: key,
+			},
+		);
 	}
-	return Millis.seconds(seconds);
+	return Millis.of(milliseconds);
 }
 
 /** Read an env value case-folded (trimmed + lowercased); undefined when unset or blank. */

--- a/packages/config/src/env.ts
+++ b/packages/config/src/env.ts
@@ -1,5 +1,5 @@
 /** Shared env-reading primitives used by every `make*` config module. */
-import { foldCase } from '@marimo-hub/core';
+import { foldCase, Millis } from '@marimo-hub/core';
 import { ConfigError } from './errors';
 import type { ConfigErrorOptions } from './errors';
 
@@ -53,6 +53,32 @@ export function parseIntEnv(env: Env, key: string): number | undefined {
 	if (!Number.isInteger(n))
 		throw new ConfigError(`Invalid ${key}: ${raw} (expected an integer)`, { variable: key });
 	return n;
+}
+
+export function parseSecondsEnv(
+	env: Env,
+	key: string,
+	opts: { dflt: number; allowZero?: boolean },
+): Millis;
+export function parseSecondsEnv(
+	env: Env,
+	key: string,
+	opts?: { dflt?: number; allowZero?: boolean },
+): Millis | undefined;
+export function parseSecondsEnv(
+	env: Env,
+	key: string,
+	opts?: { dflt?: number; allowZero?: boolean },
+): Millis | undefined {
+	const seconds = parseIntEnv(env, key) ?? opts?.dflt;
+	if (seconds === undefined) return undefined;
+	const minimum = opts?.allowZero ? 0 : 1;
+	if (seconds < minimum) {
+		throw new ConfigError(`Invalid ${key}: ${seconds} (expected an integer >= ${minimum})`, {
+			variable: key,
+		});
+	}
+	return Millis.seconds(seconds);
 }
 
 /** Read an env value case-folded (trimmed + lowercased); undefined when unset or blank. */

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -49,7 +49,7 @@ import { makeNotifier } from './notifications';
 import { makeStorage, makeSandboxBucketConfig, storageBackend } from './storage';
 import { makeWif } from './wif';
 import { makeSandboxUserHome } from './userHome';
-import { parseEnum, parseEnumOr, parseIntEnv, parseList } from './env';
+import { parseEnum, parseEnumOr, parseIntEnv, parseList, parseSecondsEnv } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
 import { checkSandboxHostIsolation } from './hostIsolation';
@@ -164,37 +164,6 @@ const DEFAULT_SESSION_IDLE_TIMEOUT_S = 1800; // 30m no-editors idle reap
 const DEFAULT_SESSION_SNAPSHOT_INTERVAL_S = 120; // 2m periodic-save floor
 const DEFAULT_SESSION_LIFETIME_EXTENSION_S = 1800; // 30m slide while editors connected
 const DEFAULT_SESSION_SWEEP_INTERVAL_S = 60;
-
-/**
- * An integer-seconds env var as `Millis`. `dflt` fills in when unset (omitted:
- * unset stays undefined). Below the floor — 1, or 0 with `allowZero` — throws,
- * so every seconds-valued knob validates and words its error identically.
- */
-function parseSecondsEnv(
-	env: Env,
-	key: string,
-	opts: { dflt: number; allowZero?: boolean },
-): Millis;
-function parseSecondsEnv(
-	env: Env,
-	key: string,
-	opts?: { dflt?: number; allowZero?: boolean },
-): Millis | undefined;
-function parseSecondsEnv(
-	env: Env,
-	key: string,
-	opts?: { dflt?: number; allowZero?: boolean },
-): Millis | undefined {
-	const n = parseIntEnv(env, key) ?? opts?.dflt;
-	if (n === undefined) return undefined;
-	const min = opts?.allowZero ? 0 : 1;
-	if (n < min) {
-		throw new ConfigError(`Invalid ${key}: ${n} (expected an integer >= ${min})`, {
-			variable: key,
-		});
-	}
-	return Millis.seconds(n);
-}
 
 /**
  * Parse the marimohub-owned session lifetime policy: the graceful TTL enforced

--- a/packages/config/src/integrationProbe.test.ts
+++ b/packages/config/src/integrationProbe.test.ts
@@ -2,7 +2,7 @@ import type * as dnsPromises from 'node:dns/promises';
 import { createServer } from 'node:http';
 import type { Server } from 'node:http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createGuardedProbe } from './integrationProbe';
+import { createGuardedHostResolver, createGuardedProbe } from './integrationProbe';
 import type { ProbeTransportRequest } from './integrationProbe';
 
 type PinnedAddress = { address: string; family: number };
@@ -218,6 +218,19 @@ describe('createGuardedProbe policy', () => {
 
 		vi.advanceTimersByTime(60_001);
 		await expect(probe.fetch('http://10.0.0.5/')).resolves.toMatchObject({ ok: true });
+	});
+});
+
+describe('createGuardedHostResolver', () => {
+	it('stops waiting for DNS when the operation signal aborts', async () => {
+		dns.delayMs = 200;
+		const controller = new AbortController();
+		const pending = createGuardedHostResolver({ allowPrivate: true, timeoutMs: 1_000 })(
+			'localhost',
+			controller.signal,
+		);
+		controller.abort();
+		await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
 	});
 });
 

--- a/packages/config/src/integrationProbe.ts
+++ b/packages/config/src/integrationProbe.ts
@@ -32,7 +32,10 @@ export interface PinnedAddress {
 	family: number;
 }
 
-export type GuardedHostResolver = (hostname: string) => Promise<PinnedAddress[]>;
+export type GuardedHostResolver = (
+	hostname: string,
+	signal?: AbortSignal,
+) => Promise<PinnedAddress[]>;
 
 export function createGuardedHostResolver(
 	options: {
@@ -41,8 +44,8 @@ export function createGuardedHostResolver(
 	} = {},
 ): GuardedHostResolver {
 	const { allowPrivate = false, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
-	return (hostname) =>
-		withDeadline(resolveAndValidate(hostname, allowPrivate), Date.now() + timeoutMs);
+	return (hostname, signal) =>
+		withDeadline(resolveAndValidate(hostname, allowPrivate), Date.now() + timeoutMs, signal);
 }
 
 /**
@@ -237,18 +240,37 @@ async function resolveAndValidate(
 }
 
 /** `dns.lookup` honours no timeout of its own, so bound it from the outside. */
-function withDeadline<T>(work: Promise<T>, deadline: number): Promise<T> {
+function withDeadline<T>(work: Promise<T>, deadline: number, signal?: AbortSignal): Promise<T> {
+	if (signal?.aborted) return Promise.reject(aborted());
 	let timer: ReturnType<typeof setTimeout> | undefined;
-	return Promise.race([
+	let onAbort: (() => void) | undefined;
+	const candidates: Promise<T>[] = [
 		work,
 		new Promise<never>((_resolve, reject) => {
 			timer = setTimeout(() => reject(timedOut()), Math.max(0, deadline - Date.now()));
 		}),
-	]).finally(() => clearTimeout(timer));
+	];
+	if (signal) {
+		candidates.push(
+			new Promise<never>((_resolve, reject) => {
+				onAbort = () => reject(aborted());
+				signal.addEventListener('abort', onAbort, { once: true });
+				if (signal.aborted) onAbort();
+			}),
+		);
+	}
+	return Promise.race(candidates).finally(() => {
+		clearTimeout(timer);
+		if (onAbort) signal?.removeEventListener('abort', onAbort);
+	});
 }
 
 function timedOut(): Error {
 	return new Error('Connection test timed out.');
+}
+
+function aborted(): Error {
+	return Object.assign(new Error('Connection test aborted.'), { name: 'AbortError' });
 }
 
 function forbidden(hostname: string): Error {

--- a/packages/config/src/integrationProbe.ts
+++ b/packages/config/src/integrationProbe.ts
@@ -27,6 +27,24 @@ export interface GuardedProbeOptions {
 	transport?: ProbeTransport;
 }
 
+export interface PinnedAddress {
+	address: string;
+	family: number;
+}
+
+export type GuardedHostResolver = (hostname: string) => Promise<PinnedAddress[]>;
+
+export function createGuardedHostResolver(
+	options: {
+		allowPrivate?: boolean;
+		timeoutMs?: number;
+	} = {},
+): GuardedHostResolver {
+	const { allowPrivate = false, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+	return (hostname) =>
+		withDeadline(resolveAndValidate(hostname, allowPrivate), Date.now() + timeoutMs);
+}
+
 /**
  * One policy-checked request: the socket may connect ONLY to `pinned` (the
  * validated addresses, in resolution order), while `url`'s hostname still
@@ -37,7 +55,7 @@ export interface ProbeTransportRequest {
 	method: string;
 	headers: Record<string, string>;
 	body?: string;
-	pinned: { address: string; family: number }[];
+	pinned: PinnedAddress[];
 	timeoutMs: number;
 	maxResponseBytes: number;
 }
@@ -166,7 +184,7 @@ const nodeTransport: ProbeTransport = (probeRequest) =>
 	});
 
 /** A DNS lookup function that returns only the pre-validated addresses. */
-function pinnedLookup(pinned: { address: string; family: number }[]): LookupFunction {
+function pinnedLookup(pinned: PinnedAddress[]): LookupFunction {
 	return ((_hostname: string, lookupOptions: unknown, callback: unknown) => {
 		const cb = callback as (err: Error | null, addr: unknown, fam?: number) => void;
 		if (typeof lookupOptions === 'object' && (lookupOptions as { all?: boolean } | null)?.all) {

--- a/packages/config/src/integrations.test.ts
+++ b/packages/config/src/integrations.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createProjectId } from '@marimo-hub/core';
 import { ACTOR, MemoryBucket } from '@marimo-hub/core/testing';
 import { ConfigError } from './errors';
-import { makeIntegrations } from './integrations';
+import { makeIntegrations, objectBrowserDeadlinesFromEnv } from './integrations';
 
 const PG_CONFIG = { host: 'db.internal', database: 'db', username: 'u', password: 'pw' };
 
@@ -138,6 +138,52 @@ describe('makeIntegrations data browser', () => {
 		).not.toThrow();
 	});
 
+	it('does not parse preview-only deadlines in metadata mode', () => {
+		expect(() =>
+			makeIntegrations(
+				{
+					MARIMOHUB_INTEGRATIONS: 'on',
+					MARIMOHUB_DATA_BROWSER: 'metadata',
+					MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: 'stale-invalid-value',
+				},
+				new MemoryBucket(),
+			),
+		).not.toThrow();
+		expect(
+			objectBrowserDeadlinesFromEnv(
+				{ MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: 'stale-invalid-value' },
+				'metadata',
+			),
+		).toEqual({
+			metadataTimeoutMs: 30_000,
+			previewTimeoutMs: 30_000,
+			resolveTimeoutMs: 30_000,
+		});
+	});
+
+	it('gives DNS resolution enough time for the longest active browser operation', () => {
+		expect(
+			objectBrowserDeadlinesFromEnv(
+				{ MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: '45' },
+				'full',
+			),
+		).toEqual({
+			metadataTimeoutMs: 30_000,
+			previewTimeoutMs: 45_000,
+			resolveTimeoutMs: 45_000,
+		});
+		expect(
+			objectBrowserDeadlinesFromEnv(
+				{ MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: '5' },
+				'full',
+			),
+		).toEqual({
+			metadataTimeoutMs: 30_000,
+			previewTimeoutMs: 5_000,
+			resolveTimeoutMs: 30_000,
+		});
+	});
+
 	it('does not add a generic sandbox fallback unless a runtime is explicitly wired', () => {
 		const runtime = {
 			available: () => false,
@@ -239,18 +285,18 @@ describe('makeIntegrations data browser', () => {
 		}
 	});
 
-	it('rejects invalid object-browser operation deadlines', () => {
-		for (const value of ['0', '-1', 'not-a-number']) {
+	it('rejects invalid full-preview operation deadlines', () => {
+		for (const value of ['0', '-1', 'not-a-number', '2147484']) {
 			expect(() =>
 				makeIntegrations(
 					{
 						MARIMOHUB_INTEGRATIONS: 'on',
-						MARIMOHUB_DATA_BROWSER: 'metadata',
+						MARIMOHUB_DATA_BROWSER: 'full',
 						MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: value,
 					},
 					new MemoryBucket(),
 				),
-			).toThrow(/expected an integer/);
+			).toThrow(/expected .*integer/);
 		}
 	});
 });

--- a/packages/config/src/integrations.test.ts
+++ b/packages/config/src/integrations.test.ts
@@ -113,12 +113,29 @@ describe('makeIntegrations data browser', () => {
 		);
 		expect(wired.dataBrowser).toEqual({ preview: false });
 		expect(wired.integrations?.listKinds().some((k) => k.supports_browse)).toBe(true);
+		expect(wired.integrations?.listKinds().find((kind) => kind.kind === 's3')).toMatchObject({
+			supports_browse: true,
+			browse_surfaces: ['objects'],
+		});
 
 		const full = makeIntegrations(
 			{ MARIMOHUB_INTEGRATIONS: 'on', MARIMOHUB_DATA_BROWSER: 'full' },
 			new MemoryBucket(),
 		);
 		expect(full.dataBrowser).toEqual({ preview: true });
+	});
+
+	it('ignores stale preview timeout values while data browsing is disabled', () => {
+		expect(() =>
+			makeIntegrations(
+				{
+					MARIMOHUB_INTEGRATIONS: 'on',
+					MARIMOHUB_DATA_BROWSER: 'off',
+					MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: 'stale-invalid-value',
+				},
+				new MemoryBucket(),
+			),
+		).not.toThrow();
 	});
 
 	it('does not add a generic sandbox fallback unless a runtime is explicitly wired', () => {
@@ -139,6 +156,31 @@ describe('makeIntegrations data browser', () => {
 			runtime,
 		);
 		expect(withRuntime.dataBrowser?.sandboxPreview).toBe(runtime);
+	});
+
+	it('passes metadata and full modes to the production S3 browser', async () => {
+		for (const [mode, expected] of [
+			['metadata', { preview: false, download: false }],
+			['full', { preview: true, download: true }],
+		] as const) {
+			const integrations = makeIntegrations(
+				{ MARIMOHUB_INTEGRATIONS: 'on', MARIMOHUB_DATA_BROWSER: mode },
+				new MemoryBucket(),
+			).integrations!;
+			const pid = createProjectId();
+			const created = await integrations.create(
+				pid,
+				{ kind: 's3', name: `s3-${mode}`, config: { auth: { method: 'ambient' } } },
+				ACTOR,
+			);
+			const capability = await integrations.browseCapability(pid, created.id, {
+				project_id: pid,
+				user_id: ACTOR,
+				user_email: 'user@example.com',
+				allow_server_ambient: true,
+			});
+			expect(capability.surfaces.objects).toMatchObject({ available: true, ...expected });
+		}
 	});
 
 	it('advertises sandbox fallback only after its runtime becomes available', async () => {
@@ -194,6 +236,21 @@ describe('makeIntegrations data browser', () => {
 					new MemoryBucket(),
 				),
 			).toThrow(/supported: off, metadata, full/);
+		}
+	});
+
+	it('rejects invalid object-browser operation deadlines', () => {
+		for (const value of ['0', '-1', 'not-a-number']) {
+			expect(() =>
+				makeIntegrations(
+					{
+						MARIMOHUB_INTEGRATIONS: 'on',
+						MARIMOHUB_DATA_BROWSER: 'metadata',
+						MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: value,
+					},
+					new MemoryBucket(),
+				),
+			).toThrow(/expected an integer/);
 		}
 	});
 });

--- a/packages/config/src/integrations.ts
+++ b/packages/config/src/integrations.ts
@@ -1,9 +1,11 @@
 import { defaultRegistry, OrgIntegrationsStore, ProjectIntegrationsStore } from '@marimo-hub/core';
 import type { Bucket, DataPreview, IntegrationProbe, Metrics } from '@marimo-hub/core';
 import type { ApiDeps } from '@marimo-hub/api';
+import { S3ObjectBrowser } from '@marimo-hub/object-browser-s3';
+import { parseSecondsEnv } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
-import { createGuardedProbe } from './integrationProbe';
+import { createGuardedHostResolver, createGuardedProbe } from './integrationProbe';
 import { makeSecretSources } from './secrets';
 
 /**
@@ -41,6 +43,26 @@ export function makeIntegrations(
 	// Parsed once so both probes interpret the same validated policy — neither
 	// depends on the other having rejected an invalid value first.
 	const policy = probePolicy(env);
+	const objectBrowsers =
+		dataBrowser === 'off'
+			? undefined
+			: (() => {
+					const timeoutMs = parseSecondsEnv(
+						env,
+						'MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS',
+						{ dflt: 30 },
+					);
+					return {
+						s3: new S3ObjectBrowser({
+							mode: dataBrowser,
+							resolveHost: createGuardedHostResolver({ allowPrivate: policy === 'private' }),
+							limits: {
+								metadataTimeoutMs: timeoutMs,
+								previewTimeoutMs: timeoutMs,
+							},
+						}),
+					};
+				})();
 	const options = {
 		bucket,
 		registry: defaultRegistry(),
@@ -48,6 +70,7 @@ export function makeIntegrations(
 		resolvers: secretSources.resolvers,
 		probe: makeProbe(policy),
 		browseProbe: makeBrowseProbe(policy, dataBrowser),
+		...(objectBrowsers ? { objectBrowsers } : {}),
 		metrics,
 	};
 	return {

--- a/packages/config/src/integrations.ts
+++ b/packages/config/src/integrations.ts
@@ -1,7 +1,7 @@
 import { defaultRegistry, OrgIntegrationsStore, ProjectIntegrationsStore } from '@marimo-hub/core';
 import type { Bucket, DataPreview, IntegrationProbe, Metrics } from '@marimo-hub/core';
 import type { ApiDeps } from '@marimo-hub/api';
-import { S3ObjectBrowser } from '@marimo-hub/object-browser-s3';
+import { DEFAULT_S3_OBJECT_BROWSER_LIMITS, S3ObjectBrowser } from '@marimo-hub/object-browser-s3';
 import { parseSecondsEnv } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
@@ -47,18 +47,17 @@ export function makeIntegrations(
 		dataBrowser === 'off'
 			? undefined
 			: (() => {
-					const timeoutMs = parseSecondsEnv(
-						env,
-						'MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS',
-						{ dflt: 30 },
-					);
+					const deadlines = objectBrowserDeadlinesFromEnv(env, dataBrowser);
 					return {
 						s3: new S3ObjectBrowser({
 							mode: dataBrowser,
-							resolveHost: createGuardedHostResolver({ allowPrivate: policy === 'private' }),
+							resolveHost: createGuardedHostResolver({
+								allowPrivate: policy === 'private',
+								timeoutMs: deadlines.resolveTimeoutMs,
+							}),
 							limits: {
-								metadataTimeoutMs: timeoutMs,
-								previewTimeoutMs: timeoutMs,
+								metadataTimeoutMs: deadlines.metadataTimeoutMs,
+								previewTimeoutMs: deadlines.previewTimeoutMs,
 							},
 						}),
 					};
@@ -86,6 +85,31 @@ export function makeIntegrations(
 						...(dataBrowser === 'full' && sandboxPreview ? { sandboxPreview } : {}),
 					},
 				}),
+	};
+}
+
+const MAX_NODE_TIMER_SECONDS = Math.floor(2_147_483_647 / 1000);
+
+export function objectBrowserDeadlinesFromEnv(
+	env: Env,
+	mode: 'metadata' | 'full',
+): {
+	metadataTimeoutMs: number;
+	previewTimeoutMs: number;
+	resolveTimeoutMs: number;
+} {
+	const metadataTimeoutMs = DEFAULT_S3_OBJECT_BROWSER_LIMITS.metadataTimeoutMs;
+	const previewTimeoutMs =
+		mode === 'full'
+			? parseSecondsEnv(env, 'MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS', {
+					dflt: DEFAULT_S3_OBJECT_BROWSER_LIMITS.previewTimeoutMs / 1000,
+					max: MAX_NODE_TIMER_SECONDS,
+				})
+			: DEFAULT_S3_OBJECT_BROWSER_LIMITS.previewTimeoutMs;
+	return {
+		metadataTimeoutMs,
+		previewTimeoutMs,
+		resolveTimeoutMs: Math.max(metadataTimeoutMs, previewTimeoutMs),
 	};
 }
 

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -7,3 +7,4 @@ export * from './credentialBroker';
 export * from './secrets';
 export * from './integrations';
 export * from './notifier';
+export * from './objectBrowser';

--- a/packages/core/src/ports/integrations.ts
+++ b/packages/core/src/ports/integrations.ts
@@ -1,4 +1,5 @@
 import type { IntegrationId, SessionId, UserId } from '../ids';
+import type { BrowseSurface, ObjectBrowseCapability } from './objectBrowser';
 
 export const INTEGRATION_CATEGORIES = [
 	'database',
@@ -73,6 +74,8 @@ export interface KindDescriptor {
 	supports_test: boolean;
 	/** Whether this deployment can browse the kind's catalog metadata. */
 	supports_browse: boolean;
+	/** Read-only resource models this deployment exposes for the kind. */
+	browse_surfaces: BrowseSurface[];
 	secret_sources: IntegrationSecretSources;
 	/** Informational package requirements for notebook code. */
 	requirements: string[];
@@ -162,6 +165,10 @@ export interface BrowseCapabilityResult {
 	 */
 	current_version: number;
 	updated_at: string;
+	surfaces: {
+		tables?: { available: boolean; preview: boolean; reason?: string };
+		objects?: ObjectBrowseCapability;
+	};
 }
 
 /** The only network path allowed to integration probes; implementations enforce egress policy. */

--- a/packages/core/src/ports/objectBrowser.ts
+++ b/packages/core/src/ports/objectBrowser.ts
@@ -1,0 +1,258 @@
+import type { ProjectId, UserId } from '../ids';
+import type { TempS3Creds } from './credentialBroker';
+
+export type BrowseSurface = 'tables' | 'objects';
+
+export interface ObjectStoreSource {
+	provider: 's3';
+	configured_bucket?: string;
+	region?: string;
+	endpoint?: string;
+	path_style: boolean;
+	auth:
+		| {
+				method: 'static';
+				access_key_id: string;
+				secret_access_key: string;
+				session_token?: string;
+		  }
+		| { method: 'ambient' };
+}
+
+export interface ObjectBrowseContext {
+	project_id: ProjectId;
+	user_id: UserId;
+	user_email: string;
+	temporary_s3_credentials?: TempS3Creds;
+	temporary_storage?: { endpoint?: string; region?: string };
+	allow_server_ambient: boolean;
+	signal?: AbortSignal;
+}
+
+export interface ObjectPageRequest {
+	limit: number;
+	cursor?: string;
+}
+
+export interface ObjectListRequest extends ObjectPageRequest {
+	bucket: string;
+	prefix?: string;
+}
+
+export interface ObjectIdentity {
+	bucket: string;
+	key: string;
+	version_id?: string;
+}
+
+export interface ObjectSearchFilters {
+	formats?: string[];
+	modified_after?: string;
+	modified_before?: string;
+	min_size?: number;
+	max_size?: number;
+}
+
+export interface ObjectSearchRequest extends ObjectPageRequest, ObjectSearchFilters {
+	bucket: string;
+	prefix?: string;
+	query: string;
+}
+
+export interface ObjectVersionRequest extends ObjectPageRequest, ObjectIdentity {}
+
+export interface ObjectPreviewRequest extends ObjectIdentity {
+	limit: number;
+	content_url: string;
+}
+
+export interface ObjectOpenRequest extends ObjectIdentity {
+	range?: string;
+	if_match?: string;
+	inline?: boolean;
+}
+
+export interface ObjectBucket {
+	name: string;
+	created_at?: string;
+	configured: boolean;
+}
+
+export interface ObjectEntry {
+	kind: 'prefix' | 'object';
+	name: string;
+	key: string;
+	size?: number;
+	last_modified?: string;
+	etag?: string;
+	storage_class?: string;
+}
+
+export interface ObjectPage<T> {
+	items: T[];
+	next_cursor: string | null;
+}
+
+export interface ObjectSearchPage extends ObjectPage<ObjectEntry> {
+	scanned: number;
+	complete: boolean;
+}
+
+export interface ObjectChecksum {
+	algorithm: string;
+	value: string;
+}
+
+export interface ObjectTag {
+	key: string;
+	value: string;
+}
+
+export interface ObjectDetail extends ObjectIdentity {
+	size: number;
+	last_modified?: string;
+	etag?: string;
+	storage_class?: string;
+	content_type?: string;
+	content_encoding?: string;
+	cache_control?: string;
+	checksums: ObjectChecksum[];
+	metadata: Record<string, string>;
+	tags?: ObjectTag[];
+	tags_available: boolean;
+	snippet?: string;
+}
+
+export interface ObjectVersion extends ObjectIdentity {
+	kind: 'version' | 'delete-marker';
+	is_latest: boolean;
+	last_modified?: string;
+	size?: number;
+	etag?: string;
+	storage_class?: string;
+	owner?: { id?: string; display_name?: string };
+}
+
+export interface TabularPreview {
+	kind: 'tabular';
+	format: 'table' | 'csv' | 'tsv' | 'json' | 'jsonl' | 'parquet';
+	columns: { name: string; type?: string }[];
+	rows: unknown[][];
+	truncated: boolean;
+	bytes_read?: number;
+	total_bytes?: number;
+	warnings: string[];
+}
+
+export type ObjectPreview =
+	| TabularPreview
+	| {
+			kind: 'text';
+			format: 'text' | 'markdown' | 'code' | 'log' | 'json';
+			text: string;
+			truncated: boolean;
+			bytes_read: number;
+			total_bytes: number;
+			warnings: string[];
+	  }
+	| {
+			kind: 'image';
+			format: 'png' | 'jpeg' | 'gif' | 'webp';
+			content_url: string;
+			width?: number;
+			height?: number;
+			total_bytes: number;
+			warnings: string[];
+	  }
+	| {
+			kind: 'unsupported';
+			reason: string;
+			detected_type?: string;
+			total_bytes: number;
+	  };
+
+export interface ObjectBody {
+	body: ReadableStream<Uint8Array>;
+	status: 200 | 206;
+	content_type: string;
+	content_length: number;
+	total_size: number;
+	content_range?: string;
+	etag?: string;
+	version_id?: string;
+	close(): void;
+}
+
+export type ObjectBrowseErrorCode =
+	| 'access_denied'
+	| 'not_found'
+	| 'precondition_failed'
+	| 'range_not_satisfiable'
+	| 'unsupported'
+	| 'invalid_cursor'
+	| 'unavailable'
+	| 'aborted';
+
+export class ObjectBrowseError extends Error {
+	readonly name = 'ObjectBrowseError';
+
+	constructor(
+		readonly code: ObjectBrowseErrorCode,
+		message: string,
+		readonly request_id?: string,
+	) {
+		super(message);
+	}
+}
+
+export interface ObjectBrowseCapability {
+	available: boolean;
+	preview: boolean;
+	download: boolean;
+	search: 'bounded-key-name';
+	versions: boolean;
+	preview_formats: string[];
+	reason?: string;
+}
+
+export interface ObjectBrowser {
+	capability(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+	): Promise<ObjectBrowseCapability> | ObjectBrowseCapability;
+	listBuckets(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectPageRequest,
+	): Promise<ObjectPage<ObjectBucket>>;
+	listObjects(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectListRequest,
+	): Promise<ObjectPage<ObjectEntry>>;
+	searchObjects(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectSearchRequest,
+	): Promise<ObjectSearchPage>;
+	headObject(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectIdentity,
+	): Promise<ObjectDetail>;
+	listVersions(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectVersionRequest,
+	): Promise<ObjectPage<ObjectVersion>>;
+	previewObject(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectPreviewRequest,
+	): Promise<ObjectPreview>;
+	openObject(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectOpenRequest,
+	): Promise<ObjectBody>;
+}

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -2240,6 +2240,87 @@ describe('data browsing', () => {
 		).rejects.toThrow('The object-store request failed.');
 	});
 
+	it('scrubs capability exceptions before returning them or running an operation', async () => {
+		const registry = new IntegrationRegistry();
+		registry.register(objectKind);
+		const listBuckets = vi.fn(objectBrowser.listBuckets);
+		const leakingBrowser: ObjectBrowser = {
+			...objectBrowser,
+			capability: async () => {
+				throw new Error('provider rejected provider-secret');
+			},
+			listBuckets,
+		};
+		const guarded = new ProjectIntegrationsStore({
+			bucket,
+			registry,
+			codec,
+			objectBrowsers: { s3: leakingBrowser },
+		});
+		const created = await guarded.create(
+			pid,
+			{ kind: 'objecty', name: 'guarded-capability', config: { token: 'provider-secret' } },
+			ACTOR,
+		);
+
+		await expect(guarded.browseCapability(pid, created.id, objectContext())).rejects.toEqual(
+			expect.objectContaining({
+				name: 'UnavailableError',
+				message: 'The object-store request failed.',
+			}),
+		);
+		await expect(
+			guarded.browseObjectBuckets(pid, created.id, objectContext(), { limit: 10 }),
+		).rejects.toEqual(
+			expect.objectContaining({
+				name: 'UnavailableError',
+				message: 'The object-store request failed.',
+			}),
+		);
+		expect(listBuckets).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['User credentials are unavailable.', 'User credentials are unavailable.'],
+		[undefined, 'This integration cannot be browsed as an object store.'],
+	] as const)(
+		'rejects object operations when the browser capability reason is %s',
+		async (reason, expected) => {
+			const registry = new IntegrationRegistry();
+			registry.register(objectKind);
+			const listBuckets = vi.fn(objectBrowser.listBuckets);
+			const unavailableBrowser: ObjectBrowser = {
+				...objectBrowser,
+				capability: () => ({
+					available: false,
+					preview: false,
+					download: false,
+					search: 'bounded-key-name',
+					versions: false,
+					preview_formats: [],
+					...(reason ? { reason } : {}),
+				}),
+				listBuckets,
+			};
+			const guarded = new ProjectIntegrationsStore({
+				bucket,
+				registry,
+				codec,
+				objectBrowsers: { s3: unavailableBrowser },
+			});
+			const created = await guarded.create(
+				pid,
+				{ kind: 'objecty', name: 'unavailable', config: { token: 'provider-secret' } },
+				ACTOR,
+			);
+
+			await expect(
+				guarded.browseObjectBuckets(pid, created.id, objectContext(), { limit: 10 }),
+			).rejects.toThrow(expected);
+			expect(listBuckets).not.toHaveBeenCalled();
+		},
+	);
+
 	it('reports the capability verdict without resolving secrets', async () => {
 		const created = await createBrowsy();
 		expect(await store.browseCapability(pid, created.id)).toEqual({

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -12,6 +12,7 @@ import { createIntegrationId, createProjectId, createSessionId } from '../../ids
 import type { ProjectId, SessionId } from '../../ids';
 import { paths } from '../../paths';
 import type { Bucket, BucketListOptions } from '../../ports/bucket';
+import type { ObjectBrowseContext, ObjectBrowser } from '../../ports/objectBrowser';
 import { SecretResolutionError } from '../../ports/secrets';
 import type { SecretResolver } from '../../ports/secrets';
 import { ACTOR, MemoryBucket } from '../../testing';
@@ -2081,6 +2082,70 @@ describe('data browsing', () => {
 			snippet: (name, namespace, table) => `load ${name}:${namespace.join('.')}.${table}`,
 		},
 	});
+	const objectKind = defineIntegration({
+		kind: 'objecty',
+		title: 'Objecty',
+		description: 'test kind',
+		category: 'storage',
+		brand: { color: '#000000' },
+		schemaVersion: 1,
+		configSchema: z.object({ token: zSecret() }),
+		render: () => ({}),
+		objectBrowse: {
+			source: (config) => ({
+				provider: 's3',
+				configured_bucket: 'lake',
+				path_style: true,
+				auth: {
+					method: 'static',
+					access_key_id: 'key',
+					secret_access_key: config.token,
+				},
+			}),
+			snippet: (name, bucket, key) => `open ${name}:s3://${bucket}/${key}`,
+		},
+	});
+	const objectBrowser: ObjectBrowser = {
+		capability: () => ({
+			available: true,
+			preview: true,
+			download: true,
+			search: 'bounded-key-name',
+			versions: true,
+			preview_formats: ['csv'],
+		}),
+		listBuckets: async (source) => ({
+			items: [{ name: source.configured_bucket!, configured: true }],
+			next_cursor: null,
+		}),
+		listObjects: async () => ({ items: [], next_cursor: null }),
+		searchObjects: async () => ({ items: [], next_cursor: null, scanned: 0, complete: true }),
+		headObject: async (_source, _context, request) => ({
+			...request,
+			size: 3,
+			checksums: [],
+			metadata: {},
+			tags_available: false,
+		}),
+		listVersions: async () => ({ items: [], next_cursor: null }),
+		previewObject: async () => ({
+			kind: 'text',
+			format: 'text',
+			text: 'abc',
+			truncated: false,
+			bytes_read: 3,
+			total_bytes: 3,
+			warnings: [],
+		}),
+		openObject: async () => ({
+			body: new ReadableStream(),
+			status: 200,
+			content_type: 'text/plain',
+			content_length: 3,
+			total_size: 3,
+			close: () => {},
+		}),
+	};
 
 	let bucket: MemoryBucket;
 	let pid: ProjectId;
@@ -2093,19 +2158,94 @@ describe('data browsing', () => {
 		const registry = new IntegrationRegistry();
 		registry.register(echoKind);
 		registry.register(browsyKind);
-		const options = { bucket, registry, codec, probe: stubProbe, browseProbe: stubProbe };
+		registry.register(objectKind);
+		const options = {
+			bucket,
+			registry,
+			codec,
+			probe: stubProbe,
+			browseProbe: stubProbe,
+			objectBrowsers: { s3: objectBrowser },
+		};
 		store = new ProjectIntegrationsStore(options);
 		orgStore = new OrgIntegrationsStore(options);
 	});
 
 	const createBrowsy = (config: Record<string, unknown> = { token: 'plain-token' }) =>
 		store.create(pid, { kind: 'browsy', name: 'lake', config }, ACTOR);
+	const objectContext = (): ObjectBrowseContext => ({
+		project_id: pid,
+		user_id: ACTOR,
+		user_email: 'actor@example.com',
+		allow_server_ambient: false,
+	});
+
+	it('gates object-only integrations by provider and keeps table operations separate', async () => {
+		const created = await store.create(
+			pid,
+			{ kind: 'objecty', name: 'objects', config: { token: 'provider-secret' } },
+			ACTOR,
+		);
+		expect(await store.browseCapability(pid, created.id, objectContext())).toMatchObject({
+			metadata: false,
+			hub_preview: false,
+			surfaces: { objects: { available: true, preview: true, download: true } },
+		});
+		expect(
+			await store.browseObjectBuckets(pid, created.id, objectContext(), { limit: 10 }),
+		).toEqual({ items: [{ name: 'lake', configured: true }], next_cursor: null });
+		expect(
+			await store.browseObjectDetail(pid, created.id, objectContext(), {
+				bucket: 'lake',
+				key: 'a.csv',
+			}),
+		).toMatchObject({ snippet: 'open objects:s3://lake/a.csv' });
+		await expect(store.browseNamespaces(pid, created.id, { limit: 10 })).rejects.toThrow(
+			/object browsing|does not support browsing/,
+		);
+
+		const registry = new IntegrationRegistry();
+		registry.register(objectKind);
+		const bare = new ProjectIntegrationsStore({ bucket, registry, codec, browseProbe: stubProbe });
+		expect(await bare.browseCapability(pid, created.id, objectContext())).toMatchObject({
+			surfaces: { objects: { available: false, reason: expect.stringContaining('not enabled') } },
+		});
+		await expect(
+			bare.browseObjectBuckets(pid, created.id, objectContext(), { limit: 10 }),
+		).rejects.toThrow(/not enabled/);
+	});
+
+	it('does not expose provider exceptions containing resolved object credentials', async () => {
+		const registry = new IntegrationRegistry();
+		registry.register(objectKind);
+		const leakingBrowser = {
+			...objectBrowser,
+			listBuckets: async () => {
+				throw new Error('provider rejected provider-secret');
+			},
+		};
+		const guarded = new ProjectIntegrationsStore({
+			bucket,
+			registry,
+			codec,
+			objectBrowsers: { s3: leakingBrowser },
+		});
+		const created = await guarded.create(
+			pid,
+			{ kind: 'objecty', name: 'guarded', config: { token: 'provider-secret' } },
+			ACTOR,
+		);
+		await expect(
+			guarded.browseObjectBuckets(pid, created.id, objectContext(), { limit: 10 }),
+		).rejects.toThrow('The object-store request failed.');
+	});
 
 	it('reports the capability verdict without resolving secrets', async () => {
 		const created = await createBrowsy();
 		expect(await store.browseCapability(pid, created.id)).toEqual({
 			metadata: true,
 			hub_preview: false,
+			surfaces: { tables: { available: true, preview: false } },
 			current_version: 1,
 			updated_at: expect.any(String),
 		});
@@ -2118,6 +2258,9 @@ describe('data browsing', () => {
 		expect(await store.browseCapability(pid, closed.id)).toEqual({
 			metadata: false,
 			hub_preview: false,
+			surfaces: {
+				tables: { available: false, preview: false, reason: 'sandbox only' },
+			},
 			current_version: 1,
 			updated_at: expect.any(String),
 			reason: 'sandbox only',
@@ -2203,6 +2346,7 @@ describe('data browsing', () => {
 		expect(await store.browseCapability(pid, orgInstance.id)).toEqual({
 			metadata: true,
 			hub_preview: false,
+			surfaces: { tables: { available: true, preview: false } },
 			current_version: 1,
 			updated_at: expect.any(String),
 		});

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -4,6 +4,7 @@ import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
 import {
 	assertVersionMatch,
 	BadRequestError,
+	DomainError,
 	NotFoundError,
 	ResourceExhaustedError,
 	UnavailableError,
@@ -43,6 +44,27 @@ import type {
 } from '../../ports/integrations';
 import type { ManagedSecretCodec, SecretRef, SecretResolver } from '../../ports/secrets';
 import { SecretResolutionError } from '../../ports/secrets';
+import { ObjectBrowseError } from '../../ports/objectBrowser';
+import type {
+	ObjectBody,
+	ObjectBrowseContext,
+	ObjectBrowser,
+	ObjectBucket,
+	ObjectDetail,
+	ObjectEntry,
+	ObjectIdentity,
+	ObjectListRequest,
+	ObjectOpenRequest,
+	ObjectPage,
+	ObjectPageRequest,
+	ObjectPreview,
+	ObjectPreviewRequest,
+	ObjectSearchPage,
+	ObjectSearchRequest,
+	ObjectStoreSource,
+	ObjectVersion,
+	ObjectVersionRequest,
+} from '../../ports/objectBrowser';
 import { metricsObserver, saga } from '../../saga';
 import {
 	CURRENT_INTEGRATION_CONFIG_VERSION,
@@ -79,6 +101,22 @@ import type { OrgIntegrationsService, ProjectIntegrationsService } from './contr
 
 /** Page size when a caller states none; the API passes its own page policy. */
 const DEFAULT_VERSION_PAGE_SIZE = 100;
+
+function unavailableTableCapability(reason: string) {
+	return { available: false, preview: false, reason };
+}
+
+function unavailableObjectCapability(reason: string) {
+	return {
+		available: false,
+		preview: false,
+		download: false,
+		search: 'bounded-key-name' as const,
+		versions: false,
+		preview_formats: [],
+		reason,
+	};
+}
 
 /** Bounds list scans and session rendering for one integration tier. */
 export const MAX_INTEGRATIONS_PER_SCOPE = 500;
@@ -175,6 +213,7 @@ export interface IntegrationsStoreOptions {
 	 * expansion) has its own budget and response cap; absence disables browsing.
 	 */
 	browseProbe?: IntegrationProbe;
+	objectBrowsers?: Partial<Record<ObjectStoreSource['provider'], ObjectBrowser>>;
 	/** Injectable clock for deterministic tests. */
 	now?: () => string;
 	metrics?: Metrics;
@@ -191,6 +230,7 @@ class ScopedIntegrationsStore {
 	private readonly resolvers: Map<string, SecretResolver>;
 	private readonly probe?: IntegrationProbe;
 	private readonly browseProbe?: IntegrationProbe;
+	private readonly objectBrowsers: Partial<Record<ObjectStoreSource['provider'], ObjectBrowser>>;
 	private readonly now: () => string;
 	private readonly metrics: Metrics;
 
@@ -203,6 +243,7 @@ class ScopedIntegrationsStore {
 		);
 		this.probe = options.probe;
 		this.browseProbe = options.browseProbe;
+		this.objectBrowsers = options.objectBrowsers ?? {};
 		this.now = options.now ?? (() => new Date().toISOString());
 		this.metrics = options.metrics ?? noopMetrics;
 	}
@@ -211,14 +252,22 @@ class ScopedIntegrationsStore {
 		// A deployment without a guarded probe must not advertise the Test action;
 		// same for browsing and its own probe.
 		const testable = this.probe !== undefined;
-		const browsable = this.browseProbe !== undefined;
+		const tableBrowsable = this.browseProbe !== undefined;
 		const secret_sources = this.secretSources();
-		return this.registry.describeAll().map((descriptor) => ({
-			...descriptor,
-			supports_test: testable && descriptor.supports_test,
-			supports_browse: browsable && descriptor.supports_browse,
-			secret_sources,
-		}));
+		return this.registry.describeAll().map((descriptor) => {
+			const browse_surfaces = descriptor.browse_surfaces.filter(
+				(surface) =>
+					(surface === 'tables' && tableBrowsable) ||
+					(surface === 'objects' && Object.values(this.objectBrowsers).some(Boolean)),
+			);
+			return {
+				...descriptor,
+				supports_test: testable && descriptor.supports_test,
+				supports_browse: browse_surfaces.length > 0,
+				browse_surfaces,
+				secret_sources,
+			};
+		});
 	}
 
 	secretSources(): IntegrationSecretSources {
@@ -699,33 +748,39 @@ class ScopedIntegrationsStore {
 	async browseCapability(
 		scope: IntegrationScope,
 		id: IntegrationId,
+		objectContext?: ObjectBrowseContext,
 	): Promise<BrowseCapabilityResult> {
 		const head = await this.getHead(scope, id);
 		const state = { current_version: head.current_version, updated_at: head.updated_at };
 		const def = this.registry.get(head.kind);
-		if (!def.browse) {
-			return {
-				metadata: false,
-				hub_preview: false,
-				...state,
-				reason: `Integration kind "${head.kind}" does not support browsing.`,
-			};
+		const surfaces: BrowseCapabilityResult['surfaces'] = {};
+		if (def.browse) {
+			surfaces.tables = this.browseProbe
+				? { available: false, preview: false }
+				: unavailableTableCapability('Data browsing is not enabled on this deployment.');
 		}
-		if (!this.browseProbe) {
-			return {
-				metadata: false,
-				hub_preview: false,
-				...state,
-				reason: 'Data browsing is not enabled on this deployment.',
-			};
+		if (def.objectBrowse) {
+			surfaces.objects = unavailableObjectCapability(
+				objectContext
+					? 'Object browsing is not enabled on this deployment.'
+					: 'Object browsing requires a user credential context.',
+			);
+		}
+		const compatibility = (reason?: string): BrowseCapabilityResult => ({
+			metadata: surfaces.tables?.available ?? false,
+			hub_preview: surfaces.tables?.preview ?? false,
+			surfaces,
+			...state,
+			...(reason ? { reason } : {}),
+		});
+		if (!def.browse && !def.objectBrowse) {
+			return compatibility(`Integration kind "${head.kind}" does not support browsing.`);
 		}
 		if (!head.enabled) {
-			return {
-				metadata: false,
-				hub_preview: false,
-				...state,
-				reason: `Integration "${head.name}" is disabled.`,
-			};
+			const reason = `Integration "${head.name}" is disabled.`;
+			if (surfaces.tables) surfaces.tables = unavailableTableCapability(reason);
+			if (surfaces.objects) surfaces.objects = unavailableObjectCapability(reason);
+			return compatibility(reason);
 		}
 		const { config } = await this.loadCurrent(scope, head);
 		const parsed = parseStoredWithPlaceholders({
@@ -734,17 +789,25 @@ class ScopedIntegrationsStore {
 			stored: config,
 		});
 		if (parsed === undefined) {
-			return {
-				metadata: false,
-				hub_preview: false,
-				...state,
-				reason: `The stored config no longer matches kind "${head.kind}" — edit and re-save it.`,
-			};
+			const reason = `The stored config no longer matches kind "${head.kind}" — edit and re-save it.`;
+			if (surfaces.tables) surfaces.tables = unavailableTableCapability(reason);
+			if (surfaces.objects) surfaces.objects = unavailableObjectCapability(reason);
+			return compatibility(reason);
 		}
-		const verdict = def.browse.available(parsed);
-		return verdict.ok
-			? { metadata: true, hub_preview: def.browse.previewRows !== undefined, ...state }
-			: { metadata: false, hub_preview: false, ...state, reason: verdict.reason };
+		if (def.browse && this.browseProbe) {
+			const verdict = def.browse.available(parsed);
+			surfaces.tables = verdict.ok
+				? { available: true, preview: def.browse.previewRows !== undefined }
+				: unavailableTableCapability(verdict.reason);
+		}
+		if (def.objectBrowse && objectContext) {
+			const source = def.objectBrowse.source(parsed);
+			const browser = this.objectBrowsers[source.provider];
+			if (browser) {
+				surfaces.objects = await browser.capability(source, objectContext);
+			}
+		}
+		return compatibility(surfaces.tables?.reason);
 	}
 
 	async browseNamespaces(
@@ -792,37 +855,145 @@ class ScopedIntegrationsStore {
 		return browse.previewRows(config, probe, namespace, table, request);
 	}
 
+	async browseObjectBuckets(
+		scope: IntegrationScope,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectPageRequest,
+	): Promise<ObjectPage<ObjectBucket>> {
+		return this.runObjectBrowse(scope, id, context, (browser, source) =>
+			browser.listBuckets(source, context, request),
+		);
+	}
+
+	async browseObjects(
+		scope: IntegrationScope,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectListRequest,
+	): Promise<ObjectPage<ObjectEntry>> {
+		return this.runObjectBrowse(scope, id, context, (browser, source) =>
+			browser.listObjects(source, context, request),
+		);
+	}
+
+	async searchObjects(
+		scope: IntegrationScope,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectSearchRequest,
+	): Promise<ObjectSearchPage> {
+		return this.runObjectBrowse(scope, id, context, (browser, source) =>
+			browser.searchObjects(source, context, request),
+		);
+	}
+
+	async browseObjectDetail(
+		scope: IntegrationScope,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectIdentity,
+	): Promise<ObjectDetail> {
+		return this.runObjectBrowse(scope, id, context, async (browser, source, name, snippet) => ({
+			...(await browser.headObject(source, context, request)),
+			snippet: snippet(name, request.bucket, request.key),
+		}));
+	}
+
+	async browseObjectVersions(
+		scope: IntegrationScope,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectVersionRequest,
+	): Promise<ObjectPage<ObjectVersion>> {
+		return this.runObjectBrowse(scope, id, context, (browser, source) =>
+			browser.listVersions(source, context, request),
+		);
+	}
+
+	async browseObjectPreview(
+		scope: IntegrationScope,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectPreviewRequest,
+	): Promise<ObjectPreview> {
+		return this.runObjectBrowse(scope, id, context, (browser, source) =>
+			browser.previewObject(source, context, request),
+		);
+	}
+
+	async openObject(
+		scope: IntegrationScope,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectOpenRequest,
+	): Promise<ObjectBody> {
+		return this.runObjectBrowse(scope, id, context, (browser, source) =>
+			browser.openObject(source, context, request),
+		);
+	}
+
+	private async runObjectBrowse<T>(
+		scope: IntegrationScope,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		run: (
+			browser: ObjectBrowser,
+			source: ObjectStoreSource,
+			name: string,
+			snippet: (instanceName: string, bucket: string, key: string) => string,
+		) => Promise<T>,
+	): Promise<T> {
+		const { head, def, config } = await this.openResolvedBrowse(scope, id);
+		if (!def.objectBrowse) {
+			throw new ValidationError(
+				`Integration kind "${head.kind}" does not support object browsing.`,
+			);
+		}
+		const source = def.objectBrowse.source(config);
+		const browser = this.objectBrowsers[source.provider];
+		if (!browser) throw new ValidationError('Object browsing is not enabled on this deployment.');
+		try {
+			return await run(browser, source, head.name, def.objectBrowse.snippet);
+		} catch (err) {
+			if (err instanceof ObjectBrowseError || err instanceof DomainError) throw err;
+			throw new UnavailableError('The object-store request failed.');
+		}
+	}
+
 	/**
 	 * Shared preamble of every browse op: load, migrate, decrypt, re-validate,
 	 * and gate — the same path `test('stored')` walks. Read-only throughout;
 	 * browsing writes nothing to the bucket.
 	 */
 	private async openBrowse(scope: IntegrationScope, id: IntegrationId) {
-		const head = await this.getHead(scope, id);
+		const { head, def, config: parsed } = await this.openResolvedBrowse(scope, id);
 		const probe = this.browseProbe;
 		if (!probe) {
 			throw new ValidationError('Data browsing is not enabled on this deployment.');
 		}
-		if (!head.enabled) {
-			throw new ValidationError(`Integration "${head.name}" is disabled.`);
-		}
-		const { def, config } = await this.loadCurrent(scope, head);
 		if (!def.browse) {
 			throw new ValidationError(`Integration kind "${head.kind}" does not support browsing.`);
 		}
+		const verdict = def.browse.available(parsed);
+		if (!verdict.ok) {
+			throw new ValidationError(`Integration "${head.name}" cannot be browsed: ${verdict.reason}.`);
+		}
+		return { head, browse: def.browse, config: parsed, probe };
+	}
+
+	private async openResolvedBrowse(scope: IntegrationScope, id: IntegrationId) {
+		const head = await this.getHead(scope, id);
+		if (!head.enabled) throw new ValidationError(`Integration "${head.name}" is disabled.`);
+		const { def, config } = await this.loadCurrent(scope, head);
 		const resolved = await this.open(scope, head.id, def, config);
-		// Never surface the Zod issues here — the resolved config is plaintext.
 		const parsed = def.configSchema.safeParse(resolved);
 		if (!parsed.success) {
 			throw new ValidationError(
 				`Stored config no longer matches kind "${def.kind}" — edit and re-save it.`,
 			);
 		}
-		const verdict = def.browse.available(parsed.data);
-		if (!verdict.ok) {
-			throw new ValidationError(`Integration "${head.name}" cannot be browsed: ${verdict.reason}.`);
-		}
-		return { head, browse: def.browse, config: parsed.data, probe };
+		return { head, def, config: parsed.data };
 	}
 
 	/** `getHead`, but absence (or a tombstone) reads as undefined instead of a 404. */
@@ -1347,8 +1518,14 @@ export class ProjectIntegrationsStore implements ProjectIntegrationsService {
 		);
 	}
 
-	browseCapability(projectId: ProjectId, id: IntegrationId): Promise<BrowseCapabilityResult> {
-		return this.withBrowseScope(projectId, id, (scope) => this.store.browseCapability(scope, id));
+	browseCapability(
+		projectId: ProjectId,
+		id: IntegrationId,
+		objectContext?: ObjectBrowseContext,
+	): Promise<BrowseCapabilityResult> {
+		return this.withBrowseScope(projectId, id, (scope) =>
+			this.store.browseCapability(scope, id, objectContext),
+		);
 	}
 
 	browseNamespaces(
@@ -1393,6 +1570,83 @@ export class ProjectIntegrationsStore implements ProjectIntegrationsService {
 	): Promise<TablePreview> {
 		return this.withBrowseScope(projectId, id, (scope) =>
 			this.store.browseTablePreview(scope, id, namespace, table, request),
+		);
+	}
+
+	browseObjectBuckets(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectPageRequest,
+	): Promise<ObjectPage<ObjectBucket>> {
+		return this.withBrowseScope(projectId, id, (scope) =>
+			this.store.browseObjectBuckets(scope, id, context, request),
+		);
+	}
+
+	browseObjects(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectListRequest,
+	): Promise<ObjectPage<ObjectEntry>> {
+		return this.withBrowseScope(projectId, id, (scope) =>
+			this.store.browseObjects(scope, id, context, request),
+		);
+	}
+
+	searchObjects(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectSearchRequest,
+	): Promise<ObjectSearchPage> {
+		return this.withBrowseScope(projectId, id, (scope) =>
+			this.store.searchObjects(scope, id, context, request),
+		);
+	}
+
+	browseObjectDetail(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectIdentity,
+	): Promise<ObjectDetail> {
+		return this.withBrowseScope(projectId, id, (scope) =>
+			this.store.browseObjectDetail(scope, id, context, request),
+		);
+	}
+
+	browseObjectVersions(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectVersionRequest,
+	): Promise<ObjectPage<ObjectVersion>> {
+		return this.withBrowseScope(projectId, id, (scope) =>
+			this.store.browseObjectVersions(scope, id, context, request),
+		);
+	}
+
+	browseObjectPreview(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectPreviewRequest,
+	): Promise<ObjectPreview> {
+		return this.withBrowseScope(projectId, id, (scope) =>
+			this.store.browseObjectPreview(scope, id, context, request),
+		);
+	}
+
+	openObject(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectOpenRequest,
+	): Promise<ObjectBody> {
+		return this.withBrowseScope(projectId, id, (scope) =>
+			this.store.openObject(scope, id, context, request),
 		);
 	}
 

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -804,7 +804,9 @@ class ScopedIntegrationsStore {
 			const source = def.objectBrowse.source(parsed);
 			const browser = this.objectBrowsers[source.provider];
 			if (browser) {
-				surfaces.objects = await browser.capability(source, objectContext);
+				surfaces.objects = await this.guardObjectBrowse(() =>
+					browser.capability(source, objectContext),
+				);
 			}
 		}
 		return compatibility(surfaces.tables?.reason);
@@ -945,16 +947,29 @@ class ScopedIntegrationsStore {
 		) => Promise<T>,
 	): Promise<T> {
 		const { head, def, config } = await this.openResolvedBrowse(scope, id);
-		if (!def.objectBrowse) {
+		const objectBrowse = def.objectBrowse;
+		if (!objectBrowse) {
 			throw new ValidationError(
 				`Integration kind "${head.kind}" does not support object browsing.`,
 			);
 		}
-		const source = def.objectBrowse.source(config);
+		const source = objectBrowse.source(config);
 		const browser = this.objectBrowsers[source.provider];
 		if (!browser) throw new ValidationError('Object browsing is not enabled on this deployment.');
+		return this.guardObjectBrowse(async () => {
+			const capability = await browser.capability(source, context);
+			if (!capability.available) {
+				throw new ValidationError(
+					capability.reason ?? 'This integration cannot be browsed as an object store.',
+				);
+			}
+			return run(browser, source, head.name, objectBrowse.snippet);
+		});
+	}
+
+	private async guardObjectBrowse<T>(run: () => Promise<T> | T): Promise<T> {
 		try {
-			return await run(browser, source, head.name, def.objectBrowse.snippet);
+			return await run();
 		} catch (err) {
 			if (err instanceof ObjectBrowseError || err instanceof DomainError) throw err;
 			throw new UnavailableError('The object-store request failed.');

--- a/packages/core/src/services/integrations/contracts.ts
+++ b/packages/core/src/services/integrations/contracts.ts
@@ -21,6 +21,24 @@ import type {
 	TestResult,
 	UpdateIntegrationInput,
 } from '../../ports/integrations';
+import type {
+	ObjectBody,
+	ObjectBrowseContext,
+	ObjectBucket,
+	ObjectDetail,
+	ObjectEntry,
+	ObjectIdentity,
+	ObjectListRequest,
+	ObjectOpenRequest,
+	ObjectPage,
+	ObjectPageRequest,
+	ObjectPreview,
+	ObjectPreviewRequest,
+	ObjectSearchPage,
+	ObjectSearchRequest,
+	ObjectVersion,
+	ObjectVersionRequest,
+} from '../../ports/objectBrowser';
 
 /** Application service for project integrations and inherited organization integrations. */
 export interface ProjectIntegrationsService {
@@ -53,7 +71,11 @@ export interface ProjectIntegrationsService {
 	 * project-first, then the inherited org tier (shadowed org instances read
 	 * as absent) — the merged view members already have.
 	 */
-	browseCapability(projectId: ProjectId, id: IntegrationId): Promise<BrowseCapabilityResult>;
+	browseCapability(
+		projectId: ProjectId,
+		id: IntegrationId,
+		objectContext?: ObjectBrowseContext,
+	): Promise<BrowseCapabilityResult>;
 	browseNamespaces(
 		projectId: ProjectId,
 		id: IntegrationId,
@@ -79,6 +101,48 @@ export interface ProjectIntegrationsService {
 		table: string,
 		request: TablePreviewRequest,
 	): Promise<TablePreview>;
+	browseObjectBuckets(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectPageRequest,
+	): Promise<ObjectPage<ObjectBucket>>;
+	browseObjects(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectListRequest,
+	): Promise<ObjectPage<ObjectEntry>>;
+	searchObjects(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectSearchRequest,
+	): Promise<ObjectSearchPage>;
+	browseObjectDetail(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectIdentity,
+	): Promise<ObjectDetail>;
+	browseObjectVersions(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectVersionRequest,
+	): Promise<ObjectPage<ObjectVersion>>;
+	browseObjectPreview(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectPreviewRequest,
+	): Promise<ObjectPreview>;
+	openObject(
+		projectId: ProjectId,
+		id: IntegrationId,
+		context: ObjectBrowseContext,
+		request: ObjectOpenRequest,
+	): Promise<ObjectBody>;
 	/** Render exactly one resolved integration for an isolated preview sandbox. */
 	resolveForPreview(
 		projectId: ProjectId,

--- a/packages/core/src/services/integrations/kinds/kinds.test.ts
+++ b/packages/core/src/services/integrations/kinds/kinds.test.ts
@@ -1243,6 +1243,17 @@ describe('kind renders (golden)', () => {
 		});
 	});
 
+	it.each([
+		['records.json', 'pl.read_json('],
+		['records.JSON', 'pl.read_json('],
+		['records.jsonl', 'pl.read_ndjson('],
+		['records.ndjson', 'pl.read_ndjson('],
+	] as const)('s3 renders the correct Polars reader for %s', (key, reader) => {
+		const snippet = s3.objectBrowse!.snippet('warehouse', 'lake', key);
+		expect(snippet).toContain(reader);
+		expect(snippet).toContain('s3://lake/');
+	});
+
 	it('resolves requirements from the selected driver, storage, and authentication branches', () => {
 		const odbc = sqlserver.configSchema.parse(FIXTURES.sqlserver);
 		const pymssql = sqlserver.configSchema.parse({

--- a/packages/core/src/services/integrations/kinds/kinds.test.ts
+++ b/packages/core/src/services/integrations/kinds/kinds.test.ts
@@ -1217,6 +1217,32 @@ describe('kind renders (golden)', () => {
 		expect(byKind.custom_env).toEqual([]);
 	});
 
+	it('s3 maps configured and ambient sources without changing credential values', () => {
+		const configured = s3.objectBrowse!.source(s3.configSchema.parse(FIXTURES.s3));
+		expect(configured).toEqual({
+			provider: 's3',
+			configured_bucket: 'lake',
+			region: 'us-east-1',
+			endpoint: 'https://minio.internal:9000',
+			path_style: true,
+			auth: {
+				method: 'static',
+				access_key_id: 'AKIAEXAMPLE',
+				secret_access_key: 's3-secret',
+				session_token: undefined,
+			},
+		});
+		const ambient = s3.objectBrowse!.source(s3.configSchema.parse({ auth: { method: 'ambient' } }));
+		expect(ambient).toEqual({
+			provider: 's3',
+			configured_bucket: undefined,
+			region: undefined,
+			endpoint: undefined,
+			path_style: false,
+			auth: { method: 'ambient' },
+		});
+	});
+
 	it('resolves requirements from the selected driver, storage, and authentication branches', () => {
 		const odbc = sqlserver.configSchema.parse(FIXTURES.sqlserver);
 		const pymssql = sqlserver.configSchema.parse({

--- a/packages/core/src/services/integrations/kinds/objectStores.ts
+++ b/packages/core/src/services/integrations/kinds/objectStores.ts
@@ -104,7 +104,10 @@ export const s3 = defineIntegration({
 			if (extension === 'csv') {
 				return `import polars as pl\n\ndf = pl.read_csv(${uri}, storage_options={"marimohub_integration": ${descriptor}})`;
 			}
-			if (extension === 'json' || extension === 'jsonl' || extension === 'ndjson') {
+			if (extension === 'json') {
+				return `import polars as pl\n\ndf = pl.read_json(${uri}, storage_options={"marimohub_integration": ${descriptor}})`;
+			}
+			if (extension === 'jsonl' || extension === 'ndjson') {
 				return `import polars as pl\n\ndf = pl.read_ndjson(${uri}, storage_options={"marimohub_integration": ${descriptor}})`;
 			}
 			if (extension === 'parquet') {

--- a/packages/core/src/services/integrations/kinds/objectStores.ts
+++ b/packages/core/src/services/integrations/kinds/objectStores.ts
@@ -78,6 +78,41 @@ export const s3 = defineIntegration({
 		'auth.session_token': { widget: 'password' },
 		ambient_env: { group: 'Authentication', order: 11, widget: 'toggle', advanced: true },
 	},
+	objectBrowse: {
+		source(config) {
+			return {
+				provider: 's3',
+				configured_bucket: config.bucket,
+				region: config.region,
+				endpoint: config.endpoint_url,
+				path_style: config.path_style,
+				auth:
+					config.auth.method === 'static'
+						? {
+								method: 'static',
+								access_key_id: config.auth.access_key_id,
+								secret_access_key: config.auth.secret_access_key,
+								session_token: config.auth.session_token,
+							}
+						: { method: 'ambient' },
+			};
+		},
+		snippet(instanceName, bucket, key) {
+			const uri = JSON.stringify(`s3://${bucket}/${key}`);
+			const descriptor = JSON.stringify(instanceName);
+			const extension = key.split('.').at(-1)?.toLowerCase();
+			if (extension === 'csv') {
+				return `import polars as pl\n\ndf = pl.read_csv(${uri}, storage_options={"marimohub_integration": ${descriptor}})`;
+			}
+			if (extension === 'json' || extension === 'jsonl' || extension === 'ndjson') {
+				return `import polars as pl\n\ndf = pl.read_ndjson(${uri}, storage_options={"marimohub_integration": ${descriptor}})`;
+			}
+			if (extension === 'parquet') {
+				return `import polars as pl\n\ndf = pl.read_parquet(${uri}, storage_options={"marimohub_integration": ${descriptor}})`;
+			}
+			return `import fsspec\n\nwith fsspec.open(${uri}, "rb", marimohub_integration=${descriptor}) as source:\n    data = source.read()`;
+		},
+	},
 
 	render({ config, instanceName }) {
 		const files: { path: string; content: string }[] = [];

--- a/packages/core/src/services/integrations/registry.test.ts
+++ b/packages/core/src/services/integrations/registry.test.ts
@@ -7,6 +7,55 @@ afterEach(() => {
 });
 
 describe('IntegrationRegistry', () => {
+	it('describes table, object, combined, and non-browsable surfaces', () => {
+		const registry = new IntegrationRegistry();
+		const base = {
+			title: 'Test',
+			description: 'test',
+			category: 'other' as const,
+			brand: { color: '#000000' },
+			schemaVersion: 1,
+			configSchema: z.object({}),
+			render: () => ({}),
+		};
+		const browse = {
+			available: () => ({ ok: true as const }),
+			listNamespaces: async () => ({ items: [], next_cursor: null }),
+			listTables: async () => ({ items: [], next_cursor: null }),
+			getTableSchema: async () => ({ columns: [] }),
+			snippet: () => '',
+		};
+		const objectBrowse = {
+			source: () => ({
+				provider: 's3' as const,
+				path_style: false,
+				auth: { method: 'ambient' as const },
+			}),
+			snippet: () => '',
+		};
+		registry.register({ ...base, kind: 'none' });
+		registry.register({ ...base, kind: 'tables', browse });
+		registry.register({ ...base, kind: 'objects', objectBrowse });
+		registry.register({ ...base, kind: 'both', browse, objectBrowse });
+
+		expect(registry.describe('none')).toMatchObject({
+			supports_browse: false,
+			browse_surfaces: [],
+		});
+		expect(registry.describe('tables')).toMatchObject({
+			supports_browse: true,
+			browse_surfaces: ['tables'],
+		});
+		expect(registry.describe('objects')).toMatchObject({
+			supports_browse: true,
+			browse_surfaces: ['objects'],
+		});
+		expect(registry.describe('both')).toMatchObject({
+			supports_browse: true,
+			browse_surfaces: ['tables', 'objects'],
+		});
+	});
+
 	it('disables an unrepresentable kind schema and logs without exception text', () => {
 		const log = vi.spyOn(console, 'error').mockImplementation(() => {});
 		const registry = new IntegrationRegistry();

--- a/packages/core/src/services/integrations/registry.ts
+++ b/packages/core/src/services/integrations/registry.ts
@@ -63,6 +63,10 @@ export class IntegrationRegistry {
 		const cached = this.descriptors.get(kind);
 		if (cached) return cached;
 		const def = this.get(kind);
+		const browse_surfaces = [
+			...(def.browse ? (['tables'] as const) : []),
+			...(def.objectBrowse ? (['objects'] as const) : []),
+		];
 		const descriptor: KindDescriptor = {
 			kind: def.kind,
 			title: def.title,
@@ -73,7 +77,8 @@ export class IntegrationRegistry {
 			json_schema: this.jsonSchema(kind),
 			ui_hints: def.uiHints ?? {},
 			supports_test: def.testConnection !== undefined,
-			supports_browse: def.browse !== undefined,
+			supports_browse: browse_surfaces.length > 0,
+			browse_surfaces,
 			secret_sources: { inline: false, references: [] },
 			requirements: def.requirements ?? [],
 		};

--- a/packages/core/src/services/integrations/sdk.ts
+++ b/packages/core/src/services/integrations/sdk.ts
@@ -15,6 +15,7 @@ import type {
 	UiHints,
 } from '../../ports/integrations';
 import type { ProjectId, SessionId, UserId } from '../../ids';
+import type { ObjectStoreSource } from '../../ports/objectBrowser';
 import { secretPaths } from './secretFields';
 import type { SecretPath } from './secretFields';
 
@@ -176,6 +177,10 @@ export interface IntegrationDefinition<S extends z.ZodType = z.ZodType> {
 	 * degraded to a generic one — the same posture as `testConnection`.
 	 */
 	browse?: BrowseCapability<z.infer<S>>;
+	objectBrowse?: {
+		source(config: z.infer<S>): ObjectStoreSource;
+		snippet(instanceName: string, bucket: string, key: string): string;
+	};
 	/**
 	 * Upgrade a stored config from an older `schemaVersion`. Chainable per step.
 	 * Operates on the STORED shape (secret fields are `{ $secret: … }` boxes) and
@@ -198,7 +203,7 @@ export function defineIntegration<S extends z.ZodType>(
 	def: IntegrationDefinition<S>,
 ): IntegrationDefinition<S> {
 	const testConnection = def.testConnection?.bind(def);
-	if (!testConnection && !def.browse) return def;
+	if (!testConnection && !def.browse && !def.objectBrowse) return def;
 	let paths: SecretPath[] | undefined;
 	const pathsOf = () =>
 		(paths ??= secretPaths(
@@ -230,6 +235,29 @@ export function defineIntegration<S extends z.ZodType>(
 				}
 			: {}),
 		...(def.browse ? { browse: guardedBrowse(def.browse, pathsOf) } : {}),
+		...(def.objectBrowse ? { objectBrowse: guardedObjectBrowse(def.objectBrowse, pathsOf) } : {}),
+	};
+}
+
+function guardedObjectBrowse<C>(
+	objectBrowse: {
+		source(config: C): ObjectStoreSource;
+		snippet(instanceName: string, bucket: string, key: string): string;
+	},
+	pathsOf: () => SecretPath[],
+) {
+	return {
+		source(config: C) {
+			try {
+				return objectBrowse.source(config);
+			} catch (err) {
+				if (err instanceof DomainError && !echoesSecret(err.message, config, pathsOf())) {
+					throw err;
+				}
+				throw new UnavailableError('The object-store request failed.');
+			}
+		},
+		snippet: objectBrowse.snippet.bind(objectBrowse),
 	};
 }
 

--- a/packages/object-browser-s3/package.json
+++ b/packages/object-browser-s3/package.json
@@ -1,0 +1,35 @@
+{
+	"name": "@marimo-hub/object-browser-s3",
+	"version": "0.0.0",
+	"private": true,
+	"license": "Apache-2.0",
+	"files": [
+		"dist"
+	],
+	"type": "module",
+	"exports": {
+		".": "./src/index.ts",
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"build": "vp pack",
+		"test": "vp test",
+		"test:coverage": "vp test --coverage",
+		"check": "vp check",
+		"typecheck": "tsc --noEmit"
+	},
+	"dependencies": {
+		"@aws-sdk/client-s3": "catalog:",
+		"@marimo-hub/core": "workspace:*",
+		"@smithy/node-http-handler": "catalog:",
+		"csv-parse": "catalog:",
+		"hyparquet": "catalog:"
+	},
+	"devDependencies": {
+		"@marimo-hub/tsconfig": "workspace:*",
+		"@types/node": "catalog:",
+		"typescript": "catalog:",
+		"vite-plus": "catalog:",
+		"vitest": "catalog:"
+	}
+}

--- a/packages/object-browser-s3/src/client.ts
+++ b/packages/object-browser-s3/src/client.ts
@@ -47,7 +47,7 @@ export function createS3ClientFactory(options: {
 			maxAttempts: 3,
 			requestHandler,
 			...(credentials ? { credentials } : {}),
-		}) as unknown as S3ClientLike;
+		}) as S3ClientLike;
 	};
 }
 

--- a/packages/object-browser-s3/src/client.ts
+++ b/packages/object-browser-s3/src/client.ts
@@ -139,7 +139,14 @@ export function createGuardedLookup(
 					cb(null, candidates[0].address, candidates[0].family);
 				}
 			},
-			() => cb(new Error('The object-store hostname is not permitted.')),
+			(error) => {
+				const name = (error as { name?: unknown } | null)?.name;
+				const message =
+					name === 'AbortError'
+						? 'The object-store hostname resolution was canceled.'
+						: 'The object-store hostname is not permitted.';
+				cb(Object.assign(new Error(message), { name: name === 'AbortError' ? name : 'Error' }));
+			},
 		);
 	}) as LookupFunction;
 }

--- a/packages/object-browser-s3/src/client.ts
+++ b/packages/object-browser-s3/src/client.ts
@@ -1,0 +1,118 @@
+import { Agent as HttpAgent } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
+import type { LookupFunction } from 'node:net';
+import { S3Client } from '@aws-sdk/client-s3';
+import type { ObjectBrowseContext, ObjectStoreSource } from '@marimo-hub/core';
+import { ObjectBrowseError } from '@marimo-hub/core';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
+
+export interface PinnedAddress {
+	address: string;
+	family: number;
+}
+
+export type GuardedHostResolver = (hostname: string) => Promise<PinnedAddress[]>;
+
+export interface S3ClientLike {
+	send(command: unknown, options?: { abortSignal?: AbortSignal }): Promise<unknown>;
+	destroy(): void;
+}
+
+export type S3ClientFactory = (
+	source: ObjectStoreSource,
+	context: ObjectBrowseContext,
+) => S3ClientLike;
+
+export function createS3ClientFactory(options: {
+	resolveHost: GuardedHostResolver;
+	connectionTimeoutMs?: number;
+	requestTimeoutMs?: number;
+}): S3ClientFactory {
+	return (source, context) => {
+		const lookup = createGuardedLookup(options.resolveHost);
+		const requestHandler = new NodeHttpHandler({
+			httpAgent: new HttpAgent({ lookup }),
+			httpsAgent: new HttpsAgent({ lookup }),
+			...enforcedTimeouts(options),
+		});
+		const credentials = credentialsFor(source, context);
+		return new S3Client({
+			region: source.region ?? context.temporary_storage?.region ?? 'us-east-1',
+			endpoint: source.endpoint,
+			forcePathStyle: source.path_style,
+			maxAttempts: 3,
+			requestHandler,
+			...(credentials ? { credentials } : {}),
+		}) as unknown as S3ClientLike;
+	};
+}
+
+export function enforcedTimeouts(options: {
+	connectionTimeoutMs?: number;
+	requestTimeoutMs?: number;
+}) {
+	return {
+		connectionTimeout: options.connectionTimeoutMs ?? 10_000,
+		requestTimeout: options.requestTimeoutMs ?? 30_000,
+		throwOnRequestTimeout: true,
+	} as const;
+}
+
+export function credentialsFor(source: ObjectStoreSource, context: ObjectBrowseContext) {
+	if (source.auth.method === 'static') {
+		return {
+			accessKeyId: source.auth.access_key_id,
+			secretAccessKey: source.auth.secret_access_key,
+			sessionToken: source.auth.session_token,
+		};
+	}
+	if (context.temporary_s3_credentials) {
+		if (!endpointsMatch(source.endpoint, context.temporary_storage?.endpoint)) {
+			throw new ObjectBrowseError(
+				'access_denied',
+				'Federated credentials are not valid for this object-store endpoint.',
+			);
+		}
+		return {
+			accessKeyId: context.temporary_s3_credentials.accessKeyId,
+			secretAccessKey: context.temporary_s3_credentials.secretAccessKey,
+			sessionToken: context.temporary_s3_credentials.sessionToken,
+		};
+	}
+	if (!context.allow_server_ambient) {
+		throw new ObjectBrowseError(
+			'access_denied',
+			'Ambient object-store access is not enabled for this integration.',
+		);
+	}
+	return;
+}
+
+export function endpointsMatch(left: string | undefined, right: string | undefined): boolean {
+	if (left === undefined || right === undefined) return left === right;
+	try {
+		return new URL(left).origin === new URL(right).origin;
+	} catch {
+		return false;
+	}
+}
+
+export function createGuardedLookup(resolveHost: GuardedHostResolver): LookupFunction {
+	return ((hostname: string, lookupOptions: unknown, callback: unknown) => {
+		const cb = callback as (err: Error | null, address?: unknown, family?: number) => void;
+		void resolveHost(hostname).then(
+			(addresses) => {
+				if (addresses.length === 0) {
+					cb(new Error('The object-store hostname did not resolve.'));
+					return;
+				}
+				if (typeof lookupOptions === 'object' && (lookupOptions as { all?: boolean } | null)?.all) {
+					cb(null, addresses);
+				} else {
+					cb(null, addresses[0].address, addresses[0].family);
+				}
+			},
+			() => cb(new Error('The object-store hostname is not permitted.')),
+		);
+	}) as LookupFunction;
+}

--- a/packages/object-browser-s3/src/client.ts
+++ b/packages/object-browser-s3/src/client.ts
@@ -1,6 +1,6 @@
 import { Agent as HttpAgent } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
-import { V4MAPPED } from 'node:dns';
+import { ALL, V4MAPPED } from 'node:dns';
 import type { LookupFunction } from 'node:net';
 import { S3Client } from '@aws-sdk/client-s3';
 import type { ObjectBrowseContext, ObjectStoreSource } from '@marimo-hub/core';
@@ -12,7 +12,10 @@ export interface PinnedAddress {
 	family: number;
 }
 
-export type GuardedHostResolver = (hostname: string) => Promise<PinnedAddress[]>;
+export type GuardedHostResolver = (
+	hostname: string,
+	signal?: AbortSignal,
+) => Promise<PinnedAddress[]>;
 
 export interface S3ClientLike {
 	send(command: unknown, options?: { abortSignal?: AbortSignal }): Promise<unknown>;
@@ -30,7 +33,7 @@ export function createS3ClientFactory(options: {
 	requestTimeoutMs?: number;
 }): S3ClientFactory {
 	return (source, context) => {
-		const lookup = createGuardedLookup(options.resolveHost);
+		const lookup = createGuardedLookup(options.resolveHost, context.signal);
 		const requestHandler = new NodeHttpHandler({
 			httpAgent: new HttpAgent({ lookup }),
 			httpsAgent: new HttpsAgent({ lookup }),
@@ -98,27 +101,33 @@ export function endpointsMatch(left: string | undefined, right: string | undefin
 	}
 }
 
-export function createGuardedLookup(resolveHost: GuardedHostResolver): LookupFunction {
+export function createGuardedLookup(
+	resolveHost: GuardedHostResolver,
+	signal?: AbortSignal,
+): LookupFunction {
 	return ((hostname: string, lookupOptions: unknown, callback: unknown) => {
 		const cb = callback as (err: Error | null, address?: unknown, family?: number) => void;
-		void resolveHost(hostname).then(
+		void resolveHost(hostname, signal).then(
 			(addresses) => {
 				const options =
-					typeof lookupOptions === 'object' && lookupOptions !== null
-						? (lookupOptions as { all?: boolean; family?: number; hints?: number })
-						: {};
+					typeof lookupOptions === 'number'
+						? { family: lookupOptions }
+						: typeof lookupOptions === 'object' && lookupOptions !== null
+							? (lookupOptions as { all?: boolean; family?: number; hints?: number })
+							: {};
 				const requestedFamily = options.family === 4 || options.family === 6 ? options.family : 0;
 				let candidates = requestedFamily
 					? addresses.filter((address) => address.family === requestedFamily)
 					: addresses;
-				if (
-					requestedFamily === 6 &&
-					candidates.length === 0 &&
-					((options.hints ?? 0) & V4MAPPED) !== 0
-				) {
-					candidates = addresses
-						.filter((address) => address.family === 4)
-						.map((address) => ({ address: `::ffff:${address.address}`, family: 6 }));
+				const hints = options.hints ?? 0;
+				if (requestedFamily === 6 && (hints & V4MAPPED) !== 0) {
+					const includeMapped = candidates.length === 0 || (hints & ALL) !== 0;
+					if (includeMapped) {
+						const mapped = addresses
+							.filter((address) => address.family === 4)
+							.map((address) => ({ address: `::ffff:${address.address}`, family: 6 }));
+						candidates = [...candidates, ...mapped];
+					}
 				}
 				if (candidates.length === 0) {
 					cb(new Error('The object-store hostname did not resolve.'));

--- a/packages/object-browser-s3/src/client.ts
+++ b/packages/object-browser-s3/src/client.ts
@@ -1,5 +1,6 @@
 import { Agent as HttpAgent } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
+import { V4MAPPED } from 'node:dns';
 import type { LookupFunction } from 'node:net';
 import { S3Client } from '@aws-sdk/client-s3';
 import type { ObjectBrowseContext, ObjectStoreSource } from '@marimo-hub/core';
@@ -102,14 +103,31 @@ export function createGuardedLookup(resolveHost: GuardedHostResolver): LookupFun
 		const cb = callback as (err: Error | null, address?: unknown, family?: number) => void;
 		void resolveHost(hostname).then(
 			(addresses) => {
-				if (addresses.length === 0) {
+				const options =
+					typeof lookupOptions === 'object' && lookupOptions !== null
+						? (lookupOptions as { all?: boolean; family?: number; hints?: number })
+						: {};
+				const requestedFamily = options.family === 4 || options.family === 6 ? options.family : 0;
+				let candidates = requestedFamily
+					? addresses.filter((address) => address.family === requestedFamily)
+					: addresses;
+				if (
+					requestedFamily === 6 &&
+					candidates.length === 0 &&
+					((options.hints ?? 0) & V4MAPPED) !== 0
+				) {
+					candidates = addresses
+						.filter((address) => address.family === 4)
+						.map((address) => ({ address: `::ffff:${address.address}`, family: 6 }));
+				}
+				if (candidates.length === 0) {
 					cb(new Error('The object-store hostname did not resolve.'));
 					return;
 				}
-				if (typeof lookupOptions === 'object' && (lookupOptions as { all?: boolean } | null)?.all) {
-					cb(null, addresses);
+				if (options.all) {
+					cb(null, candidates);
 				} else {
-					cb(null, addresses[0].address, addresses[0].family);
+					cb(null, candidates[0].address, candidates[0].family);
 				}
 			},
 			() => cb(new Error('The object-store hostname is not permitted.')),

--- a/packages/object-browser-s3/src/cursors.ts
+++ b/packages/object-browser-s3/src/cursors.ts
@@ -1,0 +1,20 @@
+import { ObjectBrowseError } from '@marimo-hub/core';
+
+export function encodeCursor(value: Record<string, unknown>): string {
+	return Buffer.from(JSON.stringify({ v: 1, ...value }), 'utf8').toString('base64url');
+}
+
+export function decodeCursor<T extends Record<string, unknown>>(
+	cursor: string | undefined,
+): Partial<T> {
+	if (!cursor) return {};
+	try {
+		const value = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as T & {
+			v?: unknown;
+		};
+		if (value.v !== 1) throw new Error('version');
+		return value;
+	} catch {
+		throw new ObjectBrowseError('invalid_cursor', 'The object-browser cursor is invalid.');
+	}
+}

--- a/packages/object-browser-s3/src/cursors.ts
+++ b/packages/object-browser-s3/src/cursors.ts
@@ -4,17 +4,32 @@ export function encodeCursor(value: Record<string, unknown>): string {
 	return Buffer.from(JSON.stringify({ v: 1, ...value }), 'utf8').toString('base64url');
 }
 
-export function decodeCursor<T extends Record<string, unknown>>(
+export function decodeCursor<const K extends string>(
 	cursor: string | undefined,
-): Partial<T> {
-	if (!cursor) return {};
+	fields: readonly K[],
+): Partial<Record<K, string>> {
+	if (cursor === undefined) return {};
 	try {
-		const value = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as T & {
-			v?: unknown;
-		};
-		if (value.v !== 1) throw new Error('version');
-		return value;
+		if (!/^[A-Za-z0-9_-]+$/.test(cursor) || cursor.length % 4 === 1) throw new Error('base64');
+		const bytes = Buffer.from(cursor, 'base64url');
+		if (bytes.toString('base64url') !== cursor) throw new Error('base64');
+		const value: unknown = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+		if (!isRecord(value) || value.v !== 1) throw new Error('version');
+		const allowed = new Set<string>(['v', ...fields]);
+		if (Object.keys(value).some((key) => !allowed.has(key))) throw new Error('shape');
+		for (const field of fields) {
+			if (value[field] !== undefined && typeof value[field] !== 'string') {
+				throw new Error('shape');
+			}
+		}
+		return Object.fromEntries(
+			fields.flatMap((field) => (typeof value[field] === 'string' ? [[field, value[field]]] : [])),
+		) as Partial<Record<K, string>>;
 	} catch {
 		throw new ObjectBrowseError('invalid_cursor', 'The object-browser cursor is invalid.');
 	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/object-browser-s3/src/errors.ts
+++ b/packages/object-browser-s3/src/errors.ts
@@ -1,0 +1,46 @@
+import { ObjectBrowseError } from '@marimo-hub/core';
+
+export function mapS3Error(error: unknown): ObjectBrowseError {
+	if (error instanceof ObjectBrowseError) return error;
+	const value = error as {
+		name?: string;
+		Code?: string;
+		$metadata?: { httpStatusCode?: number; requestId?: string };
+	};
+	const name = value?.name ?? value?.Code ?? '';
+	const status = value?.$metadata?.httpStatusCode;
+	const requestId = value?.$metadata?.requestId;
+	if (name === 'AbortError') return new ObjectBrowseError('aborted', 'The request was canceled.');
+	if (status === 403 || name === 'AccessDenied') {
+		return new ObjectBrowseError(
+			'access_denied',
+			'Access to the object store was denied.',
+			requestId,
+		);
+	}
+	if (status === 404 || name === 'NoSuchKey' || name === 'NotFound') {
+		return new ObjectBrowseError('not_found', 'The requested object was not found.', requestId);
+	}
+	if (status === 412 || name === 'PreconditionFailed') {
+		return new ObjectBrowseError(
+			'precondition_failed',
+			'The object changed before it could be read.',
+			requestId,
+		);
+	}
+	if (status === 416 || name === 'InvalidRange') {
+		return new ObjectBrowseError(
+			'range_not_satisfiable',
+			'The requested byte range is not available.',
+			requestId,
+		);
+	}
+	if (name === 'NotImplemented' || name === 'UnsupportedOperation') {
+		return new ObjectBrowseError(
+			'unsupported',
+			'This S3-compatible provider does not support the operation.',
+			requestId,
+		);
+	}
+	return new ObjectBrowseError('unavailable', 'The object-store request failed.', requestId);
+}

--- a/packages/object-browser-s3/src/formats.ts
+++ b/packages/object-browser-s3/src/formats.ts
@@ -1,0 +1,43 @@
+export type RasterImageFormat = 'png' | 'jpeg' | 'gif' | 'webp';
+
+export const S3_PREVIEW_FORMATS = [
+	'csv',
+	'tsv',
+	'json',
+	'jsonl',
+	'parquet',
+	'text',
+	'png',
+	'jpeg',
+	'gif',
+	'webp',
+] as const;
+
+export function detectRasterImage(bytes: Uint8Array): RasterImageFormat | undefined {
+	if (hasPrefix(bytes, PNG)) return 'png';
+	if (hasPrefix(bytes, JPEG)) return 'jpeg';
+	const firstSix = decodeAscii(bytes.subarray(0, 6));
+	if (firstSix === 'GIF87a' || firstSix === 'GIF89a') return 'gif';
+	if (
+		decodeAscii(bytes.subarray(0, 4)) === 'RIFF' &&
+		decodeAscii(bytes.subarray(8, 12)) === 'WEBP'
+	) {
+		return 'webp';
+	}
+	return undefined;
+}
+
+export function rasterContentType(format: RasterImageFormat): string {
+	return format === 'jpeg' ? 'image/jpeg' : `image/${format}`;
+}
+
+export function decodeAscii(bytes: Uint8Array): string {
+	return new TextDecoder().decode(bytes);
+}
+
+export function hasPrefix(bytes: Uint8Array, prefix: Uint8Array): boolean {
+	return bytes.length >= prefix.length && prefix.every((byte, index) => bytes[index] === byte);
+}
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const JPEG = new Uint8Array([0xff, 0xd8, 0xff]);

--- a/packages/object-browser-s3/src/index.test.ts
+++ b/packages/object-browser-s3/src/index.test.ts
@@ -374,6 +374,24 @@ describe('S3ObjectBrowser listing and metadata', () => {
 		});
 	});
 
+	it('retries HEAD without optional checksums when checksum retrieval is denied', async () => {
+		const denied = Object.assign(new Error('kms key detail'), {
+			name: 'AccessDenied',
+			$metadata: { httpStatusCode: 403 },
+		});
+		const test = harness([denied, { ContentLength: 12, ETag: 'etag' }, { TagSet: [] }]);
+		await expect(
+			test.browser.headObject(source, context, { bucket: 'lake', key: 'encrypted.txt' }),
+		).resolves.toMatchObject({ size: 12, etag: 'etag', checksums: [] });
+		expect(test.sent.map((call) => call.name)).toEqual([
+			'HeadObjectCommand',
+			'HeadObjectCommand',
+			'GetObjectTaggingCommand',
+		]);
+		expect(test.sent[0].input.ChecksumMode).toBe('ENABLED');
+		expect(test.sent[1].input.ChecksumMode).toBeUndefined();
+	});
+
 	it('propagates non-permission tag failures and still destroys the client', async () => {
 		const test = harness([
 			{ ContentLength: 12 },
@@ -737,6 +755,25 @@ describe('S3ObjectBrowser previews and streams', () => {
 		expect(upstreamCanceled).toBe(true);
 		expect(test.destroyed()).toBe(1);
 		opened.close();
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it('cancels an unread upstream body when close is called', async () => {
+		const cancel = vi.fn();
+		const stream = new ReadableStream<Uint8Array>({
+			pull() {
+				return new Promise(() => {});
+			},
+			cancel,
+		});
+		const test = harness([{ Body: stream, ContentLength: 1 }]);
+		const opened = await test.browser.openObject(source, context, {
+			bucket: 'lake',
+			key: 'unread.bin',
+		});
+		opened.close();
+		opened.close();
+		expect(cancel).toHaveBeenCalledOnce();
 		expect(test.destroyed()).toBe(1);
 	});
 });

--- a/packages/object-browser-s3/src/index.test.ts
+++ b/packages/object-browser-s3/src/index.test.ts
@@ -1,0 +1,819 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createProjectId, ObjectBrowseError, UserId } from '@marimo-hub/core';
+import type { ObjectBrowseContext, ObjectStoreSource } from '@marimo-hub/core';
+import type { S3ClientLike } from './client';
+import { credentialsFor, endpointsMatch } from './client';
+import { S3ObjectBrowser } from './index';
+
+const source: ObjectStoreSource = {
+	provider: 's3',
+	configured_bucket: 'lake',
+	region: 'us-east-1',
+	endpoint: 'https://s3.example.com',
+	path_style: true,
+	auth: {
+		method: 'static',
+		access_key_id: 'access',
+		secret_access_key: 'secret',
+	},
+};
+
+const context: ObjectBrowseContext = {
+	project_id: createProjectId(),
+	user_id: UserId.parse('user-1'),
+	user_email: 'ada@example.com',
+	allow_server_ambient: false,
+};
+
+interface Sent {
+	name: string;
+	input: Record<string, unknown>;
+	options?: { abortSignal?: AbortSignal };
+}
+
+function harness(
+	responses: unknown[] | ((sent: Sent) => unknown),
+	options: {
+		mode?: 'metadata' | 'full';
+		limits?: ConstructorParameters<typeof S3ObjectBrowser>[0]['limits'];
+	} = {},
+) {
+	const sent: Sent[] = [];
+	let destroyed = 0;
+	const queue = Array.isArray(responses) ? [...responses] : undefined;
+	const responder = Array.isArray(responses) ? undefined : responses;
+	const client: S3ClientLike = {
+		async send(command, commandOptions) {
+			const value = command as { constructor: { name: string }; input: Record<string, unknown> };
+			const call = { name: value.constructor.name, input: value.input, options: commandOptions };
+			sent.push(call);
+			const response = queue ? queue.shift() : await responder!(call);
+			if (response instanceof Error) throw response;
+			return response;
+		},
+		destroy() {
+			destroyed += 1;
+		},
+	};
+	return {
+		browser: new S3ObjectBrowser({
+			mode: options.mode ?? 'full',
+			limits: options.limits,
+			clientFactory: () => client,
+		}),
+		sent,
+		destroyed: () => destroyed,
+	};
+}
+
+describe('S3ObjectBrowser listing and metadata', () => {
+	it('returns the configured bucket without calling ListBuckets', async () => {
+		const test = harness([]);
+		await expect(test.browser.listBuckets(source, context, { limit: 10 })).resolves.toEqual({
+			items: [{ name: 'lake', configured: true }],
+			next_cursor: null,
+		});
+		expect(test.sent).toEqual([]);
+		expect(test.destroyed()).toBe(0);
+	});
+
+	it('lists and paginates provider buckets when the integration is not scoped', async () => {
+		const { configured_bucket: _configuredBucket, ...unscopedSource } = source;
+		const first = harness([
+			{
+				Buckets: [{ Name: 'one', CreationDate: new Date('2026-08-01T00:00:00Z') }, {}],
+				ContinuationToken: 'next bucket',
+			},
+		]);
+		const page = await first.browser.listBuckets(unscopedSource, context, { limit: 2 });
+		expect(page).toEqual({
+			items: [{ name: 'one', created_at: '2026-08-01T00:00:00.000Z', configured: false }],
+			next_cursor: expect.any(String),
+		});
+		expect(first.sent[0]).toMatchObject({
+			name: 'ListBucketsCommand',
+			input: { MaxBuckets: 2 },
+		});
+
+		const second = harness([{ Buckets: [] }]);
+		await second.browser.listBuckets(unscopedSource, context, {
+			limit: 2,
+			cursor: page.next_cursor!,
+		});
+		expect(second.sent[0].input.ContinuationToken).toBe('next bucket');
+	});
+
+	it('rejects cursors for a configured singleton bucket and malformed list cursors', async () => {
+		const test = harness([]);
+		await expect(
+			test.browser.listBuckets(source, context, { limit: 1, cursor: 'cursor' }),
+		).rejects.toMatchObject({ code: 'invalid_cursor' });
+		await expect(
+			test.browser.listObjects(source, context, {
+				bucket: 'lake',
+				limit: 1,
+				cursor: 'malformed',
+			}),
+		).rejects.toMatchObject({ code: 'invalid_cursor' });
+		expect(test.sent).toEqual([]);
+	});
+
+	it('merges direct prefixes and objects and suppresses duplicate folder markers', async () => {
+		const test = harness([
+			{
+				CommonPrefixes: [{ Prefix: 'events/daily/' }],
+				Contents: [
+					{ Key: 'events/daily/', Size: 0 },
+					{
+						Key: 'events/a ?#% ü.json',
+						Size: 4,
+						LastModified: new Date('2026-08-01T00:00:00Z'),
+						ETag: 'etag',
+					},
+				],
+				IsTruncated: true,
+				NextContinuationToken: 'opaque/+token',
+			},
+		]);
+		const page = await test.browser.listObjects(source, context, {
+			bucket: 'lake',
+			prefix: 'events/',
+			limit: 10,
+		});
+		expect(page.items).toEqual([
+			expect.objectContaining({ kind: 'object', key: 'events/a ?#% ü.json' }),
+			{ kind: 'prefix', key: 'events/daily/', name: 'daily' },
+		]);
+		expect(page.next_cursor).toEqual(expect.any(String));
+		expect(test.sent[0]).toMatchObject({
+			name: 'ListObjectsV2Command',
+			input: { Bucket: 'lake', Prefix: 'events/', Delimiter: '/' },
+		});
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it('rejects request buckets outside the configured scope', async () => {
+		const test = harness([]);
+		await expect(
+			test.browser.listObjects(source, context, { bucket: 'other', limit: 10 }),
+		).rejects.toMatchObject({ code: 'access_denied' });
+		expect(test.sent).toEqual([]);
+	});
+
+	it('reports bounded partial searches and continues with the opaque upstream token', async () => {
+		const first = harness(
+			[
+				{
+					Contents: [
+						{ Key: 'events/one.csv', Size: 1 },
+						{ Key: 'events/two.json', Size: 2 },
+					],
+					IsTruncated: true,
+					NextContinuationToken: 'next',
+				},
+			],
+			{ limits: { searchMaxKeys: 2 } },
+		);
+		const page = await first.browser.searchObjects(source, context, {
+			bucket: 'lake',
+			prefix: 'events/',
+			query: 'csv',
+			limit: 10,
+		});
+		expect(page).toMatchObject({ scanned: 2, complete: false, next_cursor: expect.any(String) });
+		expect(page.items.map((entry) => entry.key)).toEqual(['events/one.csv']);
+
+		const second = harness([{ Contents: [], IsTruncated: false }]);
+		await second.browser.searchObjects(source, context, {
+			bucket: 'lake',
+			query: 'csv',
+			limit: 10,
+			cursor: page.next_cursor!,
+		});
+		expect(second.sent[0].input.ContinuationToken).toBe('next');
+	});
+
+	it('scans in batches independent of the requested result count', async () => {
+		const test = harness([
+			{
+				Contents: [{ Key: 'events/one.json' }, { Key: 'events/two.json' }],
+				IsTruncated: false,
+			},
+		]);
+		const page = await test.browser.searchObjects(source, context, {
+			bucket: 'lake',
+			query: 'missing',
+			limit: 1,
+		});
+		expect(page).toMatchObject({ items: [], scanned: 2, complete: true });
+		expect(test.sent).toHaveLength(1);
+		expect(test.sent[0].input.MaxKeys).toBe(1_000);
+	});
+
+	it('resumes after the last examined key when a result stops within a batch', async () => {
+		const first = harness([
+			{
+				Contents: [{ Key: 'events/match-one.csv' }, { Key: 'events/match-two.csv' }],
+				IsTruncated: false,
+			},
+		]);
+		const page = await first.browser.searchObjects(source, context, {
+			bucket: 'lake',
+			prefix: 'events/',
+			query: 'match',
+			limit: 1,
+		});
+		expect(page).toMatchObject({
+			items: [expect.objectContaining({ key: 'events/match-one.csv' })],
+			complete: false,
+			next_cursor: expect.any(String),
+		});
+
+		const second = harness([{ Contents: [{ Key: 'events/match-two.csv' }], IsTruncated: false }]);
+		const resumed = await second.browser.searchObjects(source, context, {
+			bucket: 'lake',
+			prefix: 'events/',
+			query: 'match',
+			limit: 1,
+			cursor: page.next_cursor!,
+		});
+		expect(second.sent[0].input).toMatchObject({
+			StartAfter: 'events/match-one.csv',
+			ContinuationToken: undefined,
+		});
+		expect(resumed.items.map((item) => item.key)).toEqual(['events/match-two.csv']);
+		expect(resumed.complete).toBe(true);
+	});
+
+	it('rejects a search cursor that mixes continuation modes', async () => {
+		const test = harness([]);
+		const cursor = Buffer.from(
+			JSON.stringify({ v: 1, token: 'opaque', start_after: 'events/a' }),
+		).toString('base64url');
+		await expect(
+			test.browser.searchObjects(source, context, {
+				bucket: 'lake',
+				query: 'a',
+				limit: 1,
+				cursor,
+			}),
+		).rejects.toMatchObject({ code: 'invalid_cursor' });
+		expect(test.sent).toEqual([]);
+	});
+
+	it('aborts stalled metadata operations at the configured deadline', async () => {
+		vi.useFakeTimers();
+		try {
+			const test = harness(
+				(sent) =>
+					new Promise((_resolve, reject) => {
+						sent.options?.abortSignal?.addEventListener(
+							'abort',
+							() => reject(new DOMException('aborted', 'AbortError')),
+							{ once: true },
+						);
+					}),
+				{ limits: { metadataTimeoutMs: 25 } },
+			);
+			const operation = test.browser.listObjects(source, context, {
+				bucket: 'lake',
+				limit: 10,
+			});
+			const rejected = expect(operation).rejects.toMatchObject({ code: 'aborted' });
+			await vi.advanceTimersByTimeAsync(25);
+			await rejected;
+			expect(test.destroyed()).toBe(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('fails a non-advancing provider cursor', async () => {
+		const test = harness([
+			{ Contents: [], IsTruncated: true, NextContinuationToken: 'same' },
+			{ Contents: [], IsTruncated: true, NextContinuationToken: 'same' },
+		]);
+		await expect(
+			test.browser.searchObjects(source, context, {
+				bucket: 'lake',
+				query: 'missing',
+				limit: 2,
+				cursor: Buffer.from(JSON.stringify({ v: 1, token: 'same' })).toString('base64url'),
+			}),
+		).rejects.toMatchObject({ code: 'invalid_cursor' });
+	});
+
+	it('applies format, size, and modified-time filters and reports a complete search', async () => {
+		const test = harness([
+			{
+				Contents: [
+					{
+						Key: 'events/match.csv',
+						Size: 20,
+						LastModified: new Date('2026-08-02T00:00:00Z'),
+					},
+					{
+						Key: 'events/match.json',
+						Size: 20,
+						LastModified: new Date('2026-08-02T00:00:00Z'),
+					},
+					{
+						Key: 'events/match-small.csv',
+						Size: 1,
+						LastModified: new Date('2026-08-02T00:00:00Z'),
+					},
+					{
+						Key: 'events/match-old.csv',
+						Size: 20,
+						LastModified: new Date('2026-07-01T00:00:00Z'),
+					},
+				],
+				IsTruncated: false,
+			},
+		]);
+		const page = await test.browser.searchObjects(source, context, {
+			bucket: 'lake',
+			prefix: 'events/',
+			query: 'MATCH',
+			formats: ['csv'],
+			min_size: 10,
+			max_size: 30,
+			modified_after: '2026-08-01T00:00:00.000Z',
+			modified_before: '2026-08-03T00:00:00.000Z',
+			limit: 10,
+		});
+		expect(page).toMatchObject({
+			items: [expect.objectContaining({ key: 'events/match.csv' })],
+			scanned: 4,
+			complete: true,
+			next_cursor: null,
+		});
+	});
+
+	it('keeps HEAD metadata when tag permission is denied', async () => {
+		const denied = Object.assign(new Error('raw provider secret'), {
+			name: 'AccessDenied',
+			$metadata: { httpStatusCode: 403, requestId: 'request-1' },
+		});
+		const test = harness([
+			{
+				ContentLength: 12,
+				ETag: 'etag',
+				Metadata: { owner: 'data' },
+				ChecksumSHA256: 'sum',
+			},
+			denied,
+		]);
+		await expect(
+			test.browser.headObject(source, context, { bucket: 'lake', key: 'a.txt' }),
+		).resolves.toMatchObject({
+			size: 12,
+			metadata: { owner: 'data' },
+			tags_available: false,
+			checksums: [{ algorithm: 'sha256', value: 'sum' }],
+		});
+	});
+
+	it('propagates non-permission tag failures and still destroys the client', async () => {
+		const test = harness([
+			{ ContentLength: 12 },
+			Object.assign(new Error('raw provider detail'), {
+				name: 'InternalError',
+				$metadata: { httpStatusCode: 500 },
+			}),
+		]);
+		await expect(
+			test.browser.headObject(source, context, { bucket: 'lake', key: 'a.txt' }),
+		).rejects.toMatchObject({ code: 'unavailable' });
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it('filters version listings to the exact key and retains delete markers', async () => {
+		const test = harness([
+			{
+				Versions: [
+					{ Key: 'a', VersionId: 'v1', IsLatest: false },
+					{ Key: 'ab', VersionId: 'other', IsLatest: true },
+				],
+				DeleteMarkers: [{ Key: 'a', VersionId: 'v2', IsLatest: true }],
+				IsTruncated: false,
+			},
+		]);
+		const page = await test.browser.listVersions(source, context, {
+			bucket: 'lake',
+			key: 'a',
+			limit: 10,
+		});
+		expect(page.items).toEqual([
+			expect.objectContaining({ kind: 'version', version_id: 'v1' }),
+			expect.objectContaining({ kind: 'delete-marker', version_id: 'v2' }),
+		]);
+	});
+
+	it('carries both version markers across version pages', async () => {
+		const first = harness([
+			{
+				Versions: [],
+				IsTruncated: true,
+				NextKeyMarker: 'a',
+				NextVersionIdMarker: 'v2',
+			},
+		]);
+		const page = await first.browser.listVersions(source, context, {
+			bucket: 'lake',
+			key: 'a',
+			limit: 10,
+		});
+		expect(page.next_cursor).toEqual(expect.any(String));
+
+		const second = harness([{ Versions: [], IsTruncated: false }]);
+		await second.browser.listVersions(source, context, {
+			bucket: 'lake',
+			key: 'a',
+			limit: 10,
+			cursor: page.next_cursor!,
+		});
+		expect(second.sent[0].input).toMatchObject({ KeyMarker: 'a', VersionIdMarker: 'v2' });
+	});
+
+	it('maps provider failures without returning their raw message', async () => {
+		const provider = Object.assign(new Error('secret signed header'), {
+			name: 'InternalError',
+			$metadata: { httpStatusCode: 500, requestId: 'safe-id' },
+		});
+		const test = harness([provider]);
+		let error: unknown;
+		try {
+			await test.browser.listObjects(source, context, { bucket: 'lake', limit: 10 });
+		} catch (caught) {
+			error = caught;
+		}
+		expect(error).toBeInstanceOf(ObjectBrowseError);
+		expect(error).toMatchObject({ code: 'unavailable', request_id: 'safe-id' });
+		expect((error as Error).message).not.toContain('secret signed header');
+	});
+});
+
+describe('S3ObjectBrowser previews and streams', () => {
+	it('previews quoted CSV explicitly within row limits', async () => {
+		const csv = new TextEncoder().encode('name,note\nAda,"hello, world"\nLin,"multi\nline"\n');
+		const test = harness([
+			{ ContentLength: csv.length, ContentType: 'text/csv', ETag: 'etag' },
+			{ Body: body(csv) },
+		]);
+		await expect(
+			test.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'people.csv',
+				limit: 1,
+				content_url: '/content?key=people.csv',
+			}),
+		).resolves.toMatchObject({
+			kind: 'tabular',
+			format: 'csv',
+			columns: [{ name: 'name' }, { name: 'note' }],
+			rows: [['Ada', 'hello, world']],
+			truncated: true,
+		});
+	});
+
+	it('normalizes JSON bigint-like nested data without interpreting prototype keys', async () => {
+		const json = new TextEncoder().encode('[{"__proto__":"plain","nested":{"x":1}}]');
+		const test = harness([
+			{ ContentLength: json.length, ContentType: 'application/json' },
+			{ Body: body(json) },
+		]);
+		const preview = await test.browser.previewObject(source, context, {
+			bucket: 'lake',
+			key: 'data.json',
+			limit: 20,
+			content_url: '/content',
+		});
+		expect(preview).toMatchObject({
+			kind: 'tabular',
+			columns: [{ name: '__proto__' }, { name: 'nested' }],
+			rows: [['plain', '{"x":1}']],
+		});
+	});
+
+	it('allows magic-verified raster images but not extension-spoofed HTML', async () => {
+		const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+		const image = harness([{ ContentLength: png.length }, { Body: body(png) }]);
+		await expect(
+			image.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'safe.bin',
+				limit: 20,
+				content_url: '/safe-image',
+			}),
+		).resolves.toMatchObject({ kind: 'image', format: 'png', content_url: '/safe-image' });
+
+		const html = new TextEncoder().encode('<script>alert(1)</script>');
+		const spoofed = harness([
+			{ ContentLength: html.length, ContentType: 'text/html' },
+			{ Body: body(html) },
+		]);
+		await expect(
+			spoofed.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'unsafe.png',
+				limit: 20,
+				content_url: '/unsafe',
+			}),
+		).resolves.toMatchObject({ kind: 'unsupported' });
+	});
+
+	it('rejects malformed UTF-8 and distinguishes malformed from truncated JSON', async () => {
+		const invalidText = harness([
+			{ ContentLength: 1, ContentType: 'text/plain' },
+			{ Body: body(new Uint8Array([0xff])) },
+		]);
+		await expect(
+			invalidText.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'bad.txt',
+				limit: 20,
+				content_url: '/content',
+			}),
+		).rejects.toMatchObject({ code: 'unsupported' });
+
+		const malformed = new TextEncoder().encode('{bad');
+		const malformedJson = harness([
+			{ ContentLength: malformed.length, ContentType: 'application/json' },
+			{ Body: body(malformed) },
+		]);
+		await expect(
+			malformedJson.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'bad.json',
+				limit: 20,
+				content_url: '/content',
+			}),
+		).rejects.toMatchObject({ code: 'unsupported', message: 'The JSON file is malformed.' });
+
+		const truncatedJson = harness(
+			[{ ContentLength: 100, ContentType: 'application/json' }, { Body: body(malformed) }],
+			{ limits: { previewMaxBytes: malformed.length } },
+		);
+		await expect(
+			truncatedJson.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'large.json',
+				limit: 20,
+				content_url: '/content',
+			}),
+		).resolves.toMatchObject({ kind: 'unsupported', detected_type: 'json' });
+	});
+
+	it('normalizes duplicate and blank semicolon-delimited headers', async () => {
+		const csv = new TextEncoder().encode('\ufeffname;name;\nAda;Lovelace;math\n');
+		const test = harness([
+			{ ContentLength: csv.length, ContentType: 'text/csv' },
+			{ Body: body(csv) },
+		]);
+		await expect(
+			test.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'people.csv',
+				limit: 20,
+				content_url: '/content',
+			}),
+		).resolves.toMatchObject({
+			kind: 'tabular',
+			columns: [{ name: 'name' }, { name: 'name_2' }, { name: 'column_3' }],
+			rows: [['Ada', 'Lovelace', 'math']],
+		});
+	});
+
+	it('handles scalar JSON, malformed JSON Lines, and incomplete final JSON Lines records', async () => {
+		const scalar = new TextEncoder().encode('42');
+		const scalarTest = harness([
+			{ ContentLength: scalar.length, ContentType: 'application/json' },
+			{ Body: body(scalar) },
+		]);
+		await expect(
+			scalarTest.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'scalar.json',
+				limit: 20,
+				content_url: '/content',
+			}),
+		).resolves.toMatchObject({ kind: 'text', format: 'json', text: '42' });
+
+		const malformed = new TextEncoder().encode('{"ok":1}\n{bad}\n');
+		const malformedTest = harness([
+			{ ContentLength: malformed.length, ContentType: 'application/x-ndjson' },
+			{ Body: body(malformed) },
+		]);
+		await expect(
+			malformedTest.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'bad.jsonl',
+				limit: 20,
+				content_url: '/content',
+			}),
+		).rejects.toMatchObject({ code: 'unsupported' });
+
+		const partial = new TextEncoder().encode('{"ok":1}\n{"partial"');
+		const partialTest = harness(
+			[
+				{ ContentLength: partial.length + 20, ContentType: 'application/x-ndjson' },
+				{ Body: body(partial) },
+			],
+			{ limits: { previewMaxBytes: partial.length } },
+		);
+		await expect(
+			partialTest.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'partial.jsonl',
+				limit: 20,
+				content_url: '/content',
+			}),
+		).resolves.toMatchObject({
+			kind: 'tabular',
+			rows: [[1]],
+			truncated: true,
+		});
+	});
+
+	it('rejects empty, oversized, and non-image inline opens before streaming', async () => {
+		const empty = harness([{ ContentLength: 0 }]);
+		await expect(
+			empty.browser.openObject(source, context, {
+				bucket: 'lake',
+				key: 'empty.png',
+				inline: true,
+			}),
+		).rejects.toMatchObject({ code: 'unsupported' });
+		expect(empty.sent).toHaveLength(1);
+
+		const oversized = harness([{ ContentLength: 11 }], {
+			limits: { inlineImageMaxBytes: 10 },
+		});
+		await expect(
+			oversized.browser.openObject(source, context, {
+				bucket: 'lake',
+				key: 'large.png',
+				inline: true,
+			}),
+		).rejects.toMatchObject({ code: 'unsupported' });
+		expect(oversized.sent).toHaveLength(1);
+
+		const text = new TextEncoder().encode('not image');
+		const spoofed = harness([{ ContentLength: text.length, ETag: 'etag' }, { Body: body(text) }]);
+		await expect(
+			spoofed.browser.openObject(source, context, {
+				bucket: 'lake',
+				key: 'spoofed.png',
+				inline: true,
+			}),
+		).rejects.toMatchObject({ code: 'unsupported' });
+		expect(spoofed.sent).toHaveLength(2);
+		expect(spoofed.destroyed()).toBe(1);
+	});
+
+	it('pins inline reads to the HEAD ETag and releases after normal stream completion', async () => {
+		const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+		const test = harness([
+			{ ContentLength: png.length, ETag: 'head-etag' },
+			{ Body: body(png) },
+			{ Body: body(png), ContentLength: png.length, ETag: 'body-etag' },
+		]);
+		const opened = await test.browser.openObject(source, context, {
+			bucket: 'lake',
+			key: 'safe.png',
+			inline: true,
+		});
+		expect(opened).toMatchObject({ status: 200, content_type: 'image/png', total_size: 8 });
+		expect(test.sent[1].input).toMatchObject({ Range: 'bytes=0-7', IfMatch: 'head-etag' });
+		expect(test.sent[2].input).toMatchObject({ IfMatch: 'head-etag', Range: undefined });
+		expect(new Uint8Array(await new Response(opened.body).arrayBuffer())).toEqual(png);
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it('releases the client when the returned stream fails', async () => {
+		const failing = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				controller.error(new Error('stream failed'));
+			},
+		});
+		const test = harness([{ Body: failing, ContentLength: 1 }]);
+		const opened = await test.browser.openObject(source, context, {
+			bucket: 'lake',
+			key: 'data.bin',
+		});
+		await expect(new Response(opened.body).arrayBuffer()).rejects.toThrow('stream failed');
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it('preserves streaming, range metadata, and releases the client on cancellation', async () => {
+		let upstreamCanceled = false;
+		const stream = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				controller.enqueue(new Uint8Array([1, 2, 3]));
+			},
+			cancel() {
+				upstreamCanceled = true;
+			},
+		});
+		const test = harness([
+			{
+				Body: stream,
+				ContentLength: 3,
+				ContentRange: 'bytes 0-2/10',
+				ContentType: 'application/octet-stream',
+				ETag: 'etag',
+			},
+		]);
+		const opened = await test.browser.openObject(source, context, {
+			bucket: 'lake',
+			key: 'data.bin',
+			range: 'bytes=0-2',
+			if_match: 'etag',
+		});
+		expect(opened).toMatchObject({ status: 206, content_range: 'bytes 0-2/10', total_size: 10 });
+		expect(test.sent[0].input).toMatchObject({ Range: 'bytes=0-2', IfMatch: 'etag' });
+		await opened.body.cancel();
+		expect(upstreamCanceled).toBe(true);
+		expect(test.destroyed()).toBe(1);
+		opened.close();
+		expect(test.destroyed()).toBe(1);
+	});
+});
+
+describe('credential selection', () => {
+	it('prefers static, then endpoint-compatible temporary credentials', () => {
+		expect(credentialsFor(source, context)).toMatchObject({ accessKeyId: 'access' });
+		const ambient = { ...source, auth: { method: 'ambient' as const } };
+		const temporary = credentialsFor(ambient, {
+			...context,
+			temporary_storage: { endpoint: 'https://s3.example.com/' },
+			temporary_s3_credentials: {
+				accessKeyId: 'temporary',
+				secretAccessKey: 'temporary-secret',
+			},
+		});
+		expect(temporary).toMatchObject({ accessKeyId: 'temporary' });
+		expect(endpointsMatch('https://s3.example.com/a', 'https://s3.example.com/b')).toBe(true);
+	});
+
+	it('rejects endpoint mismatch and unacknowledged server ambient credentials', () => {
+		const ambient = { ...source, auth: { method: 'ambient' as const } };
+		expect(() =>
+			credentialsFor(ambient, {
+				...context,
+				temporary_storage: { endpoint: 'https://other.example.com' },
+				temporary_s3_credentials: {
+					accessKeyId: 'temporary',
+					secretAccessKey: 'temporary-secret',
+				},
+			}),
+		).toThrow(/not valid/);
+		expect(() => credentialsFor(ambient, context)).toThrow(/not enabled/);
+		expect(credentialsFor(ambient, { ...context, allow_server_ambient: true })).toBeUndefined();
+	});
+});
+
+describe('capabilities and metadata-only mode', () => {
+	it('reports credential failures without throwing', () => {
+		const ambient = { ...source, auth: { method: 'ambient' as const } };
+		const test = harness([]);
+		expect(test.browser.capability(ambient, context)).toMatchObject({
+			available: false,
+			preview: false,
+			download: false,
+			versions: false,
+			reason: expect.stringContaining('not enabled'),
+		});
+	});
+
+	it('advertises and enforces metadata-only operation boundaries', () => {
+		const test = harness([], { mode: 'metadata' });
+		expect(test.browser.capability(source, context)).toMatchObject({
+			available: true,
+			preview: false,
+			download: false,
+			preview_formats: [],
+		});
+		expect(() =>
+			test.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'a.txt',
+				limit: 20,
+				content_url: '/content',
+			}),
+		).toThrow(expect.objectContaining({ code: 'access_denied' }));
+		expect(() =>
+			test.browser.openObject(source, context, { bucket: 'lake', key: 'a.txt' }),
+		).toThrow(expect.objectContaining({ code: 'access_denied' }));
+	});
+});
+
+function body(bytes: Uint8Array): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(bytes);
+			controller.close();
+		},
+	});
+}

--- a/packages/object-browser-s3/src/index.ts
+++ b/packages/object-browser-s3/src/index.ts
@@ -120,7 +120,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 				next_cursor: null,
 			};
 		}
-		const cursor = decodeCursor<{ token?: string }>(request.cursor);
+		const cursor = decodeCursor(request.cursor, ['token']);
 		return this.metadataOperation(context, (scopedContext) =>
 			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
 				const output = await sendS3<{
@@ -159,7 +159,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 	): Promise<ObjectPage<ObjectEntry>> {
 		assertBucket(source, request.bucket);
 		const prefix = request.prefix ?? '';
-		const cursor = decodeCursor<{ token?: string }>(request.cursor);
+		const cursor = decodeCursor(request.cursor, ['token']);
 		return this.metadataOperation(context, (scopedContext) =>
 			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
 				const output = await sendS3<ListObjectsOutput>(
@@ -203,7 +203,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 	): Promise<ObjectSearchPage> {
 		assertBucket(source, request.bucket);
 		const prefix = request.prefix ?? '';
-		const cursor = decodeCursor<{ token?: string; start_after?: string }>(request.cursor);
+		const cursor = decodeCursor(request.cursor, ['token', 'start_after']);
 		if (cursor.token && cursor.start_after) {
 			throw new ObjectBrowseError('invalid_cursor', 'The object-browser cursor is invalid.');
 		}
@@ -285,16 +285,26 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		assertObjectIdentity(source, request);
 		return this.metadataOperation(context, (scopedContext) =>
 			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
-				const head = await sendS3<HeadOutput>(
-					client,
-					new HeadObjectCommand({
-						Bucket: request.bucket,
-						Key: request.key,
-						VersionId: request.version_id,
-						ChecksumMode: 'ENABLED',
-					}),
-					scopedContext.signal,
-				);
+				const input = {
+					Bucket: request.bucket,
+					Key: request.key,
+					VersionId: request.version_id,
+				};
+				let head: HeadOutput;
+				try {
+					head = await sendS3<HeadOutput>(
+						client,
+						new HeadObjectCommand({ ...input, ChecksumMode: 'ENABLED' }),
+						scopedContext.signal,
+					);
+				} catch (error) {
+					if (!(error instanceof ObjectBrowseError) || error.code !== 'access_denied') throw error;
+					head = await sendS3<HeadOutput>(
+						client,
+						new HeadObjectCommand(input),
+						scopedContext.signal,
+					);
+				}
 				let tags: { key: string; value: string }[] | undefined;
 				let tagsAvailable = false;
 				try {
@@ -328,7 +338,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		request: ObjectVersionRequest,
 	): Promise<ObjectPage<ObjectVersion>> {
 		assertObjectIdentity(source, request);
-		const cursor = decodeCursor<{ key?: string; version?: string }>(request.cursor);
+		const cursor = decodeCursor(request.cursor, ['key', 'version']);
 		return this.metadataOperation(context, (scopedContext) =>
 			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
 				const output = await sendS3<VersionsOutput>(

--- a/packages/object-browser-s3/src/index.ts
+++ b/packages/object-browser-s3/src/index.ts
@@ -1,0 +1,528 @@
+import {
+	GetObjectTaggingCommand,
+	HeadObjectCommand,
+	ListBucketsCommand,
+	ListObjectsV2Command,
+	ListObjectVersionsCommand,
+} from '@aws-sdk/client-s3';
+import type {
+	ObjectBody,
+	ObjectBrowseCapability,
+	ObjectBrowseContext,
+	ObjectBrowser,
+	ObjectBucket,
+	ObjectDetail,
+	ObjectEntry,
+	ObjectIdentity,
+	ObjectListRequest,
+	ObjectOpenRequest,
+	ObjectPage,
+	ObjectPageRequest,
+	ObjectPreview,
+	ObjectPreviewRequest,
+	ObjectSearchPage,
+	ObjectSearchRequest,
+	ObjectStoreSource,
+	ObjectVersion,
+	ObjectVersionRequest,
+} from '@marimo-hub/core';
+import { ObjectBrowseError } from '@marimo-hub/core';
+import { createS3ClientFactory, credentialsFor } from './client';
+import type { GuardedHostResolver, S3ClientFactory } from './client';
+import { decodeCursor, encodeCursor } from './cursors';
+import { mapS3Error } from './errors';
+import { S3_PREVIEW_FORMATS } from './formats';
+import { openS3Object } from './open';
+import { previewS3Object } from './preview';
+import { sendS3, withOperationDeadline, withS3Client } from './s3Request';
+import { assertBucket, assertObjectIdentity } from './validation';
+
+export interface S3ObjectBrowserLimits {
+	previewMaxBytes: number;
+	inlineImageMaxBytes: number;
+	parquetMaxRangedBytes: number;
+	searchMaxKeys: number;
+	metadataTimeoutMs: number;
+	previewTimeoutMs: number;
+}
+
+export interface S3ObjectBrowserOptions {
+	mode: 'metadata' | 'full';
+	limits?: Partial<S3ObjectBrowserLimits>;
+	resolveHost?: GuardedHostResolver;
+	clientFactory?: S3ClientFactory;
+}
+
+export const DEFAULT_S3_OBJECT_BROWSER_LIMITS: S3ObjectBrowserLimits = {
+	previewMaxBytes: 8 * 1024 * 1024,
+	inlineImageMaxBytes: 10 * 1024 * 1024,
+	parquetMaxRangedBytes: 32 * 1024 * 1024,
+	searchMaxKeys: 5_000,
+	metadataTimeoutMs: 30_000,
+	previewTimeoutMs: 30_000,
+};
+
+const SEARCH_BATCH_SIZE = 1_000;
+
+export class S3ObjectBrowser implements ObjectBrowser {
+	private readonly mode: 'metadata' | 'full';
+	private readonly limits: S3ObjectBrowserLimits;
+	private readonly clientFactory: S3ClientFactory;
+
+	constructor(options: S3ObjectBrowserOptions) {
+		this.mode = options.mode;
+		this.limits = { ...DEFAULT_S3_OBJECT_BROWSER_LIMITS, ...options.limits };
+		if (options.clientFactory) this.clientFactory = options.clientFactory;
+		else if (options.resolveHost) {
+			this.clientFactory = createS3ClientFactory({
+				resolveHost: options.resolveHost,
+				requestTimeoutMs: this.limits.metadataTimeoutMs,
+			});
+		} else {
+			throw new Error('S3ObjectBrowser requires a guarded host resolver.');
+		}
+	}
+
+	capability(source: ObjectStoreSource, context: ObjectBrowseContext): ObjectBrowseCapability {
+		try {
+			credentialsFor(source, context);
+			return {
+				available: true,
+				preview: this.mode === 'full',
+				download: this.mode === 'full',
+				search: 'bounded-key-name',
+				versions: true,
+				preview_formats: this.mode === 'full' ? [...S3_PREVIEW_FORMATS] : [],
+			};
+		} catch (error) {
+			const mapped = mapS3Error(error);
+			return {
+				available: false,
+				preview: false,
+				download: false,
+				search: 'bounded-key-name',
+				versions: false,
+				preview_formats: [],
+				reason: mapped.message,
+			};
+		}
+	}
+
+	async listBuckets(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectPageRequest,
+	): Promise<ObjectPage<ObjectBucket>> {
+		if (source.configured_bucket) {
+			if (request.cursor) throw new ObjectBrowseError('invalid_cursor', 'The cursor is invalid.');
+			return {
+				items: [{ name: source.configured_bucket, configured: true }],
+				next_cursor: null,
+			};
+		}
+		const cursor = decodeCursor<{ token?: string }>(request.cursor);
+		return this.metadataOperation(context, (scopedContext) =>
+			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+				const output = await sendS3<{
+					Buckets?: { Name?: string; CreationDate?: Date }[];
+					ContinuationToken?: string;
+				}>(
+					client,
+					new ListBucketsCommand({
+						MaxBuckets: request.limit,
+						ContinuationToken: cursor.token,
+					}),
+					scopedContext.signal,
+				);
+				return {
+					items: (output.Buckets ?? [])
+						.filter((bucket): bucket is { Name: string; CreationDate?: Date } =>
+							Boolean(bucket.Name),
+						)
+						.map((bucket) => ({
+							name: bucket.Name,
+							created_at: bucket.CreationDate?.toISOString(),
+							configured: false,
+						})),
+					next_cursor: output.ContinuationToken
+						? encodeCursor({ token: output.ContinuationToken })
+						: null,
+				};
+			}),
+		);
+	}
+
+	async listObjects(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectListRequest,
+	): Promise<ObjectPage<ObjectEntry>> {
+		assertBucket(source, request.bucket);
+		const prefix = request.prefix ?? '';
+		const cursor = decodeCursor<{ token?: string }>(request.cursor);
+		return this.metadataOperation(context, (scopedContext) =>
+			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+				const output = await sendS3<ListObjectsOutput>(
+					client,
+					new ListObjectsV2Command({
+						Bucket: request.bucket,
+						Prefix: prefix,
+						Delimiter: '/',
+						MaxKeys: request.limit,
+						ContinuationToken: cursor.token,
+					}),
+					scopedContext.signal,
+				);
+				const prefixes = new Set(
+					(output.CommonPrefixes ?? []).flatMap(({ Prefix }) => (Prefix ? [Prefix] : [])),
+				);
+				const items: ObjectEntry[] = [
+					...prefixes.values().map((key) => ({
+						kind: 'prefix' as const,
+						key,
+						name: key.slice(prefix.length).replace(/\/$/, ''),
+					})),
+					...(output.Contents ?? [])
+						.filter(({ Key, Size }) => Key && !(Size === 0 && prefixes.has(Key)))
+						.map((object) => objectEntry(object, prefix)),
+				].sort((left, right) => left.key.localeCompare(right.key));
+				return {
+					items,
+					next_cursor: output.NextContinuationToken
+						? encodeCursor({ token: output.NextContinuationToken })
+						: null,
+				};
+			}),
+		);
+	}
+
+	async searchObjects(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectSearchRequest,
+	): Promise<ObjectSearchPage> {
+		assertBucket(source, request.bucket);
+		const prefix = request.prefix ?? '';
+		const cursor = decodeCursor<{ token?: string; start_after?: string }>(request.cursor);
+		if (cursor.token && cursor.start_after) {
+			throw new ObjectBrowseError('invalid_cursor', 'The object-browser cursor is invalid.');
+		}
+		const query = request.query.toLocaleLowerCase();
+		return this.metadataOperation(context, (scopedContext) =>
+			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+				const items: ObjectEntry[] = [];
+				let scanned = 0;
+				let token = cursor.token;
+				let startAfter = cursor.start_after;
+				let complete = false;
+				let nextCursor: string | null = null;
+				while (scanned < this.limits.searchMaxKeys && items.length < request.limit) {
+					const remainingScan = this.limits.searchMaxKeys - scanned;
+					const requestToken = token;
+					const output = await sendS3<ListObjectsOutput>(
+						client,
+						new ListObjectsV2Command({
+							Bucket: request.bucket,
+							Prefix: prefix,
+							MaxKeys: Math.min(remainingScan, SEARCH_BATCH_SIZE),
+							ContinuationToken: token,
+							StartAfter: token ? undefined : startAfter,
+						}),
+						scopedContext.signal,
+					);
+					const contents = (output.Contents ?? []).filter(
+						(object): object is typeof object & { Key: string } => object.Key !== undefined,
+					);
+					for (let index = 0; index < contents.length; index += 1) {
+						const object = contents[index];
+						scanned += 1;
+						if (object.Key.slice(prefix.length).toLocaleLowerCase().includes(query)) {
+							const entry = objectEntry(object, prefix);
+							if (matchesFilters(entry, request)) items.push(entry);
+						}
+						if (scanned < this.limits.searchMaxKeys && items.length < request.limit) {
+							continue;
+						}
+						if (index < contents.length - 1) {
+							nextCursor = encodeCursor({ start_after: object.Key });
+						} else if (output.IsTruncated && output.NextContinuationToken) {
+							nextCursor = encodeCursor({ token: output.NextContinuationToken });
+						} else {
+							complete = true;
+						}
+						break;
+					}
+					if (items.length >= request.limit || scanned >= this.limits.searchMaxKeys) break;
+					if (!output.IsTruncated) {
+						complete = true;
+						break;
+					}
+					token = output.NextContinuationToken;
+					startAfter = undefined;
+					if (!token || token === requestToken) {
+						throw new ObjectBrowseError(
+							'invalid_cursor',
+							'The object-store cursor did not advance.',
+						);
+					}
+				}
+				if (!complete && !nextCursor && token) nextCursor = encodeCursor({ token });
+				return {
+					items,
+					scanned,
+					complete,
+					next_cursor: complete ? null : nextCursor,
+				};
+			}),
+		);
+	}
+
+	async headObject(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectIdentity,
+	): Promise<ObjectDetail> {
+		assertObjectIdentity(source, request);
+		return this.metadataOperation(context, (scopedContext) =>
+			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+				const head = await sendS3<HeadOutput>(
+					client,
+					new HeadObjectCommand({
+						Bucket: request.bucket,
+						Key: request.key,
+						VersionId: request.version_id,
+						ChecksumMode: 'ENABLED',
+					}),
+					scopedContext.signal,
+				);
+				let tags: { key: string; value: string }[] | undefined;
+				let tagsAvailable = false;
+				try {
+					const tagged = await sendS3<{ TagSet?: { Key?: string; Value?: string }[] }>(
+						client,
+						new GetObjectTaggingCommand({
+							Bucket: request.bucket,
+							Key: request.key,
+							VersionId: request.version_id,
+						}),
+						scopedContext.signal,
+					);
+					tags = (tagged.TagSet ?? []).flatMap((tag) =>
+						tag.Key !== undefined && tag.Value !== undefined
+							? [{ key: tag.Key, value: tag.Value }]
+							: [],
+					);
+					tagsAvailable = true;
+				} catch (error) {
+					const mapped = mapS3Error(error);
+					if (mapped.code !== 'access_denied' && mapped.code !== 'unsupported') throw mapped;
+				}
+				return detailFromHead(request, head, tags, tagsAvailable);
+			}),
+		);
+	}
+
+	async listVersions(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectVersionRequest,
+	): Promise<ObjectPage<ObjectVersion>> {
+		assertObjectIdentity(source, request);
+		const cursor = decodeCursor<{ key?: string; version?: string }>(request.cursor);
+		return this.metadataOperation(context, (scopedContext) =>
+			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+				const output = await sendS3<VersionsOutput>(
+					client,
+					new ListObjectVersionsCommand({
+						Bucket: request.bucket,
+						Prefix: request.key,
+						MaxKeys: request.limit,
+						KeyMarker: cursor.key,
+						VersionIdMarker: cursor.version,
+					}),
+					scopedContext.signal,
+				);
+				const versions: ObjectVersion[] = [
+					...(output.Versions ?? []).flatMap((version) =>
+						version.Key === request.key && version.VersionId
+							? [versionEntry(request.bucket, version, 'version')]
+							: [],
+					),
+					...(output.DeleteMarkers ?? []).flatMap((version) =>
+						version.Key === request.key && version.VersionId
+							? [versionEntry(request.bucket, version, 'delete-marker')]
+							: [],
+					),
+				].sort((left, right) =>
+					(right.last_modified ?? '').localeCompare(left.last_modified ?? ''),
+				);
+				return {
+					items: versions,
+					next_cursor:
+						output.IsTruncated && output.NextKeyMarker
+							? encodeCursor({ key: output.NextKeyMarker, version: output.NextVersionIdMarker })
+							: null,
+				};
+			}),
+		);
+	}
+
+	previewObject(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectPreviewRequest,
+	): Promise<ObjectPreview> {
+		if (this.mode !== 'full') {
+			throw new ObjectBrowseError('access_denied', 'Object previews are disabled.');
+		}
+		assertObjectIdentity(source, request);
+		return previewS3Object(this.clientFactory, this.limits, source, context, request);
+	}
+
+	openObject(
+		source: ObjectStoreSource,
+		context: ObjectBrowseContext,
+		request: ObjectOpenRequest,
+	): Promise<ObjectBody> {
+		if (this.mode !== 'full') {
+			throw new ObjectBrowseError('access_denied', 'Object downloads are disabled.');
+		}
+		assertObjectIdentity(source, request);
+		return openS3Object(this.clientFactory, this.limits, source, context, request);
+	}
+
+	private metadataOperation<T>(
+		context: ObjectBrowseContext,
+		run: (context: ObjectBrowseContext) => Promise<T>,
+	): Promise<T> {
+		return withOperationDeadline(context, this.limits.metadataTimeoutMs, run);
+	}
+}
+
+interface ListObjectsOutput {
+	Contents?: {
+		Key?: string;
+		Size?: number;
+		LastModified?: Date;
+		ETag?: string;
+		StorageClass?: string;
+	}[];
+	CommonPrefixes?: { Prefix?: string }[];
+	IsTruncated?: boolean;
+	NextContinuationToken?: string;
+}
+
+interface HeadOutput {
+	ContentLength?: number;
+	LastModified?: Date;
+	ETag?: string;
+	StorageClass?: string;
+	ContentType?: string;
+	ContentEncoding?: string;
+	CacheControl?: string;
+	VersionId?: string;
+	Metadata?: Record<string, string>;
+	ChecksumCRC32?: string;
+	ChecksumCRC32C?: string;
+	ChecksumCRC64NVME?: string;
+	ChecksumSHA1?: string;
+	ChecksumSHA256?: string;
+}
+
+interface VersionsOutput {
+	Versions?: VersionOutput[];
+	DeleteMarkers?: VersionOutput[];
+	IsTruncated?: boolean;
+	NextKeyMarker?: string;
+	NextVersionIdMarker?: string;
+}
+
+interface VersionOutput {
+	Key?: string;
+	VersionId?: string;
+	IsLatest?: boolean;
+	LastModified?: Date;
+	Size?: number;
+	ETag?: string;
+	StorageClass?: string;
+	Owner?: { ID?: string; DisplayName?: string };
+}
+
+function objectEntry(
+	object: NonNullable<ListObjectsOutput['Contents']>[number],
+	prefix: string,
+): ObjectEntry {
+	return {
+		kind: 'object',
+		name: object.Key!.slice(prefix.length),
+		key: object.Key!,
+		size: object.Size,
+		last_modified: object.LastModified?.toISOString(),
+		etag: object.ETag,
+		storage_class: object.StorageClass,
+	};
+}
+
+function matchesFilters(entry: ObjectEntry, filters: ObjectSearchRequest): boolean {
+	const extension = entry.key.split('.').at(-1)?.toLowerCase();
+	if (filters.formats?.length && (!extension || !filters.formats.includes(extension))) return false;
+	if (filters.min_size !== undefined && (entry.size ?? 0) < filters.min_size) return false;
+	if (filters.max_size !== undefined && (entry.size ?? 0) > filters.max_size) return false;
+	if (filters.modified_after && (entry.last_modified ?? '') < filters.modified_after) return false;
+	if (filters.modified_before && (entry.last_modified ?? '') > filters.modified_before)
+		return false;
+	return true;
+}
+
+function detailFromHead(
+	request: ObjectIdentity,
+	head: HeadOutput,
+	tags: { key: string; value: string }[] | undefined,
+	tagsAvailable: boolean,
+): ObjectDetail {
+	const checksums = [
+		['crc32', head.ChecksumCRC32],
+		['crc32c', head.ChecksumCRC32C],
+		['crc64nvme', head.ChecksumCRC64NVME],
+		['sha1', head.ChecksumSHA1],
+		['sha256', head.ChecksumSHA256],
+	].flatMap(([algorithm, value]) => (value ? [{ algorithm: algorithm!, value }] : []));
+	return {
+		...request,
+		version_id: head.VersionId ?? request.version_id,
+		size: head.ContentLength ?? 0,
+		last_modified: head.LastModified?.toISOString(),
+		etag: head.ETag,
+		storage_class: head.StorageClass,
+		content_type: head.ContentType,
+		content_encoding: head.ContentEncoding,
+		cache_control: head.CacheControl,
+		checksums,
+		metadata: head.Metadata ?? {},
+		tags,
+		tags_available: tagsAvailable,
+	};
+}
+
+function versionEntry(
+	bucket: string,
+	version: VersionOutput & { Key?: string; VersionId?: string },
+	kind: 'version' | 'delete-marker',
+): ObjectVersion {
+	return {
+		kind,
+		bucket,
+		key: version.Key!,
+		version_id: version.VersionId!,
+		is_latest: version.IsLatest ?? false,
+		last_modified: version.LastModified?.toISOString(),
+		size: version.Size,
+		etag: version.ETag,
+		storage_class: version.StorageClass,
+		owner: version.Owner
+			? { id: version.Owner.ID, display_name: version.Owner.DisplayName }
+			: undefined,
+	};
+}
+
+export type { GuardedHostResolver, S3ClientFactory, S3ClientLike } from './client';

--- a/packages/object-browser-s3/src/open.ts
+++ b/packages/object-browser-s3/src/open.ts
@@ -1,0 +1,123 @@
+import { GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import type {
+	ObjectBody,
+	ObjectBrowseContext,
+	ObjectOpenRequest,
+	ObjectStoreSource,
+} from '@marimo-hub/core';
+import { ObjectBrowseError } from '@marimo-hub/core';
+import type { S3ObjectBrowserLimits } from './index';
+import type { S3ClientFactory } from './client';
+import { mapS3Error } from './errors';
+import { detectRasterImage, rasterContentType } from './formats';
+import { readObjectRange, releaseClientOnce, sendS3 } from './s3Request';
+import { toWebStream } from './streams';
+
+interface GetOutput {
+	Body?: unknown;
+	ContentLength?: number;
+	ContentRange?: string;
+	ContentType?: string;
+	ETag?: string;
+	VersionId?: string;
+}
+
+export async function openS3Object(
+	clientFactory: S3ClientFactory,
+	limits: S3ObjectBrowserLimits,
+	source: ObjectStoreSource,
+	context: ObjectBrowseContext,
+	request: ObjectOpenRequest,
+): Promise<ObjectBody> {
+	const client = clientFactory(source, context);
+	const release = releaseClientOnce(client);
+	try {
+		let verifiedType: string | undefined;
+		let ifMatch = request.if_match;
+		if (request.inline) {
+			const head = await sendS3<{ ContentLength?: number; ETag?: string }>(
+				client,
+				new HeadObjectCommand({
+					Bucket: request.bucket,
+					Key: request.key,
+					VersionId: request.version_id,
+				}),
+				context.signal,
+			);
+			const size = head.ContentLength ?? 0;
+			if (size === 0) {
+				throw new ObjectBrowseError('unsupported', 'An empty object is not a raster image.');
+			}
+			if (size > limits.inlineImageMaxBytes) {
+				throw new ObjectBrowseError('unsupported', 'The image exceeds the inline preview limit.');
+			}
+			ifMatch ??= request.version_id ? undefined : head.ETag;
+			const probe = await readObjectRange(client, request, 0, Math.min(size, 16), {
+				etag: ifMatch,
+				signal: context.signal,
+			});
+			const imageFormat = detectRasterImage(probe);
+			if (!imageFormat) {
+				throw new ObjectBrowseError('unsupported', 'Only safe raster images can be shown inline.');
+			}
+			verifiedType = rasterContentType(imageFormat);
+		}
+		const output = await sendS3<GetOutput>(
+			client,
+			new GetObjectCommand({
+				Bucket: request.bucket,
+				Key: request.key,
+				VersionId: request.version_id,
+				IfMatch: ifMatch,
+				Range: request.inline ? undefined : request.range,
+			}),
+			context.signal,
+		);
+		if (!output.Body) throw new ObjectBrowseError('unavailable', 'The object body was empty.');
+		const upstream = toWebStream(output.Body).getReader();
+		const body = new ReadableStream<Uint8Array>({
+			async pull(controller) {
+				try {
+					const next = await upstream.read();
+					if (next.done) {
+						controller.close();
+						release();
+					} else {
+						controller.enqueue(next.value);
+					}
+				} catch (error) {
+					controller.error(error);
+					release();
+				}
+			},
+			async cancel(reason) {
+				try {
+					await upstream.cancel(reason);
+				} finally {
+					release();
+				}
+			},
+		});
+		const total = totalSize(output.ContentRange, output.ContentLength ?? 0);
+		return {
+			body,
+			status: output.ContentRange ? 206 : 200,
+			content_type: verifiedType ?? output.ContentType ?? 'application/octet-stream',
+			content_length: output.ContentLength ?? 0,
+			total_size: total,
+			content_range: output.ContentRange,
+			etag: output.ETag,
+			version_id: output.VersionId ?? request.version_id,
+			close: release,
+		};
+	} catch (error) {
+		release();
+		throw mapS3Error(error);
+	}
+}
+
+function totalSize(contentRange: string | undefined, contentLength: number): number {
+	if (!contentRange) return contentLength;
+	const match = /\/(\d+)$/.exec(contentRange);
+	return match ? Number(match[1]) : contentLength;
+}

--- a/packages/object-browser-s3/src/open.ts
+++ b/packages/object-browser-s3/src/open.ts
@@ -75,24 +75,32 @@ export async function openS3Object(
 		);
 		if (!output.Body) throw new ObjectBrowseError('unavailable', 'The object body was empty.');
 		const upstream = toWebStream(output.Body).getReader();
+		let upstreamClosed = false;
+		const cancelUpstream = (reason?: unknown): Promise<void> => {
+			if (upstreamClosed) return Promise.resolve();
+			upstreamClosed = true;
+			return upstream.cancel(reason);
+		};
 		const body = new ReadableStream<Uint8Array>({
 			async pull(controller) {
 				try {
 					const next = await upstream.read();
 					if (next.done) {
+						upstreamClosed = true;
 						controller.close();
 						release();
 					} else {
 						controller.enqueue(next.value);
 					}
 				} catch (error) {
+					upstreamClosed = true;
 					controller.error(error);
 					release();
 				}
 			},
 			async cancel(reason) {
 				try {
-					await upstream.cancel(reason);
+					await cancelUpstream(reason);
 				} finally {
 					release();
 				}
@@ -108,7 +116,11 @@ export async function openS3Object(
 			content_range: output.ContentRange,
 			etag: output.ETag,
 			version_id: output.VersionId ?? request.version_id,
-			close: release,
+			close() {
+				const cancellation = cancelUpstream();
+				release();
+				void cancellation.catch(() => {});
+			},
 		};
 	} catch (error) {
 		release();

--- a/packages/object-browser-s3/src/preview/index.ts
+++ b/packages/object-browser-s3/src/preview/index.ts
@@ -494,10 +494,18 @@ function scalarText(value: unknown): string {
 
 function boundTable(preview: TabularPreview): TabularPreview {
 	preview.warnings = [...new Set(preview.warnings)];
-	while (preview.rows.length > 0 && serializedByteLength(preview) > MAX_RESULT_BYTES) {
-		preview.rows.pop();
-		preview.truncated = true;
+	if (serializedByteLength(preview) <= MAX_RESULT_BYTES) return preview;
+	const rows = preview.rows;
+	preview.truncated = true;
+	let lower = 0;
+	let upper = rows.length;
+	while (lower < upper) {
+		const candidate = Math.ceil((lower + upper) / 2);
+		preview.rows = rows.slice(0, candidate);
+		if (serializedByteLength(preview) <= MAX_RESULT_BYTES) lower = candidate;
+		else upper = candidate - 1;
 	}
+	preview.rows = rows.slice(0, lower);
 	if (serializedByteLength(preview) > MAX_RESULT_BYTES) {
 		throw new ObjectBrowseError('unsupported', 'The preview result exceeds the response limit.');
 	}

--- a/packages/object-browser-s3/src/preview/index.ts
+++ b/packages/object-browser-s3/src/preview/index.ts
@@ -170,14 +170,20 @@ function previewDelimited(
 	} catch {
 		throw new ObjectBrowseError('unsupported', 'The delimited file is malformed.');
 	}
-	const header = normalizeHeaders(records.shift() ?? []);
-	const rows = records.slice(0, limit).map((row) => normalizeRow(row, warnings));
+	const rawHeader = records.shift() ?? [];
+	const visibleRows = records.slice(0, limit);
+	const header = normalizeHeaders(rawHeader.slice(0, MAX_COLUMNS));
+	const rows = visibleRows.map((row) => normalizeRow(row.slice(0, MAX_COLUMNS), warnings));
 	return boundTable({
 		kind: 'tabular',
 		format,
-		columns: header.slice(0, MAX_COLUMNS).map((name) => ({ name })),
-		rows: rows.map((row) => row.slice(0, MAX_COLUMNS)),
-		truncated: truncated || records.length > limit,
+		columns: header.map((name) => ({ name })),
+		rows,
+		truncated:
+			truncated ||
+			records.length > limit ||
+			rawHeader.length > MAX_COLUMNS ||
+			visibleRows.some((row) => row.length > MAX_COLUMNS),
 		bytes_read: bytes.byteLength,
 		total_bytes: totalBytes,
 		warnings,
@@ -209,17 +215,18 @@ function previewJsonLines(bytes: Uint8Array, totalBytes: number, limit: number):
 }
 
 function previewJson(bytes: Uint8Array, totalBytes: number, limit: number): ObjectPreview {
+	const truncated = bytes.byteLength < totalBytes;
 	let value: unknown;
 	try {
-		value = JSON.parse(decodeUtf8(bytes, bytes.byteLength < totalBytes));
+		value = JSON.parse(decodeUtf8(bytes, truncated));
 	} catch {
-		if (bytes.byteLength < totalBytes) {
+		if (truncated) {
 			return unsupported('The JSON value exceeds the preview byte limit.', 'json', totalBytes);
 		}
 		throw new ObjectBrowseError('unsupported', 'The JSON file is malformed.');
 	}
 	if (Array.isArray(value)) {
-		return valuesToTable(value, 'json', bytes.byteLength, totalBytes, false, limit);
+		return valuesToTable(value, 'json', bytes.byteLength, totalBytes, truncated, limit);
 	}
 	if (isRecord(value)) {
 		const warnings: string[] = [];
@@ -230,7 +237,7 @@ function previewJson(bytes: Uint8Array, totalBytes: number, limit: number): Obje
 			rows: Object.entries(value)
 				.slice(0, limit)
 				.map(([key, child]) => [key, normalizeValue(child, warnings)]),
-			truncated: Object.keys(value).length > limit,
+			truncated: truncated || Object.keys(value).length > limit,
 			bytes_read: bytes.byteLength,
 			total_bytes: totalBytes,
 			warnings,
@@ -241,7 +248,7 @@ function previewJson(bytes: Uint8Array, totalBytes: number, limit: number): Obje
 		kind: 'text',
 		format: 'json',
 		text,
-		truncated: false,
+		truncated,
 		bytes_read: bytes.byteLength,
 		total_bytes: totalBytes,
 		warnings: [],
@@ -486,15 +493,19 @@ function scalarText(value: unknown): string {
 }
 
 function boundTable(preview: TabularPreview): TabularPreview {
-	while (preview.rows.length > 0 && JSON.stringify(preview).length > MAX_RESULT_BYTES) {
+	preview.warnings = [...new Set(preview.warnings)];
+	while (preview.rows.length > 0 && serializedByteLength(preview) > MAX_RESULT_BYTES) {
 		preview.rows.pop();
 		preview.truncated = true;
 	}
-	if (JSON.stringify(preview).length > MAX_RESULT_BYTES) {
+	if (serializedByteLength(preview) > MAX_RESULT_BYTES) {
 		throw new ObjectBrowseError('unsupported', 'The preview result exceeds the response limit.');
 	}
-	preview.warnings = [...new Set(preview.warnings)];
 	return preview;
+}
+
+function serializedByteLength(value: unknown): number {
+	return new TextEncoder().encode(JSON.stringify(value)).byteLength;
 }
 
 function unsupported(reason: string, type: string | undefined, totalBytes: number): ObjectPreview {

--- a/packages/object-browser-s3/src/preview/index.ts
+++ b/packages/object-browser-s3/src/preview/index.ts
@@ -1,0 +1,533 @@
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import type {
+	ObjectBrowseContext,
+	ObjectPreview,
+	ObjectPreviewRequest,
+	ObjectStoreSource,
+	TabularPreview,
+} from '@marimo-hub/core';
+import { ObjectBrowseError } from '@marimo-hub/core';
+import { parse } from 'csv-parse/sync';
+import { parquetMetadataAsync, parquetReadObjects, parquetSchema } from 'hyparquet';
+import type { AsyncBuffer } from 'hyparquet';
+import type { S3ClientFactory, S3ClientLike } from '../client';
+import { decodeAscii, detectRasterImage } from '../formats';
+import type { S3ObjectBrowserLimits } from '../index';
+import { readObjectRange, sendS3, withS3Client } from '../s3Request';
+import { arrayBuffer } from '../streams';
+
+const MAX_TEXT_BYTES = 512 * 1024;
+const MAX_COLUMNS = 200;
+const MAX_CELL_BYTES = 8 * 1024;
+const MAX_RESULT_BYTES = 2 * 1024 * 1024;
+const MAX_PARQUET_REQUESTS = 64;
+
+interface HeadOutput {
+	ContentLength?: number;
+	ContentType?: string;
+	ETag?: string;
+	VersionId?: string;
+}
+
+export async function previewS3Object(
+	clientFactory: S3ClientFactory,
+	limits: S3ObjectBrowserLimits,
+	source: ObjectStoreSource,
+	context: ObjectBrowseContext,
+	request: ObjectPreviewRequest,
+): Promise<ObjectPreview> {
+	const deadline = AbortSignal.timeout(limits.previewTimeoutMs);
+	const signal = context.signal ? AbortSignal.any([context.signal, deadline]) : deadline;
+	const scopedContext = { ...context, signal };
+	return withS3Client(clientFactory, source, scopedContext, async (client) => {
+		const head = await sendS3<HeadOutput>(
+			client,
+			new HeadObjectCommand({
+				Bucket: request.bucket,
+				Key: request.key,
+				VersionId: request.version_id,
+			}),
+			signal,
+		);
+		const totalBytes = head.ContentLength ?? 0;
+		const probeLength = Math.min(totalBytes, limits.previewMaxBytes);
+		const bytes =
+			probeLength === 0
+				? new Uint8Array()
+				: await readObjectRange(client, request, 0, probeLength, {
+						etag: head.ETag,
+						signal,
+					});
+		const detected = detectFormat(
+			bytes,
+			request.key,
+			head.ContentType,
+			bytes.byteLength < totalBytes,
+		);
+		if (detected.kind === 'image') {
+			if (totalBytes > limits.inlineImageMaxBytes) {
+				return unsupported(
+					'The image exceeds the inline preview limit.',
+					detected.format,
+					totalBytes,
+				);
+			}
+			return {
+				kind: 'image',
+				format: detected.format,
+				content_url: request.content_url,
+				total_bytes: totalBytes,
+				warnings: [],
+			};
+		}
+		if (detected.kind === 'parquet') {
+			return previewParquet(client, limits, request, head, signal);
+		}
+		if (detected.kind === 'csv') {
+			return previewDelimited(
+				bytes,
+				totalBytes,
+				request.limit,
+				detected.delimiter,
+				detected.format,
+			);
+		}
+		if (detected.kind === 'jsonl') {
+			return previewJsonLines(bytes, totalBytes, request.limit);
+		}
+		if (detected.kind === 'json') return previewJson(bytes, totalBytes, request.limit);
+		if (detected.kind === 'text') {
+			return previewText(bytes, totalBytes, detected.format);
+		}
+		return unsupported('This object format cannot be previewed safely.', detected.type, totalBytes);
+	});
+}
+
+type Detected =
+	| { kind: 'image'; format: 'png' | 'jpeg' | 'gif' | 'webp' }
+	| { kind: 'parquet' }
+	| { kind: 'csv'; format: 'csv' | 'tsv'; delimiter: ',' | '\t' | ';' }
+	| { kind: 'json' }
+	| { kind: 'jsonl' }
+	| { kind: 'text'; format: 'text' | 'markdown' | 'code' | 'log' }
+	| { kind: 'unsupported'; type?: string };
+
+function detectFormat(
+	bytes: Uint8Array,
+	key: string,
+	contentType: string | undefined,
+	truncated: boolean,
+): Detected {
+	const image = detectRasterImage(bytes);
+	if (image) return { kind: 'image', format: image };
+	if (decodeAscii(bytes.slice(0, 4)) === 'PAR1') return { kind: 'parquet' };
+	const extension = key.split('.').at(-1)?.toLowerCase();
+	const safeType = contentType?.split(';', 1)[0]?.trim().toLowerCase();
+	if (safeType && ACTIVE_CONTENT_TYPES.has(safeType)) {
+		return { kind: 'unsupported', type: safeType };
+	}
+	if (safeType === 'application/x-ndjson' || extension === 'jsonl' || extension === 'ndjson') {
+		return { kind: 'jsonl' };
+	}
+	if (safeType === 'application/json' || extension === 'json') return { kind: 'json' };
+	if (safeType === 'text/csv' || extension === 'csv') {
+		return { kind: 'csv', format: 'csv', delimiter: detectDelimiter(bytes, truncated) };
+	}
+	if (safeType === 'text/tab-separated-values' || extension === 'tsv') {
+		return { kind: 'csv', format: 'tsv', delimiter: '\t' };
+	}
+	if (extension === 'parquet') return { kind: 'parquet' };
+	if (extension === 'md' || extension === 'markdown') return { kind: 'text', format: 'markdown' };
+	if (extension === 'log') return { kind: 'text', format: 'log' };
+	if (CODE_EXTENSIONS.has(extension ?? '')) return { kind: 'text', format: 'code' };
+	if (safeType?.startsWith('text/') || TEXT_EXTENSIONS.has(extension ?? '')) {
+		return { kind: 'text', format: 'text' };
+	}
+	return { kind: 'unsupported', type: safeType ?? extension };
+}
+
+function previewDelimited(
+	bytes: Uint8Array,
+	totalBytes: number,
+	limit: number,
+	delimiter: ',' | '\t' | ';',
+	format: 'csv' | 'tsv',
+): TabularPreview {
+	const warnings: string[] = [];
+	const truncated = bytes.byteLength < totalBytes;
+	let records: unknown[][];
+	try {
+		const decoded = decodeUtf8(bytes, truncated);
+		records = parse(truncated ? completeLinePrefix(decoded) : decoded, {
+			bom: true,
+			delimiter,
+			skip_empty_lines: true,
+			relax_column_count: true,
+			relax_quotes: true,
+			skip_records_with_error: truncated,
+			to: limit + 2,
+		}) as unknown[][];
+	} catch {
+		throw new ObjectBrowseError('unsupported', 'The delimited file is malformed.');
+	}
+	const header = normalizeHeaders(records.shift() ?? []);
+	const rows = records.slice(0, limit).map((row) => normalizeRow(row, warnings));
+	return boundTable({
+		kind: 'tabular',
+		format,
+		columns: header.slice(0, MAX_COLUMNS).map((name) => ({ name })),
+		rows: rows.map((row) => row.slice(0, MAX_COLUMNS)),
+		truncated: truncated || records.length > limit,
+		bytes_read: bytes.byteLength,
+		total_bytes: totalBytes,
+		warnings,
+	});
+}
+
+function completeLinePrefix(value: string): string {
+	if (value.endsWith('\n')) return value;
+	const lastNewline = value.lastIndexOf('\n');
+	return lastNewline === -1 ? '' : value.slice(0, lastNewline + 1);
+}
+
+function previewJsonLines(bytes: Uint8Array, totalBytes: number, limit: number): TabularPreview {
+	const truncated = bytes.byteLength < totalBytes;
+	const text = decodeUtf8(bytes, truncated);
+	const lines = text.split(/\r?\n/);
+	if (truncated) lines.pop();
+	const values: unknown[] = [];
+	for (const line of lines) {
+		if (!line.trim()) continue;
+		try {
+			values.push(JSON.parse(line));
+		} catch {
+			throw new ObjectBrowseError('unsupported', 'The JSON Lines file is malformed.');
+		}
+		if (values.length > limit) break;
+	}
+	return valuesToTable(values, 'jsonl', bytes.byteLength, totalBytes, truncated, limit);
+}
+
+function previewJson(bytes: Uint8Array, totalBytes: number, limit: number): ObjectPreview {
+	let value: unknown;
+	try {
+		value = JSON.parse(decodeUtf8(bytes, bytes.byteLength < totalBytes));
+	} catch {
+		if (bytes.byteLength < totalBytes) {
+			return unsupported('The JSON value exceeds the preview byte limit.', 'json', totalBytes);
+		}
+		throw new ObjectBrowseError('unsupported', 'The JSON file is malformed.');
+	}
+	if (Array.isArray(value)) {
+		return valuesToTable(value, 'json', bytes.byteLength, totalBytes, false, limit);
+	}
+	if (isRecord(value)) {
+		const warnings: string[] = [];
+		return boundTable({
+			kind: 'tabular',
+			format: 'json',
+			columns: [{ name: 'key' }, { name: 'value' }],
+			rows: Object.entries(value)
+				.slice(0, limit)
+				.map(([key, child]) => [key, normalizeValue(child, warnings)]),
+			truncated: Object.keys(value).length > limit,
+			bytes_read: bytes.byteLength,
+			total_bytes: totalBytes,
+			warnings,
+		});
+	}
+	const text = JSON.stringify(normalizeValue(value, []), null, 2);
+	return {
+		kind: 'text',
+		format: 'json',
+		text,
+		truncated: false,
+		bytes_read: bytes.byteLength,
+		total_bytes: totalBytes,
+		warnings: [],
+	};
+}
+
+function valuesToTable(
+	values: unknown[],
+	format: 'json' | 'jsonl',
+	bytesRead: number,
+	totalBytes: number,
+	alreadyTruncated: boolean,
+	limit: number,
+): TabularPreview {
+	const warnings: string[] = [];
+	const records = values.filter(isRecord);
+	if (records.length !== values.length) {
+		return boundTable({
+			kind: 'tabular',
+			format,
+			columns: [{ name: 'value' }],
+			rows: values.slice(0, limit).map((value) => [normalizeValue(value, warnings)]),
+			truncated: alreadyTruncated || values.length > limit,
+			bytes_read: bytesRead,
+			total_bytes: totalBytes,
+			warnings,
+		});
+	}
+	const columns: string[] = [];
+	const seen = new Set<string>();
+	for (const record of records) {
+		for (const key of Object.keys(record)) {
+			if (!seen.has(key) && columns.length < MAX_COLUMNS) {
+				seen.add(key);
+				columns.push(key);
+			}
+		}
+	}
+	return boundTable({
+		kind: 'tabular',
+		format,
+		columns: columns.map((name) => ({ name })),
+		rows: records
+			.slice(0, limit)
+			.map((record) => columns.map((column) => normalizeValue(record[column], warnings))),
+		truncated: alreadyTruncated || values.length > limit,
+		bytes_read: bytesRead,
+		total_bytes: totalBytes,
+		warnings,
+	});
+}
+
+function previewText(
+	bytes: Uint8Array,
+	totalBytes: number,
+	format: 'text' | 'markdown' | 'code' | 'log',
+): ObjectPreview {
+	const source = bytes.slice(0, MAX_TEXT_BYTES);
+	return {
+		kind: 'text',
+		format,
+		text: decodeUtf8(source, source.byteLength < totalBytes),
+		truncated: source.byteLength < totalBytes,
+		bytes_read: bytes.byteLength,
+		total_bytes: totalBytes,
+		warnings: [],
+	};
+}
+
+async function previewParquet(
+	client: S3ClientLike,
+	limits: S3ObjectBrowserLimits,
+	request: ObjectPreviewRequest,
+	head: HeadOutput,
+	signal: AbortSignal,
+): Promise<TabularPreview> {
+	const total = head.ContentLength ?? 0;
+	let requests = 0;
+	let bytesRead = 0;
+	const cache = new Map<string, Promise<ArrayBuffer>>();
+	const file: AsyncBuffer = {
+		byteLength: total,
+		slice(start, end = total) {
+			if (
+				!Number.isSafeInteger(start) ||
+				!Number.isSafeInteger(end) ||
+				start < 0 ||
+				end <= start ||
+				end > total
+			) {
+				return Promise.reject(
+					new ObjectBrowseError('unsupported', 'The Parquet reader requested an invalid range.'),
+				);
+			}
+			const key = `${start}:${end}`;
+			const cached = cache.get(key);
+			if (cached) return cached;
+			const length = end - start;
+			if (requests >= MAX_PARQUET_REQUESTS || bytesRead + length > limits.parquetMaxRangedBytes) {
+				return Promise.reject(
+					new ObjectBrowseError('unsupported', 'The Parquet preview exceeded its range budget.'),
+				);
+			}
+			requests += 1;
+			bytesRead += length;
+			const pending = readObjectRange(client, request, start, end, {
+				etag: head.ETag,
+				signal,
+			}).then(arrayBuffer);
+			cache.set(key, pending);
+			return pending;
+		},
+	};
+	try {
+		const metadata = await parquetMetadataAsync(file);
+		const columns = parquetSchema(metadata)
+			.children.slice(0, MAX_COLUMNS)
+			.map((column) => column.element.name);
+		const objects = await parquetReadObjects({
+			file,
+			metadata,
+			columns,
+			rowEnd: request.limit,
+		});
+		const warnings: string[] = [];
+		return boundTable({
+			kind: 'tabular',
+			format: 'parquet',
+			columns: columns.map((name) => ({ name })),
+			rows: objects.map((row) => columns.map((column) => normalizeValue(row[column], warnings))),
+			truncated:
+				BigInt(request.limit) < metadata.num_rows ||
+				columns.length < parquetSchema(metadata).children.length,
+			bytes_read: bytesRead,
+			total_bytes: total,
+			warnings,
+		});
+	} catch (error) {
+		if (error instanceof ObjectBrowseError) throw error;
+		throw new ObjectBrowseError('unsupported', 'The Parquet file could not be previewed.');
+	}
+}
+
+function decodeUtf8(bytes: Uint8Array, allowIncompleteTrailing = false): string {
+	try {
+		return new TextDecoder('utf-8', { fatal: true }).decode(bytes, {
+			stream: allowIncompleteTrailing,
+		});
+	} catch {
+		throw new ObjectBrowseError('unsupported', 'The object is not valid UTF-8 text.');
+	}
+}
+
+function detectDelimiter(bytes: Uint8Array, truncated: boolean): ',' | '\t' | ';' {
+	const prefix = bytes.slice(0, Math.min(bytes.length, 64 * 1024));
+	const text = decodeUtf8(prefix, truncated || prefix.byteLength < bytes.byteLength);
+	const counts = new Map<',' | '\t' | ';', number>([
+		[',', 0],
+		['\t', 0],
+		[';', 0],
+	]);
+	let quoted = false;
+	for (let index = 0; index < text.length; index += 1) {
+		const char = text[index];
+		if (char === '"') {
+			if (quoted && text[index + 1] === '"') index += 1;
+			else quoted = !quoted;
+		} else if (!quoted && char === '\n') break;
+		else if (!quoted && counts.has(char as ',' | '\t' | ';')) {
+			const delimiter = char as ',' | '\t' | ';';
+			counts.set(delimiter, counts.get(delimiter)! + 1);
+		}
+	}
+	return [...counts.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ?? ',';
+}
+
+function normalizeHeaders(values: unknown[]): string[] {
+	const seen = new Map<string, number>();
+	return values.map((value, index) => {
+		const base = scalarText(value).trim() || `column_${index + 1}`;
+		const count = (seen.get(base) ?? 0) + 1;
+		seen.set(base, count);
+		return count === 1 ? base : `${base}_${count}`;
+	});
+}
+
+function normalizeRow(row: unknown[], warnings: string[]): unknown[] {
+	return row.map((value) => normalizeValue(value, warnings));
+}
+
+function normalizeValue(value: unknown, warnings: string[], depth = 0): unknown {
+	if (value === null || value === undefined || typeof value === 'boolean') return value ?? null;
+	if (typeof value === 'bigint') return value.toString();
+	if (typeof value === 'number') {
+		if (Number.isFinite(value)) return value;
+		warnings.push('Some non-finite numbers were converted to strings.');
+		return String(value);
+	}
+	if (value instanceof Date) return value.toISOString();
+	if (value instanceof Uint8Array || value instanceof ArrayBuffer) return '[binary value]';
+	if (depth >= 5) return '[nested value truncated]';
+	if (typeof value === 'object') {
+		const normalized = Array.isArray(value)
+			? value.slice(0, 100).map((child) => normalizeValue(child, warnings, depth + 1))
+			: Object.fromEntries(
+					Object.entries(value as Record<string, unknown>)
+						.slice(0, 100)
+						.map(([key, child]) => [key, normalizeValue(child, warnings, depth + 1)]),
+				);
+		return truncateCell(JSON.stringify(normalized), warnings);
+	}
+	return truncateCell(scalarText(value), warnings);
+}
+
+function truncateCell(value: string, warnings: string[]): string {
+	const bytes = new TextEncoder().encode(value);
+	if (bytes.length <= MAX_CELL_BYTES) return value;
+	warnings.push('Some values were truncated to 8 KiB.');
+	return `${new TextDecoder().decode(bytes.slice(0, MAX_CELL_BYTES))}…`;
+}
+
+function scalarText(value: unknown): string {
+	if (value === null || value === undefined) return '';
+	switch (typeof value) {
+		case 'undefined':
+			return '';
+		case 'string':
+			return value;
+		case 'number':
+		case 'bigint':
+		case 'boolean':
+			return value.toString();
+		case 'symbol':
+			return value.description ?? '';
+		case 'function':
+			return '[function]';
+		case 'object':
+			return JSON.stringify(value);
+		default:
+			return '[unknown]';
+	}
+}
+
+function boundTable(preview: TabularPreview): TabularPreview {
+	while (preview.rows.length > 0 && JSON.stringify(preview).length > MAX_RESULT_BYTES) {
+		preview.rows.pop();
+		preview.truncated = true;
+	}
+	if (JSON.stringify(preview).length > MAX_RESULT_BYTES) {
+		throw new ObjectBrowseError('unsupported', 'The preview result exceeds the response limit.');
+	}
+	preview.warnings = [...new Set(preview.warnings)];
+	return preview;
+}
+
+function unsupported(reason: string, type: string | undefined, totalBytes: number): ObjectPreview {
+	return {
+		kind: 'unsupported',
+		reason,
+		detected_type: type,
+		total_bytes: totalBytes,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const CODE_EXTENSIONS = new Set([
+	'py',
+	'ts',
+	'tsx',
+	'js',
+	'jsx',
+	'css',
+	'sql',
+	'sh',
+	'yaml',
+	'yml',
+	'toml',
+	'xml',
+]);
+const TEXT_EXTENSIONS = new Set(['txt', 'text', 'conf', 'ini']);
+const ACTIVE_CONTENT_TYPES = new Set([
+	'text/html',
+	'application/xhtml+xml',
+	'image/svg+xml',
+	'application/pdf',
+]);

--- a/packages/object-browser-s3/src/preview/preview.test.ts
+++ b/packages/object-browser-s3/src/preview/preview.test.ts
@@ -155,6 +155,61 @@ describe('preview format boundaries', () => {
 		});
 	});
 
+	it.each([
+		['array', '[{"x":1}]   ', { kind: 'tabular', rows: [[1]] }],
+		['object', '{"x":1}   ', { kind: 'tabular', rows: [['x', 1]] }],
+		['scalar', '42   ', { kind: 'text', text: '42' }],
+	] as const)(
+		'marks a byte-truncated but parseable JSON %s as truncated',
+		async (_name, json, expected) => {
+			const bytes = new TextEncoder().encode(json);
+			const test = harness(
+				[
+					{ ContentLength: bytes.length + 10, ContentType: 'application/json' },
+					{ Body: body(bytes) },
+				],
+				{ previewMaxBytes: bytes.length },
+			);
+			await expect(test.preview('data.json')).resolves.toMatchObject({
+				...expected,
+				truncated: true,
+			});
+		},
+	);
+
+	it('bounds CSV fields before normalizing excluded columns', async () => {
+		const headers = Array.from({ length: 201 }, (_, index) => `c${index}`);
+		const row = [...Array.from({ length: 200 }, () => 'ok'), 'x'.repeat(9 * 1024)];
+		const bytes = new TextEncoder().encode(`${headers.join(',')}\n${row.join(',')}\n`);
+		const test = harness([
+			{ ContentLength: bytes.length, ContentType: 'text/csv' },
+			{ Body: body(bytes) },
+		]);
+		const preview = await test.preview('wide.csv');
+		expect(preview).toMatchObject({ kind: 'tabular', truncated: true, warnings: [] });
+		if (preview.kind !== 'tabular') throw new Error('Expected tabular preview.');
+		expect(preview.columns).toHaveLength(200);
+		expect(preview.rows[0]).toHaveLength(200);
+	});
+
+	it('enforces the tabular response limit in UTF-8 bytes', async () => {
+		const record = Object.fromEntries(
+			Array.from({ length: 200 }, (_, index) => [`c${index}`, 'é'.repeat(5_000)]),
+		);
+		const bytes = new TextEncoder().encode(JSON.stringify([record, record]));
+		const test = harness([
+			{ ContentLength: bytes.length, ContentType: 'application/json' },
+			{ Body: body(bytes) },
+		]);
+		const preview = await test.preview('wide.json');
+		expect(preview).toMatchObject({ kind: 'tabular', truncated: true });
+		if (preview.kind !== 'tabular') throw new Error('Expected tabular preview.');
+		expect(preview.rows).toHaveLength(1);
+		expect(new TextEncoder().encode(JSON.stringify(preview)).byteLength).toBeLessThanOrEqual(
+			2 * 1024 * 1024,
+		);
+	});
+
 	it('returns unsupported for an empty unknown object and an oversized image', async () => {
 		const empty = harness([{ ContentLength: 0 }]);
 		await expect(empty.preview('unknown.bin')).resolves.toMatchObject({

--- a/packages/object-browser-s3/src/preview/preview.test.ts
+++ b/packages/object-browser-s3/src/preview/preview.test.ts
@@ -218,17 +218,20 @@ describe('preview format boundaries', () => {
 			JSON.stringify(Array.from({ length: 100 }, () => record)),
 		);
 		const encode = vi.spyOn(TextEncoder.prototype, 'encode');
-		const test = harness([
-			{ ContentLength: bytes.length, ContentType: 'application/json' },
-			{ Body: body(bytes) },
-		]);
-		const preview = await test.preview('many-wide-rows.json', 100);
-		expect(preview).toMatchObject({ kind: 'tabular', truncated: true });
-		const previewSerializations = encode.mock.calls.filter(
-			([value]) => typeof value === 'string' && value.startsWith('{"kind":"tabular"'),
-		);
-		expect(previewSerializations.length).toBeLessThanOrEqual(10);
-		encode.mockRestore();
+		try {
+			const test = harness([
+				{ ContentLength: bytes.length, ContentType: 'application/json' },
+				{ Body: body(bytes) },
+			]);
+			const preview = await test.preview('many-wide-rows.json', 100);
+			expect(preview).toMatchObject({ kind: 'tabular', truncated: true });
+			const previewSerializations = encode.mock.calls.filter(
+				([value]) => typeof value === 'string' && value.startsWith('{"kind":"tabular"'),
+			);
+			expect(previewSerializations.length).toBeLessThanOrEqual(10);
+		} finally {
+			encode.mockRestore();
+		}
 	});
 
 	it('returns unsupported for an empty unknown object and an oversized image', async () => {

--- a/packages/object-browser-s3/src/preview/preview.test.ts
+++ b/packages/object-browser-s3/src/preview/preview.test.ts
@@ -210,6 +210,27 @@ describe('preview format boundaries', () => {
 		);
 	});
 
+	it('finds the bounded row prefix with logarithmic serializations', async () => {
+		const record = Object.fromEntries(
+			Array.from({ length: 200 }, (_, index) => [`c${index}`, 'x'.repeat(300)]),
+		);
+		const bytes = new TextEncoder().encode(
+			JSON.stringify(Array.from({ length: 100 }, () => record)),
+		);
+		const encode = vi.spyOn(TextEncoder.prototype, 'encode');
+		const test = harness([
+			{ ContentLength: bytes.length, ContentType: 'application/json' },
+			{ Body: body(bytes) },
+		]);
+		const preview = await test.preview('many-wide-rows.json', 100);
+		expect(preview).toMatchObject({ kind: 'tabular', truncated: true });
+		const previewSerializations = encode.mock.calls.filter(
+			([value]) => typeof value === 'string' && value.startsWith('{"kind":"tabular"'),
+		);
+		expect(previewSerializations.length).toBeLessThanOrEqual(10);
+		encode.mockRestore();
+	});
+
 	it('returns unsupported for an empty unknown object and an oversized image', async () => {
 		const empty = harness([{ ContentLength: 0 }]);
 		await expect(empty.preview('unknown.bin')).resolves.toMatchObject({

--- a/packages/object-browser-s3/src/preview/preview.test.ts
+++ b/packages/object-browser-s3/src/preview/preview.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createProjectId, UserId } from '@marimo-hub/core';
+import type { ObjectBrowseContext, ObjectStoreSource } from '@marimo-hub/core';
+import type { AsyncBuffer } from 'hyparquet';
+import type { S3ClientLike } from '../client';
+import { S3ObjectBrowser } from '../index';
+
+const parquet = vi.hoisted(() => ({
+	metadata: vi.fn(),
+	read: vi.fn(),
+	schema: vi.fn(),
+}));
+
+vi.mock('hyparquet', () => ({
+	parquetMetadataAsync: parquet.metadata,
+	parquetReadObjects: parquet.read,
+	parquetSchema: parquet.schema,
+}));
+
+const source: ObjectStoreSource = {
+	provider: 's3',
+	configured_bucket: 'lake',
+	path_style: false,
+	auth: {
+		method: 'static',
+		access_key_id: 'access',
+		secret_access_key: 'secret',
+	},
+};
+
+const context: ObjectBrowseContext = {
+	project_id: createProjectId(),
+	user_id: UserId.parse('user-1'),
+	user_email: 'ada@example.com',
+	allow_server_ambient: false,
+};
+
+beforeEach(() => {
+	parquet.metadata.mockReset();
+	parquet.read.mockReset();
+	parquet.schema.mockReset();
+});
+
+describe('preview format boundaries', () => {
+	it.each([
+		['page.html', 'text/html'],
+		['page.xhtml', 'application/xhtml+xml'],
+		['image.svg', 'image/svg+xml'],
+		['report.pdf', 'application/pdf'],
+	])('does not render active content for %s', async (key, contentType) => {
+		const bytes = new TextEncoder().encode('unsafe');
+		const test = harness([
+			{ ContentLength: bytes.length, ContentType: `${contentType}; charset=utf-8` },
+			{ Body: body(bytes) },
+		]);
+		await expect(test.preview(key)).resolves.toMatchObject({
+			kind: 'unsupported',
+			detected_type: contentType,
+		});
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it.each([
+		['readme.md', 'markdown'],
+		['service.log', 'log'],
+		['query.sql', 'code'],
+		['notes.txt', 'text'],
+	])('classifies %s as safe %s text', async (key, format) => {
+		const bytes = new TextEncoder().encode('hello');
+		const test = harness([{ ContentLength: bytes.length }, { Body: body(bytes) }]);
+		await expect(test.preview(key)).resolves.toMatchObject({
+			kind: 'text',
+			format,
+			text: 'hello',
+			truncated: false,
+		});
+	});
+
+	it('truncates large text to the text-specific limit', async () => {
+		const bytes = new Uint8Array(512 * 1024 + 1).fill(0x61);
+		const test = harness([{ ContentLength: bytes.length }, { Body: body(bytes) }]);
+		const preview = await test.preview('large.txt');
+		expect(preview).toMatchObject({
+			kind: 'text',
+			truncated: true,
+			bytes_read: bytes.length,
+			total_bytes: bytes.length,
+		});
+		if (preview.kind !== 'text') throw new Error('Expected text preview.');
+		expect(preview.text).toHaveLength(512 * 1024);
+	});
+
+	it.each([
+		{
+			key: 'notes.txt',
+			contentType: 'text/plain',
+			full: 'ok€rest',
+			prefix: new Uint8Array([0x6f, 0x6b, 0xe2, 0x82]),
+			expected: { kind: 'text', text: 'ok', truncated: true },
+		},
+		{
+			key: 'people.csv',
+			contentType: 'text/csv',
+			full: 'name\nAda\nZoë\n',
+			prefix: new Uint8Array([...new TextEncoder().encode('name\nAda\nZo'), 0xc3]),
+			expected: { kind: 'tabular', rows: [['Ada']], truncated: true },
+		},
+		{
+			key: 'people.jsonl',
+			contentType: 'application/x-ndjson',
+			full: '{"name":"Ada"}\n{"name":"Zoë"}\n',
+			prefix: new Uint8Array([...new TextEncoder().encode('{"name":"Ada"}\n{"name":"Zo'), 0xc3]),
+			expected: { kind: 'tabular', rows: [['Ada']], truncated: true },
+		},
+	])('drops an incomplete trailing UTF-8 code point in $key', async (fixture) => {
+		const total = new TextEncoder().encode(fixture.full).length;
+		const test = harness(
+			[{ ContentLength: total, ContentType: fixture.contentType }, { Body: body(fixture.prefix) }],
+			{ previewMaxBytes: fixture.prefix.length },
+		);
+		await expect(test.preview(fixture.key)).resolves.toMatchObject(fixture.expected);
+	});
+
+	it('still rejects invalid UTF-8 inside a truncated prefix', async () => {
+		const bytes = new Uint8Array([0x61, 0xff, 0xe2]);
+		const test = harness(
+			[{ ContentLength: bytes.length + 10, ContentType: 'text/plain' }, { Body: body(bytes) }],
+			{ previewMaxBytes: bytes.length },
+		);
+		await expect(test.preview('bad.txt')).rejects.toMatchObject({ code: 'unsupported' });
+	});
+
+	it('uses one value column for mixed JSON arrays and truncates top-level objects by row limit', async () => {
+		const mixed = new TextEncoder().encode('[1,{"x":2},null]');
+		const mixedTest = harness([
+			{ ContentLength: mixed.length, ContentType: 'application/json' },
+			{ Body: body(mixed) },
+		]);
+		await expect(mixedTest.preview('mixed.json', 2)).resolves.toMatchObject({
+			kind: 'tabular',
+			columns: [{ name: 'value' }],
+			rows: [[1], ['{"x":2}']],
+			truncated: true,
+		});
+
+		const object = new TextEncoder().encode('{"one":1,"two":2}');
+		const objectTest = harness([
+			{ ContentLength: object.length, ContentType: 'application/json' },
+			{ Body: body(object) },
+		]);
+		await expect(objectTest.preview('object.json', 1)).resolves.toMatchObject({
+			kind: 'tabular',
+			rows: [['one', 1]],
+			truncated: true,
+		});
+	});
+
+	it('returns unsupported for an empty unknown object and an oversized image', async () => {
+		const empty = harness([{ ContentLength: 0 }]);
+		await expect(empty.preview('unknown.bin')).resolves.toMatchObject({
+			kind: 'unsupported',
+			total_bytes: 0,
+		});
+		expect(empty.sent()).toHaveLength(1);
+
+		const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+		const oversized = harness([{ ContentLength: 20 }, { Body: body(png) }], {
+			inlineImageMaxBytes: 10,
+			previewMaxBytes: png.length,
+		});
+		await expect(oversized.preview('large.bin')).resolves.toMatchObject({
+			kind: 'unsupported',
+			detected_type: 'png',
+			total_bytes: 20,
+		});
+	});
+});
+
+describe('Parquet preview safety', () => {
+	it('deduplicates ranges and enforces the aggregate range budget', async () => {
+		parquet.metadata.mockImplementation(async (file: AsyncBuffer) => {
+			await file.slice(0, 4);
+			await file.slice(0, 4);
+			await file.slice(4, 8);
+			return { num_rows: 0n };
+		});
+		const bytes = new TextEncoder().encode('PAR1xxxx');
+		const test = harness(
+			[
+				{ ContentLength: bytes.length, ETag: 'etag' },
+				{ Body: body(bytes) },
+				{ Body: body(bytes.slice(0, 4)) },
+			],
+			{ parquetMaxRangedBytes: 4 },
+		);
+		await expect(test.preview('data.parquet')).rejects.toMatchObject({
+			code: 'unsupported',
+			message: 'The Parquet preview exceeded its range budget.',
+		});
+		expect(test.sent()).toHaveLength(3);
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it.each([
+		[-1, 1],
+		[1, 1],
+		[0, 9],
+	])('rejects invalid reader ranges %s:%s', async (start, end) => {
+		parquet.metadata.mockImplementation(async (file: AsyncBuffer) => file.slice(start, end));
+		const bytes = new TextEncoder().encode('PAR1xxxx');
+		const test = harness([{ ContentLength: bytes.length }, { Body: body(bytes) }]);
+		await expect(test.preview('data.parquet')).rejects.toMatchObject({ code: 'unsupported' });
+		expect(test.sent()).toHaveLength(2);
+	});
+
+	it('maps parser failures to a stable error without leaking parser details', async () => {
+		parquet.metadata.mockRejectedValue(new Error('sensitive parser detail'));
+		const bytes = new TextEncoder().encode('PAR1xxxx');
+		const test = harness([{ ContentLength: bytes.length }, { Body: body(bytes) }]);
+		let error: unknown;
+		try {
+			await test.preview('data.parquet');
+		} catch (caught) {
+			error = caught;
+		}
+		expect(error).toMatchObject({
+			code: 'unsupported',
+			message: 'The Parquet file could not be previewed.',
+		});
+		expect((error as Error).message).not.toContain('sensitive parser detail');
+	});
+
+	it('bounds columns, rows, nested values, and non-JSON scalar types', async () => {
+		const columns = Array.from({ length: 201 }, (_, index) => ({ element: { name: `c${index}` } }));
+		parquet.metadata.mockResolvedValue({ num_rows: 2n });
+		parquet.schema.mockReturnValue({ children: columns });
+		parquet.read.mockResolvedValue([
+			{
+				c0: Number.POSITIVE_INFINITY,
+				c1: 42n,
+				c2: new Date('2026-08-01T00:00:00Z'),
+				c3: new Uint8Array([1]),
+				c4: { child: { child: { child: { child: { child: { value: 1 } } } } } },
+			},
+		]);
+		const bytes = new TextEncoder().encode('PAR1xxxx');
+		const test = harness([{ ContentLength: bytes.length }, { Body: body(bytes) }]);
+		const preview = await test.preview('data.parquet', 1);
+		expect(preview).toMatchObject({
+			kind: 'tabular',
+			format: 'parquet',
+			truncated: true,
+			warnings: ['Some non-finite numbers were converted to strings.'],
+		});
+		if (preview.kind !== 'tabular') throw new Error('Expected tabular preview.');
+		expect(preview.columns).toHaveLength(200);
+		expect(preview.rows[0]?.slice(0, 4)).toEqual([
+			'Infinity',
+			'42',
+			'2026-08-01T00:00:00.000Z',
+			'[binary value]',
+		]);
+		expect(preview.rows[0]?.[4]).toContain('[nested value truncated]');
+	});
+});
+
+function harness(
+	responses: unknown[],
+	limits: ConstructorParameters<typeof S3ObjectBrowser>[0]['limits'] = {},
+) {
+	const queue = [...responses];
+	const sent: unknown[] = [];
+	let destroyed = 0;
+	const client: S3ClientLike = {
+		async send(command) {
+			sent.push(command);
+			const response = queue.shift();
+			if (response instanceof Error) throw response;
+			return response;
+		},
+		destroy() {
+			destroyed += 1;
+		},
+	};
+	const browser = new S3ObjectBrowser({ mode: 'full', limits, clientFactory: () => client });
+	return {
+		preview(key: string, limit = 20) {
+			return browser.previewObject(source, context, {
+				bucket: 'lake',
+				key,
+				limit,
+				content_url: '/content',
+			});
+		},
+		sent: () => sent,
+		destroyed: () => destroyed,
+	};
+}
+
+function body(bytes: Uint8Array): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(bytes);
+			controller.close();
+		},
+	});
+}

--- a/packages/object-browser-s3/src/primitives.test.ts
+++ b/packages/object-browser-s3/src/primitives.test.ts
@@ -183,6 +183,30 @@ describe('guarded DNS lookup', () => {
 		expect(resolver).toHaveBeenCalledWith('objects.example.com', signal);
 	});
 
+	it('preserves cancellation identity while scrubbing resolver failures', async () => {
+		const aborted = createGuardedLookup(async () => {
+			throw Object.assign(new Error('private abort detail'), { name: 'AbortError' });
+		});
+		const abortError = await lookupResult(aborted, 'objects.example.com', {}).catch(
+			(error: unknown) => error,
+		);
+		expect(abortError).toMatchObject({
+			name: 'AbortError',
+			message: 'The object-store hostname resolution was canceled.',
+		});
+		expect(mapS3Error(abortError)).toMatchObject({ code: 'aborted' });
+
+		const denied = createGuardedLookup(async () => {
+			throw Object.assign(new Error('private resolver detail'), { name: 'ResolverFailure' });
+		});
+		await expect(lookupResult(denied, 'objects.example.com', {})).rejects.toEqual(
+			expect.objectContaining({
+				name: 'Error',
+				message: 'The object-store hostname is not permitted.',
+			}),
+		);
+	});
+
 	it('fails closed for empty or rejected resolver output', async () => {
 		await expect(
 			lookupResult(

--- a/packages/object-browser-s3/src/primitives.test.ts
+++ b/packages/object-browser-s3/src/primitives.test.ts
@@ -1,0 +1,227 @@
+import { Readable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { ObjectBrowseError } from '@marimo-hub/core';
+import { createGuardedLookup, endpointsMatch, enforcedTimeouts } from './client';
+import { decodeCursor, encodeCursor } from './cursors';
+import { mapS3Error } from './errors';
+import { detectRasterImage, rasterContentType } from './formats';
+import { readBoundedBody, toWebStream } from './streams';
+import { assertBucket, assertObjectIdentity } from './validation';
+
+describe('cursor encoding', () => {
+	it('round trips opaque values and treats an absent cursor as empty', () => {
+		const cursor = encodeCursor({ token: 'opaque/+ value', count: 4 });
+		expect(decodeCursor(cursor)).toEqual({ v: 1, token: 'opaque/+ value', count: 4 });
+		expect(decodeCursor(undefined)).toEqual({});
+	});
+
+	it.each([
+		['malformed base64', '%%%'],
+		['malformed JSON', Buffer.from('{').toString('base64url')],
+		['wrong version', Buffer.from(JSON.stringify({ v: 2 })).toString('base64url')],
+		['null payload', Buffer.from('null').toString('base64url')],
+	])('rejects %s', (_label, cursor) => {
+		expect(() => decodeCursor(cursor)).toThrow(expect.objectContaining({ code: 'invalid_cursor' }));
+	});
+});
+
+describe('provider error mapping', () => {
+	it('preserves an existing safe domain error', () => {
+		const error = new ObjectBrowseError('not_found', 'safe');
+		expect(mapS3Error(error)).toBe(error);
+	});
+
+	it.each([
+		['AbortError', undefined, 'aborted'],
+		['AccessDenied', 500, 'access_denied'],
+		['Other', 403, 'access_denied'],
+		['NoSuchKey', 500, 'not_found'],
+		['NotFound', 500, 'not_found'],
+		['Other', 404, 'not_found'],
+		['PreconditionFailed', 500, 'precondition_failed'],
+		['Other', 412, 'precondition_failed'],
+		['InvalidRange', 500, 'range_not_satisfiable'],
+		['Other', 416, 'range_not_satisfiable'],
+		['NotImplemented', 500, 'unsupported'],
+		['UnsupportedOperation', 500, 'unsupported'],
+		['InternalError', 500, 'unavailable'],
+	] as const)('maps %s/%s to %s without leaking the provider message', (name, status, code) => {
+		const error = Object.assign(new Error('secret provider detail'), {
+			name,
+			$metadata: { httpStatusCode: status, requestId: 'request-id' },
+		});
+		const mapped = mapS3Error(error);
+		expect(mapped).toMatchObject({
+			code,
+			request_id: code === 'aborted' ? undefined : 'request-id',
+		});
+		expect(mapped.message).not.toContain('secret provider detail');
+	});
+});
+
+describe('format and identity validation', () => {
+	it.each([
+		['png', [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]],
+		['jpeg', [0xff, 0xd8, 0xff]],
+		['gif', [...new TextEncoder().encode('GIF87a')]],
+		['gif', [...new TextEncoder().encode('GIF89a')]],
+		['webp', [...new TextEncoder().encode('RIFFxxxxWEBP')]],
+	] as const)('detects %s magic bytes', (format, bytes) => {
+		expect(detectRasterImage(new Uint8Array(bytes))).toBe(format);
+	});
+
+	it('rejects truncated and extension-only image signatures', () => {
+		expect(detectRasterImage(new Uint8Array([0x89, 0x50]))).toBeUndefined();
+		expect(detectRasterImage(new TextEncoder().encode('picture.png'))).toBeUndefined();
+		expect(rasterContentType('jpeg')).toBe('image/jpeg');
+		expect(rasterContentType('png')).toBe('image/png');
+	});
+
+	it('enforces bucket scope and the UTF-8 key byte limit', () => {
+		const scoped = { configured_bucket: 'lake' } as Parameters<typeof assertBucket>[0];
+		expect(() => assertBucket(scoped, '')).toThrow(expect.objectContaining({ code: 'not_found' }));
+		expect(() => assertBucket(scoped, 'other')).toThrow(
+			expect.objectContaining({ code: 'access_denied' }),
+		);
+		expect(() => assertObjectIdentity(scoped, { bucket: 'lake', key: '' })).toThrow(
+			expect.objectContaining({ code: 'not_found' }),
+		);
+		expect(() =>
+			assertObjectIdentity(scoped, { bucket: 'lake', key: 'é'.repeat(512) }),
+		).not.toThrow();
+		expect(() =>
+			assertObjectIdentity(scoped, { bucket: 'lake', key: `${'é'.repeat(512)}a` }),
+		).toThrow(expect.objectContaining({ code: 'not_found' }));
+	});
+});
+
+describe('guarded DNS lookup', () => {
+	it('configures enforcing connection and socket timeouts', () => {
+		expect(enforcedTimeouts({})).toEqual({
+			connectionTimeout: 10_000,
+			requestTimeout: 30_000,
+			throwOnRequestTimeout: true,
+		});
+		expect(enforcedTimeouts({ connectionTimeoutMs: 5, requestTimeoutMs: 10 })).toEqual({
+			connectionTimeout: 5,
+			requestTimeout: 10,
+			throwOnRequestTimeout: true,
+		});
+	});
+
+	it('pins the resolver output for single and all-address lookups', async () => {
+		const resolver = vi.fn().mockResolvedValue([
+			{ address: '192.0.2.1', family: 4 },
+			{ address: '2001:db8::1', family: 6 },
+		]);
+		const lookup = createGuardedLookup(resolver);
+		const single = await lookupResult(lookup, 'objects.example.com', {});
+		const all = await lookupResult(lookup, 'objects.example.com', { all: true });
+		expect(single).toEqual({ address: '192.0.2.1', family: 4 });
+		expect(all).toEqual({
+			addresses: [
+				{ address: '192.0.2.1', family: 4 },
+				{ address: '2001:db8::1', family: 6 },
+			],
+		});
+		expect(resolver).toHaveBeenCalledTimes(2);
+	});
+
+	it('fails closed for empty or rejected resolver output', async () => {
+		await expect(
+			lookupResult(
+				createGuardedLookup(async () => []),
+				'empty.example.com',
+				{},
+			),
+		).rejects.toThrow(/did not resolve/);
+		await expect(
+			lookupResult(
+				createGuardedLookup(async () => {
+					throw new Error('private address detail');
+				}),
+				'blocked.example.com',
+				{},
+			),
+		).rejects.toThrow('The object-store hostname is not permitted.');
+	});
+
+	it('compares normalized origins and rejects malformed or partial endpoints', () => {
+		expect(endpointsMatch(undefined, undefined)).toBe(true);
+		expect(endpointsMatch(undefined, 'https://s3.example.com')).toBe(false);
+		expect(endpointsMatch('https://s3.example.com/a', 'https://s3.example.com/b')).toBe(true);
+		expect(endpointsMatch('https://s3.example.com', 'http://s3.example.com')).toBe(false);
+		expect(endpointsMatch('not a url', 'not a url')).toBe(false);
+	});
+});
+
+describe('body stream conversion', () => {
+	it('accepts web, transformed, Node, and async-iterable bodies', async () => {
+		const web = byteStream([1, 2]);
+		expect(toWebStream(web)).toBe(web);
+		await expect(
+			readBoundedBody({ transformToWebStream: () => byteStream([3]) }, 1),
+		).resolves.toEqual(new Uint8Array([3]));
+		await expect(readBoundedBody(Readable.from([Buffer.from([4, 5])]), 2)).resolves.toEqual(
+			new Uint8Array([4, 5]),
+		);
+		await expect(readBoundedBody(iterableBody([6, 7]), 2)).resolves.toEqual(new Uint8Array([6, 7]));
+	});
+
+	it('rejects invalid and oversized bodies and cancels the upstream iterator', async () => {
+		expect(() => toWebStream({})).toThrow(expect.objectContaining({ code: 'unavailable' }));
+		let returned = false;
+		const iterable = {
+			async *[Symbol.asyncIterator]() {
+				try {
+					yield new Uint8Array([1, 2]);
+					yield new Uint8Array([3]);
+				} finally {
+					returned = true;
+				}
+			},
+		};
+		await expect(readBoundedBody(iterable, 2)).rejects.toMatchObject({ code: 'unsupported' });
+		expect(returned).toBe(true);
+	});
+
+	it('propagates reader failures', async () => {
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.error(new Error('read failed'));
+			},
+		});
+		await expect(readBoundedBody(stream, 10)).rejects.toThrow('read failed');
+	});
+});
+
+function byteStream(values: number[]): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new Uint8Array(values));
+			controller.close();
+		},
+	});
+}
+
+function iterableBody(values: number[]): AsyncIterable<Uint8Array> {
+	return {
+		async *[Symbol.asyncIterator]() {
+			for (const value of values) yield new Uint8Array([value]);
+		},
+	};
+}
+
+function lookupResult(
+	lookup: ReturnType<typeof createGuardedLookup>,
+	hostname: string,
+	options: { all?: boolean },
+): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		lookup(hostname, options, (error, address, family) => {
+			if (error) reject(error);
+			else if (options.all) resolve({ addresses: address });
+			else resolve({ address, family });
+		});
+	});
+}

--- a/packages/object-browser-s3/src/primitives.test.ts
+++ b/packages/object-browser-s3/src/primitives.test.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'node:stream';
-import { V4MAPPED } from 'node:dns';
+import { ALL, V4MAPPED } from 'node:dns';
 import { describe, expect, it, vi } from 'vitest';
 import { ObjectBrowseError } from '@marimo-hub/core';
 import { createGuardedLookup, endpointsMatch, enforcedTimeouts } from './client';
@@ -161,6 +161,26 @@ describe('guarded DNS lookup', () => {
 		await expect(
 			lookupResult(ipv4Only, 'objects.example.com', { family: 6, hints: V4MAPPED }),
 		).resolves.toEqual({ address: '::ffff:192.0.2.2', family: 6 });
+		await expect(
+			lookupResult(lookup, 'objects.example.com', {
+				all: true,
+				family: 6,
+				hints: V4MAPPED | ALL,
+			}),
+		).resolves.toEqual({
+			addresses: [
+				{ address: '2001:db8::1', family: 6 },
+				{ address: '::ffff:192.0.2.1', family: 6 },
+			],
+		});
+	});
+
+	it('passes the operation abort signal to guarded resolution', async () => {
+		const signal = new AbortController().signal;
+		const resolver = vi.fn().mockResolvedValue([{ address: '192.0.2.1', family: 4 }]);
+		const lookup = createGuardedLookup(resolver, signal);
+		await lookupResult(lookup, 'objects.example.com', {});
+		expect(resolver).toHaveBeenCalledWith('objects.example.com', signal);
 	});
 
 	it('fails closed for empty or rejected resolver output', async () => {

--- a/packages/object-browser-s3/src/primitives.test.ts
+++ b/packages/object-browser-s3/src/primitives.test.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'node:stream';
+import { V4MAPPED } from 'node:dns';
 import { describe, expect, it, vi } from 'vitest';
 import { ObjectBrowseError } from '@marimo-hub/core';
 import { createGuardedLookup, endpointsMatch, enforcedTimeouts } from './client';
@@ -10,18 +11,31 @@ import { assertBucket, assertObjectIdentity } from './validation';
 
 describe('cursor encoding', () => {
 	it('round trips opaque values and treats an absent cursor as empty', () => {
-		const cursor = encodeCursor({ token: 'opaque/+ value', count: 4 });
-		expect(decodeCursor(cursor)).toEqual({ v: 1, token: 'opaque/+ value', count: 4 });
-		expect(decodeCursor(undefined)).toEqual({});
+		const cursor = encodeCursor({ token: 'opaque/+ value' });
+		expect(decodeCursor(cursor, ['token'])).toEqual({ token: 'opaque/+ value' });
+		expect(decodeCursor(undefined, ['token'])).toEqual({});
 	});
 
 	it.each([
 		['malformed base64', '%%%'],
+		['trailing base64 garbage', `${encodeCursor({ token: 'valid' })}%`],
+		['non-canonical padding', `${encodeCursor({ token: 'valid' })}=`],
+		['invalid base64 length', 'A'],
+		['empty value', ''],
 		['malformed JSON', Buffer.from('{').toString('base64url')],
 		['wrong version', Buffer.from(JSON.stringify({ v: 2 })).toString('base64url')],
 		['null payload', Buffer.from('null').toString('base64url')],
+		['array payload', Buffer.from(JSON.stringify([1])).toString('base64url')],
+		['non-string marker', Buffer.from(JSON.stringify({ v: 1, token: 42 })).toString('base64url')],
+		[
+			'unknown marker',
+			Buffer.from(JSON.stringify({ v: 1, token: 'ok', extra: 'no' })).toString('base64url'),
+		],
+		['invalid UTF-8', Buffer.from([0x7b, 0x22, 0xff, 0x22, 0x7d]).toString('base64url')],
 	])('rejects %s', (_label, cursor) => {
-		expect(() => decodeCursor(cursor)).toThrow(expect.objectContaining({ code: 'invalid_cursor' }));
+		expect(() => decodeCursor(cursor, ['token'])).toThrow(
+			expect.objectContaining({ code: 'invalid_cursor' }),
+		);
 	});
 });
 
@@ -127,6 +141,28 @@ describe('guarded DNS lookup', () => {
 		expect(resolver).toHaveBeenCalledTimes(2);
 	});
 
+	it('honors requested address families and IPv4-mapped IPv6 hints', async () => {
+		const lookup = createGuardedLookup(async () => [
+			{ address: '2001:db8::1', family: 6 },
+			{ address: '192.0.2.1', family: 4 },
+		]);
+		await expect(lookupResult(lookup, 'objects.example.com', { family: 4 })).resolves.toEqual({
+			address: '192.0.2.1',
+			family: 4,
+		});
+		await expect(
+			lookupResult(lookup, 'objects.example.com', { all: true, family: 6 }),
+		).resolves.toEqual({ addresses: [{ address: '2001:db8::1', family: 6 }] });
+
+		const ipv4Only = createGuardedLookup(async () => [{ address: '192.0.2.2', family: 4 }]);
+		await expect(lookupResult(ipv4Only, 'objects.example.com', { family: 6 })).rejects.toThrow(
+			/did not resolve/,
+		);
+		await expect(
+			lookupResult(ipv4Only, 'objects.example.com', { family: 6, hints: V4MAPPED }),
+		).resolves.toEqual({ address: '::ffff:192.0.2.2', family: 6 });
+	});
+
 	it('fails closed for empty or rejected resolver output', async () => {
 		await expect(
 			lookupResult(
@@ -215,7 +251,7 @@ function iterableBody(values: number[]): AsyncIterable<Uint8Array> {
 function lookupResult(
 	lookup: ReturnType<typeof createGuardedLookup>,
 	hostname: string,
-	options: { all?: boolean },
+	options: { all?: boolean; family?: number; hints?: number },
 ): Promise<unknown> {
 	return new Promise((resolve, reject) => {
 		lookup(hostname, options, (error, address, family) => {

--- a/packages/object-browser-s3/src/s3Request.test.ts
+++ b/packages/object-browser-s3/src/s3Request.test.ts
@@ -123,6 +123,18 @@ describe('S3 request utilities', () => {
 			readObjectRange(oversized, { bucket: 'lake', key: 'a' }, 0, 1),
 		).rejects.toMatchObject({ code: 'unsupported' });
 	});
+
+	it.each([
+		['AbortError', 'aborted'],
+		['AccessDenied', 'access_denied'],
+		['InternalError', 'unavailable'],
+	] as const)('maps %s failures raised while reading a response body', async (name, code) => {
+		const client = mockClient();
+		client.send.mockResolvedValue({ Body: failingBody(name) });
+		await expect(readObjectRange(client, { bucket: 'lake', key: 'a' }, 0, 1)).rejects.toMatchObject(
+			{ code },
+		);
+	});
 });
 
 function mockClient() {
@@ -137,6 +149,14 @@ function byteStream(values: number[]): ReadableStream<Uint8Array> {
 		start(controller) {
 			controller.enqueue(new Uint8Array(values));
 			controller.close();
+		},
+	});
+}
+
+function failingBody(name: string): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.error(Object.assign(new Error('raw provider detail'), { name }));
 		},
 	});
 }

--- a/packages/object-browser-s3/src/s3Request.test.ts
+++ b/packages/object-browser-s3/src/s3Request.test.ts
@@ -1,0 +1,142 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { describe, expect, it, vi } from 'vitest';
+import type { ObjectBrowseContext, ObjectStoreSource } from '@marimo-hub/core';
+import type { S3ClientLike } from './client';
+import {
+	readObjectRange,
+	releaseClientOnce,
+	sendS3,
+	withOperationDeadline,
+	withS3Client,
+} from './s3Request';
+
+const source = {} as ObjectStoreSource;
+const context = {} as ObjectBrowseContext;
+
+describe('S3 request utilities', () => {
+	it('passes the abort signal and maps rejected provider requests', async () => {
+		const signal = new AbortController().signal;
+		const client = mockClient();
+		client.send.mockResolvedValue({ value: true });
+		await expect(sendS3(client, { command: true }, signal)).resolves.toEqual({ value: true });
+		expect(client.send).toHaveBeenCalledWith({ command: true }, { abortSignal: signal });
+
+		client.send.mockRejectedValueOnce(Object.assign(new Error('raw'), { name: 'NoSuchKey' }));
+		await expect(sendS3(client, {})).rejects.toMatchObject({ code: 'not_found' });
+	});
+
+	it('destroys scoped clients after success and failure', async () => {
+		const success = mockClient();
+		await expect(
+			withS3Client(
+				() => success,
+				source,
+				context,
+				async () => 'done',
+			),
+		).resolves.toBe('done');
+		expect(success.destroy).toHaveBeenCalledOnce();
+
+		const failure = mockClient();
+		await expect(
+			withS3Client(
+				() => failure,
+				source,
+				context,
+				async () => {
+					throw new Error('failed');
+				},
+			),
+		).rejects.toThrow('failed');
+		expect(failure.destroy).toHaveBeenCalledOnce();
+	});
+
+	it('releases a client at most once', () => {
+		const client = mockClient();
+		const release = releaseClientOnce(client);
+		release();
+		release();
+		expect(client.destroy).toHaveBeenCalledOnce();
+	});
+
+	it('propagates caller cancellation through an operation deadline', async () => {
+		const parent = new AbortController();
+		const operation = withOperationDeadline(
+			{ ...context, signal: parent.signal },
+			1_000,
+			(scoped) =>
+				new Promise<boolean>((resolve) => {
+					scoped.signal?.addEventListener('abort', () => resolve(scoped.signal!.aborted), {
+						once: true,
+					});
+				}),
+		);
+		parent.abort();
+		await expect(operation).resolves.toBe(true);
+	});
+
+	it.each([
+		[-1, 1],
+		[1, 1],
+		[2, 1],
+		[0.5, 1],
+		[0, Number.MAX_SAFE_INTEGER + 1],
+	])('rejects an invalid half-open range %s:%s before sending', async (start, end) => {
+		const client = mockClient();
+		await expect(
+			readObjectRange(client, { bucket: 'lake', key: 'a' }, start, end),
+		).rejects.toMatchObject({ code: 'range_not_satisfiable' });
+		expect(client.send).not.toHaveBeenCalled();
+	});
+
+	it('sends a bounded inclusive S3 range with ETag protection for current objects', async () => {
+		const client = mockClient();
+		client.send.mockResolvedValue({ Body: byteStream([1, 2, 3]) });
+		await expect(
+			readObjectRange(client, { bucket: 'lake', key: 'a' }, 4, 7, { etag: 'etag' }),
+		).resolves.toEqual(new Uint8Array([1, 2, 3]));
+		const command = client.send.mock.calls[0]?.[0];
+		expect(command).toBeInstanceOf(GetObjectCommand);
+		expect((command as GetObjectCommand).input).toMatchObject({
+			Bucket: 'lake',
+			Key: 'a',
+			Range: 'bytes=4-6',
+			IfMatch: 'etag',
+		});
+	});
+
+	it('uses version pinning instead of If-Match and rejects missing or oversized bodies', async () => {
+		const missing = mockClient();
+		missing.send.mockResolvedValue({});
+		await expect(
+			readObjectRange(missing, { bucket: 'lake', key: 'a', version_id: 'v1' }, 0, 1, {
+				etag: 'ignored',
+			}),
+		).rejects.toMatchObject({ code: 'unavailable' });
+		const command = missing.send.mock.calls[0]?.[0] as GetObjectCommand;
+		expect(command.input).toMatchObject({ VersionId: 'v1' });
+		expect(command.input.IfMatch).toBeUndefined();
+
+		const oversized = mockClient();
+		oversized.send.mockResolvedValue({ Body: byteStream([1, 2]) });
+		await expect(
+			readObjectRange(oversized, { bucket: 'lake', key: 'a' }, 0, 1),
+		).rejects.toMatchObject({ code: 'unsupported' });
+	});
+});
+
+function mockClient() {
+	return {
+		send: vi.fn(),
+		destroy: vi.fn(),
+	} satisfies S3ClientLike;
+}
+
+function byteStream(values: number[]): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new Uint8Array(values));
+			controller.close();
+		},
+	});
+}

--- a/packages/object-browser-s3/src/s3Request.ts
+++ b/packages/object-browser-s3/src/s3Request.ts
@@ -84,5 +84,9 @@ export async function readObjectRange(
 		options.signal,
 	);
 	if (!output.Body) throw new ObjectBrowseError('unavailable', 'The object body was empty.');
-	return readBoundedBody(output.Body, end - start);
+	try {
+		return await readBoundedBody(output.Body, end - start);
+	} catch (error) {
+		throw mapS3Error(error);
+	}
 }

--- a/packages/object-browser-s3/src/s3Request.ts
+++ b/packages/object-browser-s3/src/s3Request.ts
@@ -1,0 +1,88 @@
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import type { ObjectBrowseContext, ObjectIdentity, ObjectStoreSource } from '@marimo-hub/core';
+import { ObjectBrowseError } from '@marimo-hub/core';
+import type { S3ClientFactory, S3ClientLike } from './client';
+import { mapS3Error } from './errors';
+import { readBoundedBody } from './streams';
+
+interface GetOutput {
+	Body?: unknown;
+}
+
+export async function sendS3<T>(
+	client: S3ClientLike,
+	command: unknown,
+	signal?: AbortSignal,
+): Promise<T> {
+	try {
+		return (await client.send(command, { abortSignal: signal })) as T;
+	} catch (error) {
+		throw mapS3Error(error);
+	}
+}
+
+export async function withS3Client<T>(
+	clientFactory: S3ClientFactory,
+	source: ObjectStoreSource,
+	context: ObjectBrowseContext,
+	run: (client: S3ClientLike) => Promise<T>,
+): Promise<T> {
+	const client = clientFactory(source, context);
+	try {
+		return await run(client);
+	} finally {
+		client.destroy();
+	}
+}
+
+export async function withOperationDeadline<T>(
+	context: ObjectBrowseContext,
+	timeoutMs: number,
+	run: (context: ObjectBrowseContext) => Promise<T>,
+): Promise<T> {
+	const controller = new AbortController();
+	const abort = () => controller.abort();
+	if (context.signal?.aborted) abort();
+	else context.signal?.addEventListener('abort', abort, { once: true });
+	const timer = setTimeout(abort, timeoutMs);
+	try {
+		return await run({ ...context, signal: controller.signal });
+	} finally {
+		clearTimeout(timer);
+		context.signal?.removeEventListener('abort', abort);
+	}
+}
+
+export function releaseClientOnce(client: S3ClientLike): () => void {
+	let released = false;
+	return () => {
+		if (released) return;
+		released = true;
+		client.destroy();
+	};
+}
+
+export async function readObjectRange(
+	client: S3ClientLike,
+	request: ObjectIdentity,
+	start: number,
+	end: number,
+	options: { etag?: string; signal?: AbortSignal } = {},
+): Promise<Uint8Array> {
+	if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < 0 || end <= start) {
+		throw new ObjectBrowseError('range_not_satisfiable', 'The requested byte range is invalid.');
+	}
+	const output = await sendS3<GetOutput>(
+		client,
+		new GetObjectCommand({
+			Bucket: request.bucket,
+			Key: request.key,
+			VersionId: request.version_id,
+			IfMatch: request.version_id ? undefined : options.etag,
+			Range: `bytes=${start}-${end - 1}`,
+		}),
+		options.signal,
+	);
+	if (!output.Body) throw new ObjectBrowseError('unavailable', 'The object body was empty.');
+	return readBoundedBody(output.Body, end - start);
+}

--- a/packages/object-browser-s3/src/streams.ts
+++ b/packages/object-browser-s3/src/streams.ts
@@ -1,0 +1,61 @@
+import { Readable } from 'node:stream';
+import { ObjectBrowseError } from '@marimo-hub/core';
+
+export function toWebStream(body: unknown): ReadableStream<Uint8Array> {
+	if (body instanceof ReadableStream) return body;
+	if (
+		body &&
+		typeof (body as { transformToWebStream?: unknown }).transformToWebStream === 'function'
+	) {
+		return (body as { transformToWebStream(): ReadableStream<Uint8Array> }).transformToWebStream();
+	}
+	if (body instanceof Readable) {
+		return Readable.toWeb(body) as ReadableStream<Uint8Array>;
+	}
+	const iterable = body as AsyncIterable<Uint8Array> | undefined;
+	if (!iterable?.[Symbol.asyncIterator]) {
+		throw new ObjectBrowseError('unavailable', 'The object store returned an invalid body.');
+	}
+	const iterator = iterable[Symbol.asyncIterator]();
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			const next = await iterator.next();
+			if (next.done) controller.close();
+			else controller.enqueue(next.value);
+		},
+		async cancel(reason) {
+			await iterator.return?.(reason);
+		},
+	});
+}
+
+export async function readBoundedBody(body: unknown, maxBytes: number): Promise<Uint8Array> {
+	const reader = toWebStream(body).getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		while (true) {
+			const next = await reader.read();
+			if (next.done) break;
+			total += next.value.byteLength;
+			if (total > maxBytes) {
+				await reader.cancel();
+				throw new ObjectBrowseError('unsupported', 'The object exceeded the read limit.');
+			}
+			chunks.push(next.value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	const result = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
+}
+
+export function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}

--- a/packages/object-browser-s3/src/validation.ts
+++ b/packages/object-browser-s3/src/validation.ts
@@ -1,0 +1,16 @@
+import type { ObjectIdentity, ObjectStoreSource } from '@marimo-hub/core';
+import { ObjectBrowseError } from '@marimo-hub/core';
+
+export function assertBucket(source: ObjectStoreSource, bucket: string): void {
+	if (!bucket) throw new ObjectBrowseError('not_found', 'A bucket is required.');
+	if (source.configured_bucket && source.configured_bucket !== bucket) {
+		throw new ObjectBrowseError('access_denied', 'The bucket is outside this integration scope.');
+	}
+}
+
+export function assertObjectIdentity(source: ObjectStoreSource, request: ObjectIdentity): void {
+	assertBucket(source, request.bucket);
+	if (!request.key || new TextEncoder().encode(request.key).length > 1_024) {
+		throw new ObjectBrowseError('not_found', 'The object key is invalid.');
+	}
+}

--- a/packages/object-browser-s3/tsconfig.json
+++ b/packages/object-browser-s3/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "@marimo-hub/tsconfig/library.json",
+	"include": ["src"]
+}

--- a/packages/object-browser-s3/vite.config.ts
+++ b/packages/object-browser-s3/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite-plus';
+
+export default defineConfig({
+	pack: { dts: true },
+	test: {
+		include: ['src/**/*.test.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'html'],
+			include: ['src/**/*.ts'],
+			exclude: ['src/**/*.test.ts'],
+			thresholds: {
+				statements: 90,
+				branches: 80,
+				functions: 90,
+				lines: 90,
+			},
+		},
+	},
+});

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -20,6 +20,7 @@ const icebergKind: IntegrationKind = {
 	ui_hints: {},
 	supports_test: true,
 	supports_browse: true,
+	browse_surfaces: ['tables'],
 	requirements: [],
 	secret_sources: { inline: false, references: [] },
 };
@@ -34,6 +35,14 @@ const lakeEntry: IntegrationEntry = {
 	created_at: '2026-01-01T00:00:00Z',
 	updated_at: '2026-01-01T00:00:00Z',
 	scope: 'project',
+};
+
+const objectKind: IntegrationKind = {
+	...icebergKind,
+	kind: 's3',
+	title: 'S3',
+	supports_browse: true,
+	browse_surfaces: ['objects'],
 };
 
 const SNIPPET = 'from pyiceberg.catalog import load_catalog\n\ncatalog = load_catalog("lake")';
@@ -51,12 +60,16 @@ function makeFetch({
 	tables = ['orders'],
 	capability = { metadata: true, preview: false },
 	namespacesDown = false,
+	kind = icebergKind,
+	entry = lakeEntry,
 }: {
 	available?: boolean;
 	pagedTables?: boolean;
 	tables?: string[];
 	capability?: { metadata: boolean; preview: boolean; reason?: string };
 	namespacesDown?: boolean;
+	kind?: IntegrationKind;
+	entry?: IntegrationEntry;
 } = {}) {
 	const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = String(input);
@@ -73,7 +86,9 @@ function makeFetch({
 		if (url.includes('/api/v1/capabilities')) {
 			return ok({ data_browser: { available, preview: false } });
 		}
-		if (url.includes('/api/v1/integrations/kinds')) return ok([icebergKind]);
+		if (url.includes('/api/v1/integrations/kinds')) {
+			return ok([kind]);
+		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/namespaces`)) {
 			if (namespacesDown) {
 				return new Response(
@@ -113,10 +128,19 @@ function makeFetch({
 			});
 		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse`)) {
-			return ok(capability);
+			return ok({
+				...capability,
+				surfaces: {
+					tables: {
+						available: capability.metadata,
+						preview: capability.preview,
+						...(capability.reason ? { reason: capability.reason } : {}),
+					},
+				},
+			});
 		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations`)) {
-			return ok({ items: [lakeEntry], next_cursor: null });
+			return ok({ items: [entry], next_cursor: null });
 		}
 		if (url.includes(`/api/v1/projects/${PID}`)) {
 			return ok({ id: PID, name: 'Demo', description: 'd', your_role: 'editor' });
@@ -348,6 +372,17 @@ describe('DataBrowserPage', () => {
 	it('reports when browsing is unavailable', async () => {
 		setup(`/projects/${PID}/data`, { available: false });
 		expect(await screen.findByText('Data browsing is not available')).toBeInTheDocument();
+	});
+
+	it('does not advertise object-only integrations through the table browser', async () => {
+		const fetchImpl = setup(`/projects/${PID}/data/${IID}`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+		});
+		expect(await screen.findByText('Nothing to browse')).toBeInTheDocument();
+		expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/browse/namespaces'))).toBe(
+			false,
+		);
 	});
 
 	it('shows the capability reason under an instance the hub cannot browse', async () => {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -41,6 +41,7 @@ import {
 } from '@/api/hooks';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { BRAND_ICONS } from '@/components/Project/brandIcons';
+import { supportsTableBrowse, tableBrowseCapability } from '@/lib/integrationBrowse';
 import { formatRelative } from '@/lib/time';
 import { cn } from '@/lib/utils';
 import type { IntegrationEntry, IntegrationKind } from '@/types';
@@ -143,7 +144,8 @@ export default function DataBrowserPage() {
 	const browsable = useMemo(
 		() =>
 			(entries ?? []).filter(
-				(entry) => entry.enabled && !entry.shadowed && kindsByName.get(entry.kind)?.supports_browse,
+				(entry) =>
+					entry.enabled && !entry.shadowed && supportsTableBrowse(kindsByName.get(entry.kind)),
 			),
 		[entries, kindsByName],
 	);
@@ -217,6 +219,7 @@ export default function DataBrowserPage() {
 
 	const selected = browsable.find((entry) => entry.id === iid);
 	const selectedCapability = useBrowseCapabilityQuery(pid!, iid ?? '', selected !== undefined);
+	const selectedTableCapability = tableBrowseCapability(selectedCapability.data);
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-6 max-md:overflow-y-auto max-md:p-3">
@@ -291,7 +294,7 @@ export default function DataBrowserPage() {
 								projectId={pid!}
 								integration={selected}
 								selection={selection}
-								previewAvailable={selectedCapability.data?.preview ?? false}
+								previewAvailable={selectedTableCapability?.preview ?? false}
 							/>
 						) : (
 							<EmptyState
@@ -330,6 +333,7 @@ function IntegrationSection({
 	onActivate: () => void;
 } & TreeHandlers) {
 	const capability = useBrowseCapabilityQuery(projectId, entry.id, active);
+	const tables = tableBrowseCapability(capability.data);
 	const iconSlug = kind?.brand.icon;
 	const BrandIcon = iconSlug ? BRAND_ICONS[iconSlug] : undefined;
 
@@ -358,7 +362,7 @@ function IntegrationSection({
 			{active &&
 				(capability.data === undefined ? (
 					<LoadState depth={1} error={capability.error ?? undefined} />
-				) : capability.data.metadata ? (
+				) : tables?.available ? (
 					<NamespaceLevel
 						projectId={projectId}
 						integrationId={entry.id}
@@ -369,7 +373,7 @@ function IntegrationSection({
 				) : (
 					<LoadState
 						depth={1}
-						hint={capability.data.reason ?? 'This instance cannot be browsed.'}
+						hint={tables?.reason ?? 'This instance cannot be browsed as a table catalog.'}
 					/>
 				))}
 		</div>

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -76,6 +76,7 @@ import {
 	useIntegrationKindsQuery,
 	useIntegrationsQuery,
 } from '@/api/hooks';
+import { supportsTableBrowse } from '@/lib/integrationBrowse';
 import { AppSessionIndicator } from './AppSessionIndicator';
 import { ProjectMembersDialog } from './ProjectMembersDialog';
 import { ProjectEnvironmentDialog } from './ProjectEnvironmentDialog';
@@ -194,7 +195,7 @@ export function Project() {
 	const { data: integrationKinds } = useIntegrationKindsQuery(dataBrowserAvailable);
 	const { data: projectIntegrations } = useIntegrationsQuery({ pid: pid! }, dataBrowserAvailable);
 	const browsableKinds = new Set(
-		(integrationKinds ?? []).filter((kind) => kind.supports_browse).map((kind) => kind.kind),
+		(integrationKinds ?? []).filter(supportsTableBrowse).map((kind) => kind.kind),
 	);
 	const browsableIntegrations = (projectIntegrations ?? []).filter(
 		(entry) => entry.enabled && !entry.shadowed && browsableKinds.has(entry.kind),

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -35,6 +35,7 @@ const postgresKind: IntegrationKind = {
 	ui_hints: {},
 	supports_test: false,
 	supports_browse: false,
+	browse_surfaces: [],
 	requirements: ['sqlalchemy>=2'],
 	secret_sources: { inline: false, references: [] },
 };
@@ -50,6 +51,7 @@ const customEnvKind: IntegrationKind = {
 	ui_hints: {},
 	supports_test: true,
 	supports_browse: false,
+	browse_surfaces: [],
 	requirements: [],
 	secret_sources: { inline: false, references: [] },
 };

--- a/packages/web/src/lib/integrationBrowse.test.ts
+++ b/packages/web/src/lib/integrationBrowse.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { IntegrationBrowseCapability, IntegrationKind } from '@/types';
+import { supportsTableBrowse, tableBrowseCapability } from './integrationBrowse';
+
+const kind = {
+	kind: 's3',
+	title: 'S3',
+	description: 'S3',
+	category: 'storage',
+	brand: { icon: 'aws', color: '#000000' },
+	schema_version: 2,
+	json_schema: { type: 'object', properties: {} },
+	ui_hints: {},
+	supports_test: true,
+	supports_browse: true,
+	browse_surfaces: ['objects'],
+	requirements: [],
+	secret_sources: { inline: false, references: [] },
+} satisfies IntegrationKind;
+
+describe('supportsTableBrowse', () => {
+	it('uses the surface discriminator when it is present', () => {
+		expect(supportsTableBrowse(kind)).toBe(false);
+		expect(supportsTableBrowse({ ...kind, browse_surfaces: ['tables'] })).toBe(true);
+	});
+
+	it('rejects missing kinds and an explicitly empty surface list', () => {
+		expect(supportsTableBrowse(undefined)).toBe(false);
+		expect(supportsTableBrowse({ ...kind, browse_surfaces: [] })).toBe(false);
+	});
+});
+
+describe('tableBrowseCapability', () => {
+	it('uses the table surface when it is present', () => {
+		const capability = {
+			surfaces: { tables: { available: false, preview: false, reason: 'disabled' } },
+			metadata: true,
+			preview: true,
+		} satisfies IntegrationBrowseCapability;
+		expect(tableBrowseCapability(capability)).toEqual({
+			available: false,
+			preview: false,
+			reason: 'disabled',
+		});
+	});
+
+	it('handles missing capabilities and table surfaces', () => {
+		expect(tableBrowseCapability(undefined)).toBeUndefined();
+		expect(
+			tableBrowseCapability({ surfaces: {}, metadata: false, preview: false }),
+		).toBeUndefined();
+	});
+});

--- a/packages/web/src/lib/integrationBrowse.ts
+++ b/packages/web/src/lib/integrationBrowse.ts
@@ -1,0 +1,11 @@
+import type { IntegrationBrowseCapability, IntegrationKind } from '@/types';
+
+export function supportsTableBrowse(kind: IntegrationKind | undefined): boolean {
+	return kind?.browse_surfaces.includes('tables') ?? false;
+}
+
+export function tableBrowseCapability(
+	capability: IntegrationBrowseCapability | undefined,
+): IntegrationBrowseCapability['surfaces']['tables'] | undefined {
+	return capability?.surfaces.tables;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     '@oxlint/plugins':
       specifier: 1.67.0
       version: 1.67.0
+    '@smithy/node-http-handler':
+      specifier: ^4.9.1
+      version: 4.9.1
     '@tailwindcss/vite':
       specifier: ^4.3.0
       version: 4.3.0
@@ -105,6 +108,12 @@ catalogs:
     clsx:
       specifier: ^2.1.1
       version: 2.1.1
+    csv-parse:
+      specifier: ^7.0.1
+      version: 7.0.1
+    hyparquet:
+      specifier: ^1.26.2
+      version: 1.26.2
     jose:
       specifier: ^6.1.3
       version: 6.2.3
@@ -821,6 +830,9 @@ importers:
       '@marimo-hub/notify-webhook':
         specifier: workspace:*
         version: link:../notify-webhook
+      '@marimo-hub/object-browser-s3':
+        specifier: workspace:*
+        version: link:../object-browser-s3
       '@marimo-hub/secrets-aws':
         specifier: workspace:*
         version: link:../secrets-aws
@@ -1016,6 +1028,40 @@ importers:
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1
+    devDependencies:
+      '@marimo-hub/tsconfig':
+        specifier: workspace:*
+        version: link:../ts-config
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.3
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite-plus:
+        specifier: 'catalog:'
+        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)'
+
+  packages/object-browser-s3:
+    dependencies:
+      '@aws-sdk/client-s3':
+        specifier: 'catalog:'
+        version: 3.1066.0
+      '@marimo-hub/core':
+        specifier: workspace:*
+        version: link:../core
+      '@smithy/node-http-handler':
+        specifier: 'catalog:'
+        version: 4.9.1
+      csv-parse:
+        specifier: 'catalog:'
+        version: 7.0.1
+      hyparquet:
+        specifier: 'catalog:'
+        version: 1.26.2
     devDependencies:
       '@marimo-hub/tsconfig':
         specifier: workspace:*
@@ -3010,10 +3056,6 @@ packages:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
-  '@smithy/node-http-handler@4.7.7':
-    resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.9.1':
     resolution: {integrity: sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==}
     engines: {node: '>=18.0.0'}
@@ -3842,6 +3884,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  csv-parse@7.0.1:
+    resolution: {integrity: sha512-+2z7Ar0APQ7Uu6fX4cn+pitRmxjZ1WPBcGmZFKmA74FCyi7Et/XZx8cjNQ5CjbZ4HCOxXCOpRBYvYH08Qa003A==}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -4144,6 +4189,9 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  hyparquet@1.26.2:
+    resolution: {integrity: sha512-6qjyK7R2tZ4vnYP1J8NpcCeDPK1UIYk3xh5XgtQUnUM1iwkYbvI6Mz3xtmpMd6AfCCeoUoJVbEq29k5GReZRWA==}
 
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
@@ -5629,8 +5677,8 @@ snapshots:
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/client-s3@3.1066.0':
@@ -5646,7 +5694,7 @@ snapshots:
       '@aws-sdk/types': 3.973.12
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
+      '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
@@ -5668,9 +5716,9 @@ snapshots:
       '@aws-sdk/types': 3.973.12
       '@aws-sdk/xml-builder': 3.972.29
       '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.24.6
+      '@smithy/core': 3.28.0
       '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.15.0
       bowser: 2.14.1
       tslib: 2.8.1
 
@@ -5689,8 +5737,8 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.50':
@@ -5705,10 +5753,10 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
+      '@smithy/core': 3.28.0
       '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@smithy/node-http-handler': 4.9.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.52':
@@ -5732,9 +5780,9 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.972.52
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
+      '@smithy/core': 3.28.0
       '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.57':
@@ -5758,8 +5806,8 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.56':
@@ -5780,9 +5828,9 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.52
       '@aws-sdk/credential-provider-web-identity': 3.972.52
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
+      '@smithy/core': 3.28.0
       '@smithy/credential-provider-imds': 4.3.8
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.59':
@@ -5803,8 +5851,8 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.50':
@@ -5821,8 +5869,8 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/token-providers': 3.1066.0
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.56':
@@ -5840,8 +5888,8 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.56':
@@ -5863,8 +5911,8 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/signature-v4-multi-region': 3.996.34
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.20':
@@ -5874,10 +5922,10 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/signature-v4-multi-region': 3.996.34
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
+      '@smithy/core': 3.28.0
       '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
-      '@smithy/types': 4.14.3
+      '@smithy/node-http-handler': 4.9.1
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.24':
@@ -5897,7 +5945,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.12
       '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.36':
@@ -5912,8 +5960,8 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1076.0':
@@ -5927,7 +5975,7 @@ snapshots:
 
   '@aws-sdk/types@3.973.12':
     dependencies:
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.14':
@@ -5941,7 +5989,7 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.29':
     dependencies:
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.15.0
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
@@ -7054,7 +7102,7 @@ snapshots:
   '@smithy/core@3.24.6':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/core@3.28.0':
@@ -7064,8 +7112,8 @@ snapshots:
 
   '@smithy/credential-provider-imds@4.3.8':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/credential-provider-imds@4.4.4':
@@ -7076,8 +7124,8 @@ snapshots:
 
   '@smithy/fetch-http-handler@5.4.6':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.6.1':
@@ -7090,12 +7138,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.7.7':
-    dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
-      tslib: 2.8.1
-
   '@smithy/node-http-handler@4.9.1':
     dependencies:
       '@smithy/core': 3.28.0
@@ -7104,8 +7146,8 @@ snapshots:
 
   '@smithy/signature-v4@5.4.6':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.0':
@@ -7902,6 +7944,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  csv-parse@7.0.1: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -8253,6 +8297,8 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
+
+  hyparquet@1.26.2: {}
 
   indent-string@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ blockExoticSubdeps: true
 
 catalog:
   '@aws-sdk/client-s3': ^3.1066.0
+  '@smithy/node-http-handler': ^4.9.1
   '@aws-sdk/client-secrets-manager': ^3.1066.0
   '@azure/core-auth': ^1.11.0
   '@azure/identity': ^4.13.1
@@ -40,6 +41,8 @@ catalog:
   class-variance-authority: ^0.7.1
   clsx: ^2.1.1
   hono: ^4.12.34
+  csv-parse: ^7.0.1
+  hyparquet: ^1.26.2
   jose: ^6.1.3
   jsdom: ^29.1.1
   lucide-react: ^1.17.0


### PR DESCRIPTION
## Summary

Adds a raw **object browser** layer so users can browse S3 buckets and objects directly — alongside the existing read-only catalog table browsing — through configured integrations.

- **core** — new `ObjectBrowser` port (`packages/core/src/ports/objectBrowser.ts`) covering list, prefix search, object detail/tagging, versions, ranged open, and content preview. A `BrowseSurface` distinction (`tables` vs `objects`) is threaded through the integrations registry, contracts, SDK, and `ProjectIntegrationsStore`.
- **`packages/object-browser-s3`** — new adapter implementing the port against the AWS S3 SDK: bucket/object listing, prefix search, object detail, versions, ranged open, and previews, with cursor pagination, host guarding, per-operation deadlines, and S3→envelope error mapping. Ships with a contract-style test suite.
- **config** — wires the S3 object-browser adapter behind the integrations probe/selector, exposed only where allowed (ambient vs static/temporary credentials).
- **api** — object-browse routes on integrations; regenerated `openapi.yaml` and generated client `schema.ts`.
- **web** — object browsing surfaced in the DataBrowser page and integration dialog, backed by a new `integrationBrowse` helper.

Follows the ports-and-adapters rule: `core`/`api` depend only on the port; the concrete `object-browser-s3` adapter is imported solely from `config`.