### PR TITLE
fix(api): cap AI request bodies and harden zip archive extraction

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -31,7 +31,7 @@ The full set of variables:
 | `MARIMOHUB_AI_UPSTREAM_PROJECT`  | no       | Optional `OpenAI-Project` header forwarded upstream (e.g. W&B Inference `entity/project` attribution).               |
 | `MARIMOHUB_AI_MAX_TOKENS`        | no       | `[ai] max_tokens` written into the notebook config.                                                                  |
 | `MARIMOHUB_AI_RULES`             | no       | `[ai] rules` — custom assistant instructions.                                                                        |
-| `MARIMOHUB_AI_TOKEN_TTL_SECONDS` | no       | Session-token lifetime in seconds (default 3600).                                                                    |
+| `MARIMOHUB_AI_TOKEN_TTL_SECONDS` | no       | AI session-token lifetime in seconds (default: `3600`). Shorter lifetimes reduce the revocation window.              |
 
 Managed AI also requires `MARIMOHUB_AUTH_SESSION_SECRET` — the per-session tokens
 are signed with it (the same secret that signs login cookies).
@@ -64,6 +64,19 @@ a sandbox — only a minted, expiring, session-scoped token. This mirrors how
 [Workload Identity Federation](/workload-identity-federation) avoids long-lived storage
 keys.
 
+::: warning Token revocation is not immediate
+AI session tokens are self-contained. The proxy checks the signature and expiration
+of each token without reading object storage. This avoids an object-storage read for
+each AI request.
+
+An issued token remains valid until it expires. Stopping the session, removing
+project access, or suspending the user does not invalidate the token.
+
+The default lifetime is one hour. Set `MARIMOHUB_AI_TOKEN_TTL_SECONDS` to a lower
+value to reduce the revocation window. AI access ends when the token expires, even
+if the notebook session remains active.
+:::
+
 ## Proxy contract
 
 The proxy implements the subset of the OpenAI API that marimo calls server-side.
@@ -75,6 +88,10 @@ server-side.
 - `POST /api/ai/v1/responses` — the same passthrough for the OpenAI Responses API,
   so a client pointed at marimo's built-in `[ai.open_ai]` provider also works.
 - `GET /api/ai/v1/models` — returns the configured/allowed models.
+
+Each request body can contain at most 10 MB. This total includes embedded file
+content. The proxy rejects larger requests with HTTP `413` and does not send them
+upstream.
 
 This is a deliberate allowlist, not a generic OpenAI passthrough: the session token
 authorizes untrusted notebook code, so the proxy exposes only the endpoints clients

--- a/packages/api/src/integrations/archive.test.ts
+++ b/packages/api/src/integrations/archive.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { gzipSync, zipSync } from 'fflate';
-import { BadRequestError } from '@marimo-hub/core';
+import { BadRequestError, MAX_WORKSPACE_FILE_BYTES } from '@marimo-hub/core';
 import { parseWorkspaceArchive } from './archive';
 
 const encode = (s: string) => new TextEncoder().encode(s);
@@ -14,6 +14,22 @@ function concat(chunks: Uint8Array[]): Uint8Array {
 		offset += c.length;
 	}
 	return out;
+}
+
+function setZipOriginalSizes(archive: Uint8Array, sizes: number[]): Uint8Array {
+	const patched = new Uint8Array(archive);
+	const view = new DataView(patched.buffer, patched.byteOffset, patched.byteLength);
+	let entry = 0;
+	for (let offset = 0; offset <= patched.length - 4; offset += 1) {
+		if (view.getUint32(offset, true) !== 0x02014b50) continue;
+		if (entry >= sizes.length)
+			throw new Error('ZIP has more central-directory entries than expected');
+		view.setUint32(offset + 24, sizes[entry], true);
+		entry += 1;
+	}
+	if (entry !== sizes.length)
+		throw new Error('ZIP has fewer central-directory entries than expected');
+	return patched;
 }
 
 /** A single 512-byte tar header with the given name, body size, and typeflag. */
@@ -96,6 +112,45 @@ describe('parseWorkspaceArchive', () => {
 		expect(() => parseWorkspaceArchive(zipSync({ '../': new Uint8Array() }), 'zip', '')).toThrow(
 			BadRequestError,
 		);
+	});
+
+	it('rejects zip files and aggregate output beyond the decompressed byte limits', () => {
+		const oneFile = zipSync({ 'large.bin': new Uint8Array() });
+		expect(() =>
+			parseWorkspaceArchive(
+				setZipOriginalSizes(oneFile, [MAX_WORKSPACE_FILE_BYTES + 1]),
+				'zip',
+				'',
+			),
+		).toThrow(/Archive file exceeds/);
+
+		const fiveFiles = zipSync(
+			Object.fromEntries(
+				Array.from({ length: 5 }, (_, index) => [`${index}.bin`, new Uint8Array()]),
+			),
+		);
+		expect(() =>
+			parseWorkspaceArchive(
+				setZipOriginalSizes(fiveFiles, [
+					MAX_WORKSPACE_FILE_BYTES,
+					MAX_WORKSPACE_FILE_BYTES,
+					MAX_WORKSPACE_FILE_BYTES,
+					MAX_WORKSPACE_FILE_BYTES,
+					1,
+				]),
+				'zip',
+				'',
+			),
+		).toThrow(/Decompressed archive exceeds/);
+	});
+
+	it('rejects zip archives with more than 1000 files', () => {
+		const archive = zipSync(
+			Object.fromEntries(
+				Array.from({ length: 1001 }, (_, index) => [`${index}.txt`, new Uint8Array()]),
+			),
+		);
+		expect(() => parseWorkspaceArchive(archive, 'zip', '')).toThrow(/1000-file limit/);
 	});
 
 	it('parses a gzipped tar (.tar.gz)', () => {

--- a/packages/api/src/integrations/archive.ts
+++ b/packages/api/src/integrations/archive.ts
@@ -1,5 +1,5 @@
 import { gunzipSync, unzipSync } from 'fflate';
-import { BadRequestError, isSafeWorkspacePath } from '@marimo-hub/core';
+import { BadRequestError, isSafeWorkspacePath, MAX_WORKSPACE_FILE_BYTES } from '@marimo-hub/core';
 
 export interface ArchiveFile {
 	path: string;
@@ -8,6 +8,7 @@ export interface ArchiveFile {
 
 /** Guard against a decompression bomb: cap the inflated tar before we parse it. */
 const MAX_DECOMPRESSED_BYTES = 100 * 1024 * 1024;
+const MAX_ARCHIVE_FILES = 1000;
 
 const decoder = new TextDecoder();
 
@@ -37,18 +38,52 @@ function toArchiveFiles(files: Map<string, Uint8Array>): ArchiveFile[] {
 }
 
 function parseZip(bytes: Uint8Array): ArchiveFile[] {
+	const paths = new Set<string>();
+	let totalBytes = 0;
+	let fileCount = 0;
+	try {
+		// Read the central directory without inflating anything. fflate sizes each
+		// output allocation from this metadata, so rejecting the complete archive in
+		// this pass prevents a late entry from exceeding the budget after earlier
+		// entries have already consumed memory.
+		unzipSync(bytes, {
+			filter: ({ name, originalSize }) => {
+				if (name.endsWith('/')) {
+					assertSafeArchiveDirectoryPath(name);
+					return false;
+				}
+				assertSafeArchiveFilePath(name);
+				if (paths.has(name)) throw new BadRequestError(`Duplicate archive path: ${name}`);
+				paths.add(name);
+				fileCount += 1;
+				if (fileCount > MAX_ARCHIVE_FILES) {
+					throw new BadRequestError(`Archive exceeds the ${MAX_ARCHIVE_FILES}-file limit`);
+				}
+				if (!Number.isSafeInteger(originalSize) || originalSize > MAX_WORKSPACE_FILE_BYTES) {
+					throw new BadRequestError(
+						`Archive file exceeds the ${MAX_WORKSPACE_FILE_BYTES}-byte limit: ${name}`,
+					);
+				}
+				totalBytes += originalSize;
+				if (totalBytes > MAX_DECOMPRESSED_BYTES) {
+					throw new BadRequestError('Decompressed archive exceeds the size limit');
+				}
+				return false;
+			},
+		});
+	} catch (error) {
+		if (error instanceof BadRequestError) throw error;
+		throw new BadRequestError('Invalid zip archive');
+	}
+
 	let unzipped: Record<string, Uint8Array>;
 	try {
-		unzipped = unzipSync(bytes);
+		unzipped = unzipSync(bytes, { filter: ({ name }) => !name.endsWith('/') });
 	} catch {
 		throw new BadRequestError('Invalid zip archive');
 	}
 	const files = new Map<string, Uint8Array>();
 	for (const [path, body] of Object.entries(unzipped)) {
-		if (path.endsWith('/')) {
-			assertSafeArchiveDirectoryPath(path);
-			continue;
-		}
 		addFile(files, path, body);
 	}
 	return toArchiveFiles(files);

--- a/packages/api/src/routes/ai.test.ts
+++ b/packages/api/src/routes/ai.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mintAiSessionToken } from '@marimo-hub/core';
+import { MAX_REQUEST_BYTES, mintAiSessionToken } from '@marimo-hub/core';
 import { MemoryBucket } from '@marimo-hub/core/testing';
 import type { ApiDeps } from '../context';
 import { createApi } from '../createApi';
@@ -89,6 +89,49 @@ describe('POST /api/ai/v1/chat/completions', () => {
 		expect(res.status).toBe(400);
 		const json = (await res.json()) as { error: { type: string } };
 		expect(json.error.type).toBe('invalid_request_error');
+	});
+
+	it('rejects a request body over 10 MB before forwarding it', async () => {
+		const fetchMock = vi.spyOn(globalThis, 'fetch');
+		const res = await app().request('/api/ai/v1/chat/completions', {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${await token()}`,
+				'content-type': 'application/json',
+				'content-length': String(MAX_REQUEST_BYTES + 1),
+			},
+			body: '{}',
+		});
+
+		expect(res.status).toBe(413);
+		await expectOpenAiError(
+			res,
+			`Request body exceeds the ${MAX_REQUEST_BYTES}-byte limit`,
+			'invalid_request_error',
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('allows a request body exactly at the 10 MB limit', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response('ok', { status: 200 }));
+		const base = { model: 'm', padding: '' };
+		const overhead = JSON.stringify(base).length;
+		const body = JSON.stringify({ ...base, padding: 'x'.repeat(MAX_REQUEST_BYTES - overhead) });
+		expect(new TextEncoder().encode(body)).toHaveLength(MAX_REQUEST_BYTES);
+
+		const res = await app().request('/api/ai/v1/chat/completions', {
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${await token()}`,
+				'content-type': 'application/json',
+			},
+			body,
+		});
+
+		expect(res.status).toBe(200);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
 	it('returns 502 when the upstream provider is unreachable', async () => {

--- a/packages/api/src/routes/ai.ts
+++ b/packages/api/src/routes/ai.ts
@@ -15,8 +15,9 @@
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { bearerAuth } from 'hono/bearer-auth';
+import { bodyLimit } from 'hono/body-limit';
 import { proxy } from 'hono/proxy';
-import { verifyAiSessionToken } from '@marimo-hub/core';
+import { MAX_REQUEST_BYTES, verifyAiSessionToken } from '@marimo-hub/core';
 import type { AiTokenClaims } from '@marimo-hub/core';
 import type { HonoEnv } from '../context';
 import { logEvent } from '../log';
@@ -126,6 +127,18 @@ export function createAiProxy(): Hono<AiEnv> {
 				message: aiError('Malformed authorization header', 'invalid_request_error'),
 			},
 			invalidToken: { message: aiError('Invalid or expired token', 'invalid_request_error') },
+		}),
+	);
+	app.use(
+		'*',
+		bodyLimit({
+			maxSize: MAX_REQUEST_BYTES,
+			onError: () =>
+				openAiError(
+					`Request body exceeds the ${MAX_REQUEST_BYTES}-byte limit`,
+					'invalid_request_error',
+					413,
+				),
 		}),
 	);
 


### PR DESCRIPTION
Hardens two untrusted-input paths surfaced during local pentesting.

## AI proxy request limit
- Enforce a 10 MB body limit (`MAX_REQUEST_BYTES`) on the AI proxy via `hono/body-limit`. Oversized requests get `413` with an OpenAI-shaped error and are never forwarded upstream.

## Zip archive extraction
- Validate zip archives from the central directory before inflating: reject per-file and aggregate decompressed-size overruns, and archives with more than 1000 files. This prevents a late oversized entry from consuming memory after earlier entries were already inflated.

## Docs
- Document the AI token revocation window (self-contained tokens stay valid until expiry) and the request-size limit in `docs/ai.md`.