### PR TITLE
feat(data-browser): S3 object browser

### DIFF
--- a/.github/workflows/object-browser-conformance.yml
+++ b/.github/workflows/object-browser-conformance.yml
@@ -1,0 +1,45 @@
+name: Object browser conformance
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  minio:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+        with:
+          version: 0.1.24
+          node-version-file: '.node-version'
+          sfw: true
+          cache: true
+          run-install: |
+            - args: ['--frozen-lockfile']
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio -p 19000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+          for i in $(seq 1 30); do
+            curl -fsS http://127.0.0.1:19000/minio/health/live && break
+            sleep 1
+            [ "$i" = 30 ] && exit 1
+          done
+      - name: Run object-browser contract
+        env:
+          MARIMOHUB_TEST_S3_ENDPOINT: http://127.0.0.1:19000
+          MARIMOHUB_TEST_S3_ACCESS_KEY: minioadmin
+          MARIMOHUB_TEST_S3_SECRET_KEY: minioadmin
+        run: vp test packages/object-browser-s3/src/minio.live.test.ts

--- a/development_docs/integrations.md
+++ b/development_docs/integrations.md
@@ -150,6 +150,11 @@ A kind can implement `BrowseCapability` when it has an HTTP metadata API. The
 capability lists namespaces, tables, and schemas. It also creates a notebook
 snippet. `MARIMOHUB_DATA_BROWSER` controls access to this capability.
 
+Object stores implement the provider-neutral `ObjectBrowser` port separately from table
+`BrowseCapability`. The S3 adapter lives in `packages/object-browser-s3`; only `packages/config`
+imports it. Core owns source/context/result contracts, and API/web dispatch on the advertised
+`tables` or `objects` surface instead of importing provider code.
+
 Kinds can implement `previewRows` for bounded reads through the guarded HTTP
 path. Other kinds use `SandboxDataPreview` when the data browser is `full`.
 
@@ -179,6 +184,16 @@ the editor role or a higher role.
 The API resolves a browse ID in the project tier before the organization tier.
 A project integration shadows an organization integration with the same name.
 Browse operations do not write to the bucket.
+
+S3 content routes are the raw-response exception to the JSON envelope on success. They authorize
+and resolve the integration before opening a stream, accept at most one byte range, set no-store and
+nosniff headers, sanitize `Content-Disposition`, and release the provider client on completion,
+failure, deadline, or client cancellation. Pre-stream failures still use the standard envelope.
+
+Metadata lists use a short state-token cache. Details, search, previews, tags, versions, streams,
+credentials, provider clients, and failures are never cached. Explicit preview/download reads append
+audit events; navigation does not. Live S3 transport behavior is covered by
+`objectBrowseContract` against pinned MinIO in the Object browser conformance workflow.
 
 Servers differ in pagination and namespace addressing, so the `iceberg_rest`
 client filters listings to direct children, stops on a non-advancing page

--- a/development_docs/integrations.md
+++ b/development_docs/integrations.md
@@ -190,9 +190,10 @@ and resolve the integration before opening a stream, accept at most one byte ran
 nosniff headers, sanitize `Content-Disposition`, and release the provider client on completion,
 failure, deadline, or client cancellation. Pre-stream failures still use the standard envelope.
 
-Metadata lists use a short state-token cache. Details, search, previews, tags, versions, streams,
-credentials, provider clients, and failures are never cached. Explicit preview/download reads append
-audit events; navigation does not. Live S3 transport behavior is covered by
+Metadata lists use a short state-token cache. Short-lived federated credentials are cached in memory
+until their refresh window; details, search, previews, tags, versions, streams, provider clients, and
+failures are not cached. Explicit preview/download reads append audit events; navigation does not.
+Live S3 transport behavior is covered by
 `objectBrowseContract` against pinned MinIO in the Object browser conformance workflow.
 
 Servers differ in pagination and namespace addressing, so the `iceberg_rest`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -513,6 +513,16 @@ Integration management and session injection are enabled. Project entries use
 | `MARIMOHUB_DATA_PREVIEW_MAX_CONCURRENT_PER_USER` | Maximum number of preview sandboxes for one user. | — | `1` | — |
 | `MARIMOHUB_DATA_PREVIEW_STARTUP_TIMEOUT_SECONDS` | Maximum time to start and prepare a preview sandbox. | — | `120` | — |
 | `MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS` | Maximum time for the fixed PyIceberg scan. | — | `30` | — |
+| `MARIMOHUB_OBJECT_BROWSER_ALLOW_SERVER_AMBIENT_CREDENTIALS` | Allow editors to browse ambient-auth S3 integrations with the control-plane AWS identity when compatible project WIF credentials are unavailable. Keep this off unless that identity is intentionally available to project editors. | — | `false` | — |
+| `MARIMOHUB_OBJECT_BROWSER_METADATA_TIMEOUT_SECONDS` | Maximum time for one object listing or metadata operation, including DNS resolution. | — | `30` | — |
+| `MARIMOHUB_OBJECT_BROWSER_PREVIEW_TIMEOUT_SECONDS` | Maximum time for one bounded object preview, including DNS resolution and ranged reads. | — | `30` | — |
+| `MARIMOHUB_OBJECT_BROWSER_PREVIEW_MAX_BYTES` | Maximum source bytes read for CSV, JSON, JSON Lines, and text previews. | — | `8388608` | — |
+| `MARIMOHUB_OBJECT_BROWSER_INLINE_IMAGE_MAX_BYTES` | Maximum size of a magic-byte-validated raster image shown inline. | — | `10485760` | — |
+| `MARIMOHUB_OBJECT_BROWSER_PARQUET_MAX_RANGED_BYTES` | Maximum total bytes fetched across ranged requests for one Parquet preview. | — | `33554432` | — |
+| `MARIMOHUB_OBJECT_BROWSER_SEARCH_MAX_KEYS` | Maximum keys scanned by one bounded object-name search request. | — | `5000` | — |
+| `MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS` | Maximum object content streams held by one server process. | — | `16` | — |
+| `MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS_PER_USER` | Maximum object content streams one user can hold on one server process. | — | `2` | — |
+| `MARIMOHUB_OBJECT_BROWSER_DOWNLOAD_TIMEOUT_SECONDS` | Maximum lifetime of one proxied object content stream. | — | `3600` | — |
 
 ### Off
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -30,17 +30,18 @@ See the two-phase policy in `development_docs/migrations.md`.
 Integration configuration is versioned. Each save creates an immutable
 revision. Each session records the revisions that it uses.
 
-## Browse catalog metadata
+## Browse data
 
 Set `MARIMOHUB_DATA_BROWSER=metadata` to enable the Data page and browse API.
-Set it to `full` to also enable row previews. Integrations must be enabled, and
+Set it to `full` to also enable row and object previews and object downloads. Integrations must be enabled, and
 the integration probe must not be `off`.
 
 Editors and higher roles can use the Data page at `/projects/{pid}/data`.
 They do not need to start a session. The URL stores the selected integration,
-namespace, table, and filter, so a link restores the same view.
+surface, table or object identity, and search scope, so a link restores the same view.
 
-The Data page lists namespaces, tables, and table schemas. The schema view
+The Data page lists namespaces, tables, and table schemas for catalog integrations. S3 integrations
+retain bucket, prefix, and object semantics; they are not presented as tables. The schema view
 shows columns, partition fields, and available snapshot statistics. It also
 provides notebook code that loads the table through the integration. The
 **Open in notebook** action creates a notebook in the project with that code
@@ -50,6 +51,73 @@ notebook's dependencies before you run it.
 Browsing is read-only. Iceberg REST and ClickHouse use HTTP GET requests. Trino
 submits hub-generated `SHOW`, `DESCRIBE`, and bounded `SELECT` statements. All
 requests use the egress policy from `MARIMOHUB_INTEGRATIONS_PROBE`.
+
+### S3 object browsing
+
+S3 object browsing supports configured-bucket or accessible-bucket navigation, direct prefix
+listing, bounded key-name search, object metadata and tags, read-only version history, explicit
+previews, notebook snippets, and streamed downloads. It never uploads, deletes, restores, renames,
+or edits upstream objects or metadata.
+
+When an S3 integration sets `bucket`, the browser exposes only that bucket and does not call
+`ListBuckets`. This is a user-interface scope, not an IAM restriction: notebook code still has every
+permission granted to the integration credentials. Without `bucket`, the browser calls
+`ListBuckets` and shows the accessible result.
+
+Metadata mode prevents the hub from returning object bodies; full mode permits explicit previews
+and downloads. S3 authorizes `HeadObject` with the same read actions as content, so IAM cannot grant
+metadata-only HEAD access separately. Grant only the actions needed by the selected features:
+
+- `s3:ListAllMyBuckets` only when the integration has no configured bucket;
+- `s3:ListBucket` for prefixes and bounded key-name search;
+- `s3:GetObject` for current-object metadata and, in full mode, previews and downloads;
+- `s3:GetObjectVersion` for selected-version metadata and, in full mode, previews and downloads;
+- `s3:ListBucketVersions` for version history;
+- `s3:GetObjectTagging` when tags should appear. A denied tag request does not hide other metadata.
+
+Substring search is a bounded recursive S3 listing, not a persistent index or content search. The
+Data page reports how many keys were scanned and whether more keys may exist. Continue the search
+to scan the next bounded segment. Prefix navigation uses S3's native `Prefix` operation and is less
+expensive.
+
+Selecting an object performs metadata reads only. Content is fetched after **Load preview** or
+**Download**. CSV, TSV, JSON, JSON Lines, Parquet, UTF-8 text/code/Markdown/logs, and magic-byte-
+validated PNG, JPEG, GIF, and WebP files can be previewed within configured byte, row, column,
+request, result, and deadline limits. HTML, SVG, PDF, archives, executables, unknown binary files,
+and oversized images are never rendered inline. Truncated previews say so.
+
+Downloads stay behind hub authorization and stream from S3 through the server. They support one
+HTTP byte range, preserve ETag/version preconditions, use safe attachment filenames, and propagate
+client cancellation upstream. The hub does not return S3 credentials or presigned URLs.
+
+The raw content endpoint is
+`GET /api/v1/projects/{pid}/integrations/{iid}/browse/objects/content`. It requires `bucket` and
+`key`; `version_id`, `etag`, and `inline=true` are optional. Editors and higher roles can send one
+`Range: bytes=…` header and receive `200` or `206`. Pre-stream failures use the standard JSON error
+envelope, including `403`, `404`, `412`, `416`, `429`, and `503` responses.
+
+Static integration credentials are used only for that integration. Ambient-auth integrations use
+short-lived project WIF credentials when the project enables a compatible target. The WIF storage
+endpoint and integration endpoint must be the same canonical origin. Otherwise, ambient object
+browsing remains unavailable unless the operator explicitly sets
+`MARIMOHUB_OBJECT_BROWSER_ALLOW_SERVER_AMBIENT_CREDENTIALS=true`. That setting grants project
+editors access through the control-plane AWS identity and should be enabled only intentionally.
+
+Custom endpoints use the configured guarded/private integration egress policy. `guarded` rejects
+private, loopback, link-local, metadata, and other reserved targets. Use `private` only when an
+on-premises S3-compatible endpoint must be reachable. Every final SDK hostname, including generated
+virtual-host names and retries, is resolved, checked, and pinned before transport.
+
+Successful object previews and opened downloads create `integration.object.preview` and
+`integration.object.download` audit events. Routine listing, search, and metadata navigation do not.
+Object content, credentials, signed headers, and provider error text are not stored in browse
+caches or audit events.
+
+S3-compatible implementations can omit operations such as bucket discovery, tags, checksums, or
+versioning. Configure a bucket when `ListBuckets` is unavailable; the Data page reports optional
+features that the target or credentials do not support. For a private endpoint that times out,
+verify `MARIMOHUB_INTEGRATIONS_PROBE=private`, DNS visibility from the server, TLS trust, and the
+object-browser timeout/limit settings in [Configuration](./configuration.md).
 
 The hub supports Iceberg REST Catalog, Trino, and ClickHouse. Trino uses the
 catalog → schema → table hierarchy. ClickHouse uses database → table.
@@ -98,8 +166,9 @@ Each request checks whether the integration is available before it reads the
 cache. Disabling or shadowing an integration therefore takes effect immediately.
 A new configuration version uses a new cache entry.
 
-Each replica can cache namespace and table lists for one minute. It can cache
-schemas for five minutes. Browse requests have a per-user rate limit. The
+Each replica can cache namespace and table lists for one minute and S3 bucket/object lists for 15 seconds.
+It can cache table schemas for five minutes. Searches, previews, tags, versions, content, failures,
+and authorization denials are not cached. Browse requests have per-user rate limits. The
 **Refresh** action bypasses the response cache, but it still uses the rate
 limit.
 

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -1677,6 +1677,7 @@ components:
                 search:
                   type: string
                   enum:
+                    - none
                     - bounded-key-name
                 versions:
                   type: boolean
@@ -1790,6 +1791,286 @@ components:
       required:
         - columns
         - rows
+    IntegrationObjectBucket:
+      type: object
+      properties:
+        name:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        configured:
+          type: boolean
+      required:
+        - name
+        - configured
+    IntegrationObjectEntry:
+      type: object
+      properties:
+        kind:
+          type: string
+          enum:
+            - prefix
+            - object
+        name:
+          type: string
+        key:
+          type: string
+        size:
+          type: number
+          minimum: 0
+        last_modified:
+          type: string
+          format: date-time
+        etag:
+          type: string
+        storage_class:
+          type: string
+      required:
+        - kind
+        - name
+        - key
+    IntegrationObjectDetail:
+      type: object
+      properties:
+        bucket:
+          type: string
+        key:
+          type: string
+        version_id:
+          type: string
+        size:
+          type: number
+          minimum: 0
+        last_modified:
+          type: string
+          format: date-time
+        etag:
+          type: string
+        storage_class:
+          type: string
+        content_type:
+          type: string
+        content_encoding:
+          type: string
+        cache_control:
+          type: string
+        checksums:
+          type: array
+          items:
+            type: object
+            properties:
+              algorithm:
+                type: string
+              value:
+                type: string
+            required:
+              - algorithm
+              - value
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        tags:
+          type: array
+          items:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                type: string
+            required:
+              - key
+              - value
+        tags_available:
+          type: boolean
+        snippet:
+          type: string
+      required:
+        - bucket
+        - key
+        - size
+        - checksums
+        - metadata
+        - tags_available
+    IntegrationObjectVersion:
+      type: object
+      properties:
+        bucket:
+          type: string
+        key:
+          type: string
+        version_id:
+          type: string
+        kind:
+          type: string
+          enum:
+            - version
+            - delete-marker
+        is_latest:
+          type: boolean
+        last_modified:
+          type: string
+          format: date-time
+        size:
+          type: number
+          minimum: 0
+        etag:
+          type: string
+        storage_class:
+          type: string
+        owner:
+          type: object
+          properties:
+            id:
+              type: string
+            display_name:
+              type: string
+      required:
+        - bucket
+        - key
+        - kind
+        - is_latest
+    IntegrationObjectPreview:
+      oneOf:
+        - type: object
+          properties:
+            kind:
+              type: string
+              enum:
+                - tabular
+            format:
+              type: string
+              enum:
+                - table
+                - csv
+                - tsv
+                - json
+                - jsonl
+                - parquet
+            columns:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                required:
+                  - name
+            rows:
+              type: array
+              items:
+                type: array
+                items: {}
+            truncated:
+              type: boolean
+            bytes_read:
+              type: number
+              minimum: 0
+            total_bytes:
+              type: number
+              minimum: 0
+            warnings:
+              type: array
+              items:
+                type: string
+          required:
+            - kind
+            - format
+            - columns
+            - rows
+            - truncated
+            - warnings
+        - type: object
+          properties:
+            kind:
+              type: string
+              enum:
+                - text
+            format:
+              type: string
+              enum:
+                - text
+                - markdown
+                - code
+                - log
+                - json
+            text:
+              type: string
+            truncated:
+              type: boolean
+            bytes_read:
+              type: number
+              minimum: 0
+            total_bytes:
+              type: number
+              minimum: 0
+            warnings:
+              type: array
+              items:
+                type: string
+          required:
+            - kind
+            - format
+            - text
+            - truncated
+            - bytes_read
+            - total_bytes
+            - warnings
+        - type: object
+          properties:
+            kind:
+              type: string
+              enum:
+                - image
+            format:
+              type: string
+              enum:
+                - png
+                - jpeg
+                - gif
+                - webp
+            content_url:
+              type: string
+            width:
+              type: integer
+              exclusiveMinimum: 0
+            height:
+              type: integer
+              exclusiveMinimum: 0
+            total_bytes:
+              type: number
+              minimum: 0
+            warnings:
+              type: array
+              items:
+                type: string
+          required:
+            - kind
+            - format
+            - content_url
+            - total_bytes
+            - warnings
+        - type: object
+          properties:
+            kind:
+              type: string
+              enum:
+                - unsupported
+            reason:
+              type: string
+            detected_type:
+              type: string
+            total_bytes:
+              type: number
+              minimum: 0
+          required:
+            - kind
+            - reason
+            - total_bytes
     User:
       type: object
       properties:
@@ -7743,6 +8024,890 @@ paths:
                       - true
                   data:
                     $ref: '#/components/schemas/IntegrationTablePreview'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/integrations/{iid}/browse/objects/buckets:
+    get:
+      tags:
+        - Integrations
+      summary: List object-store buckets (editor or above)
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+        - schema:
+            type: string
+            pattern: ^intg-[0-9a-z]{16}$
+            example: intg-7h2k9qm4xz7rp3w8
+          required: true
+          name: iid
+          in: path
+        - schema:
+            type: integer
+            exclusiveMinimum: 0
+            maximum: 100
+            default: 50
+            example: 50
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            enum:
+              - 'true'
+              - 'false'
+            example: 'false'
+          required: false
+          name: fresh
+          in: query
+      responses:
+        '200':
+          description: Buckets visible through the integration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/IntegrationObjectBucket'
+                      next_cursor:
+                        type:
+                          - string
+                          - 'null'
+                    required:
+                      - items
+                      - next_cursor
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/integrations/{iid}/browse/objects:
+    get:
+      tags:
+        - Integrations
+      summary: List direct object-store children (editor or above)
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+        - schema:
+            type: string
+            pattern: ^intg-[0-9a-z]{16}$
+            example: intg-7h2k9qm4xz7rp3w8
+          required: true
+          name: iid
+          in: path
+        - schema:
+            type: integer
+            exclusiveMinimum: 0
+            maximum: 100
+            default: 50
+            example: 50
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            enum:
+              - 'true'
+              - 'false'
+            example: 'false'
+          required: false
+          name: fresh
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: analytics-lake
+          required: true
+          name: bucket
+          in: query
+        - schema:
+            type: string
+            example: events/2026/
+          required: false
+          name: prefix
+          in: query
+      responses:
+        '200':
+          description: Direct prefixes and objects
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/IntegrationObjectEntry'
+                      next_cursor:
+                        type:
+                          - string
+                          - 'null'
+                    required:
+                      - items
+                      - next_cursor
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/integrations/{iid}/browse/objects/search:
+    get:
+      tags:
+        - Integrations
+      summary: Run a bounded object-key search (editor or above)
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+        - schema:
+            type: string
+            pattern: ^intg-[0-9a-z]{16}$
+            example: intg-7h2k9qm4xz7rp3w8
+          required: true
+          name: iid
+          in: path
+        - schema:
+            type: integer
+            exclusiveMinimum: 0
+            maximum: 100
+            default: 50
+            example: 50
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: analytics-lake
+          required: true
+          name: bucket
+          in: query
+        - schema:
+            type: string
+            example: events/2026/
+          required: false
+          name: prefix
+          in: query
+        - schema:
+            type: string
+            minLength: 2
+            maxLength: 1024
+          required: true
+          name: query
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: formats
+          in: query
+        - schema:
+            type: string
+            format: date-time
+          required: false
+          name: modified_after
+          in: query
+        - schema:
+            type: string
+            format: date-time
+          required: false
+          name: modified_before
+          in: query
+        - schema:
+            type:
+              - number
+              - 'null'
+            minimum: 0
+          required: false
+          name: min_size
+          in: query
+        - schema:
+            type:
+              - number
+              - 'null'
+            minimum: 0
+          required: false
+          name: max_size
+          in: query
+      responses:
+        '200':
+          description: Bounded object-key search results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/IntegrationObjectEntry'
+                      next_cursor:
+                        type:
+                          - string
+                          - 'null'
+                      scanned:
+                        type: integer
+                        minimum: 0
+                      complete:
+                        type: boolean
+                    required:
+                      - items
+                      - next_cursor
+                      - scanned
+                      - complete
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/integrations/{iid}/browse/objects/head:
+    get:
+      tags:
+        - Integrations
+      summary: Read object metadata and tags (editor or above)
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+        - schema:
+            type: string
+            pattern: ^intg-[0-9a-z]{16}$
+            example: intg-7h2k9qm4xz7rp3w8
+          required: true
+          name: iid
+          in: path
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: analytics-lake
+          required: true
+          name: bucket
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+            example: events/2026/part-001.jsonl
+          required: true
+          name: key
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 2048
+          required: false
+          name: version_id
+          in: query
+      responses:
+        '200':
+          description: Object metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/IntegrationObjectDetail'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/integrations/{iid}/browse/objects/versions:
+    get:
+      tags:
+        - Integrations
+      summary: List object versions and delete markers (editor or above)
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+        - schema:
+            type: string
+            pattern: ^intg-[0-9a-z]{16}$
+            example: intg-7h2k9qm4xz7rp3w8
+          required: true
+          name: iid
+          in: path
+        - schema:
+            type: integer
+            exclusiveMinimum: 0
+            maximum: 100
+            default: 50
+            example: 50
+          required: false
+          name: limit
+          in: query
+        - schema:
+            type: string
+          required: false
+          name: cursor
+          in: query
+        - schema:
+            type: string
+            enum:
+              - 'true'
+              - 'false'
+            example: 'false'
+          required: false
+          name: fresh
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 255
+            example: analytics-lake
+          required: true
+          name: bucket
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+            example: events/2026/part-001.jsonl
+          required: true
+          name: key
+          in: query
+        - schema:
+            type: string
+            minLength: 1
+            maxLength: 2048
+          required: false
+          name: version_id
+          in: query
+      responses:
+        '200':
+          description: Object versions and delete markers
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/IntegrationObjectVersion'
+                      next_cursor:
+                        type:
+                          - string
+                          - 'null'
+                    required:
+                      - items
+                      - next_cursor
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/integrations/{iid}/browse/objects/preview:
+    post:
+      tags:
+        - Integrations
+      summary: Preview bounded object content (editor or above)
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+        - schema:
+            type: string
+            pattern: ^intg-[0-9a-z]{16}$
+            example: intg-7h2k9qm4xz7rp3w8
+          required: true
+          name: iid
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                bucket:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                  example: analytics-lake
+                key:
+                  type: string
+                  minLength: 1
+                  example: events/2026/part-001.jsonl
+                version_id:
+                  type: string
+                  minLength: 1
+                  maxLength: 2048
+                limit:
+                  type: integer
+                  exclusiveMinimum: 0
+                  maximum: 100
+                  default: 20
+              required:
+                - bucket
+                - key
+      responses:
+        '200':
+          description: Bounded object preview
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/IntegrationObjectPreview'
                 required:
                   - success
                   - data

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -339,7 +339,16 @@ export interface ApiDeps {
 	 * Absent disables the browse routes (404). `sandboxPreview` is the fallback
 	 * for kinds without a cheap HTTP-native preview.
 	 */
-	dataBrowser?: { preview: boolean; sandboxPreview?: DataPreview };
+	dataBrowser?: {
+		preview: boolean;
+		sandboxPreview?: DataPreview;
+		objectBrowser?: {
+			allowServerAmbientCredentials: boolean;
+			maxConcurrentDownloads: number;
+			maxConcurrentDownloadsPerUser: number;
+			downloadTimeoutMs: Millis;
+		};
+	};
 	/**
 	 * Build/deploy identity surfaced read-only by `GET /api/v1/version` (the UI's
 	 * footer info popover). Baked into the image at build time and read from env

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from '@hono/zod-openapi';
 import {
 	AesGcmSecretCodec,
 	defaultRegistry,
 	defineIntegration,
 	IntegrationRegistry,
+	Millis,
 	OrgIntegrationsStore,
 	ProjectIntegrationsStore,
 	UnavailableError,
@@ -14,8 +15,12 @@ import type { ObjectBrowser } from '@marimo-hub/core';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
 import { ACTOR, uid } from '@marimo-hub/core/testing';
 import { createInitializedBucket, createTestApi, expectError, expectOk } from '../testing';
+import { clearObjectCredentialCacheForTests } from './objectBrowse';
+import { clearIntegrationBrowseStateForTests } from './integrations';
 
 const codec = new AesGcmSecretCodec({ kek: '/ECMzY/eM7nlHPPNu+OM2wv0lWiFuHUScSJxNmh64N8=' });
+
+afterEach(() => vi.restoreAllMocks());
 
 /** U+001F, the separator multi-part namespaces use in query params. */
 const SEP = String.fromCharCode(0x1f);
@@ -76,33 +81,92 @@ const sandboxBrowsyKind = defineIntegration({
 });
 
 const objectBrowser: ObjectBrowser = {
-	capability: () => ({
-		available: true,
-		preview: false,
-		download: false,
-		search: 'bounded-key-name',
-		versions: true,
-		preview_formats: [],
+	capability: (source, context) => {
+		const available =
+			source.auth.method === 'static' ||
+			context.temporary_s3_credentials !== undefined ||
+			context.allow_server_ambient;
+		return {
+			available,
+			preview: available,
+			download: available,
+			search: 'bounded-key-name',
+			versions: available,
+			preview_formats: available ? ['csv', 'text', 'png'] : [],
+			...(available ? {} : { reason: 'No object-store credentials are available.' }),
+		};
+	},
+	listBuckets: async () => ({
+		items: [{ name: 'lake', configured: true }],
+		next_cursor: null,
 	}),
-	listBuckets: async () => ({ items: [], next_cursor: null }),
-	listObjects: async () => ({ items: [], next_cursor: null }),
-	searchObjects: async () => ({ items: [], next_cursor: null, scanned: 0, complete: true }),
+	listObjects: async (_source, _context, request) => ({
+		items: [
+			{ kind: 'prefix', name: 'daily/', key: `${request.prefix ?? ''}daily/` },
+			{
+				kind: 'object',
+				name: 'events.jsonl',
+				key: `${request.prefix ?? ''}events.jsonl`,
+				size: 12,
+				etag: '"etag"',
+			},
+		],
+		next_cursor: request.cursor ?? null,
+	}),
+	searchObjects: async (_source, _context, request) => ({
+		items: [
+			{ kind: 'object', name: request.query, key: `${request.prefix ?? ''}${request.query}` },
+		],
+		next_cursor: request.cursor ?? null,
+		scanned: 37,
+		complete: request.cursor !== undefined,
+	}),
 	headObject: async (_source, _context, request) => ({
 		...request,
-		size: 0,
+		size: 12,
+		etag: '"etag"',
+		content_type: 'text/plain',
 		checksums: [],
 		metadata: {},
 		tags_available: false,
 	}),
-	listVersions: async () => ({ items: [], next_cursor: null }),
-	previewObject: async () => ({
-		kind: 'unsupported',
-		reason: 'disabled',
-		total_bytes: 0,
+	listVersions: async (_source, _context, request) => ({
+		items: [
+			{
+				bucket: request.bucket,
+				key: request.key,
+				version_id: 'v1',
+				kind: 'version',
+				is_latest: true,
+				size: 12,
+			},
+		],
+		next_cursor: null,
 	}),
-	openObject: async () => {
-		throw new Error('not used');
-	},
+	previewObject: async () => ({
+		kind: 'text',
+		format: 'text',
+		text: 'hello object',
+		truncated: false,
+		bytes_read: 12,
+		total_bytes: 12,
+		warnings: [],
+	}),
+	openObject: async (_source, _context, request) => ({
+		body: new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('hello object'));
+				controller.close();
+			},
+		}),
+		status: request.range ? 206 : 200,
+		content_type: 'text/plain',
+		content_length: 12,
+		total_size: 12,
+		...(request.range ? { content_range: 'bytes 0-4/12' } : {}),
+		etag: '"etag"',
+		close: () => {},
+	}),
 };
 
 function browserDeps(bucket: MemoryBucket) {
@@ -122,7 +186,15 @@ function browserDeps(bucket: MemoryBucket) {
 	return {
 		integrations: new ProjectIntegrationsStore(options),
 		orgIntegrations: new OrgIntegrationsStore(options),
-		dataBrowser: { preview: false },
+		dataBrowser: {
+			preview: false,
+			objectBrowser: {
+				allowServerAmbientCredentials: false,
+				maxConcurrentDownloads: 16,
+				maxConcurrentDownloadsPerUser: 2,
+				downloadTimeoutMs: Millis.of(60_000),
+			},
+		},
 	};
 }
 
@@ -132,6 +204,8 @@ describe('Data browser routes', () => {
 	let deps: ReturnType<typeof browserDeps>;
 
 	beforeEach(async () => {
+		clearObjectCredentialCacheForTests();
+		clearIntegrationBrowseStateForTests();
 		bucket = await createInitializedBucket();
 		deps = browserDeps(bucket);
 		request = createTestApi({ bucket, userId: ACTOR, deps }).request;
@@ -151,6 +225,24 @@ describe('Data browser routes', () => {
 				kind: 'browsy',
 				name,
 				config: { token: 'tok' },
+			}),
+			201,
+		);
+	}
+
+	async function createObjectStore(pid: string, name = 'objects') {
+		return expectOk<{ id: string }>(
+			await request('POST', `/projects/${pid}/integrations`, {
+				kind: 's3',
+				name,
+				config: {
+					bucket: 'lake',
+					auth: {
+						method: 'static',
+						access_key_id: 'access',
+						secret_access_key: 'secret',
+					},
+				},
 			}),
 			201,
 		);
@@ -199,7 +291,7 @@ describe('Data browser routes', () => {
 		});
 	});
 
-	it('does not advertise object-only instances until object routes are available', async () => {
+	it('advertises object-only instances with surface-specific capabilities', async () => {
 		const pid = await createProject();
 		const created = await expectOk<{ id: string }>(
 			await request('POST', `/projects/${pid}/integrations`, {
@@ -222,8 +314,232 @@ describe('Data browser routes', () => {
 		expect(capability).toEqual({
 			metadata: false,
 			preview: false,
-			surfaces: {},
+			surfaces: {
+				objects: {
+					available: true,
+					preview: true,
+					download: true,
+					search: 'bounded-key-name',
+					versions: true,
+					preview_formats: ['csv', 'text', 'png'],
+				},
+			},
 		});
+	});
+
+	it('lists buckets and opaque Unicode object keys, then returns detail and versions', async () => {
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		const base = `/projects/${pid}/integrations/${created.id}/browse/objects`;
+
+		expect(await expectOk(await request('GET', `${base}/buckets`))).toEqual({
+			items: [{ name: 'lake', configured: true }],
+			next_cursor: null,
+		});
+		const prefix = 'space and %/日本語/?#';
+		const listed = await expectOk<{ items: { key: string }[] }>(
+			await request('GET', `${base}?bucket=lake&prefix=${encodeURIComponent(prefix)}`),
+		);
+		expect(listed.items.map((item) => item.key)).toEqual([
+			`${prefix}daily/`,
+			`${prefix}events.jsonl`,
+		]);
+
+		const key = `${prefix}events.jsonl`;
+		const detail = await expectOk<{ key: string; snippet?: string }>(
+			await request('GET', `${base}/head?bucket=lake&key=${encodeURIComponent(key)}`),
+		);
+		expect(detail).toMatchObject({ key, snippet: expect.stringContaining('s3://lake/') });
+		const versions = await expectOk<{ items: { version_id?: string }[] }>(
+			await request('GET', `${base}/versions?bucket=lake&key=${encodeURIComponent(key)}`),
+		);
+		expect(versions.items).toEqual([expect.objectContaining({ version_id: 'v1' })]);
+	});
+
+	it('reports bounded search progress and rejects inconsistent filters', async () => {
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		const base = `/projects/${pid}/integrations/${created.id}/browse/objects/search`;
+		const first = await expectOk<{
+			items: { key: string }[];
+			scanned: number;
+			complete: boolean;
+		}>(await request('GET', `${base}?bucket=lake&prefix=events%2F&query=needle`));
+		expect(first).toMatchObject({
+			items: [{ key: 'events/needle' }],
+			scanned: 37,
+			complete: false,
+		});
+		await expectError(await request('GET', `${base}?bucket=lake&query=x`), 422, 'VALIDATION_ERROR');
+		await expectError(
+			await request('GET', `${base}?bucket=lake&query=needle&min_size=10&max_size=1`),
+			422,
+			'VALIDATION_ERROR',
+		);
+		await expectError(
+			await request(
+				'GET',
+				`${base}?bucket=lake&query=needle&modified_after=2026-08-12T00%3A00%3A00Z&modified_before=2026-08-11T00%3A00%3A00Z`,
+			),
+			422,
+			'VALIDATION_ERROR',
+		);
+	});
+
+	it('enforces object search and preview budgets independently', async () => {
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		const search = `/projects/${pid}/integrations/${created.id}/browse/objects/search?bucket=lake&query=needle`;
+		for (let index = 0; index < 5; index += 1) await expectOk(await request('GET', search));
+		await expectError(await request('GET', search), 429, 'RESOURCE_EXHAUSTED');
+
+		const preview = `/projects/${pid}/integrations/${created.id}/browse/objects/preview`;
+		for (let index = 0; index < 10; index += 1) {
+			await expectOk(
+				await request('POST', preview, { bucket: 'lake', key: 'events.jsonl', limit: 5 }),
+			);
+		}
+		await expectError(
+			await request('POST', preview, { bucket: 'lake', key: 'events.jsonl', limit: 5 }),
+			429,
+			'RESOURCE_EXHAUSTED',
+		);
+	});
+
+	it('rejects operations disabled by the object capability before calling the adapter', async () => {
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		vi.spyOn(objectBrowser, 'capability').mockReturnValue({
+			available: true,
+			preview: false,
+			download: false,
+			search: 'none',
+			versions: false,
+			preview_formats: [],
+		});
+		const search = vi.spyOn(objectBrowser, 'searchObjects');
+		const versions = vi.spyOn(objectBrowser, 'listVersions');
+		const preview = vi.spyOn(objectBrowser, 'previewObject');
+		const open = vi.spyOn(objectBrowser, 'openObject');
+		const base = `/projects/${pid}/integrations/${created.id}/browse/objects`;
+		await expectError(
+			await request('GET', `${base}/search?bucket=lake&query=needle`),
+			422,
+			'VALIDATION_ERROR',
+		);
+		await expectError(
+			await request('GET', `${base}/versions?bucket=lake&key=events.jsonl`),
+			422,
+			'VALIDATION_ERROR',
+		);
+		await expectError(
+			await request('POST', `${base}/preview`, { bucket: 'lake', key: 'events.jsonl' }),
+			404,
+			'NOT_FOUND',
+		);
+		await expectError(
+			await request('GET', `${base}/content?bucket=lake&key=events.jsonl`),
+			404,
+			'NOT_FOUND',
+		);
+		expect(search).not.toHaveBeenCalled();
+		expect(versions).not.toHaveBeenCalled();
+		expect(preview).not.toHaveBeenCalled();
+		expect(open).not.toHaveBeenCalled();
+	});
+
+	it('previews and streams object content with audits, range headers, and safe filenames', async () => {
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		const base = `/projects/${pid}/integrations/${created.id}/browse/objects`;
+		const key = 'reports/evil\r\n";name.txt';
+		const previewResponse = await request('POST', `${base}/preview`, {
+			bucket: 'lake',
+			key,
+			limit: 5,
+		});
+		expect(previewResponse.headers.get('cache-control')).toBe('no-store');
+		expect(await expectOk(previewResponse)).toMatchObject({
+			kind: 'text',
+			text: 'hello object',
+		});
+
+		const content = await request(
+			'GET',
+			`${base}/content?bucket=lake&key=${encodeURIComponent(key)}&etag=${encodeURIComponent('"etag"')}`,
+			undefined,
+			{ Range: 'bytes=0-4' },
+		);
+		expect(content.status).toBe(206);
+		expect(content.headers.get('cache-control')).toBe('private, no-store');
+		expect(content.headers.get('content-range')).toBe('bytes 0-4/12');
+		expect(content.headers.get('content-type')).toBe('application/octet-stream');
+		expect(content.headers.get('content-disposition')).not.toMatch(/[\r\n]/);
+		expect(await content.text()).toBe('hello object');
+
+		const events = await expectOk<{ event: string; key?: string }[]>(
+			await request('GET', `/projects/${pid}/events`),
+		);
+		expect(events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ event: 'integration.object.preview', key }),
+				expect.objectContaining({ event: 'integration.object.download', key }),
+			]),
+		);
+	});
+
+	it('does not cache object details that may contain tags', async () => {
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		const url = `/projects/${pid}/integrations/${created.id}/browse/objects/head?bucket=lake&key=events.jsonl`;
+		let detailCalls = 0;
+		const original = deps.integrations.browseObjectDetail.bind(deps.integrations);
+		deps.integrations.browseObjectDetail = (async (...args: Parameters<typeof original>) => {
+			detailCalls += 1;
+			return original(...args);
+		}) as typeof original;
+
+		await expectOk(await request('GET', url));
+		await expectOk(await request('GET', url));
+		expect(detailCalls).toBe(2);
+	});
+
+	it('rejects excess concurrent downloads and releases the permit after cancellation', async () => {
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		deps.dataBrowser.objectBrowser.maxConcurrentDownloads = 1;
+		deps.dataBrowser.objectBrowser.maxConcurrentDownloadsPerUser = 1;
+		const url = `/projects/${pid}/integrations/${created.id}/browse/objects/content?bucket=lake&key=events.jsonl`;
+
+		const first = await request('GET', url);
+		expect(first.status).toBe(200);
+		await expectError(await request('GET', url), 429, 'RESOURCE_EXHAUSTED');
+		await first.body?.cancel();
+
+		const afterCancel = await request('GET', url);
+		expect(afterCancel.status).toBe(200);
+		expect(await afterCancel.text()).toBe('hello object');
+	});
+
+	it('rejects malformed ranges and overlong keys before opening content', async () => {
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		const base = `/projects/${pid}/integrations/${created.id}/browse/objects`;
+		for (const range of ['bytes=0-1,4-5', 'items=0-1', 'bytes=-']) {
+			await expectError(
+				await request('GET', `${base}/content?bucket=lake&key=a.txt`, undefined, {
+					Range: range,
+				}),
+				416,
+				'BAD_REQUEST',
+			);
+		}
+		const oversized = encodeURIComponent('😀'.repeat(300));
+		await expectError(
+			await request('GET', `${base}/head?bucket=lake&key=${oversized}`),
+			422,
+			'VALIDATION_ERROR',
+		);
 	});
 
 	it('previews rows on demand with no-store and appends an audit event', async () => {
@@ -430,6 +746,80 @@ describe('Data browser routes', () => {
 		});
 	});
 
+	it('single-flights expiring WIF credentials for ambient object browsing', async () => {
+		const pid = await createProject();
+		await expectOk(await request('PATCH', `/projects/${pid}`, { federation: { enabled: true } }));
+		const staticStore = await createObjectStore(pid, 'static-with-wif');
+		const ambient = await expectOk<{ id: string }>(
+			await request('POST', `/projects/${pid}/integrations`, {
+				kind: 's3',
+				name: 'ambient-objects',
+				config: { bucket: 'lake', auth: { method: 'ambient' } },
+			}),
+			201,
+		);
+		let exchanges = 0;
+		const wifApi = createTestApi({
+			bucket,
+			userId: ACTOR,
+			deps: {
+				...deps,
+				wif: {
+					issuer: { mint: async () => 'jwt', jwks: async () => ({ keys: [] }) } as never,
+					issuerUrl: 'https://hub.example.com',
+					target: {
+						broker: {
+							exchange: async () => {
+								exchanges += 1;
+								await new Promise((resolve) => setTimeout(resolve, 10));
+								return {
+									accessKeyId: 'temporary-key',
+									secretAccessKey: 'temporary-secret',
+									expiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+								};
+							},
+						},
+						storage: { region: 'us-east-1' },
+						audience: 'storage',
+					},
+				},
+			},
+		}).request;
+		await expectOk(await wifApi('GET', `/projects/${pid}/integrations/${staticStore.id}/browse`));
+		expect(exchanges).toBe(0);
+		const url = `/projects/${pid}/integrations/${ambient.id}/browse`;
+		const responses = await Promise.all([wifApi('GET', url), wifApi('GET', url)]);
+		const results = await Promise.all(
+			responses.map((response) => expectOk<Record<string, unknown>>(response)),
+		);
+		expect(results).toHaveLength(2);
+		expect(exchanges).toBe(1);
+	});
+
+	it('keeps ambient object browsing unavailable without WIF or explicit server opt-in', async () => {
+		const pid = await createProject();
+		const ambient = await expectOk<{ id: string }>(
+			await request('POST', `/projects/${pid}/integrations`, {
+				kind: 's3',
+				name: 'ambient-denied',
+				config: { bucket: 'lake', auth: { method: 'ambient' } },
+			}),
+			201,
+		);
+		const capability = await expectOk<{
+			surfaces: { objects: { available: boolean; reason?: string } };
+		}>(await request('GET', `/projects/${pid}/integrations/${ambient.id}/browse`));
+		expect(capability.surfaces.objects).toMatchObject({
+			available: false,
+			reason: 'No object-store credentials are available.',
+		});
+		await expectError(
+			await request('GET', `/projects/${pid}/integrations/${ambient.id}/browse/objects/buckets`),
+			422,
+			'VALIDATION_ERROR',
+		);
+	});
+
 	it('editor can browse; viewer cannot', async () => {
 		const pid = await createProject();
 		const created = await createBrowsable(pid);
@@ -458,6 +848,15 @@ describe('Data browser routes', () => {
 		);
 		await expectError(
 			await asViewer('GET', `/projects/${pid}/integrations/${created.id}/browse`),
+			403,
+			'FORBIDDEN',
+		);
+		const objectStore = await createObjectStore(pid, 'viewer-objects');
+		await expectError(
+			await asViewer(
+				'GET',
+				`/projects/${pid}/integrations/${objectStore.id}/browse/objects?bucket=lake`,
+			),
 			403,
 			'FORBIDDEN',
 		);

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -384,6 +384,12 @@ describe('Data browser routes', () => {
 			422,
 			'VALIDATION_ERROR',
 		);
+		await expectOk(
+			await request(
+				'GET',
+				`${base}?bucket=lake&query=needle&modified_after=2026-08-12T00%3A00%3A00.1Z&modified_before=2026-08-12T00%3A00%3A00.100Z`,
+			),
+		);
 	});
 
 	it('enforces object search and preview budgets independently', async () => {
@@ -818,6 +824,48 @@ describe('Data browser routes', () => {
 			422,
 			'VALIDATION_ERROR',
 		);
+	});
+
+	it('does not fall through to ambient server credentials when WIF exchange fails', async () => {
+		const pid = await createProject();
+		await expectOk(await request('PATCH', `/projects/${pid}`, { federation: { enabled: true } }));
+		const ambient = await expectOk<{ id: string }>(
+			await request('POST', `/projects/${pid}/integrations`, {
+				kind: 's3',
+				name: 'federated-objects',
+				config: { bucket: 'lake', auth: { method: 'ambient' } },
+			}),
+			201,
+		);
+		deps.dataBrowser.objectBrowser.allowServerAmbientCredentials = true;
+		const federatedApi = createTestApi({
+			bucket,
+			userId: ACTOR,
+			deps: {
+				...deps,
+				wif: {
+					issuer: { mint: async () => 'jwt', jwks: async () => ({ keys: [] }) } as never,
+					issuerUrl: 'https://hub.example.com',
+					target: {
+						broker: {
+							exchange: async () => {
+								throw new Error('broker unavailable');
+							},
+						},
+						storage: { region: 'us-east-1' },
+						audience: 'storage',
+					},
+				},
+			},
+		}).request;
+
+		const capability = await expectOk<{
+			surfaces: { objects: { available: boolean; reason?: string } };
+		}>(await federatedApi('GET', `/projects/${pid}/integrations/${ambient.id}/browse`));
+		expect(capability.surfaces.objects).toMatchObject({
+			available: false,
+			reason: 'No object-store credentials are available.',
+		});
 	});
 
 	it('editor can browse; viewer cannot', async () => {

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -1699,7 +1699,7 @@ app.openapi(searchObjects, async (c) => {
 	if (
 		query.modified_after !== undefined &&
 		query.modified_before !== undefined &&
-		query.modified_after > query.modified_before
+		Date.parse(query.modified_after) > Date.parse(query.modified_before)
 	) {
 		throw new ValidationError('modified_after cannot be later than modified_before.');
 	}
@@ -1914,7 +1914,7 @@ app.get('/projects/:pid/integrations/:iid/browse/objects/content', async (c) => 
 		if (object.content_range) headers.set('Content-Range', object.content_range);
 		if (object.etag) headers.set('ETag', object.etag);
 		if (object.version_id) headers.set('X-Marimohub-Object-Version', object.version_id);
-		return new Response(streamObjectBody(object, release, finish), {
+		return new Response(streamObjectBody(object, release, finish, controller.signal), {
 			status: object.status,
 			headers,
 		});

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -12,9 +12,11 @@ import {
 	createSlidingWindowBudget,
 } from '@marimo-hub/core';
 import type {
+	AuthUser,
 	IntegrationDetail,
 	IntegrationEntry,
 	DataPreview,
+	Project,
 	ProjectIntegrationsService,
 	OrgIntegrationsService,
 	TestIntegrationRequest,
@@ -45,6 +47,15 @@ import {
 	PaginationQuery,
 } from '../pagination';
 import { appendAudit } from '../log';
+import {
+	acquireDownload,
+	makeObjectBrowseContext,
+	objectContentDisposition,
+	runObjectBrowse,
+	safeObjectContentType,
+	streamObjectBody,
+	validRangeHeader,
+} from './objectBrowse';
 
 const IntegrationIdSchema = z.string().regex(IntegrationId.regex).refine(IntegrationId.is);
 const IntegrationNameSchema = z.string().regex(/^[a-z][a-z0-9-]{0,31}$/);
@@ -428,7 +439,7 @@ const BrowseCapabilitySchema = z
 					available: z.boolean(),
 					preview: z.boolean(),
 					download: z.boolean(),
-					search: z.literal('bounded-key-name'),
+					search: z.enum(['none', 'bounded-key-name']),
 					versions: z.boolean(),
 					preview_formats: z.array(z.string()),
 					reason: z.string().optional(),
@@ -597,6 +608,283 @@ const browseTablePreview = createRoute({
 		200: jsonContent(
 			z.object({ success: z.literal(true), data: BrowsePreviewSchema }),
 			'Column names and a bounded row sample',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404, 429),
+	},
+});
+
+const ObjectBucketValue = z
+	.string()
+	.min(1)
+	.max(255)
+	.openapi({ param: { name: 'bucket', in: 'query' }, example: 'analytics-lake' });
+const ObjectPrefixValue = z
+	.string()
+	.refine((value) => new TextEncoder().encode(value).byteLength <= 1024, {
+		message: "Prefix exceeds S3's 1,024-byte UTF-8 limit.",
+	})
+	.openapi({ param: { name: 'prefix', in: 'query' }, example: 'events/2026/' });
+const ObjectKeyValue = z
+	.string()
+	.min(1)
+	.refine((value) => new TextEncoder().encode(value).byteLength <= 1024, {
+		message: "Key exceeds S3's 1,024-byte UTF-8 limit.",
+	})
+	.openapi({ param: { name: 'key', in: 'query' }, example: 'events/2026/part-001.jsonl' });
+const ObjectVersionIdValue = z.string().min(1).max(2048);
+const ObjectVersionValue = ObjectVersionIdValue.optional().openapi({
+	param: { name: 'version_id', in: 'query' },
+});
+const ObjectPageQuery = z.object({
+	limit: z.coerce
+		.number()
+		.int()
+		.positive()
+		.max(100)
+		.default(50)
+		.openapi({ param: { name: 'limit', in: 'query' }, example: 50 }),
+	cursor: BrowsePageQuery.shape.cursor,
+	fresh: BrowsePageQuery.shape.fresh,
+});
+const ObjectIdentityQuery = z.object({
+	bucket: ObjectBucketValue,
+	key: ObjectKeyValue,
+	version_id: ObjectVersionValue,
+});
+
+const ObjectBucketSchema = z
+	.object({
+		name: z.string(),
+		created_at: z.iso.datetime().optional(),
+		configured: z.boolean(),
+	})
+	.openapi('IntegrationObjectBucket');
+const ObjectEntrySchema = z
+	.object({
+		kind: z.enum(['prefix', 'object']),
+		name: z.string(),
+		key: z.string(),
+		size: z.number().nonnegative().optional(),
+		last_modified: z.iso.datetime().optional(),
+		etag: z.string().optional(),
+		storage_class: z.string().optional(),
+	})
+	.openapi('IntegrationObjectEntry');
+const ObjectDetailSchema = z
+	.object({
+		bucket: z.string(),
+		key: z.string(),
+		version_id: z.string().optional(),
+		size: z.number().nonnegative(),
+		last_modified: z.iso.datetime().optional(),
+		etag: z.string().optional(),
+		storage_class: z.string().optional(),
+		content_type: z.string().optional(),
+		content_encoding: z.string().optional(),
+		cache_control: z.string().optional(),
+		checksums: z.array(z.object({ algorithm: z.string(), value: z.string() })),
+		metadata: z.record(z.string(), z.string()),
+		tags: z.array(z.object({ key: z.string(), value: z.string() })).optional(),
+		tags_available: z.boolean(),
+		snippet: z.string().optional(),
+	})
+	.openapi('IntegrationObjectDetail');
+const ObjectVersionSchema = z
+	.object({
+		bucket: z.string(),
+		key: z.string(),
+		version_id: z.string().optional(),
+		kind: z.enum(['version', 'delete-marker']),
+		is_latest: z.boolean(),
+		last_modified: z.iso.datetime().optional(),
+		size: z.number().nonnegative().optional(),
+		etag: z.string().optional(),
+		storage_class: z.string().optional(),
+		owner: z.object({ id: z.string().optional(), display_name: z.string().optional() }).optional(),
+	})
+	.openapi('IntegrationObjectVersion');
+const TabularObjectPreviewSchema = z.object({
+	kind: z.literal('tabular'),
+	format: z.enum(['table', 'csv', 'tsv', 'json', 'jsonl', 'parquet']),
+	columns: z.array(z.object({ name: z.string(), type: z.string().optional() })),
+	rows: z.array(z.array(z.unknown())),
+	truncated: z.boolean(),
+	bytes_read: z.number().nonnegative().optional(),
+	total_bytes: z.number().nonnegative().optional(),
+	warnings: z.array(z.string()),
+});
+const ObjectPreviewSchema = z
+	.discriminatedUnion('kind', [
+		TabularObjectPreviewSchema,
+		z.object({
+			kind: z.literal('text'),
+			format: z.enum(['text', 'markdown', 'code', 'log', 'json']),
+			text: z.string(),
+			truncated: z.boolean(),
+			bytes_read: z.number().nonnegative(),
+			total_bytes: z.number().nonnegative(),
+			warnings: z.array(z.string()),
+		}),
+		z.object({
+			kind: z.literal('image'),
+			format: z.enum(['png', 'jpeg', 'gif', 'webp']),
+			content_url: z.string(),
+			width: z.number().int().positive().optional(),
+			height: z.number().int().positive().optional(),
+			total_bytes: z.number().nonnegative(),
+			warnings: z.array(z.string()),
+		}),
+		z.object({
+			kind: z.literal('unsupported'),
+			reason: z.string(),
+			detected_type: z.string().optional(),
+			total_bytes: z.number().nonnegative(),
+		}),
+	])
+	.openapi('IntegrationObjectPreview');
+
+const browseObjectBuckets = createRoute({
+	method: 'get',
+	path: '/projects/{pid}/integrations/{iid}/browse/objects/buckets',
+	tags: ['Integrations'],
+	summary: 'List object-store buckets (editor or above)',
+	request: { params: IntegrationIdParam, query: ObjectPageQuery },
+	responses: {
+		200: jsonContent(
+			z.object({
+				success: z.literal(true),
+				data: z.object({ items: z.array(ObjectBucketSchema), next_cursor: z.string().nullable() }),
+			}),
+			'Buckets visible through the integration',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404, 429),
+	},
+});
+
+const browseObjects = createRoute({
+	method: 'get',
+	path: '/projects/{pid}/integrations/{iid}/browse/objects',
+	tags: ['Integrations'],
+	summary: 'List direct object-store children (editor or above)',
+	request: {
+		params: IntegrationIdParam,
+		query: ObjectPageQuery.extend({
+			bucket: ObjectBucketValue,
+			prefix: ObjectPrefixValue.optional(),
+		}),
+	},
+	responses: {
+		200: jsonContent(
+			z.object({
+				success: z.literal(true),
+				data: z.object({ items: z.array(ObjectEntrySchema), next_cursor: z.string().nullable() }),
+			}),
+			'Direct prefixes and objects',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404, 429),
+	},
+});
+
+const searchObjects = createRoute({
+	method: 'get',
+	path: '/projects/{pid}/integrations/{iid}/browse/objects/search',
+	tags: ['Integrations'],
+	summary: 'Run a bounded object-key search (editor or above)',
+	request: {
+		params: IntegrationIdParam,
+		query: ObjectPageQuery.omit({ fresh: true }).extend({
+			bucket: ObjectBucketValue,
+			prefix: ObjectPrefixValue.optional(),
+			query: z.string().trim().min(2).max(1024),
+			formats: z.string().optional(),
+			modified_after: z.iso.datetime().optional(),
+			modified_before: z.iso.datetime().optional(),
+			min_size: z.coerce.number().nonnegative().optional(),
+			max_size: z.coerce.number().nonnegative().optional(),
+		}),
+	},
+	responses: {
+		200: jsonContent(
+			z.object({
+				success: z.literal(true),
+				data: z.object({
+					items: z.array(ObjectEntrySchema),
+					next_cursor: z.string().nullable(),
+					scanned: z.number().int().nonnegative(),
+					complete: z.boolean(),
+				}),
+			}),
+			'Bounded object-key search results',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404, 429),
+	},
+});
+
+const browseObjectHead = createRoute({
+	method: 'get',
+	path: '/projects/{pid}/integrations/{iid}/browse/objects/head',
+	tags: ['Integrations'],
+	summary: 'Read object metadata and tags (editor or above)',
+	request: {
+		params: IntegrationIdParam,
+		query: ObjectIdentityQuery,
+	},
+	responses: {
+		200: jsonContent(
+			z.object({ success: z.literal(true), data: ObjectDetailSchema }),
+			'Object metadata',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404, 429),
+	},
+});
+
+const browseObjectVersions = createRoute({
+	method: 'get',
+	path: '/projects/{pid}/integrations/{iid}/browse/objects/versions',
+	tags: ['Integrations'],
+	summary: 'List object versions and delete markers (editor or above)',
+	request: {
+		params: IntegrationIdParam,
+		query: ObjectPageQuery.extend(ObjectIdentityQuery.shape),
+	},
+	responses: {
+		200: jsonContent(
+			z.object({
+				success: z.literal(true),
+				data: z.object({ items: z.array(ObjectVersionSchema), next_cursor: z.string().nullable() }),
+			}),
+			'Object versions and delete markers',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404, 429),
+	},
+});
+
+const browseObjectPreview = createRoute({
+	method: 'post',
+	path: '/projects/{pid}/integrations/{iid}/browse/objects/preview',
+	tags: ['Integrations'],
+	summary: 'Preview bounded object content (editor or above)',
+	request: {
+		params: IntegrationIdParam,
+		body: jsonBody(
+			z.object({
+				bucket: ObjectBucketValue,
+				key: ObjectKeyValue,
+				version_id: ObjectVersionIdValue.optional(),
+				limit: z.number().int().positive().max(100).default(20),
+			}),
+		),
+	},
+	responses: {
+		200: jsonContent(
+			z.object({ success: z.literal(true), data: ObjectPreviewSchema }),
+			'Bounded object preview',
 		),
 		...commonErrors(),
 		...errorResponses(403, 404, 429),
@@ -778,6 +1066,73 @@ async function assertBrowsable(
 	return `${capability.current_version}:${capability.updated_at}`;
 }
 
+async function resolveObjectAccess(
+	deps: ApiDeps,
+	project: Project,
+	user: AuthUser,
+	integrations: ProjectIntegrationsService,
+	pid: ProjectId,
+	iid: IntegrationId,
+	signal?: AbortSignal,
+) {
+	const wifEligible = Boolean(deps.wif && project.federation?.enabled);
+	const base = await makeObjectBrowseContext(deps, project, user, signal, {
+		integrationId: iid,
+		includeFederated: false,
+		allowServerAmbient: wifEligible
+			? false
+			: deps.dataBrowser?.objectBrowser?.allowServerAmbientCredentials,
+	});
+	const baseCapability = await runObjectBrowse(() => integrations.browseCapability(pid, iid, base));
+	if (baseCapability.surfaces.objects?.available || !wifEligible) {
+		return { context: base, capability: baseCapability };
+	}
+	const federated = await makeObjectBrowseContext(deps, project, user, signal, {
+		integrationId: iid,
+	});
+	return {
+		context: federated,
+		capability: await runObjectBrowse(() => integrations.browseCapability(pid, iid, federated)),
+	};
+}
+
+function requireObjectCapability(
+	capability: Awaited<ReturnType<ProjectIntegrationsService['browseCapability']>>,
+) {
+	const objects = capability.surfaces.objects;
+	if (!objects?.available) {
+		throw new ValidationError(objects?.reason ?? 'This integration cannot browse objects.');
+	}
+	return {
+		stateToken: `${capability.current_version}:${capability.updated_at}`,
+		capability: objects,
+	};
+}
+
+async function resolveAuthorizedObjectAccess(
+	deps: ApiDeps,
+	user: AuthUser,
+	integrations: ProjectIntegrationsService,
+	pid: ProjectId,
+	iid: IntegrationId,
+	signal?: AbortSignal,
+) {
+	const project = await assertProjectRole(deps.services.projects, pid, user, 'editor', deps.policy);
+	return resolveObjectAccess(deps, project, user, integrations, pid, iid, signal);
+}
+
+async function requireAuthorizedObjectAccess(
+	deps: ApiDeps,
+	user: AuthUser,
+	integrations: ProjectIntegrationsService,
+	pid: ProjectId,
+	iid: IntegrationId,
+	signal?: AbortSignal,
+) {
+	const access = await resolveAuthorizedObjectAccess(deps, user, integrations, pid, iid, signal);
+	return { context: access.context, ...requireObjectCapability(access.capability) };
+}
+
 /**
  * Per-replica TTL cache over successful browse results, so tree navigation
  * does not re-spend probe budget on every expansion. Bounded: expired entries
@@ -863,11 +1218,7 @@ const app = createApp();
 
 app.openapi(listKinds, (c) => {
 	const integrations = requireIntegrations(c.get('deps'));
-	const data = integrations.listKinds().map((kind) => {
-		const browse_surfaces = kind.browse_surfaces.filter((surface) => surface === 'tables');
-		return { ...kind, browse_surfaces, supports_browse: browse_surfaces.length > 0 };
-	});
-	return c.json({ success: true as const, data }, 200);
+	return c.json({ success: true as const, data: integrations.listKinds() }, 200);
 });
 
 app.openapi(listIntegrations, async (c) => {
@@ -998,7 +1349,14 @@ const testBudget = createSlidingWindowBudget<string>({ limit: 10, windowMs: 60_0
 // Sized against the browse probe's process-wide cap (360/min): a bounded Trino
 // statement spends at most 12 probe requests, so one user can hold at most 240
 // of the shared allowance.
-const browseBudget = createSlidingWindowBudget<string>({ limit: 20, windowMs: 60_000 });
+const createBrowseBudget = () => createSlidingWindowBudget<string>({ limit: 20, windowMs: 60_000 });
+const createObjectSearchBudget = () =>
+	createSlidingWindowBudget<string>({ limit: 5, windowMs: 60_000 });
+const createObjectPreviewBudget = () =>
+	createSlidingWindowBudget<string>({ limit: 10, windowMs: 60_000 });
+let browseBudget = createBrowseBudget();
+let objectSearchBudget = createObjectSearchBudget();
+let objectPreviewBudget = createObjectPreviewBudget();
 
 function assertTestBudget(userId: string): void {
 	if (!testBudget.consume(userId)) {
@@ -1012,8 +1370,28 @@ function assertBrowseBudget(userId: string): void {
 	}
 }
 
+function assertObjectSearchBudget(userId: string): void {
+	if (!objectSearchBudget.consume(userId)) {
+		throw new ResourceExhaustedError('Too many object searches — try again in a minute.');
+	}
+}
+
+function assertObjectPreviewBudget(userId: string): void {
+	if (!objectPreviewBudget.consume(userId)) {
+		throw new ResourceExhaustedError('Too many object previews — try again in a minute.');
+	}
+}
+
 export function trackedTestBudgets(): number {
 	return testBudget.tracked();
+}
+
+export function clearIntegrationBrowseStateForTests(): void {
+	browseBudget = createBrowseBudget();
+	objectSearchBudget = createObjectSearchBudget();
+	objectPreviewBudget = createObjectPreviewBudget();
+	browseCache.clear();
+	inflightBrowse.clear();
 }
 
 app.openapi(copyIntegration, async (c) => {
@@ -1081,8 +1459,14 @@ app.openapi(browseCapability, async (c) => {
 	const user = c.get('user');
 	const { pid, iid } = c.req.valid('param');
 	const { integrations, preview } = requireDataBrowser(deps);
-	await assertProjectRole(deps.services.projects, pid, user, 'editor', deps.policy);
-	const capability = await integrations.browseCapability(pid, iid);
+	const { capability } = await resolveAuthorizedObjectAccess(
+		deps,
+		user,
+		integrations,
+		pid,
+		iid,
+		c.req.raw.signal,
+	);
 	const tablePreview =
 		preview &&
 		capability.metadata &&
@@ -1091,14 +1475,17 @@ app.openapi(browseCapability, async (c) => {
 		{
 			success: true,
 			data: {
-				surfaces: capability.surfaces.tables
-					? {
-							tables: {
-								...capability.surfaces.tables,
-								preview: tablePreview,
-							},
-						}
-					: {},
+				surfaces: {
+					...(capability.surfaces.tables
+						? {
+								tables: {
+									...capability.surfaces.tables,
+									preview: tablePreview,
+								},
+							}
+						: {}),
+					...(capability.surfaces.objects ? { objects: capability.surfaces.objects } : {}),
+				},
 				metadata: capability.metadata,
 				preview: tablePreview,
 				...(capability.reason !== undefined ? { reason: capability.reason } : {}),
@@ -1238,6 +1625,304 @@ app.openapi(browseTablePreview, async (c) => {
 			}),
 	);
 	return c.json({ success: true, data }, 200);
+});
+
+const OBJECT_METADATA_TTL_MS = 15_000;
+
+app.openapi(browseObjectBuckets, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { pid, iid } = c.req.valid('param');
+	const { limit, cursor, fresh } = c.req.valid('query');
+	const { integrations } = requireDataBrowser(deps);
+	const { context, stateToken } = await requireAuthorizedObjectAccess(
+		deps,
+		user,
+		integrations,
+		pid,
+		iid,
+		c.req.raw.signal,
+	);
+	const request = { limit, ...(cursor ? { cursor } : {}) };
+	const data = await cachedBrowse(
+		JSON.stringify([pid, iid, user.id, stateToken, 'object-buckets', request]),
+		OBJECT_METADATA_TTL_MS,
+		fresh === 'true',
+		() => assertBrowseBudget(user.id),
+		() => runObjectBrowse(() => integrations.browseObjectBuckets(pid, iid, context, request)),
+	);
+	return c.json({ success: true, data }, 200);
+});
+
+app.openapi(browseObjects, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { pid, iid } = c.req.valid('param');
+	const { bucket, prefix, limit, cursor, fresh } = c.req.valid('query');
+	const { integrations } = requireDataBrowser(deps);
+	const { context, stateToken } = await requireAuthorizedObjectAccess(
+		deps,
+		user,
+		integrations,
+		pid,
+		iid,
+		c.req.raw.signal,
+	);
+	const request = {
+		bucket,
+		limit,
+		...(prefix !== undefined ? { prefix } : {}),
+		...(cursor ? { cursor } : {}),
+	};
+	const data = await cachedBrowse(
+		JSON.stringify([pid, iid, user.id, stateToken, 'objects', request]),
+		OBJECT_METADATA_TTL_MS,
+		fresh === 'true',
+		() => assertBrowseBudget(user.id),
+		() => runObjectBrowse(() => integrations.browseObjects(pid, iid, context, request)),
+	);
+	return c.json({ success: true, data }, 200);
+});
+
+app.openapi(searchObjects, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { pid, iid } = c.req.valid('param');
+	const query = c.req.valid('query');
+	if (
+		query.min_size !== undefined &&
+		query.max_size !== undefined &&
+		query.min_size > query.max_size
+	) {
+		throw new ValidationError('min_size cannot exceed max_size.');
+	}
+	if (
+		query.modified_after !== undefined &&
+		query.modified_before !== undefined &&
+		query.modified_after > query.modified_before
+	) {
+		throw new ValidationError('modified_after cannot be later than modified_before.');
+	}
+	const { integrations } = requireDataBrowser(deps);
+	const { capability, context } = await requireAuthorizedObjectAccess(
+		deps,
+		user,
+		integrations,
+		pid,
+		iid,
+		c.req.raw.signal,
+	);
+	if (capability.search !== 'bounded-key-name') {
+		throw new ValidationError('Object search is unavailable.');
+	}
+	assertObjectSearchBudget(user.id);
+	const formats = query.formats
+		?.split(',')
+		.map((value) => value.trim())
+		.filter(Boolean);
+	const data = await runObjectBrowse(() =>
+		integrations.searchObjects(pid, iid, context, {
+			bucket: query.bucket,
+			query: query.query,
+			limit: query.limit,
+			...(query.prefix !== undefined ? { prefix: query.prefix } : {}),
+			...(query.cursor ? { cursor: query.cursor } : {}),
+			...(formats?.length ? { formats } : {}),
+			...(query.modified_after ? { modified_after: query.modified_after } : {}),
+			...(query.modified_before ? { modified_before: query.modified_before } : {}),
+			...(query.min_size !== undefined ? { min_size: query.min_size } : {}),
+			...(query.max_size !== undefined ? { max_size: query.max_size } : {}),
+		}),
+	);
+	return c.json({ success: true, data }, 200);
+});
+
+app.openapi(browseObjectHead, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { pid, iid } = c.req.valid('param');
+	const { bucket, key, version_id } = c.req.valid('query');
+	const { integrations } = requireDataBrowser(deps);
+	const { context } = await requireAuthorizedObjectAccess(
+		deps,
+		user,
+		integrations,
+		pid,
+		iid,
+		c.req.raw.signal,
+	);
+	const request = { bucket, key, ...(version_id ? { version_id } : {}) };
+	assertBrowseBudget(user.id);
+	const data = await runObjectBrowse(() =>
+		integrations.browseObjectDetail(pid, iid, context, request),
+	);
+	return c.json({ success: true, data }, 200);
+});
+
+app.openapi(browseObjectVersions, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { pid, iid } = c.req.valid('param');
+	const { bucket, key, version_id, limit, cursor } = c.req.valid('query');
+	const { integrations } = requireDataBrowser(deps);
+	const { capability, context } = await requireAuthorizedObjectAccess(
+		deps,
+		user,
+		integrations,
+		pid,
+		iid,
+		c.req.raw.signal,
+	);
+	if (!capability.versions) throw new ValidationError('Object versions are unavailable.');
+	assertBrowseBudget(user.id);
+	const data = await runObjectBrowse(() =>
+		integrations.browseObjectVersions(pid, iid, context, {
+			bucket,
+			key,
+			limit,
+			...(version_id ? { version_id } : {}),
+			...(cursor ? { cursor } : {}),
+		}),
+	);
+	return c.json({ success: true, data }, 200);
+});
+
+app.openapi(browseObjectPreview, async (c) => {
+	c.header('Cache-Control', 'no-store');
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { pid, iid } = c.req.valid('param');
+	const body = c.req.valid('json');
+	const { integrations } = requireDataBrowser(deps);
+	const { capability, context } = await requireAuthorizedObjectAccess(
+		deps,
+		user,
+		integrations,
+		pid,
+		iid,
+		c.req.raw.signal,
+	);
+	if (!capability.preview) throw new NotFoundError('Object preview is not enabled.');
+	assertObjectPreviewBudget(user.id);
+	const contentParams = new URLSearchParams({ bucket: body.bucket, key: body.key, inline: 'true' });
+	if (body.version_id) contentParams.set('version_id', body.version_id);
+	const data = await runObjectBrowse(() =>
+		integrations.browseObjectPreview(pid, iid, context, {
+			...body,
+			content_url: `/api/v1/projects/${pid}/integrations/${iid}/browse/objects/content?${contentParams}`,
+		}),
+	);
+	if (data.kind !== 'image') {
+		await appendAudit(
+			{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+			'integration.object.preview',
+			() =>
+				deps.services.events.append({
+					event: 'integration.object.preview',
+					actor: user.id,
+					project_id: pid,
+					integration_id: iid,
+					bucket: body.bucket,
+					key: body.key,
+					...(body.version_id ? { version_id: body.version_id } : {}),
+					format: data.kind === 'unsupported' ? data.detected_type : data.format,
+					bytes: 'bytes_read' in data ? data.bytes_read : undefined,
+					request_id: c.get('requestId'),
+				}),
+		);
+	}
+	return c.json({ success: true, data }, 200);
+});
+
+app.get('/projects/:pid/integrations/:iid/browse/objects/content', async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const parsedIds = IntegrationIdParam.safeParse({
+		pid: c.req.param('pid'),
+		iid: c.req.param('iid'),
+	});
+	if (!parsedIds.success) throw new NotFoundError('Integration not found.');
+	const parsed = ObjectIdentityQuery.extend({
+		inline: z.enum(['true', 'false']).default('false'),
+		etag: z.string().max(1024).optional(),
+	}).safeParse(c.req.query());
+	if (!parsed.success) throw new ValidationError('Invalid object content request.');
+	const { pid, iid } = parsedIds.data;
+	const { bucket, key, version_id, inline, etag } = parsed.data;
+	const { integrations } = requireDataBrowser(deps);
+	const project = await assertProjectRole(deps.services.projects, pid, user, 'editor', deps.policy);
+	const release = acquireDownload(deps, user.id);
+	const controller = new AbortController();
+	const abort = () => controller.abort();
+	c.req.raw.signal.addEventListener('abort', abort, { once: true });
+	const timeout = setTimeout(abort, deps.dataBrowser!.objectBrowser!.downloadTimeoutMs);
+	const finish = () => {
+		clearTimeout(timeout);
+		c.req.raw.signal.removeEventListener('abort', abort);
+	};
+	try {
+		const access = await resolveObjectAccess(
+			deps,
+			project,
+			user,
+			integrations,
+			pid,
+			iid,
+			controller.signal,
+		);
+		const { capability } = requireObjectCapability(access.capability);
+		const context = access.context;
+		if (!capability.download) throw new NotFoundError('Object downloads are not enabled.');
+		const range = validRangeHeader(c.req.header('range'));
+		const object = await runObjectBrowse(() =>
+			integrations.openObject(pid, iid, context, {
+				bucket,
+				key,
+				...(version_id ? { version_id } : {}),
+				...(range ? { range } : {}),
+				...(etag ? { if_match: etag } : {}),
+				inline: inline === 'true',
+			}),
+		);
+		const event = inline === 'true' ? 'integration.object.preview' : 'integration.object.download';
+		await appendAudit(
+			{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+			event,
+			() =>
+				deps.services.events.append({
+					event,
+					actor: user.id,
+					project_id: pid,
+					integration_id: iid,
+					bucket,
+					key,
+					...(version_id ? { version_id } : {}),
+					...(range ? { range } : {}),
+					bytes: object.content_length,
+					request_id: c.get('requestId'),
+				}),
+		);
+		const headers = new Headers({
+			'Accept-Ranges': 'bytes',
+			'Cache-Control': 'private, no-store',
+			'Content-Disposition': objectContentDisposition(key, inline === 'true'),
+			'Content-Length': String(object.content_length),
+			'Content-Type': safeObjectContentType(object.content_type, inline === 'true'),
+			'X-Content-Type-Options': 'nosniff',
+		});
+		if (inline === 'true') headers.set('Content-Security-Policy', "default-src 'none'; sandbox");
+		if (object.content_range) headers.set('Content-Range', object.content_range);
+		if (object.etag) headers.set('ETag', object.etag);
+		if (object.version_id) headers.set('X-Marimohub-Object-Version', object.version_id);
+		return new Response(streamObjectBody(object, release, finish), {
+			status: object.status,
+			headers,
+		});
+	} catch (error) {
+		finish();
+		release();
+		throw error;
+	}
 });
 
 app.openapi(listOrgIntegrations, async (c) => {

--- a/packages/api/src/routes/objectBrowse.test.ts
+++ b/packages/api/src/routes/objectBrowse.test.ts
@@ -121,6 +121,7 @@ describe('object browse credentials', () => {
 			throw new Error('broker-secret');
 		});
 		const deps = wifDeps(exchange);
+		deps.dataBrowser!.objectBrowser!.allowServerAmbientCredentials = true;
 		const withoutWif = await makeObjectBrowseContext(deps, project, user, undefined, {
 			includeFederated: false,
 			allowServerAmbient: true,
@@ -130,6 +131,7 @@ describe('object browse credentials', () => {
 
 		const failed = await makeObjectBrowseContext(deps, project, user);
 		expect(failed.temporary_s3_credentials).toBeUndefined();
+		expect(failed.allow_server_ambient).toBe(false);
 		expect(exchange).toHaveBeenCalledTimes(1);
 	});
 
@@ -291,6 +293,45 @@ describe('object content response helpers', () => {
 		await expect(streamObjectBody(object, release, finish).cancel('gone')).rejects.toThrow(
 			'cancel failed',
 		);
+		expect(close).toHaveBeenCalledOnce();
+		expect(release).toHaveBeenCalledOnce();
+		expect(finish).toHaveBeenCalledOnce();
+	});
+
+	it('aborts an open response stream and releases its permit at the operation deadline', async () => {
+		const controller = new AbortController();
+		const close = vi.fn();
+		const release = vi.fn();
+		const finish = vi.fn();
+		const upstreamCancel = vi.fn();
+		const object = body(new ReadableStream({ cancel: upstreamCancel }), close);
+		const reader = streamObjectBody(object, release, finish, controller.signal).getReader();
+		const pending = reader.read();
+
+		controller.abort();
+
+		await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+		await vi.waitFor(() => expect(upstreamCancel).toHaveBeenCalledOnce());
+		expect(close).toHaveBeenCalledOnce();
+		expect(release).toHaveBeenCalledOnce();
+		expect(finish).toHaveBeenCalledOnce();
+	});
+
+	it('releases an unread response stream when its deadline expires', async () => {
+		const controller = new AbortController();
+		const close = vi.fn();
+		const release = vi.fn();
+		const finish = vi.fn();
+		const stream = streamObjectBody(
+			body(new ReadableStream({ pull() {} }), close),
+			release,
+			finish,
+			controller.signal,
+		);
+
+		controller.abort();
+
+		await expect(stream.getReader().read()).rejects.toMatchObject({ name: 'AbortError' });
 		expect(close).toHaveBeenCalledOnce();
 		expect(release).toHaveBeenCalledOnce();
 		expect(finish).toHaveBeenCalledOnce();

--- a/packages/api/src/routes/objectBrowse.test.ts
+++ b/packages/api/src/routes/objectBrowse.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Millis, ObjectBrowseError, ResourceExhaustedError, UserId } from '@marimo-hub/core';
+import type { ApiDeps } from '../context';
+import type { ObjectBody, Project, TempS3Creds } from '@marimo-hub/core';
+import {
+	acquireDownload,
+	clearObjectCredentialCacheForTests,
+	makeObjectBrowseContext,
+	objectContentDisposition,
+	runObjectBrowse,
+	safeObjectContentType,
+	streamObjectBody,
+	validRangeHeader,
+} from './objectBrowse';
+
+const project = {
+	id: 'proj-01J00000000000000000000000',
+	federation: { enabled: true },
+} as Project;
+const user = { id: UserId.parse('user-object-test'), email: 'object@example.com' };
+
+beforeEach(() => clearObjectCredentialCacheForTests());
+
+function wifDeps(exchange: () => Promise<TempS3Creds>): ApiDeps {
+	return {
+		wif: {
+			issuer: { mint: vi.fn(async () => 'jwt') } as never,
+			issuerUrl: 'https://hub.example.com',
+			target: {
+				audience: 'storage',
+				storage: { endpoint: 'https://s3.example.com', region: 'us-east-1' },
+				broker: { exchange },
+			},
+		},
+		dataBrowser: {
+			preview: true,
+			objectBrowser: {
+				allowServerAmbientCredentials: false,
+				maxConcurrentDownloads: 1,
+				maxConcurrentDownloadsPerUser: 1,
+				downloadTimeoutMs: Millis.of(60_000),
+			},
+		},
+	} as unknown as ApiDeps;
+}
+
+describe('object browse credentials', () => {
+	it('single-flights and caches credentials with a usable expiry', async () => {
+		const exchange = vi.fn(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			return {
+				accessKeyId: 'temporary',
+				secretAccessKey: 'secret',
+				expiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+			};
+		});
+		const deps = wifDeps(exchange);
+		const contexts = await Promise.all([
+			makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'a' }),
+			makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'a' }),
+		]);
+		expect(
+			contexts.every((context) => context.temporary_s3_credentials?.accessKeyId === 'temporary'),
+		).toBe(true);
+		await makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'a' });
+		expect(exchange).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not cache credentials without a valid expiry or across integrations', async () => {
+		const exchange = vi.fn<() => Promise<TempS3Creds>>(async () => ({
+			accessKeyId: 'temporary',
+			secretAccessKey: 'secret',
+		}));
+		const deps = wifDeps(exchange);
+		await makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'a' });
+		await makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'a' });
+		expect(exchange).toHaveBeenCalledTimes(2);
+
+		exchange.mockResolvedValue({
+			accessKeyId: 'temporary',
+			secretAccessKey: 'secret',
+			expiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+		});
+		await makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'b' });
+		await makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'c' });
+		expect(exchange).toHaveBeenCalledTimes(4);
+	});
+
+	it('refreshes credentials that expire inside the five-minute safety window', async () => {
+		const exchange = vi.fn(async () => ({
+			accessKeyId: 'temporary',
+			secretAccessKey: 'secret',
+			expiration: new Date(Date.now() + 4 * 60 * 1000).toISOString(),
+		}));
+		const deps = wifDeps(exchange);
+		await makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'a' });
+		await makeObjectBrowseContext(deps, project, user, undefined, { integrationId: 'a' });
+		expect(exchange).toHaveBeenCalledTimes(2);
+	});
+
+	it('bounds the credential cache and evicts the oldest integration', async () => {
+		const exchange = vi.fn(async () => ({
+			accessKeyId: 'temporary',
+			secretAccessKey: 'secret',
+			expiration: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+		}));
+		const deps = wifDeps(exchange);
+		for (let index = 0; index < 257; index += 1) {
+			await makeObjectBrowseContext(deps, project, user, undefined, {
+				integrationId: `integration-${index}`,
+			});
+		}
+		await makeObjectBrowseContext(deps, project, user, undefined, {
+			integrationId: 'integration-0',
+		});
+		expect(exchange).toHaveBeenCalledTimes(258);
+	});
+
+	it('can suppress federation and safely falls back when an exchange fails', async () => {
+		const exchange = vi.fn(async (): Promise<TempS3Creds> => {
+			throw new Error('broker-secret');
+		});
+		const deps = wifDeps(exchange);
+		const withoutWif = await makeObjectBrowseContext(deps, project, user, undefined, {
+			includeFederated: false,
+			allowServerAmbient: true,
+		});
+		expect(withoutWif).toMatchObject({ allow_server_ambient: true });
+		expect(exchange).not.toHaveBeenCalled();
+
+		const failed = await makeObjectBrowseContext(deps, project, user);
+		expect(failed.temporary_s3_credentials).toBeUndefined();
+		expect(exchange).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not mint credentials for a project without federation enabled', async () => {
+		const exchange = vi.fn(async () => ({
+			accessKeyId: 'temporary',
+			secretAccessKey: 'secret',
+		}));
+		const signal = new AbortController().signal;
+		const context = await makeObjectBrowseContext(
+			wifDeps(exchange),
+			{ ...project, federation: { enabled: false } },
+			user,
+			signal,
+		);
+		expect(context).toMatchObject({
+			allow_server_ambient: false,
+			project_id: project.id,
+			signal,
+		});
+		expect(context.temporary_s3_credentials).toBeUndefined();
+		expect(exchange).not.toHaveBeenCalled();
+	});
+});
+
+describe('object error mapping', () => {
+	it.each([
+		['access_denied', 'ForbiddenError'],
+		['not_found', 'NotFoundError'],
+		['precondition_failed', 'PreconditionFailedError'],
+		['invalid_cursor', 'ValidationError'],
+		['unsupported', 'ValidationError'],
+		['aborted', 'UnavailableError'],
+		['unavailable', 'UnavailableError'],
+	] as const)('maps %s into a safe domain error', async (code, name) => {
+		await expect(
+			runObjectBrowse(async () => {
+				throw new ObjectBrowseError(code, 'safe message');
+			}),
+		).rejects.toMatchObject({ name, message: 'safe message' });
+	});
+
+	it('maps invalid ranges to 416 and preserves unrelated errors', async () => {
+		await expect(
+			runObjectBrowse(async () => {
+				throw new ObjectBrowseError('range_not_satisfiable', 'bad range');
+			}),
+		).rejects.toMatchObject({ status: 416, message: 'bad range' });
+		const unrelated = new Error('unrelated');
+		await expect(
+			runObjectBrowse(async () => {
+				throw unrelated;
+			}),
+		).rejects.toBe(unrelated);
+	});
+});
+
+describe('object content response helpers', () => {
+	it('sanitizes fallback filenames while preserving a UTF-8 filename', () => {
+		const value = objectContentDisposition('reports/日本語\r\n";%.csv', false);
+		expect(value).toMatch(/^attachment; filename="[^"]+"; filename\*=UTF-8''/);
+		expect(value).not.toMatch(/[\r\n]/);
+		expect(value).toContain('%E6%97%A5%E6%9C%AC%E8%AA%9E');
+		expect(objectContentDisposition('folder/', true)).toContain('inline; filename="download"');
+		expect(objectContentDisposition("reports/a!b'c(d)*.txt", false)).toContain(
+			"filename*=UTF-8''a%21b%27c%28d%29%2A.txt",
+		);
+		expect(() => objectContentDisposition(`reports/${'a'.repeat(254)}😀`, false)).not.toThrow();
+	});
+
+	it('accepts one byte range and rejects malformed or multiple ranges', () => {
+		expect(validRangeHeader(undefined)).toBeUndefined();
+		expect(validRangeHeader('bytes=0-')).toBe('bytes=0-');
+		expect(validRangeHeader('bytes=-10')).toBe('bytes=-10');
+		for (const value of ['bytes=0-1,2-3', 'items=0-1', 'bytes=-']) {
+			expect(() => validRangeHeader(value)).toThrow(/one valid byte range/);
+		}
+	});
+
+	it('allows only verified raster response types inline', () => {
+		expect(safeObjectContentType('image/png', true)).toBe('image/png');
+		expect(safeObjectContentType('image/svg+xml', true)).toBe('application/octet-stream');
+		expect(safeObjectContentType('text/html', false)).toBe('application/octet-stream');
+	});
+
+	it('releases stream permits on completion and cancellation', async () => {
+		const deps = wifDeps(async () => ({ accessKeyId: 'unused', secretAccessKey: 'unused' }));
+		const firstRelease = acquireDownload(deps, user.id);
+		expect(() => acquireDownload(deps, user.id)).toThrow(ResourceExhaustedError);
+		const close = vi.fn();
+		const first = body(
+			new ReadableStream({
+				start(controller) {
+					controller.enqueue(new Uint8Array([1]));
+					controller.close();
+				},
+			}),
+			close,
+		);
+		await new Response(streamObjectBody(first, firstRelease, () => {})).arrayBuffer();
+		const secondRelease = acquireDownload(deps, user.id);
+		const second = body(new ReadableStream({ pull() {} }), close);
+		await streamObjectBody(second, secondRelease, () => {}).cancel('gone');
+		expect(close).toHaveBeenCalledTimes(1);
+		const thirdRelease = acquireDownload(deps, user.id);
+		thirdRelease();
+	});
+
+	it('enforces both per-user and process download limits with idempotent release', () => {
+		const deps = wifDeps(async () => ({ accessKeyId: 'unused', secretAccessKey: 'unused' }));
+		deps.dataBrowser!.objectBrowser!.maxConcurrentDownloads = 3;
+		deps.dataBrowser!.objectBrowser!.maxConcurrentDownloadsPerUser = 2;
+		const first = acquireDownload(deps, 'user-a');
+		const second = acquireDownload(deps, 'user-a');
+		expect(() => acquireDownload(deps, 'user-a')).toThrow(ResourceExhaustedError);
+		const otherUser = acquireDownload(deps, 'user-b');
+		expect(() => acquireDownload(deps, 'user-c')).toThrow(ResourceExhaustedError);
+
+		first();
+		first();
+		const third = acquireDownload(deps, 'user-c');
+		second();
+		otherUser();
+		third();
+	});
+
+	it('closes the object and releases its permit after a stream error', async () => {
+		const close = vi.fn();
+		const release = vi.fn();
+		const finish = vi.fn();
+		const object = body(
+			new ReadableStream({
+				pull() {
+					throw new Error('upstream failed');
+				},
+			}),
+			close,
+		);
+		await expect(
+			new Response(streamObjectBody(object, release, finish)).arrayBuffer(),
+		).rejects.toThrow('upstream failed');
+		expect(close).toHaveBeenCalledOnce();
+		expect(release).toHaveBeenCalledOnce();
+		expect(finish).toHaveBeenCalledOnce();
+	});
+
+	it('cleans up even when upstream cancellation rejects', async () => {
+		const close = vi.fn();
+		const release = vi.fn();
+		const finish = vi.fn();
+		const object = body(
+			new ReadableStream({
+				cancel() {
+					throw new Error('cancel failed');
+				},
+			}),
+			close,
+		);
+		await expect(streamObjectBody(object, release, finish).cancel('gone')).rejects.toThrow(
+			'cancel failed',
+		);
+		expect(close).toHaveBeenCalledOnce();
+		expect(release).toHaveBeenCalledOnce();
+		expect(finish).toHaveBeenCalledOnce();
+	});
+
+	it('rejects downloads when object browsing is not configured', () => {
+		expect(() => acquireDownload({} as ApiDeps, user.id)).toThrow(/not enabled/);
+	});
+});
+
+function body(stream: ReadableStream<Uint8Array>, close: () => void): ObjectBody {
+	return {
+		body: stream,
+		status: 200,
+		content_type: 'application/octet-stream',
+		content_length: 1,
+		total_size: 1,
+		close,
+	};
+}

--- a/packages/api/src/routes/objectBrowse.ts
+++ b/packages/api/src/routes/objectBrowse.ts
@@ -42,20 +42,18 @@ export async function makeObjectBrowseContext(
 	} = {},
 ): Promise<ObjectBrowseContext> {
 	const browser = deps.dataBrowser?.objectBrowser;
-	const wif = deps.wif;
-	const useFederatedCredentials = Boolean(
-		options.includeFederated !== false && wif && project.federation?.enabled,
-	);
+	const wif =
+		options.includeFederated !== false && project.federation?.enabled ? deps.wif : undefined;
 	const context: ObjectBrowseContext = {
 		project_id: project.id,
 		user_id: user.id,
 		user_email: user.email,
-		allow_server_ambient: useFederatedCredentials
+		allow_server_ambient: wif
 			? false
 			: (options.allowServerAmbient ?? browser?.allowServerAmbientCredentials ?? false),
 		...(signal ? { signal } : {}),
 	};
-	if (!useFederatedCredentials || !wif) {
+	if (!wif) {
 		return context;
 	}
 

--- a/packages/api/src/routes/objectBrowse.ts
+++ b/packages/api/src/routes/objectBrowse.ts
@@ -42,15 +42,20 @@ export async function makeObjectBrowseContext(
 	} = {},
 ): Promise<ObjectBrowseContext> {
 	const browser = deps.dataBrowser?.objectBrowser;
+	const wif = deps.wif;
+	const useFederatedCredentials = Boolean(
+		options.includeFederated !== false && wif && project.federation?.enabled,
+	);
 	const context: ObjectBrowseContext = {
 		project_id: project.id,
 		user_id: user.id,
 		user_email: user.email,
-		allow_server_ambient:
-			options.allowServerAmbient ?? browser?.allowServerAmbientCredentials ?? false,
+		allow_server_ambient: useFederatedCredentials
+			? false
+			: (options.allowServerAmbient ?? browser?.allowServerAmbientCredentials ?? false),
 		...(signal ? { signal } : {}),
 	};
-	if (!(options.includeFederated !== false && deps.wif && project.federation?.enabled)) {
+	if (!useFederatedCredentials || !wif) {
 		return context;
 	}
 
@@ -64,7 +69,7 @@ export async function makeObjectBrowseContext(
 		? {
 				...context,
 				temporary_s3_credentials: temporary,
-				temporary_storage: deps.wif.target.storage,
+				temporary_storage: wif.target.storage,
 			}
 		: context;
 }
@@ -203,19 +208,49 @@ export function streamObjectBody(
 	object: ObjectBody,
 	release: () => void,
 	onFinish: () => void,
+	signal?: AbortSignal,
 ): ReadableStream<Uint8Array> {
 	const reader = object.body.getReader();
 	let finished = false;
+	let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
 	const finish = () => {
 		if (finished) return;
 		finished = true;
-		onFinish();
-		release();
+		signal?.removeEventListener('abort', abort);
+		try {
+			onFinish();
+		} finally {
+			release();
+		}
+	};
+	const close = () => {
+		try {
+			object.close();
+		} finally {
+			finish();
+		}
+	};
+	const abort = () => {
+		if (finished) return;
+		const reason =
+			signal?.reason ?? new DOMException('The object download was aborted.', 'AbortError');
+		try {
+			streamController?.error(reason);
+		} finally {
+			void reader.cancel(reason).catch(() => {});
+			close();
+		}
 	};
 	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			streamController = controller;
+			if (signal?.aborted) abort();
+			else signal?.addEventListener('abort', abort, { once: true });
+		},
 		async pull(controller) {
 			try {
 				const next = await reader.read();
+				if (finished) return;
 				if (next.done) {
 					controller.close();
 					finish();
@@ -223,17 +258,16 @@ export function streamObjectBody(
 					controller.enqueue(next.value);
 				}
 			} catch (error) {
+				if (finished) return;
 				controller.error(error);
-				object.close();
-				finish();
+				close();
 			}
 		},
 		async cancel(reason) {
 			try {
 				await reader.cancel(reason);
 			} finally {
-				object.close();
-				finish();
+				close();
 			}
 		},
 	});

--- a/packages/api/src/routes/objectBrowse.ts
+++ b/packages/api/src/routes/objectBrowse.ts
@@ -1,0 +1,277 @@
+import { HTTPException } from 'hono/http-exception';
+import {
+	createSessionId,
+	exchangeFederatedStorageCredentials,
+	ForbiddenError,
+	NotFoundError,
+	ObjectBrowseError,
+	PreconditionFailedError,
+	ResourceExhaustedError,
+	UnavailableError,
+	ValidationError,
+} from '@marimo-hub/core';
+import type {
+	AuthUser,
+	ObjectBody,
+	ObjectBrowseContext,
+	Project,
+	TempS3Creds,
+} from '@marimo-hub/core';
+import type { ApiDeps } from '../context';
+
+const CACHE_REFRESH_SKEW_MS = 5 * 60 * 1000;
+const MAX_CREDENTIAL_CACHE_ENTRIES = 256;
+
+interface CachedCredentials {
+	credentials: TempS3Creds;
+	expiresAt: number;
+}
+
+const credentials = new Map<string, CachedCredentials>();
+const credentialLoads = new Map<string, Promise<TempS3Creds | undefined>>();
+
+export async function makeObjectBrowseContext(
+	deps: ApiDeps,
+	project: Project,
+	user: AuthUser,
+	signal?: AbortSignal,
+	options: {
+		integrationId?: string;
+		includeFederated?: boolean;
+		allowServerAmbient?: boolean;
+	} = {},
+): Promise<ObjectBrowseContext> {
+	const browser = deps.dataBrowser?.objectBrowser;
+	const context: ObjectBrowseContext = {
+		project_id: project.id,
+		user_id: user.id,
+		user_email: user.email,
+		allow_server_ambient:
+			options.allowServerAmbient ?? browser?.allowServerAmbientCredentials ?? false,
+		...(signal ? { signal } : {}),
+	};
+	if (!(options.includeFederated !== false && deps.wif && project.federation?.enabled)) {
+		return context;
+	}
+
+	const temporary = await cachedFederatedCredentials(
+		deps,
+		project.id,
+		user.id,
+		options.integrationId,
+	);
+	return temporary
+		? {
+				...context,
+				temporary_s3_credentials: temporary,
+				temporary_storage: deps.wif.target.storage,
+			}
+		: context;
+}
+
+async function cachedFederatedCredentials(
+	deps: ApiDeps,
+	projectId: Project['id'],
+	userId: AuthUser['id'],
+	integrationId?: string,
+): Promise<TempS3Creds | undefined> {
+	const wif = deps.wif;
+	if (!wif) return undefined;
+	const key = JSON.stringify([
+		projectId,
+		userId,
+		integrationId ?? null,
+		wif.target.audience,
+		wif.target.storage.endpoint ?? null,
+		wif.target.storage.region ?? null,
+	]);
+	const now = Date.now();
+	const cached = credentials.get(key);
+	if (cached && cached.expiresAt - CACHE_REFRESH_SKEW_MS > now) return cached.credentials;
+	if (cached) credentials.delete(key);
+
+	const pending = credentialLoads.get(key);
+	if (pending) return pending;
+	const load = exchangeFederatedStorageCredentials(
+		wif.issuer,
+		wif.issuerUrl,
+		wif.target,
+		projectId,
+		createSessionId(),
+	)
+		.then((value) => {
+			const expiresAt = value.expiration ? Date.parse(value.expiration) : Number.NaN;
+			if (Number.isFinite(expiresAt) && expiresAt - CACHE_REFRESH_SKEW_MS > Date.now()) {
+				sweepCredentialCache(Date.now());
+				credentials.set(key, { credentials: value, expiresAt });
+			}
+			return value;
+		})
+		.catch((): undefined => {})
+		.finally(() => credentialLoads.delete(key));
+	credentialLoads.set(key, load);
+	return load;
+}
+
+function sweepCredentialCache(now: number): void {
+	for (const [key, cached] of credentials) {
+		if (cached.expiresAt <= now) credentials.delete(key);
+	}
+	while (credentials.size >= MAX_CREDENTIAL_CACHE_ENTRIES) {
+		const oldest = credentials.keys().next().value;
+		if (oldest === undefined) break;
+		credentials.delete(oldest);
+	}
+}
+
+export function clearObjectCredentialCacheForTests(): void {
+	credentials.clear();
+	credentialLoads.clear();
+}
+
+export async function runObjectBrowse<T>(operation: () => Promise<T>): Promise<T> {
+	try {
+		return await operation();
+	} catch (error) {
+		if (!(error instanceof ObjectBrowseError)) throw error;
+		switch (error.code) {
+			case 'access_denied':
+				throw new ForbiddenError(error.message);
+			case 'not_found':
+				throw new NotFoundError(error.message);
+			case 'precondition_failed':
+				throw new PreconditionFailedError(error.message);
+			case 'range_not_satisfiable':
+				throw new HTTPException(416, { message: error.message });
+			case 'invalid_cursor':
+			case 'unsupported':
+				throw new ValidationError(error.message);
+			case 'aborted':
+			case 'unavailable':
+				throw new UnavailableError(error.message);
+		}
+	}
+}
+
+interface DownloadLimits {
+	maxConcurrentDownloads: number;
+	maxConcurrentDownloadsPerUser: number;
+}
+
+class DownloadGate {
+	private active = 0;
+	private readonly activeByUser = new Map<string, number>();
+
+	constructor(private readonly limits: DownloadLimits) {}
+
+	acquire(userId: string): () => void {
+		const userActive = this.activeByUser.get(userId) ?? 0;
+		if (
+			this.active >= this.limits.maxConcurrentDownloads ||
+			userActive >= this.limits.maxConcurrentDownloadsPerUser
+		) {
+			throw new ResourceExhaustedError('Too many object downloads are active — try again later.');
+		}
+		this.active += 1;
+		this.activeByUser.set(userId, userActive + 1);
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			this.active -= 1;
+			const remaining = (this.activeByUser.get(userId) ?? 1) - 1;
+			if (remaining === 0) this.activeByUser.delete(userId);
+			else this.activeByUser.set(userId, remaining);
+		};
+	}
+}
+
+const downloadGates = new WeakMap<object, DownloadGate>();
+
+export function acquireDownload(deps: ApiDeps, userId: string): () => void {
+	const limits = deps.dataBrowser?.objectBrowser;
+	if (!limits) throw new NotFoundError('Object downloads are not enabled on this deployment.');
+	let gate = downloadGates.get(limits);
+	if (!gate) {
+		gate = new DownloadGate(limits);
+		downloadGates.set(limits, gate);
+	}
+	return gate.acquire(userId);
+}
+
+export function streamObjectBody(
+	object: ObjectBody,
+	release: () => void,
+	onFinish: () => void,
+): ReadableStream<Uint8Array> {
+	const reader = object.body.getReader();
+	let finished = false;
+	const finish = () => {
+		if (finished) return;
+		finished = true;
+		onFinish();
+		release();
+	};
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			try {
+				const next = await reader.read();
+				if (next.done) {
+					controller.close();
+					finish();
+				} else {
+					controller.enqueue(next.value);
+				}
+			} catch (error) {
+				controller.error(error);
+				object.close();
+				finish();
+			}
+		},
+		async cancel(reason) {
+			try {
+				await reader.cancel(reason);
+			} finally {
+				object.close();
+				finish();
+			}
+		},
+	});
+}
+
+export function objectContentDisposition(key: string, inline: boolean): string {
+	const last = key.split('/').at(-1) || 'download';
+	const safe =
+		Array.from(last, (character) => {
+			const code = character.codePointAt(0) ?? 0;
+			return code < 32 || code === 127 || character === '/' || character === '\\' ? '_' : character;
+		})
+			.slice(0, 255)
+			.join('') || 'download';
+	const fallback =
+		safe
+			.normalize('NFKD')
+			.replaceAll(/[^\x20-\x7e]/g, '_')
+			.replaceAll(/["%;]/g, '_')
+			.slice(0, 150) || 'download';
+	const encoded = encodeURIComponent(safe).replaceAll(
+		/[!'()*]/g,
+		(char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+	);
+	return `${inline ? 'inline' : 'attachment'}; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}
+
+export function safeObjectContentType(contentType: string, inline: boolean): string {
+	if (!inline) return 'application/octet-stream';
+	return ['image/png', 'image/jpeg', 'image/gif', 'image/webp'].includes(contentType)
+		? contentType
+		: 'application/octet-stream';
+}
+
+export function validRangeHeader(value: string | undefined): string | undefined {
+	if (value === undefined) return undefined;
+	if (!/^bytes=(?:\d+-\d*|\d*-\d+)$/.test(value)) {
+		throw new HTTPException(416, { message: 'Only one valid byte range is supported.' });
+	}
+	return value;
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -36,6 +36,11 @@ export type IntegrationBrowseNamespacePage =
 export type IntegrationBrowseTablePage = components['schemas']['IntegrationBrowseTablePage'];
 export type IntegrationTableSchema = components['schemas']['IntegrationTableSchema'];
 export type IntegrationTablePreview = components['schemas']['IntegrationTablePreview'];
+export type IntegrationObjectBucket = components['schemas']['IntegrationObjectBucket'];
+export type IntegrationObjectEntry = components['schemas']['IntegrationObjectEntry'];
+export type IntegrationObjectDetail = components['schemas']['IntegrationObjectDetail'];
+export type IntegrationObjectVersion = components['schemas']['IntegrationObjectVersion'];
+export type IntegrationObjectPreview = components['schemas']['IntegrationObjectPreview'];
 /** A single saved notebook revision (was `Version`). */
 export type NotebookVersion = components['schemas']['NotebookVersion'];
 /** Read-only deployment metadata from `GET /api/v1/version`. */

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -6676,6 +6676,778 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/projects/{pid}/integrations/{iid}/browse/objects/buckets': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** List object-store buckets (editor or above) */
+		get: {
+			parameters: {
+				query?: {
+					limit?: number;
+					cursor?: string;
+					fresh?: 'true' | 'false';
+				};
+				header?: never;
+				path: {
+					pid: string;
+					iid: string;
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Buckets visible through the integration */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: {
+								items: components['schemas']['IntegrationObjectBucket'][];
+								next_cursor: string | null;
+							};
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Access forbidden */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Resource limit reached */
+				429: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/projects/{pid}/integrations/{iid}/browse/objects': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** List direct object-store children (editor or above) */
+		get: {
+			parameters: {
+				query: {
+					limit?: number;
+					cursor?: string;
+					fresh?: 'true' | 'false';
+					bucket: string;
+					prefix?: string;
+				};
+				header?: never;
+				path: {
+					pid: string;
+					iid: string;
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Direct prefixes and objects */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: {
+								items: components['schemas']['IntegrationObjectEntry'][];
+								next_cursor: string | null;
+							};
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Access forbidden */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Resource limit reached */
+				429: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/projects/{pid}/integrations/{iid}/browse/objects/search': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** Run a bounded object-key search (editor or above) */
+		get: {
+			parameters: {
+				query: {
+					limit?: number;
+					cursor?: string;
+					bucket: string;
+					prefix?: string;
+					query: string;
+					formats?: string;
+					modified_after?: string;
+					modified_before?: string;
+					min_size?: number | null;
+					max_size?: number | null;
+				};
+				header?: never;
+				path: {
+					pid: string;
+					iid: string;
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Bounded object-key search results */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: {
+								items: components['schemas']['IntegrationObjectEntry'][];
+								next_cursor: string | null;
+								scanned: number;
+								complete: boolean;
+							};
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Access forbidden */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Resource limit reached */
+				429: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/projects/{pid}/integrations/{iid}/browse/objects/head': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** Read object metadata and tags (editor or above) */
+		get: {
+			parameters: {
+				query: {
+					bucket: string;
+					key: string;
+					version_id?: string;
+				};
+				header?: never;
+				path: {
+					pid: string;
+					iid: string;
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Object metadata */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['IntegrationObjectDetail'];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Access forbidden */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Resource limit reached */
+				429: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/projects/{pid}/integrations/{iid}/browse/objects/versions': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** List object versions and delete markers (editor or above) */
+		get: {
+			parameters: {
+				query: {
+					limit?: number;
+					cursor?: string;
+					fresh?: 'true' | 'false';
+					bucket: string;
+					key: string;
+					version_id?: string;
+				};
+				header?: never;
+				path: {
+					pid: string;
+					iid: string;
+				};
+				cookie?: never;
+			};
+			requestBody?: never;
+			responses: {
+				/** @description Object versions and delete markers */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: {
+								items: components['schemas']['IntegrationObjectVersion'][];
+								next_cursor: string | null;
+							};
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Access forbidden */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Resource limit reached */
+				429: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/projects/{pid}/integrations/{iid}/browse/objects/preview': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/** Preview bounded object content (editor or above) */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					pid: string;
+					iid: string;
+				};
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					'application/json': {
+						/** @example analytics-lake */
+						bucket: string;
+						/** @example events/2026/part-001.jsonl */
+						key: string;
+						version_id?: string;
+						/** @default 20 */
+						limit?: number;
+					};
+				};
+			};
+			responses: {
+				/** @description Bounded object preview */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['IntegrationObjectPreview'];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Access forbidden */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Resource limit reached */
+				429: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/org/integrations': {
 		parameters: {
 			query?: never;
@@ -8571,7 +9343,7 @@ export interface components {
 					preview: boolean;
 					download: boolean;
 					/** @enum {string} */
-					search: 'bounded-key-name';
+					search: 'none' | 'bounded-key-name';
 					versions: boolean;
 					preview_formats: string[];
 					reason?: string;
@@ -8611,6 +9383,111 @@ export interface components {
 			columns: string[];
 			rows: unknown[][];
 		};
+		IntegrationObjectBucket: {
+			name: string;
+			/** Format: date-time */
+			created_at?: string;
+			configured: boolean;
+		};
+		IntegrationObjectEntry: {
+			/** @enum {string} */
+			kind: 'prefix' | 'object';
+			name: string;
+			key: string;
+			size?: number;
+			/** Format: date-time */
+			last_modified?: string;
+			etag?: string;
+			storage_class?: string;
+		};
+		IntegrationObjectDetail: {
+			bucket: string;
+			key: string;
+			version_id?: string;
+			size: number;
+			/** Format: date-time */
+			last_modified?: string;
+			etag?: string;
+			storage_class?: string;
+			content_type?: string;
+			content_encoding?: string;
+			cache_control?: string;
+			checksums: {
+				algorithm: string;
+				value: string;
+			}[];
+			metadata: {
+				[key: string]: string;
+			};
+			tags?: {
+				key: string;
+				value: string;
+			}[];
+			tags_available: boolean;
+			snippet?: string;
+		};
+		IntegrationObjectVersion: {
+			bucket: string;
+			key: string;
+			version_id?: string;
+			/** @enum {string} */
+			kind: 'version' | 'delete-marker';
+			is_latest: boolean;
+			/** Format: date-time */
+			last_modified?: string;
+			size?: number;
+			etag?: string;
+			storage_class?: string;
+			owner?: {
+				id?: string;
+				display_name?: string;
+			};
+		};
+		IntegrationObjectPreview:
+			| {
+					/** @enum {string} */
+					kind: 'tabular';
+					/** @enum {string} */
+					format: 'table' | 'csv' | 'tsv' | 'json' | 'jsonl' | 'parquet';
+					columns: {
+						name: string;
+						type?: string;
+					}[];
+					rows: unknown[][];
+					truncated: boolean;
+					bytes_read?: number;
+					total_bytes?: number;
+					warnings: string[];
+			  }
+			| {
+					/** @enum {string} */
+					kind: 'text';
+					/** @enum {string} */
+					format: 'text' | 'markdown' | 'code' | 'log' | 'json';
+					text: string;
+					truncated: boolean;
+					bytes_read: number;
+					total_bytes: number;
+					warnings: string[];
+			  }
+			| {
+					/** @enum {string} */
+					kind: 'image';
+					/** @enum {string} */
+					format: 'png' | 'jpeg' | 'gif' | 'webp';
+					content_url: string;
+					width?: number;
+					height?: number;
+					total_bytes: number;
+					warnings: string[];
+			  }
+			| {
+					/** @enum {string} */
+					kind: 'unsupported';
+					reason: string;
+					detected_type?: string;
+					total_bytes: number;
+			  };
 		User: {
 			id: string;
 			email: string;

--- a/packages/config/src/integrations.test.ts
+++ b/packages/config/src/integrations.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { createProjectId } from '@marimo-hub/core';
 import { ACTOR, MemoryBucket } from '@marimo-hub/core/testing';
 import { ConfigError } from './errors';
-import { makeIntegrations, objectBrowserDeadlinesFromEnv } from './integrations';
+import {
+	makeIntegrations,
+	objectBrowserDeadlinesFromEnv,
+	objectBrowserLimitsFromEnv,
+} from './integrations';
 
 const PG_CONFIG = { host: 'db.internal', database: 'db', username: 'u', password: 'pw' };
 
@@ -111,7 +115,15 @@ describe('makeIntegrations data browser', () => {
 			{ MARIMOHUB_INTEGRATIONS: 'on', MARIMOHUB_DATA_BROWSER: 'metadata' },
 			new MemoryBucket(),
 		);
-		expect(wired.dataBrowser).toEqual({ preview: false });
+		expect(wired.dataBrowser).toMatchObject({
+			preview: false,
+			objectBrowser: {
+				allowServerAmbientCredentials: false,
+				maxConcurrentDownloads: 16,
+				maxConcurrentDownloadsPerUser: 2,
+				downloadTimeoutMs: 3_600_000,
+			},
+		});
 		expect(wired.integrations?.listKinds().some((k) => k.supports_browse)).toBe(true);
 		expect(wired.integrations?.listKinds().find((kind) => kind.kind === 's3')).toMatchObject({
 			supports_browse: true,
@@ -122,7 +134,7 @@ describe('makeIntegrations data browser', () => {
 			{ MARIMOHUB_INTEGRATIONS: 'on', MARIMOHUB_DATA_BROWSER: 'full' },
 			new MemoryBucket(),
 		);
-		expect(full.dataBrowser).toEqual({ preview: true });
+		expect(full.dataBrowser).toMatchObject({ preview: true });
 	});
 
 	it('ignores stale preview timeout values while data browsing is disabled', () => {
@@ -144,14 +156,15 @@ describe('makeIntegrations data browser', () => {
 				{
 					MARIMOHUB_INTEGRATIONS: 'on',
 					MARIMOHUB_DATA_BROWSER: 'metadata',
-					MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: 'stale-invalid-value',
+					MARIMOHUB_OBJECT_BROWSER_PREVIEW_TIMEOUT_SECONDS: 'stale-invalid-value',
+					MARIMOHUB_OBJECT_BROWSER_DOWNLOAD_TIMEOUT_SECONDS: 'stale-invalid-value',
 				},
 				new MemoryBucket(),
 			),
 		).not.toThrow();
 		expect(
 			objectBrowserDeadlinesFromEnv(
-				{ MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: 'stale-invalid-value' },
+				{ MARIMOHUB_OBJECT_BROWSER_PREVIEW_TIMEOUT_SECONDS: 'stale-invalid-value' },
 				'metadata',
 			),
 		).toEqual({
@@ -164,7 +177,7 @@ describe('makeIntegrations data browser', () => {
 	it('gives DNS resolution enough time for the longest active browser operation', () => {
 		expect(
 			objectBrowserDeadlinesFromEnv(
-				{ MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: '45' },
+				{ MARIMOHUB_OBJECT_BROWSER_PREVIEW_TIMEOUT_SECONDS: '45' },
 				'full',
 			),
 		).toEqual({
@@ -174,13 +187,16 @@ describe('makeIntegrations data browser', () => {
 		});
 		expect(
 			objectBrowserDeadlinesFromEnv(
-				{ MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: '5' },
+				{
+					MARIMOHUB_OBJECT_BROWSER_METADATA_TIMEOUT_SECONDS: '20',
+					MARIMOHUB_OBJECT_BROWSER_PREVIEW_TIMEOUT_SECONDS: '5',
+				},
 				'full',
 			),
 		).toEqual({
-			metadataTimeoutMs: 30_000,
+			metadataTimeoutMs: 20_000,
 			previewTimeoutMs: 5_000,
-			resolveTimeoutMs: 30_000,
+			resolveTimeoutMs: 20_000,
 		});
 	});
 
@@ -285,18 +301,66 @@ describe('makeIntegrations data browser', () => {
 		}
 	});
 
-	it('rejects invalid full-preview operation deadlines', () => {
+	it('rejects invalid object-browser operation deadlines', () => {
 		for (const value of ['0', '-1', 'not-a-number', '2147484']) {
+			for (const key of [
+				'MARIMOHUB_OBJECT_BROWSER_METADATA_TIMEOUT_SECONDS',
+				'MARIMOHUB_OBJECT_BROWSER_PREVIEW_TIMEOUT_SECONDS',
+			] as const) {
+				expect(() =>
+					makeIntegrations(
+						{
+							MARIMOHUB_INTEGRATIONS: 'on',
+							MARIMOHUB_DATA_BROWSER: 'full',
+							[key]: value,
+						},
+						new MemoryBucket(),
+					),
+				).toThrow(/expected .*integer/);
+			}
+		}
+	});
+
+	it('parses object-browser limits and rejects unsafe combinations', () => {
+		expect(
+			objectBrowserLimitsFromEnv(
+				{
+					MARIMOHUB_OBJECT_BROWSER_PREVIEW_MAX_BYTES: '1024',
+					MARIMOHUB_OBJECT_BROWSER_INLINE_IMAGE_MAX_BYTES: '2048',
+					MARIMOHUB_OBJECT_BROWSER_PARQUET_MAX_RANGED_BYTES: '4096',
+					MARIMOHUB_OBJECT_BROWSER_SEARCH_MAX_KEYS: '250',
+				},
+				'full',
+			),
+		).toEqual({
+			previewMaxBytes: 1024,
+			inlineImageMaxBytes: 2048,
+			parquetMaxRangedBytes: 4096,
+			searchMaxKeys: 250,
+		});
+
+		for (const value of ['0', '-1', 'not-an-integer', '9007199254740992']) {
 			expect(() =>
 				makeIntegrations(
 					{
 						MARIMOHUB_INTEGRATIONS: 'on',
 						MARIMOHUB_DATA_BROWSER: 'full',
-						MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS: value,
+						MARIMOHUB_OBJECT_BROWSER_SEARCH_MAX_KEYS: value,
 					},
 					new MemoryBucket(),
 				),
-			).toThrow(/expected .*integer/);
+			).toThrow(ConfigError);
 		}
+		expect(() =>
+			makeIntegrations(
+				{
+					MARIMOHUB_INTEGRATIONS: 'on',
+					MARIMOHUB_DATA_BROWSER: 'full',
+					MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS: '2',
+					MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS_PER_USER: '3',
+				},
+				new MemoryBucket(),
+			),
+		).toThrow(/cannot exceed/);
 	});
 });

--- a/packages/config/src/integrations.ts
+++ b/packages/config/src/integrations.ts
@@ -1,8 +1,13 @@
-import { defaultRegistry, OrgIntegrationsStore, ProjectIntegrationsStore } from '@marimo-hub/core';
+import {
+	defaultRegistry,
+	Millis,
+	OrgIntegrationsStore,
+	ProjectIntegrationsStore,
+} from '@marimo-hub/core';
 import type { Bucket, DataPreview, IntegrationProbe, Metrics } from '@marimo-hub/core';
 import type { ApiDeps } from '@marimo-hub/api';
 import { DEFAULT_S3_OBJECT_BROWSER_LIMITS, S3ObjectBrowser } from '@marimo-hub/object-browser-s3';
-import { parseSecondsEnv } from './env';
+import { parseBool, parseIntEnv, parseSecondsEnv } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
 import { createGuardedHostResolver, createGuardedProbe } from './integrationProbe';
@@ -48,6 +53,7 @@ export function makeIntegrations(
 			? undefined
 			: (() => {
 					const deadlines = objectBrowserDeadlinesFromEnv(env, dataBrowser);
+					const limits = objectBrowserLimitsFromEnv(env, dataBrowser);
 					return {
 						s3: new S3ObjectBrowser({
 							mode: dataBrowser,
@@ -56,6 +62,7 @@ export function makeIntegrations(
 								timeoutMs: deadlines.resolveTimeoutMs,
 							}),
 							limits: {
+								...limits,
 								metadataTimeoutMs: deadlines.metadataTimeoutMs,
 								previewTimeoutMs: deadlines.previewTimeoutMs,
 							},
@@ -82,13 +89,119 @@ export function makeIntegrations(
 			: {
 					dataBrowser: {
 						preview: dataBrowser === 'full',
+						objectBrowser: objectBrowserApiConfigFromEnv(env, dataBrowser),
 						...(dataBrowser === 'full' && sandboxPreview ? { sandboxPreview } : {}),
 					},
 				}),
 	};
 }
 
+const DEFAULT_MAX_CONCURRENT_DOWNLOADS = 16;
+const DEFAULT_MAX_CONCURRENT_DOWNLOADS_PER_USER = 2;
+const DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 3600;
 const MAX_NODE_TIMER_SECONDS = Math.floor(2_147_483_647 / 1000);
+
+function positiveIntFromEnv(env: Env, key: string, dflt: number): number {
+	const value = parseIntEnv(env, key) ?? dflt;
+	if (!Number.isSafeInteger(value) || value < 1) {
+		throw new ConfigError(`Invalid ${key}: ${value} (expected a positive safe integer)`, {
+			variable: key,
+			docs: 'docs/integrations.md',
+		});
+	}
+	return value;
+}
+
+function fullModePositiveIntFromEnv(
+	env: Env,
+	mode: 'metadata' | 'full',
+	key: string,
+	dflt: number,
+): number {
+	return mode === 'full' ? positiveIntFromEnv(env, key, dflt) : dflt;
+}
+
+function objectBrowserTimeoutFromEnv(env: Env, key: string, dfltMs: number) {
+	return parseSecondsEnv(env, key, {
+		dflt: dfltMs / 1000,
+		max: MAX_NODE_TIMER_SECONDS,
+	});
+}
+
+export function objectBrowserLimitsFromEnv(
+	env: Env,
+	mode: 'metadata' | 'full',
+): Pick<
+	typeof DEFAULT_S3_OBJECT_BROWSER_LIMITS,
+	'previewMaxBytes' | 'inlineImageMaxBytes' | 'parquetMaxRangedBytes' | 'searchMaxKeys'
+> {
+	return {
+		previewMaxBytes: fullModePositiveIntFromEnv(
+			env,
+			mode,
+			'MARIMOHUB_OBJECT_BROWSER_PREVIEW_MAX_BYTES',
+			DEFAULT_S3_OBJECT_BROWSER_LIMITS.previewMaxBytes,
+		),
+		inlineImageMaxBytes: fullModePositiveIntFromEnv(
+			env,
+			mode,
+			'MARIMOHUB_OBJECT_BROWSER_INLINE_IMAGE_MAX_BYTES',
+			DEFAULT_S3_OBJECT_BROWSER_LIMITS.inlineImageMaxBytes,
+		),
+		parquetMaxRangedBytes: fullModePositiveIntFromEnv(
+			env,
+			mode,
+			'MARIMOHUB_OBJECT_BROWSER_PARQUET_MAX_RANGED_BYTES',
+			DEFAULT_S3_OBJECT_BROWSER_LIMITS.parquetMaxRangedBytes,
+		),
+		searchMaxKeys: positiveIntFromEnv(
+			env,
+			'MARIMOHUB_OBJECT_BROWSER_SEARCH_MAX_KEYS',
+			DEFAULT_S3_OBJECT_BROWSER_LIMITS.searchMaxKeys,
+		),
+	};
+}
+
+function objectBrowserApiConfigFromEnv(env: Env, mode: 'metadata' | 'full') {
+	const maxConcurrentDownloads = fullModePositiveIntFromEnv(
+		env,
+		mode,
+		'MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS',
+		DEFAULT_MAX_CONCURRENT_DOWNLOADS,
+	);
+	const maxConcurrentDownloadsPerUser = fullModePositiveIntFromEnv(
+		env,
+		mode,
+		'MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS_PER_USER',
+		DEFAULT_MAX_CONCURRENT_DOWNLOADS_PER_USER,
+	);
+	if (maxConcurrentDownloadsPerUser > maxConcurrentDownloads) {
+		throw new ConfigError(
+			'MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS_PER_USER cannot exceed ' +
+				'MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS.',
+			{
+				variable: 'MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS_PER_USER',
+				docs: 'docs/integrations.md',
+			},
+		);
+	}
+	return {
+		allowServerAmbientCredentials: parseBool(
+			env,
+			'MARIMOHUB_OBJECT_BROWSER_ALLOW_SERVER_AMBIENT_CREDENTIALS',
+		),
+		maxConcurrentDownloads,
+		maxConcurrentDownloadsPerUser,
+		downloadTimeoutMs:
+			mode === 'full'
+				? objectBrowserTimeoutFromEnv(
+						env,
+						'MARIMOHUB_OBJECT_BROWSER_DOWNLOAD_TIMEOUT_SECONDS',
+						Millis.seconds(DEFAULT_DOWNLOAD_TIMEOUT_SECONDS),
+					)
+				: Millis.seconds(DEFAULT_DOWNLOAD_TIMEOUT_SECONDS),
+	};
+}
 
 export function objectBrowserDeadlinesFromEnv(
 	env: Env,
@@ -98,13 +211,18 @@ export function objectBrowserDeadlinesFromEnv(
 	previewTimeoutMs: number;
 	resolveTimeoutMs: number;
 } {
-	const metadataTimeoutMs = DEFAULT_S3_OBJECT_BROWSER_LIMITS.metadataTimeoutMs;
+	const metadataTimeoutMs = objectBrowserTimeoutFromEnv(
+		env,
+		'MARIMOHUB_OBJECT_BROWSER_METADATA_TIMEOUT_SECONDS',
+		DEFAULT_S3_OBJECT_BROWSER_LIMITS.metadataTimeoutMs,
+	);
 	const previewTimeoutMs =
 		mode === 'full'
-			? parseSecondsEnv(env, 'MARIMOHUB_DATA_PREVIEW_EXECUTION_TIMEOUT_SECONDS', {
-					dflt: DEFAULT_S3_OBJECT_BROWSER_LIMITS.previewTimeoutMs / 1000,
-					max: MAX_NODE_TIMER_SECONDS,
-				})
+			? objectBrowserTimeoutFromEnv(
+					env,
+					'MARIMOHUB_OBJECT_BROWSER_PREVIEW_TIMEOUT_SECONDS',
+					DEFAULT_S3_OBJECT_BROWSER_LIMITS.previewTimeoutMs,
+				)
 			: DEFAULT_S3_OBJECT_BROWSER_LIMITS.previewTimeoutMs;
 	return {
 		metadataTimeoutMs,

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -1486,6 +1486,70 @@ See the [secret-source guide](./integration-secrets.md).`,
 						description: 'Maximum time for the fixed PyIceberg scan.',
 						default: '30',
 					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_ALLOW_SERVER_AMBIENT_CREDENTIALS',
+						name: 'Allow server credentials for object browsing',
+						description:
+							'Allow editors to browse ambient-auth S3 integrations with the control-plane AWS identity when compatible project WIF credentials are unavailable. Keep this off unless that identity is intentionally available to project editors.',
+						default: 'false',
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_METADATA_TIMEOUT_SECONDS',
+						name: 'Object-metadata timeout',
+						description:
+							'Maximum time for one object listing or metadata operation, including DNS resolution.',
+						default: '30',
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_PREVIEW_TIMEOUT_SECONDS',
+						name: 'Object-preview timeout',
+						description:
+							'Maximum time for one bounded object preview, including DNS resolution and ranged reads.',
+						default: '30',
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_PREVIEW_MAX_BYTES',
+						name: 'Object-preview source byte limit',
+						description: 'Maximum source bytes read for CSV, JSON, JSON Lines, and text previews.',
+						default: String(8 * 1024 * 1024),
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_INLINE_IMAGE_MAX_BYTES',
+						name: 'Inline-image byte limit',
+						description: 'Maximum size of a magic-byte-validated raster image shown inline.',
+						default: String(10 * 1024 * 1024),
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_PARQUET_MAX_RANGED_BYTES',
+						name: 'Parquet ranged-read byte limit',
+						description:
+							'Maximum total bytes fetched across ranged requests for one Parquet preview.',
+						default: String(32 * 1024 * 1024),
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_SEARCH_MAX_KEYS',
+						name: 'Object-search scan limit',
+						description: 'Maximum keys scanned by one bounded object-name search request.',
+						default: '5000',
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS',
+						name: 'Max concurrent object downloads',
+						description: 'Maximum object content streams held by one server process.',
+						default: '16',
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_MAX_CONCURRENT_DOWNLOADS_PER_USER',
+						name: 'Max object downloads per user',
+						description: 'Maximum object content streams one user can hold on one server process.',
+						default: '2',
+					},
+					{
+						id: 'MARIMOHUB_OBJECT_BROWSER_DOWNLOAD_TIMEOUT_SECONDS',
+						name: 'Object-download timeout',
+						description: 'Maximum lifetime of one proxied object content stream.',
+						default: '3600',
+					},
 				],
 			},
 			{

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
 		"./testing/contract": "./src/testing/bucketContract.ts",
 		"./testing/compute-contract": "./src/testing/computeContract.ts",
 		"./testing/browse-contract": "./src/testing/browseContract.ts",
+		"./testing/object-browse-contract": "./src/testing/objectBrowseContract.ts",
 		"./package.json": "./package.json"
 	},
 	"scripts": {

--- a/packages/core/src/ports/objectBrowser.ts
+++ b/packages/core/src/ports/objectBrowser.ts
@@ -209,7 +209,7 @@ export interface ObjectBrowseCapability {
 	available: boolean;
 	preview: boolean;
 	download: boolean;
-	search: 'bounded-key-name';
+	search: 'none' | 'bounded-key-name';
 	versions: boolean;
 	preview_formats: string[];
 	reason?: string;

--- a/packages/core/src/services/identity/federation.ts
+++ b/packages/core/src/services/identity/federation.ts
@@ -5,7 +5,7 @@
  * mint → exchange → env-map pipeline in one place.
  */
 import type { ProjectId, SessionId } from '../../ids';
-import type { FederationTarget } from '../../ports/credentialBroker';
+import type { FederationTarget, TempS3Creds } from '../../ports/credentialBroker';
 import { s3CredsToEnv } from './s3CredsEnv';
 import type { WorkloadIdentityIssuer } from './WorkloadIdentityIssuer';
 
@@ -32,12 +32,28 @@ export async function exchangeFederatedStorageEnv(
 	projectId: ProjectId,
 	sessionId: SessionId,
 ): Promise<Record<string, string>> {
+	const creds = await exchangeFederatedStorageCredentials(
+		issuer,
+		issuerUrl,
+		target,
+		projectId,
+		sessionId,
+	);
+	return s3CredsToEnv(creds, target.storage.endpoint, target.storage.region);
+}
+
+export async function exchangeFederatedStorageCredentials(
+	issuer: WorkloadIdentityIssuer,
+	issuerUrl: string,
+	target: FederationTarget,
+	projectId: ProjectId,
+	sessionId: SessionId,
+): Promise<TempS3Creds> {
 	const jwt = await issuer.mint({
 		iss: issuerUrl,
 		sub: projectSubject(projectId),
 		aud: target.audience,
 		extraClaims: { project_id: projectId, session_id: sessionId },
 	});
-	const creds = await target.broker.exchange(jwt);
-	return s3CredsToEnv(creds, target.storage.endpoint, target.storage.region);
+	return target.broker.exchange(jwt);
 }

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -171,7 +171,11 @@ export type {
 export { WorkloadIdentityIssuer } from './identity/WorkloadIdentityIssuer';
 export type { WifClaims, JwksKey } from './identity/WorkloadIdentityIssuer';
 export { s3CredsToEnv } from './identity/s3CredsEnv';
-export { exchangeFederatedStorageEnv, projectSubject } from './identity/federation';
+export {
+	exchangeFederatedStorageCredentials,
+	exchangeFederatedStorageEnv,
+	projectSubject,
+} from './identity/federation';
 export {
 	buildMarimoAiToml,
 	marimoAiContributor,

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -2295,7 +2295,7 @@ describe('data browsing', () => {
 					available: false,
 					preview: false,
 					download: false,
-					search: 'bounded-key-name',
+					search: 'none',
 					versions: false,
 					preview_formats: [],
 					...(reason ? { reason } : {}),

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -112,7 +112,7 @@ function unavailableObjectCapability(reason: string) {
 		available: false,
 		preview: false,
 		download: false,
-		search: 'bounded-key-name' as const,
+		search: 'none' as const,
 		versions: false,
 		preview_formats: [],
 		reason,
@@ -810,7 +810,11 @@ class ScopedIntegrationsStore {
 				);
 			}
 		}
-		return compatibility(surfaces.tables?.reason);
+		const anySurfaceAvailable =
+			(surfaces.tables?.available ?? false) || (surfaces.objects?.available ?? false);
+		return compatibility(
+			anySurfaceAvailable ? undefined : (surfaces.tables?.reason ?? surfaces.objects?.reason),
+		);
 	}
 
 	async browseNamespaces(

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,6 +1,7 @@
 export * from './MemoryBucket';
 export * from './MemoryNotifier';
 export * from './notificationFixtures';
+export * from './objectBrowseContract';
 export * from './RecordingBucket';
 export * from './assertions';
 export * from './fakes';

--- a/packages/core/src/testing/objectBrowseContract.ts
+++ b/packages/core/src/testing/objectBrowseContract.ts
@@ -1,0 +1,166 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type {
+	ObjectBrowseContext,
+	ObjectBrowser,
+	ObjectEntry,
+	ObjectStoreSource,
+} from '../ports/objectBrowser';
+
+export interface ObjectBrowseContractFixture {
+	bucket: string;
+	prefix: string;
+	directObject: string;
+	nestedObject: string;
+	versionedObject: string;
+}
+
+export interface ObjectBrowseContractOptions {
+	browser: ObjectBrowser;
+	source: ObjectStoreSource;
+	context: ObjectBrowseContext;
+	setup(): Promise<ObjectBrowseContractFixture>;
+	teardown?(fixture: ObjectBrowseContractFixture): Promise<void>;
+}
+
+export function objectBrowseContract(
+	name: string,
+	options: () => ObjectBrowseContractOptions,
+): void {
+	describe(`Object browse contract: ${name}`, () => {
+		let opts: ObjectBrowseContractOptions;
+		let fixture: ObjectBrowseContractFixture;
+
+		beforeAll(async () => {
+			opts = options();
+			fixture = await opts.setup();
+		}, 30_000);
+
+		afterAll(async () => {
+			if (fixture) await opts.teardown?.(fixture)?.catch(() => {});
+		});
+
+		async function collect(
+			load: (cursor?: string) => Promise<{ items: ObjectEntry[]; next_cursor: string | null }>,
+		): Promise<ObjectEntry[]> {
+			const items: ObjectEntry[] = [];
+			const cursors = new Set<string>();
+			let cursor: string | undefined;
+			for (let page = 0; page < 100; page++) {
+				const result = await load(cursor);
+				items.push(...result.items);
+				if (result.next_cursor === null) return items;
+				if (cursors.has(result.next_cursor)) throw new Error('object pagination cycled');
+				cursors.add(result.next_cursor);
+				cursor = result.next_cursor;
+			}
+			throw new Error('object pagination did not terminate');
+		}
+
+		it('lists the configured bucket without discovering unrelated buckets', async () => {
+			const page = await opts.browser.listBuckets(opts.source, opts.context, { limit: 1 });
+			expect(page).toEqual({
+				items: [{ name: fixture.bucket, configured: true }],
+				next_cursor: null,
+			});
+		});
+
+		it('lists only direct children with stable pagination and no duplicates', async () => {
+			const items = await collect((cursor) =>
+				opts.browser.listObjects(opts.source, opts.context, {
+					bucket: fixture.bucket,
+					prefix: fixture.prefix,
+					limit: 1,
+					...(cursor ? { cursor } : {}),
+				}),
+			);
+			expect(items).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ kind: 'object', key: fixture.directObject }),
+					expect.objectContaining({ kind: 'prefix', key: `${fixture.prefix}nested/` }),
+				]),
+			);
+			expect(items.some((item) => item.key === fixture.nestedObject)).toBe(false);
+			expect(new Set(items.map((item) => `${item.kind}:${item.key}`)).size).toBe(items.length);
+		});
+
+		it('reads exact metadata and a bounded preview', async () => {
+			const detail = await opts.browser.headObject(opts.source, opts.context, {
+				bucket: fixture.bucket,
+				key: fixture.directObject,
+			});
+			expect(detail).toMatchObject({
+				bucket: fixture.bucket,
+				key: fixture.directObject,
+				content_type: 'text/csv',
+			});
+			const preview = await opts.browser.previewObject(opts.source, opts.context, {
+				bucket: fixture.bucket,
+				key: fixture.directObject,
+				limit: 1,
+				content_url: '/unused',
+			});
+			expect(preview).toMatchObject({ kind: 'tabular', format: 'csv', truncated: true });
+		});
+
+		it('searches progressively and preserves a continuation cursor', async () => {
+			const first = await opts.browser.searchObjects(opts.source, opts.context, {
+				bucket: fixture.bucket,
+				prefix: fixture.prefix,
+				query: 'contract',
+				limit: 1,
+			});
+			expect(first.scanned).toBeGreaterThan(0);
+			expect(first.items.length).toBeLessThanOrEqual(1);
+			if (!first.complete) {
+				expect(first.next_cursor).not.toBeNull();
+				const second = await opts.browser.searchObjects(opts.source, opts.context, {
+					bucket: fixture.bucket,
+					prefix: fixture.prefix,
+					query: 'contract',
+					limit: 10,
+					cursor: first.next_cursor!,
+				});
+				expect(second.scanned).toBeGreaterThan(0);
+			}
+		});
+
+		it('streams an exact byte range and reports version identity', async () => {
+			const body = await opts.browser.openObject(opts.source, opts.context, {
+				bucket: fixture.bucket,
+				key: fixture.directObject,
+				range: 'bytes=0-3',
+			});
+			try {
+				expect(body.status).toBe(206);
+				expect(new TextDecoder().decode(await readAll(body.body))).toBe('name');
+			} finally {
+				body.close();
+			}
+			const versions = await opts.browser.listVersions(opts.source, opts.context, {
+				bucket: fixture.bucket,
+				key: fixture.versionedObject,
+				limit: 10,
+			});
+			expect(
+				versions.items.filter((item) => item.kind === 'version').length,
+			).toBeGreaterThanOrEqual(2);
+			expect(versions.items.every((item) => item.key === fixture.versionedObject)).toBe(true);
+		});
+	});
+}
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+	const chunks: Uint8Array[] = [];
+	let length = 0;
+	for await (const chunk of stream) {
+		chunks.push(chunk);
+		length += chunk.length;
+	}
+	const value = new Uint8Array(length);
+	let offset = 0;
+	for (const chunk of chunks) {
+		value.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return value;
+}

--- a/packages/core/src/testing/objectBrowseContract.ts
+++ b/packages/core/src/testing/objectBrowseContract.ts
@@ -36,7 +36,7 @@ export function objectBrowseContract(
 		}, 30_000);
 
 		afterAll(async () => {
-			if (fixture) await opts.teardown?.(fixture)?.catch(() => {});
+			if (fixture) await opts.teardown?.(fixture);
 		});
 
 		async function collect(

--- a/packages/object-browser-s3/src/index.test.ts
+++ b/packages/object-browser-s3/src/index.test.ts
@@ -819,6 +819,7 @@ describe('capabilities and metadata-only mode', () => {
 			available: false,
 			preview: false,
 			download: false,
+			search: 'none',
 			versions: false,
 			reason: expect.stringContaining('not enabled'),
 		});

--- a/packages/object-browser-s3/src/index.test.ts
+++ b/packages/object-browser-s3/src/index.test.ts
@@ -310,7 +310,7 @@ describe('S3ObjectBrowser listing and metadata', () => {
 					{
 						Key: 'events/match.csv',
 						Size: 20,
-						LastModified: new Date('2026-08-02T00:00:00Z'),
+						LastModified: new Date('2026-08-02T00:00:00.100Z'),
 					},
 					{
 						Key: 'events/match.json',
@@ -338,8 +338,8 @@ describe('S3ObjectBrowser listing and metadata', () => {
 			formats: ['csv'],
 			min_size: 10,
 			max_size: 30,
-			modified_after: '2026-08-01T00:00:00.000Z',
-			modified_before: '2026-08-03T00:00:00.000Z',
+			modified_after: '2026-08-02T00:00:00.1Z',
+			modified_before: '2026-08-02T00:00:00.1000Z',
 			limit: 10,
 		});
 		expect(page).toMatchObject({

--- a/packages/object-browser-s3/src/index.ts
+++ b/packages/object-browser-s3/src/index.ts
@@ -74,9 +74,14 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		this.limits = { ...DEFAULT_S3_OBJECT_BROWSER_LIMITS, ...options.limits };
 		if (options.clientFactory) this.clientFactory = options.clientFactory;
 		else if (options.resolveHost) {
+			const transportTimeoutMs = Math.max(
+				this.limits.metadataTimeoutMs,
+				this.limits.previewTimeoutMs,
+			);
 			this.clientFactory = createS3ClientFactory({
 				resolveHost: options.resolveHost,
-				requestTimeoutMs: this.limits.metadataTimeoutMs,
+				connectionTimeoutMs: transportTimeoutMs,
+				requestTimeoutMs: transportTimeoutMs,
 			});
 		} else {
 			throw new Error('S3ObjectBrowser requires a guarded host resolver.');
@@ -100,7 +105,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 				available: false,
 				preview: false,
 				download: false,
-				search: 'bounded-key-name',
+				search: 'none',
 				versions: false,
 				preview_formats: [],
 				reason: mapped.message,

--- a/packages/object-browser-s3/src/index.ts
+++ b/packages/object-browser-s3/src/index.ts
@@ -483,8 +483,16 @@ function matchesFilters(entry: ObjectEntry, filters: ObjectSearchRequest): boole
 	if (filters.formats?.length && (!extension || !filters.formats.includes(extension))) return false;
 	if (filters.min_size !== undefined && (entry.size ?? 0) < filters.min_size) return false;
 	if (filters.max_size !== undefined && (entry.size ?? 0) > filters.max_size) return false;
-	if (filters.modified_after && (entry.last_modified ?? '') < filters.modified_after) return false;
-	if (filters.modified_before && (entry.last_modified ?? '') > filters.modified_before)
+	if (
+		filters.modified_after &&
+		(!entry.last_modified || Date.parse(entry.last_modified) < Date.parse(filters.modified_after))
+	)
+		return false;
+	if (
+		filters.modified_before &&
+		entry.last_modified &&
+		Date.parse(entry.last_modified) > Date.parse(filters.modified_before)
+	)
 		return false;
 	return true;
 }

--- a/packages/object-browser-s3/src/minio.live.test.ts
+++ b/packages/object-browser-s3/src/minio.live.test.ts
@@ -1,0 +1,119 @@
+import {
+	CreateBucketCommand,
+	DeleteBucketCommand,
+	DeleteObjectsCommand,
+	ListObjectVersionsCommand,
+	PutBucketVersioningCommand,
+	PutObjectCommand,
+	S3Client,
+} from '@aws-sdk/client-s3';
+import { describe, it } from 'vitest';
+import { createProjectId, UserId } from '@marimo-hub/core';
+import { objectBrowseContract } from '@marimo-hub/core/testing/object-browse-contract';
+import { S3ObjectBrowser } from './index';
+
+const endpoint = process.env.MARIMOHUB_TEST_S3_ENDPOINT;
+const accessKeyId = process.env.MARIMOHUB_TEST_S3_ACCESS_KEY ?? 'minioadmin';
+const secretAccessKey = process.env.MARIMOHUB_TEST_S3_SECRET_KEY ?? 'minioadmin';
+const bucket = `marimohub-object-browser-${process.pid}`;
+const prefix = `contract-${Date.now()}/`;
+const credentials = { accessKeyId, secretAccessKey };
+const source = {
+	provider: 's3' as const,
+	configured_bucket: bucket,
+	region: 'us-east-1',
+	endpoint,
+	path_style: true,
+	auth: {
+		method: 'static' as const,
+		access_key_id: accessKeyId,
+		secret_access_key: secretAccessKey,
+	},
+};
+const context = {
+	project_id: createProjectId(),
+	user_id: UserId.parse('object-contract'),
+	user_email: 'object-contract@example.com',
+	allow_server_ambient: false,
+};
+
+if (endpoint)
+	objectBrowseContract('S3-compatible MinIO', () => ({
+		browser: new S3ObjectBrowser({
+			mode: 'full',
+			resolveHost: async (hostname) => {
+				if (hostname !== '127.0.0.1' && hostname !== 'localhost') {
+					throw new Error('unexpected live-test hostname');
+				}
+				return [{ address: '127.0.0.1', family: 4 }];
+			},
+		}),
+		source,
+		context,
+		async setup() {
+			const client = setupClient();
+			await client.send(new CreateBucketCommand({ Bucket: bucket }));
+			await client.send(
+				new PutBucketVersioningCommand({
+					Bucket: bucket,
+					VersioningConfiguration: { Status: 'Enabled' },
+				}),
+			);
+			const directObject = `${prefix}contract.csv`;
+			const nestedObject = `${prefix}nested/contract.txt`;
+			const versionedObject = `${prefix}versioned.txt`;
+			await client.send(
+				new PutObjectCommand({
+					Bucket: bucket,
+					Key: directObject,
+					Body: 'name,value\nfirst,1\nsecond,2\n',
+					ContentType: 'text/csv',
+				}),
+			);
+			await client.send(
+				new PutObjectCommand({ Bucket: bucket, Key: nestedObject, Body: 'nested contract' }),
+			);
+			await client.send(
+				new PutObjectCommand({ Bucket: bucket, Key: versionedObject, Body: 'version one' }),
+			);
+			await client.send(
+				new PutObjectCommand({ Bucket: bucket, Key: versionedObject, Body: 'version two' }),
+			);
+			client.destroy();
+			return { bucket, prefix, directObject, nestedObject, versionedObject };
+		},
+		async teardown() {
+			const client = setupClient();
+			const listed = await client.send(new ListObjectVersionsCommand({ Bucket: bucket }));
+			const objects = [
+				...(listed.Versions ?? []).map((item) => ({ Key: item.Key, VersionId: item.VersionId })),
+				...(listed.DeleteMarkers ?? []).map((item) => ({
+					Key: item.Key,
+					VersionId: item.VersionId,
+				})),
+			].filter((item): item is { Key: string; VersionId: string } =>
+				Boolean(item.Key && item.VersionId),
+			);
+			if (objects.length > 0) {
+				await client.send(
+					new DeleteObjectsCommand({ Bucket: bucket, Delete: { Objects: objects } }),
+				);
+			}
+			await client.send(new DeleteBucketCommand({ Bucket: bucket }));
+			client.destroy();
+		},
+	}));
+else {
+	describe.skip('Object browse contract: S3-compatible MinIO', () => {
+		it('requires MARIMOHUB_TEST_S3_ENDPOINT', () => {});
+	});
+}
+
+function setupClient(): S3Client {
+	return new S3Client({
+		endpoint,
+		region: 'us-east-1',
+		forcePathStyle: true,
+		credentials,
+	});
+}

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -716,6 +716,12 @@ const BROWSE_SCHEMA_STALE_MS = 300_000;
  */
 let bypassBrowseCache = 0;
 const freshQuery = () => (bypassBrowseCache > 0 ? { fresh: 'true' as const } : {});
+const browsePath = (projectId: string, integrationId: string) => ({
+	pid: projectId,
+	iid: integrationId,
+});
+const cursorQuery = (cursor: string | null): { cursor?: string } => (cursor ? { cursor } : {});
+const nextCursor = (page: { next_cursor: string | null }) => page.next_cursor;
 
 /**
  * Client-side mirror of the server's 30 fresh ops/min/user budget, spent in
@@ -796,7 +802,7 @@ export function useBrowseCapabilityQuery(projectId: string, integrationId: strin
 		queryFn: () =>
 			apiData(
 				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse', {
-					params: { path: { pid: projectId, iid: integrationId } },
+					params: { path: browsePath(projectId, integrationId) },
 				}),
 			),
 	});
@@ -817,16 +823,16 @@ export function useBrowseNamespacesQuery(
 			apiData(
 				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/namespaces', {
 					params: {
-						path: { pid: projectId, iid: integrationId },
+						path: browsePath(projectId, integrationId),
 						query: {
 							...(parent.length > 0 ? { parent: parent.join(NAMESPACE_JOINER) } : {}),
-							...(pageParam ? { cursor: pageParam } : {}),
+							...cursorQuery(pageParam),
 							...freshQuery(),
 						},
 					},
 				}),
 			),
-		getNextPageParam: (lastPage) => lastPage.next_cursor,
+		getNextPageParam: nextCursor,
 	});
 }
 
@@ -845,16 +851,16 @@ export function useBrowseTablesQuery(
 			apiData(
 				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/tables', {
 					params: {
-						path: { pid: projectId, iid: integrationId },
+						path: browsePath(projectId, integrationId),
 						query: {
 							namespace: namespace.join(NAMESPACE_JOINER),
-							...(pageParam ? { cursor: pageParam } : {}),
+							...cursorQuery(pageParam),
 							...freshQuery(),
 						},
 					},
 				}),
 			),
-		getNextPageParam: (lastPage) => lastPage.next_cursor,
+		getNextPageParam: nextCursor,
 	});
 }
 
@@ -873,7 +879,7 @@ export function useBrowseTableSchemaQuery(
 			apiData(
 				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/schema', {
 					params: {
-						path: { pid: projectId, iid: integrationId },
+						path: browsePath(projectId, integrationId),
 						query: { namespace: namespace.join(NAMESPACE_JOINER), table, ...freshQuery() },
 					},
 				}),
@@ -886,11 +892,172 @@ export function useBrowseTablePreview(projectId: string, integrationId: string) 
 		mutationFn: (input: { namespace: string[]; table: string; limit?: number }) =>
 			apiData(
 				apiClient.POST('/api/v1/projects/{pid}/integrations/{iid}/browse/preview', {
-					params: { path: { pid: projectId, iid: integrationId } },
+					params: { path: browsePath(projectId, integrationId) },
 					body: input,
 				}),
 			),
 	});
+}
+
+export function useObjectBucketsQuery(projectId: string, integrationId: string, enabled = true) {
+	return useInfiniteQuery({
+		queryKey: browseKeys.objectBuckets(projectId, integrationId),
+		enabled,
+		staleTime: BROWSE_LIST_STALE_MS,
+		initialPageParam: null as string | null,
+		queryFn: ({ pageParam }) =>
+			apiData(
+				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/objects/buckets', {
+					params: {
+						path: browsePath(projectId, integrationId),
+						query: { ...cursorQuery(pageParam), ...freshQuery() },
+					},
+				}),
+			),
+		getNextPageParam: nextCursor,
+	});
+}
+
+export function useObjectsQuery(
+	projectId: string,
+	integrationId: string,
+	bucket: string,
+	prefix: string,
+	enabled = true,
+) {
+	return useInfiniteQuery({
+		queryKey: browseKeys.objects(projectId, integrationId, bucket, prefix),
+		enabled: enabled && bucket !== '',
+		staleTime: BROWSE_LIST_STALE_MS,
+		initialPageParam: null as string | null,
+		queryFn: ({ pageParam }) =>
+			apiData(
+				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/objects', {
+					params: {
+						path: browsePath(projectId, integrationId),
+						query: {
+							bucket,
+							...(prefix ? { prefix } : {}),
+							...cursorQuery(pageParam),
+							...freshQuery(),
+						},
+					},
+				}),
+			),
+		getNextPageParam: nextCursor,
+	});
+}
+
+export function useObjectSearchQuery(
+	projectId: string,
+	integrationId: string,
+	bucket: string,
+	prefix: string,
+	query: string,
+) {
+	return useInfiniteQuery({
+		queryKey: browseKeys.objectSearch(projectId, integrationId, bucket, prefix, query),
+		enabled: bucket !== '' && query.trim().length >= 2,
+		initialPageParam: null as string | null,
+		queryFn: ({ pageParam }) =>
+			apiData(
+				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/objects/search', {
+					params: {
+						path: browsePath(projectId, integrationId),
+						query: {
+							bucket,
+							query: query.trim(),
+							...(prefix ? { prefix } : {}),
+							...cursorQuery(pageParam),
+						},
+					},
+				}),
+			),
+		getNextPageParam: nextCursor,
+	});
+}
+
+export function useObjectDetailQuery(
+	projectId: string,
+	integrationId: string,
+	bucket: string,
+	key: string,
+	versionId?: string,
+) {
+	return useQuery({
+		queryKey: browseKeys.objectDetail(projectId, integrationId, bucket, key, versionId),
+		enabled: bucket !== '' && key !== '',
+		staleTime: BROWSE_LIST_STALE_MS,
+		queryFn: () =>
+			apiData(
+				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/objects/head', {
+					params: {
+						path: browsePath(projectId, integrationId),
+						query: {
+							bucket,
+							key,
+							...(versionId ? { version_id: versionId } : {}),
+						},
+					},
+				}),
+			),
+	});
+}
+
+export function useObjectVersionsQuery(
+	projectId: string,
+	integrationId: string,
+	bucket: string,
+	key: string,
+	enabled = true,
+) {
+	return useInfiniteQuery({
+		queryKey: browseKeys.objectVersions(projectId, integrationId, bucket, key),
+		enabled: enabled && bucket !== '' && key !== '',
+		initialPageParam: null as string | null,
+		queryFn: ({ pageParam }) =>
+			apiData(
+				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/objects/versions', {
+					params: {
+						path: browsePath(projectId, integrationId),
+						query: {
+							bucket,
+							key,
+							...cursorQuery(pageParam),
+						},
+					},
+				}),
+			),
+		getNextPageParam: nextCursor,
+	});
+}
+
+export function useObjectPreview(projectId: string, integrationId: string) {
+	return useMutation({
+		mutationFn: (input: { bucket: string; key: string; version_id?: string; limit?: number }) =>
+			apiData(
+				apiClient.POST('/api/v1/projects/{pid}/integrations/{iid}/browse/objects/preview', {
+					params: { path: browsePath(projectId, integrationId) },
+					body: input,
+				}),
+			),
+	});
+}
+
+export function objectContentUrl(input: {
+	projectId: string;
+	integrationId: string;
+	bucket: string;
+	key: string;
+	versionId?: string;
+	etag?: string;
+	inline?: boolean;
+}): string {
+	const params = new URLSearchParams({ bucket: input.bucket, key: input.key });
+	if (input.versionId) params.set('version_id', input.versionId);
+	if (input.etag) params.set('etag', input.etag);
+	if (input.inline) params.set('inline', 'true');
+	return `/api/v1/projects/${encodeURIComponent(input.projectId)}/integrations/${encodeURIComponent(input.integrationId)}/browse/objects/content?${params}`;
 }
 
 // Notebooks

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -33,6 +33,36 @@ export const browseKeys = {
 		[...browseKeys.all, projectId, integrationId, 'tables', namespace] as const,
 	schema: (projectId: string, integrationId: string, namespace: readonly string[], table: string) =>
 		[...browseKeys.all, projectId, integrationId, 'schema', namespace, table] as const,
+	objectBuckets: (projectId: string, integrationId: string) =>
+		[...browseKeys.all, projectId, integrationId, 'object-buckets'] as const,
+	objects: (projectId: string, integrationId: string, bucket: string, prefix: string) =>
+		[...browseKeys.all, projectId, integrationId, 'objects', bucket, prefix] as const,
+	objectSearch: (
+		projectId: string,
+		integrationId: string,
+		bucket: string,
+		prefix: string,
+		query: string,
+	) =>
+		[...browseKeys.all, projectId, integrationId, 'object-search', bucket, prefix, query] as const,
+	objectDetail: (
+		projectId: string,
+		integrationId: string,
+		bucket: string,
+		key: string,
+		versionId?: string,
+	) =>
+		[
+			...browseKeys.all,
+			projectId,
+			integrationId,
+			'object-detail',
+			bucket,
+			key,
+			versionId ?? null,
+		] as const,
+	objectVersions: (projectId: string, integrationId: string, bucket: string, key: string) =>
+		[...browseKeys.all, projectId, integrationId, 'object-versions', bucket, key] as const,
 };
 
 export const integrationKeys = {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -690,20 +690,14 @@ describe('DataBrowserPage', () => {
 
 	it('resets a multi-selection when revisiting its URL through history', async () => {
 		const user = userEvent.setup();
-		setup(
-			[
-				`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=second.csv`,
-				`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=first.csv`,
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=first.csv`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectEntries: [
+				{ kind: 'object', name: 'first.csv', key: 'first.csv', size: 12 },
+				{ kind: 'object', name: 'second.csv', key: 'second.csv', size: 24 },
 			],
-			{
-				kind: objectKind,
-				entry: { ...lakeEntry, kind: 's3' },
-				objectEntries: [
-					{ kind: 'object', name: 'first.csv', key: 'first.csv', size: 12 },
-					{ kind: 'object', name: 'second.csv', key: 'second.csv', size: 24 },
-				],
-			},
-		);
+		});
 
 		await screen.findByRole('button', { name: /^first\.csv/ });
 		const second = screen.getByRole('button', { name: /^second\.csv/ });

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -82,6 +82,7 @@ function makeFetch({
 	objectBuckets = [{ name: 'lake', configured: true }],
 	objectBucketsSecond = [],
 	objectBucketNextCursor = null,
+	objectBucketNextFailure,
 	objectEntries = [
 		{ kind: 'prefix', name: 'daily/', key: 'daily/' },
 		{ kind: 'object', name: 'events.jsonl', key: 'events.jsonl', size: 12 },
@@ -114,6 +115,7 @@ function makeFetch({
 	objectBuckets?: { name: string; configured: boolean }[];
 	objectBucketsSecond?: { name: string; configured: boolean }[];
 	objectBucketNextCursor?: string | null;
+	objectBucketNextFailure?: string;
 	objectEntries?: unknown[];
 	objectEntriesSecond?: unknown[];
 	objectNextCursor?: string | null;
@@ -124,6 +126,7 @@ function makeFetch({
 	objectPreview?: unknown;
 	objectFailures?: Partial<Record<ObjectFailure, string>>;
 } = {}) {
+	let nextBucketFailure = objectBucketNextFailure;
 	const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = String(input);
 		const method = init?.method ?? 'GET';
@@ -150,6 +153,11 @@ function makeFetch({
 		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/objects/buckets`)) {
 			if (objectFailures.buckets) return failed(objectFailures.buckets);
+			if (target.searchParams.has('cursor') && nextBucketFailure) {
+				const message = nextBucketFailure;
+				nextBucketFailure = undefined;
+				return failed(message);
+			}
 			return target.searchParams.has('cursor')
 				? ok({ items: objectBucketsSecond, next_cursor: null })
 				: ok({ items: objectBuckets, next_cursor: objectBucketNextCursor });
@@ -304,7 +312,7 @@ function HistoryControls() {
 	);
 }
 
-function setup(route: string, fetchOpts?: Parameters<typeof makeFetch>[0]) {
+function setup(route: string | string[], fetchOpts?: Parameters<typeof makeFetch>[0]) {
 	installMatchMedia();
 	const fetchImpl = makeFetch(fetchOpts);
 	renderWithClient(
@@ -572,6 +580,25 @@ describe('DataBrowserPage', () => {
 		).toBe(true);
 	});
 
+	it('keeps loaded buckets visible and retries a failed next page', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectBuckets: [{ name: 'first', configured: false }],
+			objectBucketsSecond: [{ name: 'second', configured: false }],
+			objectBucketNextCursor: 'bucket-page-2',
+			objectBucketNextFailure: 'The next bucket page failed.',
+		});
+
+		await user.click(await screen.findByRole('button', { name: 'Load more buckets' }));
+		expect(await screen.findByText('The next bucket page failed.')).toBeInTheDocument();
+		expect(screen.getByText('first')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Retry loading buckets' }));
+		expect(await screen.findByText('second')).toBeInTheDocument();
+		expect(screen.queryByText('The next bucket page failed.')).not.toBeInTheDocument();
+	});
+
 	it('explains when credentials discover no buckets', async () => {
 		setup(`/projects/${PID}/data/${IID}?surface=objects`, {
 			kind: objectKind,
@@ -641,6 +668,35 @@ describe('DataBrowserPage', () => {
 		expect(await screen.findByText('s3://lake/second.csv')).toBeInTheDocument();
 		await user.click(screen.getByRole('button', { name: 'Copy 1 selected URI' }));
 		expect(await navigator.clipboard.readText()).toBe('s3://lake/second.csv');
+	});
+
+	it('keeps history selection synchronized after toggling the current URL object', async () => {
+		const user = userEvent.setup();
+		setup(
+			[
+				`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=second.csv`,
+				`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=first.csv`,
+			],
+			{
+				kind: objectKind,
+				entry: { ...lakeEntry, kind: 's3' },
+				objectEntries: [
+					{ kind: 'object', name: 'first.csv', key: 'first.csv', size: 12 },
+					{ kind: 'object', name: 'second.csv', key: 'second.csv', size: 24 },
+				],
+			},
+		);
+
+		const first = (await screen.findByText('first.csv')).closest('button')!;
+		await user.keyboard('{Control>}');
+		await user.click(first);
+		await user.keyboard('{/Control}');
+		await user.click(screen.getByTestId('history-back'));
+		expect(await screen.findByText('s3://lake/second.csv')).toBeInTheDocument();
+		await user.click(screen.getByTestId('history-forward'));
+		expect(await screen.findByText('s3://lake/first.csv')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Copy 1 selected URI' }));
+		expect(await navigator.clipboard.readText()).toBe('s3://lake/first.csv');
 	});
 
 	it('does not carry a loaded preview into another object detail', async () => {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -54,6 +54,15 @@ function ok(data: unknown) {
 	});
 }
 
+function failed(message: string) {
+	return new Response(
+		JSON.stringify({ success: false, error: { code: 'SERVICE_UNAVAILABLE', message } }),
+		{ status: 503, headers: { 'Content-Type': 'application/json' } },
+	);
+}
+
+type ObjectFailure = 'buckets' | 'objects' | 'search' | 'detail' | 'versions' | 'preview';
+
 function makeFetch({
 	available = true,
 	pagedTables = false,
@@ -62,6 +71,27 @@ function makeFetch({
 	namespacesDown = false,
 	kind = icebergKind,
 	entry = lakeEntry,
+	objectSearch = 'bounded-key-name',
+	objectBuckets = [{ name: 'lake', configured: true }],
+	objectEntries = [
+		{ kind: 'prefix', name: 'daily/', key: 'daily/' },
+		{ kind: 'object', name: 'events.jsonl', key: 'events.jsonl', size: 12 },
+	],
+	objectEntriesSecond = [],
+	objectNextCursor = null,
+	objectDetail = {},
+	objectVersions = [],
+	notebookFailure,
+	objectPreview = {
+		kind: 'text',
+		format: 'text',
+		text: 'hello object',
+		truncated: false,
+		bytes_read: 12,
+		total_bytes: 12,
+		warnings: [],
+	},
+	objectFailures = {},
 }: {
 	available?: boolean;
 	pagedTables?: boolean;
@@ -70,13 +100,28 @@ function makeFetch({
 	namespacesDown?: boolean;
 	kind?: IntegrationKind;
 	entry?: IntegrationEntry;
+	objectSearch?: 'none' | 'bounded-key-name';
+	objectBuckets?: { name: string; configured: boolean }[];
+	objectEntries?: unknown[];
+	objectEntriesSecond?: unknown[];
+	objectNextCursor?: string | null;
+	objectDetail?: Record<string, unknown>;
+	objectVersions?: unknown[];
+	notebookFailure?: string;
+	objectPreview?: unknown;
+	objectFailures?: Partial<Record<ObjectFailure, string>>;
 } = {}) {
 	const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = String(input);
 		const method = init?.method ?? 'GET';
 		if (method === 'POST' && url.includes(`/api/v1/projects/${PID}/notebooks`)) {
+			if (notebookFailure) return failed(notebookFailure);
 			const body = JSON.parse(String(init?.body)) as { title: string };
 			return ok({ id: 'nb_1', project_id: PID, title: body.title });
+		}
+		if (method === 'POST' && url.endsWith('/browse/objects/preview')) {
+			if (objectFailures.preview) return failed(objectFailures.preview);
+			return ok(objectPreview);
 		}
 		if (method === 'POST' && url.endsWith('/browse/preview')) {
 			return ok({ columns: ['id', 'status'], rows: [[1, 'paid']] });
@@ -88,6 +133,52 @@ function makeFetch({
 		}
 		if (url.includes('/api/v1/integrations/kinds')) {
 			return ok([kind]);
+		}
+		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/objects/buckets`)) {
+			if (objectFailures.buckets) return failed(objectFailures.buckets);
+			return ok({ items: objectBuckets, next_cursor: null });
+		}
+		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/objects/head`)) {
+			if (objectFailures.detail) return failed(objectFailures.detail);
+			return ok({
+				bucket: 'lake',
+				key: target.searchParams.get('key'),
+				size: 12,
+				etag: '"etag"',
+				content_type: 'text/plain',
+				checksums: [],
+				metadata: {},
+				tags_available: false,
+				snippet: 'import polars as pl',
+				...objectDetail,
+			});
+		}
+		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/objects/versions`)) {
+			if (objectFailures.versions) return failed(objectFailures.versions);
+			return ok({ items: objectVersions, next_cursor: null });
+		}
+		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/objects/search`)) {
+			if (objectFailures.search) return failed(objectFailures.search);
+			const continuing = target.searchParams.has('cursor');
+			return ok({
+				items: [
+					{
+						kind: 'object',
+						name: continuing ? 'needle-second.jsonl' : 'needle.jsonl',
+						key: continuing ? 'needle-second.jsonl' : 'needle.jsonl',
+						size: 12,
+					},
+				],
+				next_cursor: continuing ? null : 'continue',
+				scanned: 5000,
+				complete: continuing,
+			});
+		}
+		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/objects`)) {
+			if (objectFailures.objects) return failed(objectFailures.objects);
+			return target.searchParams.has('cursor')
+				? ok({ items: objectEntriesSecond, next_cursor: null })
+				: ok({ items: objectEntries, next_cursor: objectNextCursor });
 		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/namespaces`)) {
 			if (namespacesDown) {
@@ -128,6 +219,22 @@ function makeFetch({
 			});
 		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse`)) {
+			if (kind.browse_surfaces.includes('objects')) {
+				return ok({
+					metadata: false,
+					preview: false,
+					surfaces: {
+						objects: {
+							available: true,
+							preview: true,
+							download: true,
+							search: objectSearch,
+							versions: true,
+							preview_formats: ['text'],
+						},
+					},
+				});
+			}
 			return ok({
 				...capability,
 				surfaces: {
@@ -374,13 +481,414 @@ describe('DataBrowserPage', () => {
 		expect(await screen.findByText('Data browsing is not available')).toBeInTheDocument();
 	});
 
-	it('does not advertise object-only integrations through the table browser', async () => {
+	it('dispatches object-only integrations to the object browser', async () => {
 		const fetchImpl = setup(`/projects/${PID}/data/${IID}`, {
 			kind: objectKind,
 			entry: { ...lakeEntry, kind: 's3' },
 		});
-		expect(await screen.findByText('Nothing to browse')).toBeInTheDocument();
+		expect(await screen.findByText('events.jsonl')).toBeInTheDocument();
+		expect(screen.getByText('daily/')).toBeInTheDocument();
 		expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/browse/namespaces'))).toBe(
+			false,
+		);
+		expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/browse/objects'))).toBe(
+			true,
+		);
+	});
+
+	it('selects among discovered buckets and reports empty or failed discovery', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = setup(`/projects/${PID}/data/${IID}?surface=objects`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectBuckets: [
+				{ name: 'lake', configured: false },
+				{ name: 'archive', configured: false },
+			],
+		});
+		await user.click(await screen.findByRole('button', { name: 'archive' }));
+		await waitFor(() => {
+			const listCall = fetchImpl.mock.calls.find(([url]) => {
+				const target = new URL(String(url), 'http://test');
+				return target.pathname.endsWith('/browse/objects') && target.searchParams.has('bucket');
+			});
+			expect(new URL(String(listCall?.[0]), 'http://test').searchParams.get('bucket')).toBe(
+				'archive',
+			);
+		});
+	});
+
+	it('explains when credentials discover no buckets', async () => {
+		setup(`/projects/${PID}/data/${IID}?surface=objects`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectBuckets: [],
+		});
+		expect(await screen.findByText('No buckets available')).toBeInTheDocument();
+		expect(
+			screen.getByText('The integration credentials did not return an accessible bucket.'),
+		).toBeInTheDocument();
+	});
+
+	it('shows actionable bucket and object-list failures', async () => {
+		setup(`/projects/${PID}/data/${IID}?surface=objects`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectFailures: { buckets: 'Bucket discovery failed. Check S3 permissions.' },
+		});
+		expect(
+			await screen.findByText('Bucket discovery failed. Check S3 permissions.'),
+		).toBeInTheDocument();
+
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectFailures: { objects: 'Object listing failed. Check ListBucket access.' },
+		});
+		expect(
+			await screen.findByText('Object listing failed. Check ListBucket access.'),
+		).toBeInTheDocument();
+	});
+
+	it('round-trips object selection in the URL and loads previews only on request', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = setup(
+			`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`,
+			{ kind: objectKind, entry: { ...lakeEntry, kind: 's3' } },
+		);
+		expect(await screen.findByText('s3://lake/events.jsonl')).toBeInTheDocument();
+		expect(fetchImpl.mock.calls.some(([url]) => String(url).endsWith('/objects/preview'))).toBe(
+			false,
+		);
+		await user.click(screen.getByRole('tab', { name: 'Preview' }));
+		await user.click(screen.getByRole('button', { name: 'Load preview' }));
+		expect(await screen.findByText('hello object')).toBeInTheDocument();
+	});
+
+	it('preserves URL-sensitive Unicode keys in detail and download links', async () => {
+		const key = 'reports/日本語 ?#%/events.jsonl';
+		setup(
+			`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=${encodeURIComponent(key)}`,
+			{ kind: objectKind, entry: { ...lakeEntry, kind: 's3' } },
+		);
+
+		expect(await screen.findByText(`s3://lake/${key}`)).toBeInTheDocument();
+		const download = screen.getByRole('link', { name: 'Download' });
+		const target = new URL(download.getAttribute('href')!, 'http://test');
+		expect(target.searchParams.get('bucket')).toBe('lake');
+		expect(target.searchParams.get('key')).toBe(key);
+	});
+
+	it('renders checksums and tags and selects only concrete object versions', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectDetail: {
+				checksums: [{ algorithm: 'SHA256', value: 'abc123' }],
+				metadata: { owner: 'analytics' },
+				tags_available: true,
+				tags: [{ key: 'environment', value: 'production' }],
+				last_modified: '2026-08-12T12:00:00Z',
+			},
+			objectVersions: [
+				{
+					bucket: 'lake',
+					key: 'events.jsonl',
+					version_id: 'v1',
+					kind: 'version',
+					is_latest: false,
+					last_modified: '2026-08-11T12:00:00Z',
+				},
+				{
+					bucket: 'lake',
+					key: 'events.jsonl',
+					version_id: 'deleted',
+					kind: 'delete-marker',
+					is_latest: true,
+				},
+			],
+		});
+
+		expect(await screen.findByText('abc123')).toBeInTheDocument();
+		expect(screen.getByText('analytics')).toBeInTheDocument();
+		expect(screen.getByText('production')).toBeInTheDocument();
+		await user.click(screen.getByRole('tab', { name: 'Versions' }));
+		expect(screen.getByRole('button', { name: /Delete marker/ })).toBeDisabled();
+		await user.click(screen.getByRole('button', { name: /v1/ }));
+		await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('version=v1'));
+	});
+
+	it.each([
+		[
+			'tabular',
+			{
+				kind: 'tabular',
+				format: 'csv',
+				columns: [{ name: 'name' }],
+				rows: [['first'], ['first']],
+				truncated: true,
+				warnings: ['A malformed final row was omitted.'],
+			},
+			'A malformed final row was omitted.',
+		],
+		[
+			'image',
+			{
+				kind: 'image',
+				format: 'png',
+				content_url: '/api/v1/image-content',
+				width: 32,
+				height: 16,
+				total_bytes: 100,
+				warnings: [],
+			},
+			'Object preview',
+		],
+		[
+			'unsupported',
+			{
+				kind: 'unsupported',
+				reason: 'Archives cannot be previewed safely.',
+				total_bytes: 100,
+			},
+			'Archives cannot be previewed safely.',
+		],
+	] as const)(
+		'renders an explicit %s preview and offers reload',
+		async (_kind, preview, expected) => {
+			const user = userEvent.setup();
+			setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`, {
+				kind: objectKind,
+				entry: { ...lakeEntry, kind: 's3' },
+				objectPreview: preview,
+			});
+			await user.click(await screen.findByRole('tab', { name: 'Preview' }));
+			await user.click(screen.getByRole('button', { name: 'Load preview' }));
+			if (_kind === 'image')
+				expect(await screen.findByRole('img', { name: expected })).toBeInTheDocument();
+			else expect(await screen.findByText(expected)).toBeInTheDocument();
+			expect(screen.getByRole('button', { name: 'Reload preview' })).toBeInTheDocument();
+		},
+	);
+
+	it('hides server search when the adapter does not provide it', async () => {
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&q=ignored`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectSearch: 'none',
+		});
+
+		expect(await screen.findByText('events.jsonl')).toBeInTheDocument();
+		expect(screen.queryByRole('textbox', { name: 'Search object keys' })).not.toBeInTheDocument();
+	});
+
+	it('submits bounded object search explicitly and reports partial progress', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+		});
+		await screen.findByText('events.jsonl');
+		const input = screen.getByRole('textbox', { name: 'Search object keys' });
+		await user.type(input, 'needle');
+		expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/objects/search'))).toBe(
+			false,
+		);
+		await user.click(screen.getByRole('button', { name: 'Search object keys' }));
+		expect(await screen.findByText('needle.jsonl')).toBeInTheDocument();
+		expect(screen.getByText(/matches after scanning/)).toHaveTextContent(
+			'1 matches after scanning 5000 keys; more may exist.',
+		);
+		await user.click(screen.getByRole('button', { name: 'Continue search' }));
+		await waitFor(() =>
+			expect(
+				fetchImpl.mock.calls.some(
+					([url]) =>
+						String(url).includes('/objects/search') && String(url).includes('cursor=continue'),
+				),
+			).toBe(true),
+		);
+	});
+
+	it('pages object listings through the reachable fallback button', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectNextCursor: 'p2',
+			objectEntriesSecond: [{ kind: 'object', name: 'second.csv', key: 'second.csv', size: 24 }],
+		});
+
+		await user.click(await screen.findByRole('button', { name: 'Load more' }));
+		expect(await screen.findByText('second.csv')).toBeInTheDocument();
+	});
+
+	it('multi-selects object URIs and clears selection while navigating prefixes', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectEntries: [
+				{ kind: 'prefix', name: 'daily/', key: 'daily/' },
+				{ kind: 'object', name: 'first.csv', key: 'first.csv', size: 12 },
+				{ kind: 'object', name: 'second.csv', key: 'second.csv', size: 24 },
+			],
+		});
+
+		await user.click((await screen.findByText('first.csv')).closest('button')!);
+		await user.keyboard('{Control>}');
+		await user.click(screen.getByText('second.csv').closest('button')!);
+		await user.keyboard('{/Control}');
+		const copy = screen.getByRole('button', { name: 'Copy 2 selected URIs' });
+		await user.click(copy);
+		expect(await navigator.clipboard.readText()).toBe('s3://lake/first.csv\ns3://lake/second.csv');
+
+		await user.click(screen.getByText('daily/').closest('button')!);
+		expect(screen.queryByRole('button', { name: /Copy .* selected/ })).not.toBeInTheDocument();
+		await waitFor(() =>
+			expect(screen.getByTestId('location')).toHaveTextContent('prefix=daily%2F'),
+		);
+		const row = await screen.findByText('first.csv');
+		row.closest('button')!.focus();
+		await user.keyboard('{Backspace}');
+		await waitFor(() => expect(screen.getByTestId('location')).not.toHaveTextContent('prefix='));
+	});
+
+	it('applies loaded type, size, date, and sort controls without searching', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectEntries: [
+				{
+					kind: 'object',
+					name: 'old.csv',
+					key: 'old.csv',
+					size: 100,
+					last_modified: '2026-08-10T12:00:00Z',
+				},
+				{
+					kind: 'object',
+					name: 'new.py',
+					key: 'new.py',
+					size: 2 * 1024 * 1024,
+					last_modified: '2026-08-12T12:00:00Z',
+				},
+				{ kind: 'object', name: 'large.png', key: 'large.png', size: 200 * 1024 * 1024 },
+			],
+		});
+		await screen.findByText('new.py');
+
+		await user.selectOptions(screen.getByLabelText('Type'), 'text');
+		expect(screen.getByText('new.py')).toBeInTheDocument();
+		expect(screen.queryByText('old.csv')).not.toBeInTheDocument();
+		await user.selectOptions(screen.getByLabelText('Type'), 'all');
+		await user.selectOptions(screen.getByLabelText('Size'), 'large');
+		expect(screen.getByText('large.png')).toBeInTheDocument();
+		expect(screen.queryByText('new.py')).not.toBeInTheDocument();
+		await user.selectOptions(screen.getByLabelText('Size'), 'all');
+		await user.type(screen.getByLabelText('Modified after'), '2026-08-11');
+		expect(screen.getByText('new.py')).toBeInTheDocument();
+		expect(screen.queryByText('old.csv')).not.toBeInTheDocument();
+		await user.selectOptions(screen.getByLabelText('Sort loaded results'), 'name-desc');
+		expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/objects/search'))).toBe(
+			false,
+		);
+	});
+
+	it('creates a notebook from the object-specific load snippet', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = setup(
+			`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`,
+			{ kind: objectKind, entry: { ...lakeEntry, kind: 's3' } },
+		);
+		await user.click(await screen.findByRole('button', { name: 'Open in notebook' }));
+		await waitFor(() =>
+			expect(screen.getByTestId('location')).toHaveTextContent(`/projects/${PID}/notebooks/nb_1`),
+		);
+		const post = fetchImpl.mock.calls.find(
+			([url, init]) => String(url).includes('/notebooks') && init?.method === 'POST',
+		);
+		const body = JSON.parse(String(post?.[1]?.body)) as { code: string };
+		expect(body.code).toContain('# s3://lake/events.jsonl');
+		expect(body.code).toContain('    import polars as pl');
+	});
+
+	it('preserves object selection when shared notebook creation fails', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			notebookFailure: 'Notebook creation failed.',
+		});
+		await user.click(await screen.findByRole('button', { name: 'Open in notebook' }));
+		await waitFor(() =>
+			expect(screen.getByRole('button', { name: 'Open in notebook' })).toBeEnabled(),
+		);
+		expect(screen.getByTestId('location')).toHaveTextContent('key=events.jsonl');
+		expect(screen.getByText('s3://lake/events.jsonl')).toBeInTheDocument();
+	});
+
+	it('keeps an explicit preview failure inline with a retry action', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectFailures: { preview: 'Preview failed. Try a smaller object.' },
+		});
+		await user.click(await screen.findByRole('tab', { name: 'Preview' }));
+		await user.click(screen.getByRole('button', { name: 'Load preview' }));
+		expect(
+			await screen.findByText('Preview failed. Try a smaller object.', { selector: 'p' }),
+		).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Load preview' })).toBeInTheDocument();
+	});
+
+	it('keeps an object metadata failure inside the detail pane', async () => {
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectFailures: { detail: 'Object metadata is unavailable.' },
+		});
+		expect(await screen.findByText('Object metadata is unavailable.')).toBeInTheDocument();
+	});
+
+	it('keeps an object search failure inside the listing pane', async () => {
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&q=needle`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectFailures: { search: 'Object search reached its scan limit.' },
+		});
+		expect(await screen.findByText('Object search reached its scan limit.')).toBeInTheDocument();
+	});
+
+	it('keeps an object version failure inside the versions panel', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectFailures: { versions: 'Object versions are unavailable.' },
+		});
+		await user.click(await screen.findByRole('tab', { name: 'Versions' }));
+		expect(await screen.findByText('Object versions are unavailable.')).toBeInTheDocument();
+	});
+
+	it('filters and keyboard-navigates loaded object rows without a server request', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+		});
+		const object = await screen.findByText('events.jsonl');
+		const objectButton = object.closest('button')!;
+		objectButton.focus();
+		await user.keyboard('{ArrowUp}');
+		expect(screen.getByText('daily/').closest('button')).toHaveFocus();
+
+		await user.selectOptions(screen.getByLabelText('Type'), 'text');
+		expect(screen.queryByText('events.jsonl')).not.toBeInTheDocument();
+		expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/objects/search'))).toBe(
 			false,
 		);
 	});

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -61,7 +61,14 @@ function failed(message: string) {
 	);
 }
 
-type ObjectFailure = 'buckets' | 'objects' | 'search' | 'detail' | 'versions' | 'preview';
+type ObjectFailure =
+	| 'capability'
+	| 'buckets'
+	| 'objects'
+	| 'search'
+	| 'detail'
+	| 'versions'
+	| 'preview';
 
 function makeFetch({
 	available = true,
@@ -73,6 +80,8 @@ function makeFetch({
 	entry = lakeEntry,
 	objectSearch = 'bounded-key-name',
 	objectBuckets = [{ name: 'lake', configured: true }],
+	objectBucketsSecond = [],
+	objectBucketNextCursor = null,
 	objectEntries = [
 		{ kind: 'prefix', name: 'daily/', key: 'daily/' },
 		{ kind: 'object', name: 'events.jsonl', key: 'events.jsonl', size: 12 },
@@ -82,6 +91,7 @@ function makeFetch({
 	objectDetail = {},
 	objectVersions = [],
 	notebookFailure,
+	notebookGate,
 	objectPreview = {
 		kind: 'text',
 		format: 'text',
@@ -102,12 +112,15 @@ function makeFetch({
 	entry?: IntegrationEntry;
 	objectSearch?: 'none' | 'bounded-key-name';
 	objectBuckets?: { name: string; configured: boolean }[];
+	objectBucketsSecond?: { name: string; configured: boolean }[];
+	objectBucketNextCursor?: string | null;
 	objectEntries?: unknown[];
 	objectEntriesSecond?: unknown[];
 	objectNextCursor?: string | null;
 	objectDetail?: Record<string, unknown>;
 	objectVersions?: unknown[];
 	notebookFailure?: string;
+	notebookGate?: Promise<void>;
 	objectPreview?: unknown;
 	objectFailures?: Partial<Record<ObjectFailure, string>>;
 } = {}) {
@@ -115,6 +128,7 @@ function makeFetch({
 		const url = String(input);
 		const method = init?.method ?? 'GET';
 		if (method === 'POST' && url.includes(`/api/v1/projects/${PID}/notebooks`)) {
+			await notebookGate;
 			if (notebookFailure) return failed(notebookFailure);
 			const body = JSON.parse(String(init?.body)) as { title: string };
 			return ok({ id: 'nb_1', project_id: PID, title: body.title });
@@ -136,7 +150,9 @@ function makeFetch({
 		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/objects/buckets`)) {
 			if (objectFailures.buckets) return failed(objectFailures.buckets);
-			return ok({ items: objectBuckets, next_cursor: null });
+			return target.searchParams.has('cursor')
+				? ok({ items: objectBucketsSecond, next_cursor: null })
+				: ok({ items: objectBuckets, next_cursor: objectBucketNextCursor });
 		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/objects/head`)) {
 			if (objectFailures.detail) return failed(objectFailures.detail);
@@ -219,6 +235,7 @@ function makeFetch({
 			});
 		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse`)) {
+			if (objectFailures.capability) return failed(objectFailures.capability);
 			if (kind.browse_surfaces.includes('objects')) {
 				return ok({
 					metadata: false,
@@ -273,6 +290,20 @@ function DeepLink({ to }: { to: string }) {
 	);
 }
 
+function HistoryControls() {
+	const navigate = useNavigate();
+	return (
+		<>
+			<button type="button" data-testid="history-back" onClick={() => void navigate(-1)}>
+				back
+			</button>
+			<button type="button" data-testid="history-forward" onClick={() => void navigate(1)}>
+				forward
+			</button>
+		</>
+	);
+}
+
 function setup(route: string, fetchOpts?: Parameters<typeof makeFetch>[0]) {
 	installMatchMedia();
 	const fetchImpl = makeFetch(fetchOpts);
@@ -284,6 +315,7 @@ function setup(route: string, fetchOpts?: Parameters<typeof makeFetch>[0]) {
 			</Routes>
 			<LocationProbe />
 			<DeepLink to={`/projects/${PID}/data/${IID}?ns=sales&table=orders`} />
+			<HistoryControls />
 		</>,
 		{ route },
 	);
@@ -518,6 +550,28 @@ describe('DataBrowserPage', () => {
 		});
 	});
 
+	it('pages bucket discovery before choosing a bucket', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = setup(`/projects/${PID}/data/${IID}?surface=objects`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectBuckets: [{ name: 'first', configured: false }],
+			objectBucketsSecond: [{ name: 'second', configured: false }],
+			objectBucketNextCursor: 'bucket-page-2',
+		});
+
+		expect(await screen.findByText('first')).toBeInTheDocument();
+		expect(screen.queryByText('second')).not.toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Load more buckets' }));
+		expect(await screen.findByText('second')).toBeInTheDocument();
+		expect(
+			fetchImpl.mock.calls.some(
+				([url]) =>
+					String(url).includes('/objects/buckets') && String(url).includes('cursor=bucket-page-2'),
+			),
+		).toBe(true);
+	});
+
 	it('explains when credentials discover no buckets', async () => {
 		setup(`/projects/${PID}/data/${IID}?surface=objects`, {
 			kind: objectKind,
@@ -563,6 +617,65 @@ describe('DataBrowserPage', () => {
 		await user.click(screen.getByRole('tab', { name: 'Preview' }));
 		await user.click(screen.getByRole('button', { name: 'Load preview' }));
 		expect(await screen.findByText('hello object')).toBeInTheDocument();
+	});
+
+	it('resets selection to the URL object after back and forward navigation', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=first.csv`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectEntries: [
+				{ kind: 'object', name: 'first.csv', key: 'first.csv', size: 12 },
+				{ kind: 'object', name: 'second.csv', key: 'second.csv', size: 24 },
+			],
+		});
+
+		await user.click((await screen.findByText('second.csv')).closest('button')!);
+		await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('key=second.csv'));
+		await user.click(screen.getByTestId('history-back'));
+		expect(await screen.findByText('s3://lake/first.csv')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Copy 1 selected URI' }));
+		expect(await navigator.clipboard.readText()).toBe('s3://lake/first.csv');
+
+		await user.click(screen.getByTestId('history-forward'));
+		expect(await screen.findByText('s3://lake/second.csv')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Copy 1 selected URI' }));
+		expect(await navigator.clipboard.readText()).toBe('s3://lake/second.csv');
+	});
+
+	it('does not carry a loaded preview into another object detail', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=first.csv`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectEntries: [
+				{ kind: 'object', name: 'first.csv', key: 'first.csv', size: 12 },
+				{ kind: 'object', name: 'second.csv', key: 'second.csv', size: 24 },
+			],
+		});
+
+		await user.click(await screen.findByRole('tab', { name: 'Preview' }));
+		await user.click(screen.getByRole('button', { name: 'Load preview' }));
+		expect(await screen.findByText('hello object')).toBeInTheDocument();
+		await user.click(screen.getByText('second.csv').closest('button')!);
+		await user.click(await screen.findByRole('tab', { name: 'Preview' }));
+		expect(screen.getByRole('button', { name: 'Load preview' })).toBeInTheDocument();
+		expect(screen.queryByText('hello object')).not.toBeInTheDocument();
+	});
+
+	it('reports rejected key and snippet clipboard writes', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+		});
+		await screen.findByText('s3://lake/events.jsonl');
+		const write = vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(new Error('denied'));
+
+		await user.click(screen.getByRole('button', { name: 'Copy key' }));
+		expect(await screen.findByText('Could not copy to clipboard')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Copy snippet' }));
+		expect(write).toHaveBeenCalledTimes(2);
 	});
 
 	it('preserves URL-sensitive Unicode keys in detail and download links', async () => {
@@ -741,8 +854,11 @@ describe('DataBrowserPage', () => {
 		await user.click(screen.getByText('second.csv').closest('button')!);
 		await user.keyboard('{/Control}');
 		const copy = screen.getByRole('button', { name: 'Copy 2 selected URIs' });
+		const write = vi.spyOn(navigator.clipboard, 'writeText');
 		await user.click(copy);
-		expect(await navigator.clipboard.readText()).toBe('s3://lake/first.csv\ns3://lake/second.csv');
+		await waitFor(() =>
+			expect(write).toHaveBeenCalledWith('s3://lake/first.csv\ns3://lake/second.csv'),
+		);
 
 		await user.click(screen.getByText('daily/').closest('button')!);
 		expect(screen.queryByRole('button', { name: /Copy .* selected/ })).not.toBeInTheDocument();
@@ -813,6 +929,36 @@ describe('DataBrowserPage', () => {
 		const body = JSON.parse(String(post?.[1]?.body)) as { code: string };
 		expect(body.code).toContain('# s3://lake/events.jsonl');
 		expect(body.code).toContain('    import polars as pl');
+	});
+
+	it('disables object notebook creation while the request is pending', async () => {
+		const user = userEvent.setup();
+		let releaseNotebook!: () => void;
+		const notebookGate = new Promise<void>((resolve) => {
+			releaseNotebook = resolve;
+		});
+		const fetchImpl = setup(
+			`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`,
+			{
+				kind: objectKind,
+				entry: { ...lakeEntry, kind: 's3' },
+				notebookGate,
+			},
+		);
+
+		await user.click(await screen.findByRole('button', { name: 'Open in notebook' }));
+		const pending = await screen.findByRole('button', { name: 'Creating notebook…' });
+		expect(pending).toBeDisabled();
+		await user.click(pending);
+		expect(
+			fetchImpl.mock.calls.filter(
+				([url, init]) => String(url).includes('/notebooks') && init?.method === 'POST',
+			),
+		).toHaveLength(1);
+		releaseNotebook();
+		await waitFor(() =>
+			expect(screen.getByTestId('location')).toHaveTextContent(`/projects/${PID}/notebooks/nb_1`),
+		);
 	});
 
 	it('preserves object selection when shared notebook creation fails', async () => {
@@ -900,6 +1046,17 @@ describe('DataBrowserPage', () => {
 
 		expect(await screen.findByText('sandbox only')).toBeInTheDocument();
 		expect(screen.queryByTestId('browse-namespace')).not.toBeInTheDocument();
+	});
+
+	it('shows an object capability request failure instead of a perpetual loading message', async () => {
+		setup(`/projects/${PID}/data/${IID}?surface=objects`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectFailures: { capability: 'S3 capability check failed.' },
+		});
+
+		expect(await screen.findByText('S3 capability check failed.')).toBeInTheDocument();
+		expect(screen.queryByText('Checking object-store access…')).not.toBeInTheDocument();
 	});
 
 	it('shows the upstream error inline when a listing fails', async () => {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -611,6 +611,24 @@ describe('DataBrowserPage', () => {
 		).toBeInTheDocument();
 	});
 
+	it('shows a refetch failure instead of a cached empty bucket state', async () => {
+		const user = userEvent.setup();
+		const objectFailures: Partial<Record<ObjectFailure, string>> = {};
+		setup(`/projects/${PID}/data/${IID}?surface=objects`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectBuckets: [],
+			objectFailures,
+		});
+		expect(await screen.findByText('No buckets available')).toBeInTheDocument();
+
+		objectFailures.buckets = 'Bucket refresh failed.';
+		await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+		expect(await screen.findByText('Bucket refresh failed.')).toBeInTheDocument();
+		expect(screen.queryByText('No buckets available')).not.toBeInTheDocument();
+	});
+
 	it('shows actionable bucket and object-list failures', async () => {
 		setup(`/projects/${PID}/data/${IID}?surface=objects`, {
 			kind: objectKind,
@@ -670,7 +688,7 @@ describe('DataBrowserPage', () => {
 		expect(await navigator.clipboard.readText()).toBe('s3://lake/second.csv');
 	});
 
-	it('keeps history selection synchronized after toggling the current URL object', async () => {
+	it('resets a multi-selection when revisiting its URL through history', async () => {
 		const user = userEvent.setup();
 		setup(
 			[
@@ -687,16 +705,34 @@ describe('DataBrowserPage', () => {
 			},
 		);
 
-		const first = (await screen.findByText('first.csv')).closest('button')!;
+		await screen.findByRole('button', { name: /^first\.csv/ });
+		const second = screen.getByRole('button', { name: /^second\.csv/ });
 		await user.keyboard('{Control>}');
-		await user.click(first);
+		await user.click(second);
 		await user.keyboard('{/Control}');
+		expect(screen.getByRole('button', { name: 'Copy 2 selected URIs' })).toBeInTheDocument();
 		await user.click(screen.getByTestId('history-back'));
-		expect(await screen.findByText('s3://lake/second.csv')).toBeInTheDocument();
-		await user.click(screen.getByTestId('history-forward'));
 		expect(await screen.findByText('s3://lake/first.csv')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /^first\.csv/ })).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		);
+		expect(screen.getByRole('button', { name: /^second\.csv/ })).toHaveAttribute(
+			'aria-pressed',
+			'false',
+		);
+		await user.click(screen.getByTestId('history-forward'));
+		expect(await screen.findByText('s3://lake/second.csv')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /^first\.csv/ })).toHaveAttribute(
+			'aria-pressed',
+			'false',
+		);
+		expect(screen.getByRole('button', { name: /^second\.csv/ })).toHaveAttribute(
+			'aria-pressed',
+			'true',
+		);
 		await user.click(screen.getByRole('button', { name: 'Copy 1 selected URI' }));
-		expect(await navigator.clipboard.readText()).toBe('s3://lake/first.csv');
+		expect(await navigator.clipboard.readText()).toBe('s3://lake/second.csv');
 	});
 
 	it('does not carry a loaded preview into another object detail', async () => {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -46,6 +46,7 @@ import {
 	tableBrowseCapability,
 } from '@/lib/integrationBrowse';
 import { formatRelative } from '@/lib/time';
+import { errorMessage } from '@/lib/errors';
 import { cn } from '@/lib/utils';
 import type { IntegrationEntry, IntegrationKind } from '@/types';
 import { useSeededNotebook } from './notebookSeed';
@@ -325,7 +326,11 @@ export default function DataBrowserPage() {
 								<EmptyState
 									icon={<Folder />}
 									message="Object browsing unavailable"
-									description={selectedObjectCapability?.reason ?? 'Checking object-store access…'}
+									description={
+										selectedCapability.error
+											? errorMessage(selectedCapability.error)
+											: (selectedObjectCapability?.reason ?? 'Checking object-store access…')
+									}
 								/>
 							)
 						) : selected && selection ? (

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
-import { toast } from 'sonner';
 import {
 	ArrowLeft,
 	Check,
@@ -34,17 +33,24 @@ import {
 	useBrowseTablePreview,
 	useBrowseTablesQuery,
 	useCapabilitiesQuery,
-	useCreateNotebook,
 	useIntegrationKindsQuery,
 	useIntegrationsQuery,
 	useProjectQuery,
 } from '@/api/hooks';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { BRAND_ICONS } from '@/components/Project/brandIcons';
-import { supportsTableBrowse, tableBrowseCapability } from '@/lib/integrationBrowse';
+import {
+	objectBrowseCapability,
+	supportsObjectBrowse,
+	supportsTableBrowse,
+	tableBrowseCapability,
+} from '@/lib/integrationBrowse';
 import { formatRelative } from '@/lib/time';
 import { cn } from '@/lib/utils';
 import type { IntegrationEntry, IntegrationKind } from '@/types';
+import { useSeededNotebook } from './notebookSeed';
+import { ObjectBrowser } from './ObjectBrowser';
+import { TabularPreviewGrid } from './TabularPreviewGrid';
 
 /** Namespace parts join with U+001F in the `ns` query param, so dots round-trip. */
 const NS_JOIN = '\u001f';
@@ -85,42 +91,6 @@ function expandedWithAncestry(
 	return next;
 }
 
-/** A marimo notebook seeded with the table's load snippet as its data cell. */
-function seededNotebookCode(heading: string, snippet: string): string {
-	const cellBody = snippet
-		.split('\n')
-		.map((line) => (line === '' ? '' : `    ${line}`))
-		.join('\n');
-	return [
-		'import marimo',
-		'',
-		'app = marimo.App(width="medium", sql_output="native")',
-		'',
-		'',
-		'@app.cell',
-		'def _():',
-		'    import marimo as mo',
-		'    return (mo,)',
-		'',
-		'',
-		'@app.cell(hide_code=True)',
-		'def _(mo):',
-		`    mo.md(${JSON.stringify(`# ${heading}`)})`,
-		'    return',
-		'',
-		'',
-		'@app.cell',
-		'def _():',
-		cellBody,
-		'    return',
-		'',
-		'',
-		'if __name__ == "__main__":',
-		'    app.run()',
-		'',
-	].join('\n');
-}
-
 /**
  * Full-page, deep-linkable browser over the project's integrations:
  * `/projects/:pid/data/:iid?ns=…&table=…&q=…`. The tree is lazy and paged;
@@ -145,7 +115,10 @@ export default function DataBrowserPage() {
 		() =>
 			(entries ?? []).filter(
 				(entry) =>
-					entry.enabled && !entry.shadowed && supportsTableBrowse(kindsByName.get(entry.kind)),
+					entry.enabled &&
+					!entry.shadowed &&
+					(supportsTableBrowse(kindsByName.get(entry.kind)) ||
+						supportsObjectBrowse(kindsByName.get(entry.kind))),
 			),
 		[entries, kindsByName],
 	);
@@ -203,9 +176,11 @@ export default function DataBrowserPage() {
 		});
 	};
 
-	const selectIntegration = (id: string) => {
+	const selectIntegration = (entry: IntegrationEntry) => {
 		// A different integration means a different tree; selection does not carry.
-		void navigate(`/projects/${pid}/data/${id}${query ? `?q=${encodeURIComponent(query)}` : ''}`);
+		const kind = kindsByName.get(entry.kind);
+		const surface = supportsTableBrowse(kind) ? 'tables' : 'objects';
+		void navigate(`/projects/${pid}/data/${entry.id}?surface=${surface}`);
 	};
 
 	const refresh = async () => {
@@ -218,8 +193,32 @@ export default function DataBrowserPage() {
 	};
 
 	const selected = browsable.find((entry) => entry.id === iid);
+	const selectedKind = selected ? kindsByName.get(selected.kind) : undefined;
+	const requestedSurface = searchParams.get('surface');
+	const selectedSurface =
+		requestedSurface === 'objects' && supportsObjectBrowse(selectedKind)
+			? 'objects'
+			: supportsTableBrowse(selectedKind)
+				? 'tables'
+				: supportsObjectBrowse(selectedKind)
+					? 'objects'
+					: undefined;
 	const selectedCapability = useBrowseCapabilityQuery(pid!, iid ?? '', selected !== undefined);
 	const selectedTableCapability = tableBrowseCapability(selectedCapability.data);
+	const selectedObjectCapability = objectBrowseCapability(selectedCapability.data);
+	const selectSurface = (surface: 'tables' | 'objects') => {
+		setSearchParams((current) => {
+			const next = new URLSearchParams(current);
+			next.set('surface', surface);
+			for (const name of surface === 'objects'
+				? ['ns', 'table']
+				: ['bucket', 'prefix', 'key', 'version']) {
+				next.delete(name);
+			}
+			next.delete('q');
+			return next;
+		});
+	};
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-6 max-md:overflow-y-auto max-md:p-3">
@@ -245,6 +244,24 @@ export default function DataBrowserPage() {
 					</Button>
 				)}
 			</div>
+			{selectedKind && supportsTableBrowse(selectedKind) && supportsObjectBrowse(selectedKind) && (
+				<div className="flex w-fit rounded-md border border-input p-1" aria-label="Browse surface">
+					<Button
+						size="sm"
+						variant={selectedSurface === 'tables' ? 'primary' : 'ghost'}
+						onPress={() => selectSurface('tables')}
+					>
+						Tables
+					</Button>
+					<Button
+						size="sm"
+						variant={selectedSurface === 'objects' ? 'primary' : 'ghost'}
+						onPress={() => selectSurface('objects')}
+					>
+						Objects
+					</Button>
+				</div>
+			)}
 
 			{!available ? (
 				<EmptyState
@@ -261,12 +278,14 @@ export default function DataBrowserPage() {
 			) : (
 				<div className="grid min-h-0 flex-1 grid-cols-[minmax(18rem,1fr)_minmax(0,2fr)] gap-4 text-sm max-lg:grid-cols-1 max-lg:overflow-y-auto">
 					<div className="flex min-h-0 flex-col gap-2 overflow-hidden rounded-xl border bg-card p-3 max-lg:max-h-[50vh]">
-						<SearchField
-							aria-label="Filter tables"
-							placeholder="Filter tables..."
-							value={query}
-							onChange={setQuery}
-						/>
+						{selectedSurface !== 'objects' && (
+							<SearchField
+								aria-label="Filter tables"
+								placeholder="Filter tables..."
+								value={query}
+								onChange={setQuery}
+							/>
+						)}
 						<div className="min-h-0 flex-1 overflow-y-auto">
 							{browsable.map((entry) => (
 								<IntegrationSection
@@ -275,18 +294,41 @@ export default function DataBrowserPage() {
 									entry={entry}
 									kind={kindsByName.get(entry.kind)}
 									active={entry.id === iid}
+									showTree={entry.id === iid && selectedSurface === 'tables'}
 									query={query}
 									selection={entry.id === iid ? selection : null}
 									isExpanded={isExpanded}
 									toggleExpanded={toggleExpanded}
-									onActivate={() => selectIntegration(entry.id)}
+									onActivate={() => selectIntegration(entry)}
 									onSelectTable={selectTable}
 								/>
 							))}
 						</div>
 					</div>
-					<div className="min-h-0 overflow-y-auto rounded-xl border bg-card p-4">
-						{selected && selection ? (
+					<div
+						className={cn(
+							'min-h-0',
+							selectedSurface !== 'objects' && 'overflow-y-auto rounded-xl border bg-card p-4',
+						)}
+					>
+						{selected && selectedSurface === 'objects' ? (
+							selectedObjectCapability?.available ? (
+								<ObjectBrowser
+									projectId={pid!}
+									integration={selected}
+									previewAvailable={selectedObjectCapability.preview}
+									downloadAvailable={selectedObjectCapability.download}
+									searchAvailable={selectedObjectCapability.search === 'bounded-key-name'}
+									versionsAvailable={selectedObjectCapability.versions}
+								/>
+							) : (
+								<EmptyState
+									icon={<Folder />}
+									message="Object browsing unavailable"
+									description={selectedObjectCapability?.reason ?? 'Checking object-store access…'}
+								/>
+							)
+						) : selected && selection ? (
 							<TableDetail
 								// Remount per table so per-table state (the column filter)
 								// never carries over and blanks the next table's columns.
@@ -323,6 +365,7 @@ function IntegrationSection({
 	entry,
 	kind,
 	active,
+	showTree,
 	onActivate,
 	...handlers
 }: {
@@ -330,6 +373,7 @@ function IntegrationSection({
 	entry: IntegrationEntry;
 	kind: IntegrationKind | undefined;
 	active: boolean;
+	showTree: boolean;
 	onActivate: () => void;
 } & TreeHandlers) {
 	const capability = useBrowseCapabilityQuery(projectId, entry.id, active);
@@ -360,6 +404,7 @@ function IntegrationSection({
 				</span>
 			</button>
 			{active &&
+				showTree &&
 				(capability.data === undefined ? (
 					<LoadState depth={1} error={capability.error ?? undefined} />
 				) : tables?.available ? (
@@ -597,25 +642,19 @@ function TableDetail({
 	);
 	const { copied, copy } = useCopyToClipboard();
 	const [columnFilter, setColumnFilter] = useState('');
-	const createNotebook = useCreateNotebook(projectId);
-	const navigate = useNavigate();
+	const seededNotebook = useSeededNotebook(projectId);
 	const qualifiedName = [...selection.namespace, selection.table].join('.');
 
 	const openInNotebook = async () => {
 		const snippet = schema.data?.snippet;
 		if (!snippet) return;
 		const title = `explore_${selection.table}`;
-		try {
-			const created = await createNotebook.mutateAsync({
-				title,
-				description: `Explore ${qualifiedName} via the ${integration.name} integration`,
-				code: seededNotebookCode(qualifiedName, snippet),
-			});
-			toast.success(`Created "${title}"`);
-			void navigate(`/projects/${projectId}/notebooks/${created.id}`, { state: { title } });
-		} catch {
-			// Keep the page state; the global mutation handler reports the error.
-		}
+		await seededNotebook.create({
+			title,
+			heading: qualifiedName,
+			description: `Explore ${qualifiedName} via the ${integration.name} integration`,
+			snippet,
+		});
 	};
 
 	if (schema.data === undefined) {
@@ -698,10 +737,10 @@ function TableDetail({
 					<Button
 						variant="primary"
 						onPress={() => void openInNotebook()}
-						isDisabled={createNotebook.isPending}
+						isDisabled={seededNotebook.isPending}
 					>
 						<NotebookPen className="size-4" />
-						{createNotebook.isPending ? 'Creating…' : 'Open in notebook'}
+						{seededNotebook.isPending ? 'Creating…' : 'Open in notebook'}
 					</Button>
 				)}
 			</div>
@@ -839,65 +878,14 @@ function TableDetailTabs({
 						{preview.error instanceof Error ? preview.error.message : 'Request failed'}
 					</p>
 				)}
-				{preview.data && <PreviewTable data={preview.data} />}
+				{preview.data && (
+					<TabularPreviewGrid
+						columns={preview.data.columns}
+						rows={preview.data.rows}
+						emptyMessage="This table returned no rows."
+					/>
+				)}
 			</TabPanel>
 		</Tabs>
 	);
-}
-
-function PreviewTable({ data }: { data: { columns: string[]; rows: unknown[][] } }) {
-	if (data.rows.length === 0) {
-		return <p className="text-xs text-muted-foreground">This table returned no rows.</p>;
-	}
-	return (
-		<div className="overflow-x-auto rounded-md border border-input">
-			<table className="w-full whitespace-nowrap text-left text-xs">
-				<thead className="bg-muted/40">
-					<tr>
-						{data.columns.map((column) => (
-							<th key={column} className="px-3 py-2 font-medium">
-								{column}
-							</th>
-						))}
-					</tr>
-				</thead>
-				<tbody>
-					{keyedRows(data.rows).map(({ key, row }) => (
-						<tr key={key} className="border-t border-input/50">
-							{data.columns.map((column, columnIndex) => (
-								<td
-									key={column}
-									className="max-w-80 truncate px-3 py-2 font-mono"
-									title={renderCell(row[columnIndex])}
-								>
-									{renderCell(row[columnIndex])}
-								</td>
-							))}
-						</tr>
-					))}
-				</tbody>
-			</table>
-		</div>
-	);
-}
-
-function keyedRows(rows: unknown[][]): { key: string; row: unknown[] }[] {
-	const counts = new Map<string, number>();
-	return rows.map((row) => {
-		const base = JSON.stringify(row) ?? '[unserializable]';
-		const occurrence = counts.get(base) ?? 0;
-		counts.set(base, occurrence + 1);
-		return { key: `${base}:${occurrence}`, row };
-	});
-}
-
-function renderCell(value: unknown): string {
-	if (value === null) return 'null';
-	if (typeof value === 'string') return value;
-	if (typeof value === 'number' || typeof value === 'boolean') return String(value);
-	try {
-		return JSON.stringify(value) ?? '';
-	} catch {
-		return '[unserializable]';
-	}
 }

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -63,6 +63,13 @@ export function ObjectBrowser({
 	const selectionLocation = objectSelectionLocation(bucket, prefix, key);
 	const selectedKeys =
 		selection.location === selectionLocation ? selection.keys : new Set(key ? [key] : []);
+	useEffect(() => {
+		setSelection((current) =>
+			current.location === selectionLocation
+				? current
+				: { location: selectionLocation, keys: new Set(key ? [key] : []) },
+		);
+	}, [key, selectionLocation]);
 	const listing = useObjectsQuery(
 		projectId,
 		integration.id,
@@ -189,7 +196,7 @@ export function ObjectBrowser({
 							) : (
 								<Skeleton className="h-9 w-full" />
 							)
-						) : bucketItems.length === 0 && !buckets.hasNextPage ? (
+						) : !buckets.error && bucketItems.length === 0 && !buckets.hasNextPage ? (
 							<EmptyState
 								icon={<Folder />}
 								message="No buckets available"

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
@@ -15,6 +15,7 @@ import {
 } from '@/api/hooks';
 import { Button, Chip, EmptyState, IconButton, Skeleton, TextField } from '@/components/ui';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { errorMessage } from '@/lib/errors';
 import { cn } from '@/lib/utils';
 import type { IntegrationEntry, IntegrationObjectEntry, IntegrationObjectPreview } from '@/types';
 import { useSeededNotebook } from './notebookSeed';
@@ -49,12 +50,31 @@ export function ObjectBrowser({
 	const [sizeFilter, setSizeFilter] = useState('all');
 	const [modifiedAfter, setModifiedAfter] = useState('');
 	const [sort, setSort] = useState('name-asc');
-	const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+	const [selection, setSelection] = useState(() => ({
+		location: objectSelectionLocation(bucketParam, prefix, key),
+		keys: new Set(key ? [key] : []),
+	}));
+	const pendingSelectionLocation = useRef<string | undefined>(undefined);
 	const [searchDraft, setSearchDraft] = useState(searchQuery);
 	useEffect(() => setSearchDraft(searchQuery), [searchQuery]);
 	const buckets = useObjectBucketsQuery(projectId, integration.id);
 	const bucketItems = buckets.data?.pages.flatMap((page) => page.items) ?? [];
-	const bucket = bucketParam || (bucketItems.length === 1 ? bucketItems[0].name : '');
+	const bucket =
+		bucketParam || (bucketItems.length === 1 && !buckets.hasNextPage ? bucketItems[0].name : '');
+	const selectionLocation = objectSelectionLocation(bucket, prefix, key);
+	const selectedKeys =
+		selection.location === selectionLocation ? selection.keys : new Set(key ? [key] : []);
+	useEffect(() => {
+		if (pendingSelectionLocation.current === selectionLocation) {
+			pendingSelectionLocation.current = undefined;
+			return;
+		}
+		setSelection((current) =>
+			current.location === selectionLocation
+				? current
+				: { location: selectionLocation, keys: new Set(key ? [key] : []) },
+		);
+	}, [key, selectionLocation]);
 	const listing = useObjectsQuery(
 		projectId,
 		integration.id,
@@ -110,11 +130,15 @@ export function ObjectBrowser({
 		});
 	};
 	const selectBucket = (value: string) => {
-		setSelectedKeys(new Set());
+		const location = objectSelectionLocation(value, '', '');
+		pendingSelectionLocation.current = location;
+		setSelection({ location, keys: new Set() });
 		update({ bucket: value, prefix: undefined, key: undefined, version: undefined, q: undefined });
 	};
 	const selectPrefix = (value: string) => {
-		setSelectedKeys(new Set());
+		const location = objectSelectionLocation(bucket, value, '');
+		pendingSelectionLocation.current = location;
+		setSelection({ location, keys: new Set() });
 		setSearchDraft('');
 		update({ prefix: value, key: undefined, version: undefined, q: undefined });
 	};
@@ -122,12 +146,18 @@ export function ObjectBrowser({
 		if (entry.kind === 'prefix') {
 			selectPrefix(entry.key);
 		} else {
-			setSelectedKeys((current) => {
-				if (!(event?.metaKey || event?.ctrlKey)) return new Set([entry.key]);
-				const next = new Set(current);
+			const location = objectSelectionLocation(bucket, prefix, entry.key);
+			pendingSelectionLocation.current = location;
+			setSelection((current) => {
+				if (!(event?.metaKey || event?.ctrlKey)) {
+					return { location, keys: new Set([entry.key]) };
+				}
+				const next = new Set(
+					current.location === selectionLocation ? current.keys : key ? [key] : [],
+				);
 				if (next.has(entry.key)) next.delete(entry.key);
 				else next.add(entry.key);
-				return next;
+				return { location, keys: next };
 			});
 			update({ key: entry.key, version: undefined });
 		}
@@ -135,12 +165,12 @@ export function ObjectBrowser({
 	const parentPrefix = prefix ? prefix.replace(/[^/]+\/$/, '') : '';
 	const searchSummary = search.data?.pages.at(-1);
 	const listError = activeSearchQuery ? search.error : listing.error;
+	const { copy: copySelection } = useCopyToClipboard();
 	const copySelectedUris = () => {
 		const keys = selectedKeys.size > 0 ? [...selectedKeys] : key ? [key] : [];
-		void navigator.clipboard
-			.writeText(keys.map((value) => `s3://${bucket}/${value}`).join('\n'))
-			.then(() => toast.success(`Copied ${keys.length} object URI${keys.length === 1 ? '' : 's'}`))
-			.catch(() => toast.error('Could not copy object URIs'));
+		void copySelection(keys.map((value) => `s3://${bucket}/${value}`).join('\n')).then((copied) => {
+			if (copied) toast.success(`Copied ${keys.length} object URI${keys.length === 1 ? '' : 's'}`);
+		});
 	};
 	const handleListKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
 		if (event.key === 'Backspace' && prefix) {
@@ -179,18 +209,29 @@ export function ObjectBrowser({
 								description="The integration credentials did not return an accessible bucket."
 							/>
 						) : (
-							bucketItems.map((item) => (
-								<button
-									key={item.name}
-									type="button"
-									onClick={() => selectBucket(item.name)}
-									className="flex w-full touch-manipulation items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-md:min-h-11"
-								>
-									<Folder className="size-4" aria-hidden />
-									<span className="truncate">{item.name}</span>
-									{item.configured && <Chip className="ml-auto">configured</Chip>}
-								</button>
-							))
+							<>
+								{bucketItems.map((item) => (
+									<button
+										key={item.name}
+										type="button"
+										onClick={() => selectBucket(item.name)}
+										className="flex w-full touch-manipulation items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-md:min-h-11"
+									>
+										<Folder className="size-4" aria-hidden />
+										<span className="truncate">{item.name}</span>
+										{item.configured && <Chip className="ml-auto">configured</Chip>}
+									</button>
+								))}
+								{buckets.hasNextPage && (
+									<Button
+										className="mt-2 w-full"
+										isDisabled={buckets.isFetchingNextPage}
+										onPress={() => void buckets.fetchNextPage()}
+									>
+										{buckets.isFetchingNextPage ? 'Loading buckets…' : 'Load more buckets'}
+									</Button>
+								)}
+							</>
 						)}
 					</div>
 				) : (
@@ -388,6 +429,7 @@ export function ObjectBrowser({
 			<section className="min-h-0 overflow-y-auto rounded-xl border bg-card p-4">
 				{bucket && key ? (
 					<ObjectDetail
+						key={JSON.stringify([bucket, key, versionId ?? null])}
 						projectId={projectId}
 						integration={integration}
 						bucket={bucket}
@@ -440,7 +482,6 @@ function ObjectDetail({
 		versionsAvailable,
 	);
 	const preview = useObjectPreview(projectId, integration.id);
-	const { copied, copy } = useCopyToClipboard();
 	const seededNotebook = useSeededNotebook(projectId);
 	if (!detail.data) {
 		return detail.error ? (
@@ -485,37 +526,13 @@ function ObjectDetail({
 					</p>
 				</div>
 				<div className="flex flex-wrap gap-2">
-					<IconButton
-						label={copied ? 'Copied URI' : 'Copy URI'}
-						tooltip="Copy URI"
-						onPress={() => void copy(uri)}
-					>
-						{copied ? (
-							<Check className="size-4" aria-hidden />
-						) : (
-							<Copy className="size-4" aria-hidden />
-						)}
-					</IconButton>
-					<IconButton
-						label="Copy key"
-						tooltip="Copy key"
-						onPress={() => void navigator.clipboard.writeText(objectKey)}
-					>
-						<Copy className="size-4" aria-hidden />
-					</IconButton>
+					<CopyIconButton label="URI" value={uri} />
+					<CopyIconButton label="key" value={objectKey} />
+					{detail.data.snippet && <CopyIconButton label="snippet" value={detail.data.snippet} />}
 					{detail.data.snippet && (
-						<IconButton
-							label="Copy snippet"
-							tooltip="Copy snippet"
-							onPress={() => void navigator.clipboard.writeText(detail.data.snippet ?? '')}
-						>
-							<Copy className="size-4" aria-hidden />
-						</IconButton>
-					)}
-					{detail.data.snippet && (
-						<Button onPress={() => void openInNotebook()}>
+						<Button isDisabled={seededNotebook.isPending} onPress={() => void openInNotebook()}>
 							<NotebookPen className="size-4" aria-hidden />
-							Open in notebook
+							{seededNotebook.isPending ? 'Creating notebook…' : 'Open in notebook'}
 						</Button>
 					)}
 					{downloadAvailable && (
@@ -807,14 +824,27 @@ function ObjectFilterSelect({
 	);
 }
 
+function CopyIconButton({ label, value }: { label: string; value: string }) {
+	const { copied, copy } = useCopyToClipboard();
+	return (
+		<IconButton
+			label={`${copied ? 'Copied' : 'Copy'} ${label}`}
+			tooltip={`Copy ${label}`}
+			onPress={() => void copy(value)}
+		>
+			{copied ? <Check className="size-4" aria-hidden /> : <Copy className="size-4" aria-hidden />}
+		</IconButton>
+	);
+}
+
 function safeNotebookTitle(key: string): string {
 	return (
 		(key.split('/').at(-1) ?? 'object').replaceAll(/[^a-zA-Z0-9_-]+/g, '_').slice(0, 48) || 'object'
 	);
 }
 
-function errorMessage(error: unknown): string {
-	return error instanceof Error ? error.message : 'The object-store request failed.';
+function objectSelectionLocation(bucket: string, prefix: string, key: string): string {
+	return JSON.stringify([bucket, prefix, key]);
 }
 
 const tabClass =

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
@@ -54,7 +54,6 @@ export function ObjectBrowser({
 		location: objectSelectionLocation(bucketParam, prefix, key),
 		keys: new Set(key ? [key] : []),
 	}));
-	const pendingSelectionLocation = useRef<string | undefined>(undefined);
 	const [searchDraft, setSearchDraft] = useState(searchQuery);
 	useEffect(() => setSearchDraft(searchQuery), [searchQuery]);
 	const buckets = useObjectBucketsQuery(projectId, integration.id);
@@ -64,17 +63,6 @@ export function ObjectBrowser({
 	const selectionLocation = objectSelectionLocation(bucket, prefix, key);
 	const selectedKeys =
 		selection.location === selectionLocation ? selection.keys : new Set(key ? [key] : []);
-	useEffect(() => {
-		if (pendingSelectionLocation.current === selectionLocation) {
-			pendingSelectionLocation.current = undefined;
-			return;
-		}
-		setSelection((current) =>
-			current.location === selectionLocation
-				? current
-				: { location: selectionLocation, keys: new Set(key ? [key] : []) },
-		);
-	}, [key, selectionLocation]);
 	const listing = useObjectsQuery(
 		projectId,
 		integration.id,
@@ -131,13 +119,11 @@ export function ObjectBrowser({
 	};
 	const selectBucket = (value: string) => {
 		const location = objectSelectionLocation(value, '', '');
-		pendingSelectionLocation.current = location;
 		setSelection({ location, keys: new Set() });
 		update({ bucket: value, prefix: undefined, key: undefined, version: undefined, q: undefined });
 	};
 	const selectPrefix = (value: string) => {
 		const location = objectSelectionLocation(bucket, value, '');
-		pendingSelectionLocation.current = location;
 		setSelection({ location, keys: new Set() });
 		setSearchDraft('');
 		update({ prefix: value, key: undefined, version: undefined, q: undefined });
@@ -147,7 +133,6 @@ export function ObjectBrowser({
 			selectPrefix(entry.key);
 		} else {
 			const location = objectSelectionLocation(bucket, prefix, entry.key);
-			pendingSelectionLocation.current = location;
 			setSelection((current) => {
 				if (!(event?.metaKey || event?.ctrlKey)) {
 					return { location, keys: new Set([entry.key]) };
@@ -198,11 +183,13 @@ export function ObjectBrowser({
 				{bucket === '' ? (
 					<div className="min-h-0 overflow-y-auto">
 						<p className="mb-2 text-xs font-medium text-muted-foreground">Buckets</p>
-						{buckets.error ? (
-							<p className="p-3 text-sm text-destructive">{errorMessage(buckets.error)}</p>
-						) : buckets.data === undefined ? (
-							<Skeleton className="h-9 w-full" />
-						) : bucketItems.length === 0 ? (
+						{buckets.data === undefined ? (
+							buckets.error ? (
+								<p className="p-3 text-sm text-destructive">{errorMessage(buckets.error)}</p>
+							) : (
+								<Skeleton className="h-9 w-full" />
+							)
+						) : bucketItems.length === 0 && !buckets.hasNextPage ? (
 							<EmptyState
 								icon={<Folder />}
 								message="No buckets available"
@@ -222,13 +209,20 @@ export function ObjectBrowser({
 										{item.configured && <Chip className="ml-auto">configured</Chip>}
 									</button>
 								))}
+								{buckets.error && (
+									<p className="p-3 text-sm text-destructive">{errorMessage(buckets.error)}</p>
+								)}
 								{buckets.hasNextPage && (
 									<Button
 										className="mt-2 w-full"
 										isDisabled={buckets.isFetchingNextPage}
 										onPress={() => void buckets.fetchNextPage()}
 									>
-										{buckets.isFetchingNextPage ? 'Loading buckets…' : 'Load more buckets'}
+										{buckets.isFetchingNextPage
+											? 'Loading buckets…'
+											: buckets.error
+												? 'Retry loading buckets'
+												: 'Load more buckets'}
 									</Button>
 								)}
 							</>

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -1,0 +1,821 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
+import { toast } from 'sonner';
+import { ArrowUp, Check, Copy, Download, File, Folder, NotebookPen, Search } from 'lucide-react';
+import {
+	objectContentUrl,
+	useObjectBucketsQuery,
+	useObjectDetailQuery,
+	useObjectPreview,
+	useObjectSearchQuery,
+	useObjectsQuery,
+	useObjectVersionsQuery,
+} from '@/api/hooks';
+import { Button, Chip, EmptyState, IconButton, Skeleton, TextField } from '@/components/ui';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { cn } from '@/lib/utils';
+import type { IntegrationEntry, IntegrationObjectEntry, IntegrationObjectPreview } from '@/types';
+import { useSeededNotebook } from './notebookSeed';
+import { TabularPreviewGrid } from './TabularPreviewGrid';
+
+interface ObjectBrowserProps {
+	projectId: string;
+	integration: IntegrationEntry;
+	previewAvailable: boolean;
+	downloadAvailable: boolean;
+	searchAvailable: boolean;
+	versionsAvailable: boolean;
+}
+
+export function ObjectBrowser({
+	projectId,
+	integration,
+	previewAvailable,
+	downloadAvailable,
+	searchAvailable,
+	versionsAvailable,
+}: ObjectBrowserProps) {
+	const [params, setParams] = useSearchParams();
+	const bucketParam = params.get('bucket') ?? '';
+	const prefix = params.get('prefix') ?? '';
+	const key = params.get('key') ?? '';
+	const versionId = params.get('version') ?? undefined;
+	const searchQuery = params.get('q') ?? '';
+	const activeSearchQuery = searchAvailable ? searchQuery : '';
+	const [filter, setFilter] = useState('');
+	const [formatFilter, setFormatFilter] = useState('all');
+	const [sizeFilter, setSizeFilter] = useState('all');
+	const [modifiedAfter, setModifiedAfter] = useState('');
+	const [sort, setSort] = useState('name-asc');
+	const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+	const [searchDraft, setSearchDraft] = useState(searchQuery);
+	useEffect(() => setSearchDraft(searchQuery), [searchQuery]);
+	const buckets = useObjectBucketsQuery(projectId, integration.id);
+	const bucketItems = buckets.data?.pages.flatMap((page) => page.items) ?? [];
+	const bucket = bucketParam || (bucketItems.length === 1 ? bucketItems[0].name : '');
+	const listing = useObjectsQuery(
+		projectId,
+		integration.id,
+		bucket,
+		prefix,
+		activeSearchQuery === '',
+	);
+	const search = useObjectSearchQuery(projectId, integration.id, bucket, prefix, activeSearchQuery);
+	const loaded = useMemo(
+		() =>
+			activeSearchQuery
+				? (search.data?.pages.flatMap((page) => page.items) ?? [])
+				: (listing.data?.pages.flatMap((page) => page.items) ?? []),
+		[activeSearchQuery, listing.data, search.data],
+	);
+	const entries = useMemo(() => {
+		const normalized = filter.trim().toLocaleLowerCase();
+		const after = modifiedAfter ? Date.parse(`${modifiedAfter}T00:00:00Z`) : undefined;
+		const filtered = loaded.filter((entry) => {
+			if (normalized && !entry.name.toLocaleLowerCase().includes(normalized)) return false;
+			if (entry.kind === 'prefix') return true;
+			if (formatFilter !== 'all' && objectFormat(entry.name) !== formatFilter) return false;
+			if (sizeFilter === 'small' && (entry.size ?? 0) >= 1024 * 1024) return false;
+			if (
+				sizeFilter === 'medium' &&
+				((entry.size ?? 0) < 1024 * 1024 || (entry.size ?? 0) >= 100 * 1024 * 1024)
+			)
+				return false;
+			if (sizeFilter === 'large' && (entry.size ?? 0) < 100 * 1024 * 1024) return false;
+			if (after !== undefined && (!entry.last_modified || Date.parse(entry.last_modified) < after))
+				return false;
+			return true;
+		});
+		return filtered.toSorted((left, right) => {
+			if (left.kind !== right.kind) return left.kind === 'prefix' ? -1 : 1;
+			if (sort === 'name-desc') return right.name.localeCompare(left.name);
+			if (sort === 'size-desc') return (right.size ?? -1) - (left.size ?? -1);
+			if (sort === 'modified-desc')
+				return (right.last_modified ?? '').localeCompare(left.last_modified ?? '');
+			return left.name.localeCompare(right.name);
+		});
+	}, [filter, formatFilter, loaded, modifiedAfter, sizeFilter, sort]);
+
+	const update = (changes: Record<string, string | undefined>) => {
+		setParams((current) => {
+			const next = new URLSearchParams(current);
+			next.set('surface', 'objects');
+			for (const [name, value] of Object.entries(changes)) {
+				if (value) next.set(name, value);
+				else next.delete(name);
+			}
+			return next;
+		});
+	};
+	const selectBucket = (value: string) => {
+		setSelectedKeys(new Set());
+		update({ bucket: value, prefix: undefined, key: undefined, version: undefined, q: undefined });
+	};
+	const selectPrefix = (value: string) => {
+		setSelectedKeys(new Set());
+		setSearchDraft('');
+		update({ prefix: value, key: undefined, version: undefined, q: undefined });
+	};
+	const selectEntry = (entry: IntegrationObjectEntry, event?: MouseEvent<HTMLButtonElement>) => {
+		if (entry.kind === 'prefix') {
+			selectPrefix(entry.key);
+		} else {
+			setSelectedKeys((current) => {
+				if (!(event?.metaKey || event?.ctrlKey)) return new Set([entry.key]);
+				const next = new Set(current);
+				if (next.has(entry.key)) next.delete(entry.key);
+				else next.add(entry.key);
+				return next;
+			});
+			update({ key: entry.key, version: undefined });
+		}
+	};
+	const parentPrefix = prefix ? prefix.replace(/[^/]+\/$/, '') : '';
+	const searchSummary = search.data?.pages.at(-1);
+	const listError = activeSearchQuery ? search.error : listing.error;
+	const copySelectedUris = () => {
+		const keys = selectedKeys.size > 0 ? [...selectedKeys] : key ? [key] : [];
+		void navigator.clipboard
+			.writeText(keys.map((value) => `s3://${bucket}/${value}`).join('\n'))
+			.then(() => toast.success(`Copied ${keys.length} object URI${keys.length === 1 ? '' : 's'}`))
+			.catch(() => toast.error('Could not copy object URIs'));
+	};
+	const handleListKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+		if (event.key === 'Backspace' && prefix) {
+			event.preventDefault();
+			selectPrefix(parentPrefix);
+			return;
+		}
+		if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+		const rows = [
+			...(event.currentTarget
+				.closest('fieldset')
+				?.querySelectorAll<HTMLButtonElement>('[data-object-row]') ?? []),
+		];
+		if (rows.length === 0) return;
+		event.preventDefault();
+		const current = rows.indexOf(document.activeElement as HTMLButtonElement);
+		const next =
+			event.key === 'ArrowDown' ? Math.min(current + 1, rows.length - 1) : Math.max(current - 1, 0);
+		rows[next].focus();
+	};
+
+	return (
+		<div className="grid min-h-0 grid-cols-[minmax(20rem,1fr)_minmax(0,1.25fr)] gap-4 max-lg:grid-cols-1">
+			<section className="flex min-h-0 flex-col gap-3 overflow-hidden rounded-xl border bg-card p-3">
+				{bucket === '' ? (
+					<div className="min-h-0 overflow-y-auto">
+						<p className="mb-2 text-xs font-medium text-muted-foreground">Buckets</p>
+						{buckets.error ? (
+							<p className="p-3 text-sm text-destructive">{errorMessage(buckets.error)}</p>
+						) : buckets.data === undefined ? (
+							<Skeleton className="h-9 w-full" />
+						) : bucketItems.length === 0 ? (
+							<EmptyState
+								icon={<Folder />}
+								message="No buckets available"
+								description="The integration credentials did not return an accessible bucket."
+							/>
+						) : (
+							bucketItems.map((item) => (
+								<button
+									key={item.name}
+									type="button"
+									onClick={() => selectBucket(item.name)}
+									className="flex w-full touch-manipulation items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-md:min-h-11"
+								>
+									<Folder className="size-4" aria-hidden />
+									<span className="truncate">{item.name}</span>
+									{item.configured && <Chip className="ml-auto">configured</Chip>}
+								</button>
+							))
+						)}
+					</div>
+				) : (
+					<>
+						<div className="flex flex-wrap items-center gap-1 text-xs">
+							<Button size="sm" variant="ghost" onPress={() => selectBucket('')}>
+								{bucket}
+							</Button>
+							{prefixParts(prefix).map(({ label, value }) => (
+								<span key={value} className="flex items-center gap-1">
+									<span className="text-muted-foreground">/</span>
+									<Button size="sm" variant="ghost" onPress={() => selectPrefix(value)}>
+										{label}
+									</Button>
+								</span>
+							))}
+						</div>
+						{searchAvailable && (
+							<div className="grid grid-cols-[1fr_auto] gap-2">
+								<form
+									className="flex gap-2"
+									onSubmit={(event) => {
+										event.preventDefault();
+										const query = searchDraft.trim();
+										if (query.length === 0 || query.length >= 2) update({ q: query || undefined });
+									}}
+								>
+									<TextField
+										name="object-search"
+										autoComplete="off"
+										spellCheck="false"
+										aria-label="Search object keys"
+										placeholder="Search this prefix…"
+										value={searchDraft}
+										onChange={setSearchDraft}
+										className="min-w-0 flex-1"
+										error={
+											searchDraft.trim().length === 1 ? 'Enter at least two characters.' : undefined
+										}
+									/>
+									<Button type="submit" aria-label="Search object keys">
+										<Search className="size-4" aria-hidden />
+									</Button>
+								</form>
+								{searchQuery && (
+									<Button
+										onPress={() => {
+											setSearchDraft('');
+											update({ q: undefined });
+										}}
+									>
+										Clear search
+									</Button>
+								)}
+							</div>
+						)}
+						<TextField
+							name="loaded-object-filter"
+							autoComplete="off"
+							spellCheck="false"
+							aria-label="Filter loaded objects"
+							placeholder="Filter loaded results…"
+							value={filter}
+							onChange={setFilter}
+						/>
+						<div className="grid grid-cols-2 gap-2 text-xs xl:grid-cols-4">
+							<ObjectFilterSelect
+								label="Type"
+								name="object-format-filter"
+								value={formatFilter}
+								onChange={setFormatFilter}
+							>
+								<option value="all">All loaded types</option>
+								<option value="data">Data</option>
+								<option value="text">Text</option>
+								<option value="image">Images</option>
+								<option value="other">Other</option>
+							</ObjectFilterSelect>
+							<ObjectFilterSelect
+								label="Size"
+								name="object-size-filter"
+								value={sizeFilter}
+								onChange={setSizeFilter}
+							>
+								<option value="all">Any loaded size</option>
+								<option value="small">Under 1 MiB</option>
+								<option value="medium">1–100 MiB</option>
+								<option value="large">100 MiB+</option>
+							</ObjectFilterSelect>
+							<label className="flex flex-col gap-1 text-muted-foreground">
+								Modified after
+								<input
+									type="date"
+									aria-label="Modified after"
+									name="object-modified-after"
+									autoComplete="off"
+									value={modifiedAfter}
+									onChange={(event) => setModifiedAfter(event.target.value)}
+									className="h-9 rounded-md border border-input bg-background px-2 text-foreground"
+								/>
+							</label>
+							<ObjectFilterSelect
+								label="Sort loaded results"
+								name="object-sort"
+								value={sort}
+								onChange={setSort}
+							>
+								<option value="name-asc">Name A–Z</option>
+								<option value="name-desc">Name Z–A</option>
+								<option value="size-desc">Largest first</option>
+								<option value="modified-desc">Newest first</option>
+							</ObjectFilterSelect>
+						</div>
+						{selectedKeys.size > 0 && (
+							<Button size="sm" onPress={copySelectedUris}>
+								Copy {selectedKeys.size} selected URI{selectedKeys.size === 1 ? '' : 's'}
+							</Button>
+						)}
+						{activeSearchQuery && searchSummary && (
+							<output className="text-xs text-muted-foreground">
+								{loaded.length} matches after scanning{' '}
+								{search.data?.pages.reduce((n, p) => n + p.scanned, 0)} keys
+								{searchSummary.complete ? '.' : '; more may exist.'}
+							</output>
+						)}
+						{listError && <p className="text-sm text-destructive">{errorMessage(listError)}</p>}
+						<fieldset className="min-h-0 flex-1 overflow-y-auto">
+							<legend className="sr-only">Objects</legend>
+							{prefix && !activeSearchQuery && (
+								<button
+									type="button"
+									onKeyDown={handleListKeyDown}
+									onClick={() => selectPrefix(parentPrefix)}
+									className="flex w-full touch-manipulation items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-md:min-h-11"
+								>
+									<ArrowUp className="size-4" aria-hidden /> Parent prefix
+								</button>
+							)}
+							{entries.map((entry) => (
+								<button
+									key={`${entry.kind}:${entry.key}`}
+									data-object-row
+									type="button"
+									aria-pressed={entry.kind === 'object' && selectedKeys.has(entry.key)}
+									onKeyDown={handleListKeyDown}
+									onClick={(event) => selectEntry(entry, event)}
+									className={cn(
+										'grid w-full touch-manipulation grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-md:min-h-11 [content-visibility:auto] [contain-intrinsic-size:auto_44px]',
+										entry.kind === 'object' &&
+											selectedKeys.has(entry.key) &&
+											'bg-primary/10 text-primary',
+									)}
+								>
+									{entry.kind === 'prefix' ? (
+										<Folder className="size-4" aria-hidden />
+									) : (
+										<File className="size-4" aria-hidden />
+									)}
+									<span className="min-w-0">
+										<span className="block truncate">{entry.name}</span>
+										{entry.kind === 'object' && (
+											<span className="block truncate text-[11px] text-muted-foreground">
+												{[objectFormatLabel(entry.name), entry.storage_class, entry.etag]
+													.filter(Boolean)
+													.join(' · ')}
+											</span>
+										)}
+									</span>
+									<span className="text-right text-xs text-muted-foreground tabular-nums">
+										{entry.size === undefined ? '' : formatBytes(entry.size)}
+										{entry.last_modified && (
+											<span className="block">{formatDateTime(entry.last_modified)}</span>
+										)}
+									</span>
+								</button>
+							))}
+							{entries.length === 0 && (listing.data || search.data) && (
+								<p className="p-4 text-center text-xs text-muted-foreground">No objects found.</p>
+							)}
+							{(activeSearchQuery ? search.hasNextPage : listing.hasNextPage) && (
+								<Button
+									className="mt-2 w-full"
+									onPress={() =>
+										void (activeSearchQuery ? search.fetchNextPage() : listing.fetchNextPage())
+									}
+								>
+									{activeSearchQuery ? 'Continue search' : 'Load more'}
+								</Button>
+							)}
+						</fieldset>
+					</>
+				)}
+			</section>
+
+			<section className="min-h-0 overflow-y-auto rounded-xl border bg-card p-4">
+				{bucket && key ? (
+					<ObjectDetail
+						projectId={projectId}
+						integration={integration}
+						bucket={bucket}
+						objectKey={key}
+						versionId={versionId}
+						previewAvailable={previewAvailable}
+						downloadAvailable={downloadAvailable}
+						versionsAvailable={versionsAvailable}
+						onVersion={(value) => update({ version: value })}
+					/>
+				) : (
+					<EmptyState
+						icon={<File />}
+						message="Select an object"
+						description="Choose an object to inspect metadata, preview content, browse versions, or download it."
+					/>
+				)}
+			</section>
+		</div>
+	);
+}
+
+function ObjectDetail({
+	projectId,
+	integration,
+	bucket,
+	objectKey,
+	versionId,
+	previewAvailable,
+	downloadAvailable,
+	versionsAvailable,
+	onVersion,
+}: {
+	projectId: string;
+	integration: IntegrationEntry;
+	bucket: string;
+	objectKey: string;
+	versionId?: string;
+	previewAvailable: boolean;
+	downloadAvailable: boolean;
+	versionsAvailable: boolean;
+	onVersion: (version?: string) => void;
+}) {
+	const detail = useObjectDetailQuery(projectId, integration.id, bucket, objectKey, versionId);
+	const versions = useObjectVersionsQuery(
+		projectId,
+		integration.id,
+		bucket,
+		objectKey,
+		versionsAvailable,
+	);
+	const preview = useObjectPreview(projectId, integration.id);
+	const { copied, copy } = useCopyToClipboard();
+	const seededNotebook = useSeededNotebook(projectId);
+	if (!detail.data) {
+		return detail.error ? (
+			<p className="text-destructive">
+				{detail.error instanceof Error ? detail.error.message : 'Request failed'}
+			</p>
+		) : (
+			<div className="flex flex-col gap-2">
+				<Skeleton className="h-5 w-48" />
+				<Skeleton className="h-4 w-full" />
+			</div>
+		);
+	}
+	const uri = `s3://${bucket}/${objectKey}`;
+	const downloadUrl = objectContentUrl({
+		projectId,
+		integrationId: integration.id,
+		bucket,
+		key: objectKey,
+		versionId,
+		etag: detail.data.etag,
+	});
+	const openInNotebook = async () => {
+		if (!detail.data.snippet) return;
+		const title = `explore_${safeNotebookTitle(objectKey)}`;
+		await seededNotebook.create({
+			title,
+			heading: uri,
+			description: `Explore ${uri} via the ${integration.name} integration`,
+			snippet: detail.data.snippet,
+		});
+	};
+	return (
+		<div className="flex flex-col gap-4">
+			<div className="flex flex-wrap items-start justify-between gap-3">
+				<div className="min-w-0">
+					<h2 className="break-all font-semibold" translate="no">
+						{objectKey}
+					</h2>
+					<p className="break-all font-mono text-xs text-muted-foreground" translate="no">
+						{uri}
+					</p>
+				</div>
+				<div className="flex flex-wrap gap-2">
+					<IconButton
+						label={copied ? 'Copied URI' : 'Copy URI'}
+						tooltip="Copy URI"
+						onPress={() => void copy(uri)}
+					>
+						{copied ? (
+							<Check className="size-4" aria-hidden />
+						) : (
+							<Copy className="size-4" aria-hidden />
+						)}
+					</IconButton>
+					<IconButton
+						label="Copy key"
+						tooltip="Copy key"
+						onPress={() => void navigator.clipboard.writeText(objectKey)}
+					>
+						<Copy className="size-4" aria-hidden />
+					</IconButton>
+					{detail.data.snippet && (
+						<IconButton
+							label="Copy snippet"
+							tooltip="Copy snippet"
+							onPress={() => void navigator.clipboard.writeText(detail.data.snippet ?? '')}
+						>
+							<Copy className="size-4" aria-hidden />
+						</IconButton>
+					)}
+					{detail.data.snippet && (
+						<Button onPress={() => void openInNotebook()}>
+							<NotebookPen className="size-4" aria-hidden />
+							Open in notebook
+						</Button>
+					)}
+					{downloadAvailable && (
+						<a
+							href={downloadUrl}
+							className="inline-flex h-9 touch-manipulation items-center justify-center gap-2 rounded-md border border-input bg-card px-3.5 text-[13px] font-medium shadow-xs transition-colors hover:border-primary/50 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-md:min-h-11"
+						>
+							<Download className="size-4" aria-hidden />
+							Download
+						</a>
+					)}
+				</div>
+			</div>
+			<div className="flex flex-wrap gap-2">
+				<Chip>{formatBytes(detail.data.size)}</Chip>
+				{detail.data.content_type && <Chip>{detail.data.content_type}</Chip>}
+				{detail.data.storage_class && <Chip>{detail.data.storage_class}</Chip>}
+				{versionId && <Chip>version {versionId}</Chip>}
+			</div>
+			<Tabs defaultSelectedKey="metadata" className="flex flex-col gap-4">
+				<TabList aria-label="Object details" className="flex border-b border-input">
+					<Tab id="metadata" className={tabClass}>
+						Metadata
+					</Tab>
+					{previewAvailable && (
+						<Tab id="preview" className={tabClass}>
+							Preview
+						</Tab>
+					)}
+					{versionsAvailable && (
+						<Tab id="versions" className={tabClass}>
+							Versions
+						</Tab>
+					)}
+				</TabList>
+				<TabPanel id="metadata" className="flex flex-col gap-3">
+					<MetadataRows
+						values={{
+							Size: formatBytes(detail.data.size),
+							ETag: detail.data.etag,
+							'Last modified': formatDateTime(detail.data.last_modified),
+							'Content type': detail.data.content_type,
+							'Content encoding': detail.data.content_encoding,
+							'Cache control': detail.data.cache_control,
+						}}
+					/>
+					{Object.keys(detail.data.metadata).length > 0 && (
+						<MetadataRows values={detail.data.metadata} />
+					)}
+					{detail.data.checksums.length > 0 && (
+						<MetadataRows
+							values={Object.fromEntries(
+								detail.data.checksums.map((checksum) => [
+									`Checksum ${checksum.algorithm}`,
+									checksum.value,
+								]),
+							)}
+						/>
+					)}
+					{detail.data.tags_available ? (
+						detail.data.tags && detail.data.tags.length > 0 ? (
+							<MetadataRows
+								values={Object.fromEntries(
+									detail.data.tags.map((tag) => [`Tag ${tag.key}`, tag.value]),
+								)}
+							/>
+						) : (
+							<p className="text-xs text-muted-foreground">No object tags.</p>
+						)
+					) : (
+						<p className="text-xs text-muted-foreground">
+							Tags are unavailable with these credentials.
+						</p>
+					)}
+				</TabPanel>
+				{previewAvailable && (
+					<TabPanel id="preview">
+						<PreviewPanel
+							preview={preview}
+							input={{ bucket, key: objectKey, ...(versionId ? { version_id: versionId } : {}) }}
+						/>
+					</TabPanel>
+				)}
+				{versionsAvailable && (
+					<TabPanel id="versions" className="flex flex-col gap-2">
+						<Button
+							size="sm"
+							variant={!versionId ? 'primary' : 'default'}
+							onPress={() => onVersion(undefined)}
+						>
+							Current object
+						</Button>
+						{versions.data?.pages
+							.flatMap((page) => page.items)
+							.map((item) => (
+								<button
+									key={`${item.kind}:${item.version_id ?? item.last_modified}`}
+									type="button"
+									disabled={item.kind === 'delete-marker'}
+									onClick={() => onVersion(item.version_id)}
+									className={cn(
+										'flex touch-manipulation items-center justify-between rounded-md border px-3 py-2 text-left text-xs hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 max-md:min-h-11',
+										item.version_id === versionId && 'border-primary bg-primary/5',
+									)}
+								>
+									<span>{item.kind === 'delete-marker' ? 'Delete marker' : item.version_id}</span>
+									<span className="tabular-nums">
+										{item.is_latest ? 'latest' : formatDateTime(item.last_modified)}
+									</span>
+								</button>
+							))}
+						{versions.error && (
+							<p className="text-sm text-destructive">{errorMessage(versions.error)}</p>
+						)}
+						{versions.hasNextPage && (
+							<Button onPress={() => void versions.fetchNextPage()}>Load more versions</Button>
+						)}
+					</TabPanel>
+				)}
+			</Tabs>
+		</div>
+	);
+}
+
+function PreviewPanel({
+	preview,
+	input,
+}: {
+	preview: ReturnType<typeof useObjectPreview>;
+	input: { bucket: string; key: string; version_id?: string };
+}) {
+	if (!preview.data)
+		return (
+			<div className="flex flex-col items-start gap-2">
+				<p className="text-sm text-muted-foreground">
+					Content is fetched only when you request it.
+				</p>
+				<Button
+					variant="primary"
+					isDisabled={preview.isPending}
+					onPress={() => preview.mutate({ ...input, limit: 20 })}
+				>
+					{preview.isPending ? 'Loading…' : 'Load preview'}
+				</Button>
+				{preview.error && <p className="text-sm text-destructive">{preview.error.message}</p>}
+			</div>
+		);
+	const warnings = 'warnings' in preview.data ? preview.data.warnings : [];
+	return (
+		<div className="flex flex-col items-start gap-3">
+			<div className="w-full">
+				<PreviewResult value={preview.data} />
+			</div>
+			{warnings.length > 0 && (
+				<ul className="list-disc pl-5 text-xs text-amber-700 dark:text-amber-300">
+					{warnings.map((warning) => (
+						<li key={warning}>{warning}</li>
+					))}
+				</ul>
+			)}
+			<Button
+				isDisabled={preview.isPending}
+				onPress={() => preview.mutate({ ...input, limit: 20 })}
+			>
+				{preview.isPending ? 'Loading…' : 'Reload preview'}
+			</Button>
+		</div>
+	);
+}
+
+function PreviewResult({ value }: { value: IntegrationObjectPreview }) {
+	if (value.kind === 'text')
+		return (
+			<pre className="max-h-[32rem] overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted/40 p-3 text-xs">
+				{value.text}
+			</pre>
+		);
+	if (value.kind === 'image')
+		return (
+			<img
+				src={value.content_url}
+				alt="Object preview"
+				width={value.width ?? 1024}
+				height={value.height ?? 768}
+				loading="lazy"
+				className="max-h-[32rem] max-w-full rounded-md border object-contain"
+			/>
+		);
+	if (value.kind === 'unsupported')
+		return <p className="text-sm text-muted-foreground">{value.reason}</p>;
+	return (
+		<TabularPreviewGrid columns={value.columns} rows={value.rows} truncated={value.truncated} />
+	);
+}
+
+function MetadataRows({ values }: { values: Record<string, string | undefined> }) {
+	return (
+		<dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-2 text-xs">
+			{Object.entries(values)
+				.filter(([, value]) => value !== undefined)
+				.map(([name, value]) => (
+					<div key={name} className="contents">
+						<dt className="font-medium text-muted-foreground">{name}</dt>
+						<dd className="break-all font-mono">{value}</dd>
+					</div>
+				))}
+		</dl>
+	);
+}
+
+function prefixParts(prefix: string): { label: string; value: string }[] {
+	let value = '';
+	return prefix
+		.split('/')
+		.filter(Boolean)
+		.map((label) => {
+			value += `${label}/`;
+			return { label, value };
+		});
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ['KiB', 'MiB', 'GiB', 'TiB'];
+	let value = bytes;
+	let index = -1;
+	while (value >= 1024 && index < units.length - 1) {
+		value /= 1024;
+		index += 1;
+	}
+	return `${value >= 10 ? Math.round(value) : value.toFixed(1)} ${units[index]}`;
+}
+
+function formatDateTime(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) return value;
+	return new Intl.DateTimeFormat(undefined, {
+		dateStyle: 'medium',
+		timeStyle: 'short',
+	}).format(date);
+}
+
+function objectFormat(name: string): 'data' | 'text' | 'image' | 'other' {
+	const extension = name.split('.').at(-1)?.toLocaleLowerCase();
+	if (extension && ['csv', 'tsv', 'json', 'jsonl', 'ndjson', 'parquet'].includes(extension)) {
+		return 'data';
+	}
+	if (
+		extension &&
+		['txt', 'log', 'md', 'py', 'js', 'ts', 'tsx', 'sql', 'yaml', 'yml'].includes(extension)
+	) {
+		return 'text';
+	}
+	if (extension && ['png', 'jpg', 'jpeg', 'gif', 'webp'].includes(extension)) return 'image';
+	return 'other';
+}
+
+function objectFormatLabel(name: string): string {
+	const extension = name.split('.').at(-1)?.toLocaleUpperCase();
+	return extension && extension.length <= 10 ? extension : 'Object';
+}
+
+function ObjectFilterSelect({
+	label,
+	name,
+	value,
+	onChange,
+	children,
+}: {
+	label: string;
+	name: string;
+	value: string;
+	onChange: (value: string) => void;
+	children: ReactNode;
+}) {
+	return (
+		<label className="flex flex-col gap-1 text-muted-foreground">
+			{label}
+			<select
+				name={name}
+				value={value}
+				onChange={(event) => onChange(event.target.value)}
+				className="h-9 rounded-md border border-input bg-background px-2 text-foreground"
+			>
+				{children}
+			</select>
+		</label>
+	);
+}
+
+function safeNotebookTitle(key: string): string {
+	return (
+		(key.split('/').at(-1) ?? 'object').replaceAll(/[^a-zA-Z0-9_-]+/g, '_').slice(0, 48) || 'object'
+	);
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : 'The object-store request failed.';
+}
+
+const tabClass =
+	'cursor-pointer border-b-2 border-transparent px-3 py-2 text-xs text-muted-foreground outline-none data-[selected]:border-primary data-[selected]:text-foreground focus-visible:ring-2 focus-visible:ring-ring';

--- a/packages/web/src/components/DataBrowser/TabularPreviewGrid.test.tsx
+++ b/packages/web/src/components/DataBrowser/TabularPreviewGrid.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { TabularPreviewGrid } from './TabularPreviewGrid';
 
@@ -14,5 +14,14 @@ describe('TabularPreviewGrid', () => {
 		expect(screen.getAllByText('123')).toHaveLength(2);
 		expect(screen.getByText('[unserializable]')).toBeInTheDocument();
 		expect(screen.getByText('Preview truncated.')).toBeInTheDocument();
+	});
+
+	it('serializes object cells once per render', () => {
+		const toJSON = vi.fn(() => ({ value: 'large' }));
+
+		render(<TabularPreviewGrid columns={['value']} rows={[[{ toJSON }]]} />);
+
+		expect(screen.getByText('{"value":"large"}')).toBeInTheDocument();
+		expect(toJSON).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/web/src/components/DataBrowser/TabularPreviewGrid.test.tsx
+++ b/packages/web/src/components/DataBrowser/TabularPreviewGrid.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TabularPreviewGrid } from './TabularPreviewGrid';
+
+describe('TabularPreviewGrid', () => {
+	it('renders bigint and unserializable values without using them as raw JSON keys', () => {
+		const circular: { self?: unknown } = {};
+		circular.self = circular;
+
+		render(
+			<TabularPreviewGrid columns={['value']} rows={[[123n], [circular], [123n]]} truncated />,
+		);
+
+		expect(screen.getAllByText('123')).toHaveLength(2);
+		expect(screen.getByText('[unserializable]')).toBeInTheDocument();
+		expect(screen.getByText('Preview truncated.')).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/components/DataBrowser/TabularPreviewGrid.tsx
+++ b/packages/web/src/components/DataBrowser/TabularPreviewGrid.tsx
@@ -64,7 +64,7 @@ function keyedNames(names: string[]): { key: string; name: string }[] {
 function keyedRows(rows: unknown[][]): { key: string; row: unknown[] }[] {
 	const counts = new Map<string, number>();
 	return rows.map((row) => {
-		const base = JSON.stringify(row) ?? '[unserializable]';
+		const base = JSON.stringify(row.map(renderCell));
 		const occurrence = counts.get(base) ?? 0;
 		counts.set(base, occurrence + 1);
 		return { key: `${base}:${occurrence}`, row };

--- a/packages/web/src/components/DataBrowser/TabularPreviewGrid.tsx
+++ b/packages/web/src/components/DataBrowser/TabularPreviewGrid.tsx
@@ -1,0 +1,86 @@
+export function TabularPreviewGrid({
+	columns,
+	rows,
+	emptyMessage = 'This preview returned no rows.',
+	truncated = false,
+}: {
+	columns: readonly (string | { name: string })[];
+	rows: unknown[][];
+	emptyMessage?: string;
+	truncated?: boolean;
+}) {
+	if (rows.length === 0) {
+		return <p className="text-xs text-muted-foreground">{emptyMessage}</p>;
+	}
+	const names = columns.map((column) => (typeof column === 'string' ? column : column.name));
+	const headers = keyedNames(names);
+	return (
+		<div>
+			<div className="overflow-x-auto rounded-md border border-input">
+				<table className="w-full whitespace-nowrap text-left text-xs tabular-nums">
+					<thead className="bg-muted/40">
+						<tr>
+							{headers.map(({ key, name }) => (
+								<th key={key} className="px-3 py-2 font-medium">
+									{name}
+								</th>
+							))}
+						</tr>
+					</thead>
+					<tbody>
+						{keyedRows(rows).map(({ key, row }) => (
+							<tr key={key} className="border-t border-input/50">
+								{headers.map(({ key: columnKey }, index) => {
+									const value = renderCell(row[index]);
+									return (
+										<td
+											key={columnKey}
+											className="max-w-80 truncate px-3 py-2 font-mono"
+											title={value}
+										>
+											{value}
+										</td>
+									);
+								})}
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+			{truncated && <p className="mt-2 text-xs text-muted-foreground">Preview truncated.</p>}
+		</div>
+	);
+}
+
+function keyedNames(names: string[]): { key: string; name: string }[] {
+	const counts = new Map<string, number>();
+	return names.map((name) => {
+		const occurrence = counts.get(name) ?? 0;
+		counts.set(name, occurrence + 1);
+		return { key: `${name}:${occurrence}`, name };
+	});
+}
+
+function keyedRows(rows: unknown[][]): { key: string; row: unknown[] }[] {
+	const counts = new Map<string, number>();
+	return rows.map((row) => {
+		const base = JSON.stringify(row) ?? '[unserializable]';
+		const occurrence = counts.get(base) ?? 0;
+		counts.set(base, occurrence + 1);
+		return { key: `${base}:${occurrence}`, row };
+	});
+}
+
+function renderCell(value: unknown): string {
+	if (value === null) return 'null';
+	if (value === undefined) return '';
+	if (typeof value === 'string') return value;
+	if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+		return String(value);
+	}
+	try {
+		return JSON.stringify(value) ?? '';
+	} catch {
+		return '[unserializable]';
+	}
+}

--- a/packages/web/src/components/DataBrowser/TabularPreviewGrid.tsx
+++ b/packages/web/src/components/DataBrowser/TabularPreviewGrid.tsx
@@ -28,10 +28,10 @@ export function TabularPreviewGrid({
 						</tr>
 					</thead>
 					<tbody>
-						{keyedRows(rows).map(({ key, row }) => (
+						{keyedRows(rows).map(({ key, cells }) => (
 							<tr key={key} className="border-t border-input/50">
 								{headers.map(({ key: columnKey }, index) => {
-									const value = renderCell(row[index]);
+									const value = cells[index] ?? '';
 									return (
 										<td
 											key={columnKey}
@@ -61,13 +61,14 @@ function keyedNames(names: string[]): { key: string; name: string }[] {
 	});
 }
 
-function keyedRows(rows: unknown[][]): { key: string; row: unknown[] }[] {
+function keyedRows(rows: unknown[][]): { key: string; cells: string[] }[] {
 	const counts = new Map<string, number>();
 	return rows.map((row) => {
-		const base = JSON.stringify(row.map(renderCell));
+		const cells = Array.from(row, renderCell);
+		const base = JSON.stringify(cells);
 		const occurrence = counts.get(base) ?? 0;
 		counts.set(base, occurrence + 1);
-		return { key: `${base}:${occurrence}`, row };
+		return { key: `${base}:${occurrence}`, cells };
 	});
 }
 

--- a/packages/web/src/components/DataBrowser/notebookSeed.ts
+++ b/packages/web/src/components/DataBrowser/notebookSeed.ts
@@ -1,0 +1,69 @@
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { useCreateNotebook } from '@/api/hooks';
+
+export function seededNotebookCode(heading: string, snippet: string): string {
+	const cellBody = snippet
+		.split('\n')
+		.map((line) => (line === '' ? '' : `    ${line}`))
+		.join('\n');
+	return [
+		'import marimo',
+		'',
+		'app = marimo.App(width="medium", sql_output="native")',
+		'',
+		'',
+		'@app.cell',
+		'def _():',
+		'    import marimo as mo',
+		'    return (mo,)',
+		'',
+		'',
+		'@app.cell(hide_code=True)',
+		'def _(mo):',
+		`    mo.md(${JSON.stringify(`# ${heading}`)})`,
+		'    return',
+		'',
+		'',
+		'@app.cell',
+		'def _():',
+		cellBody,
+		'    return',
+		'',
+		'',
+		'if __name__ == "__main__":',
+		'    app.run()',
+		'',
+	].join('\n');
+}
+
+export function useSeededNotebook(projectId: string) {
+	const createNotebook = useCreateNotebook(projectId);
+	const navigate = useNavigate();
+	return {
+		isPending: createNotebook.isPending,
+		create: async ({
+			title,
+			heading,
+			description,
+			snippet,
+		}: {
+			title: string;
+			heading: string;
+			description: string;
+			snippet: string;
+		}) => {
+			try {
+				const created = await createNotebook.mutateAsync({
+					title,
+					description,
+					code: seededNotebookCode(heading, snippet),
+				});
+				toast.success(`Created "${title}"`);
+				void navigate(`/projects/${projectId}/notebooks/${created.id}`, { state: { title } });
+			} catch {
+				// Preserve the browser selection; the shared mutation handler reports the failure.
+			}
+		},
+	};
+}

--- a/packages/web/src/lib/integrationBrowse.ts
+++ b/packages/web/src/lib/integrationBrowse.ts
@@ -4,8 +4,18 @@ export function supportsTableBrowse(kind: IntegrationKind | undefined): boolean 
 	return kind?.browse_surfaces.includes('tables') ?? false;
 }
 
+export function supportsObjectBrowse(kind: IntegrationKind | undefined): boolean {
+	return kind?.browse_surfaces.includes('objects') ?? false;
+}
+
 export function tableBrowseCapability(
 	capability: IntegrationBrowseCapability | undefined,
 ): IntegrationBrowseCapability['surfaces']['tables'] | undefined {
 	return capability?.surfaces.tables;
+}
+
+export function objectBrowseCapability(
+	capability: IntegrationBrowseCapability | undefined,
+): IntegrationBrowseCapability['surfaces']['objects'] | undefined {
+	return capability?.surfaces.objects;
 }

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -28,6 +28,11 @@ import type {
 	IntegrationBrowseTablePage as ClientIntegrationBrowseTablePage,
 	IntegrationTableSchema as ClientIntegrationTableSchema,
 	IntegrationTablePreview as ClientIntegrationTablePreview,
+	IntegrationObjectBucket as ClientIntegrationObjectBucket,
+	IntegrationObjectEntry as ClientIntegrationObjectEntry,
+	IntegrationObjectDetail as ClientIntegrationObjectDetail,
+	IntegrationObjectVersion as ClientIntegrationObjectVersion,
+	IntegrationObjectPreview as ClientIntegrationObjectPreview,
 	ResolvedUser as ClientResolvedUser,
 	ApiToken as ClientApiToken,
 	ApiTokenCreated as ClientApiTokenCreated,
@@ -81,6 +86,11 @@ export type IntegrationBrowseTablePage = ClientIntegrationBrowseTablePage;
 /** Columns, partitioning, and load snippet for a browsed table. */
 export type IntegrationTableSchema = ClientIntegrationTableSchema;
 export type IntegrationTablePreview = ClientIntegrationTablePreview;
+export type IntegrationObjectBucket = ClientIntegrationObjectBucket;
+export type IntegrationObjectEntry = ClientIntegrationObjectEntry;
+export type IntegrationObjectDetail = ClientIntegrationObjectDetail;
+export type IntegrationObjectVersion = ClientIntegrationObjectVersion;
+export type IntegrationObjectPreview = ClientIntegrationObjectPreview;
 /** A resolved user identity ({ id, email, name }) from `GET /api/v1/users`. */
 export type ResolvedUser = ClientResolvedUser;
 /** A personal access token's metadata (never the secret). */


### PR DESCRIPTION
Adds an ObjectBrowser port with an S3 adapter, a `/objectBrowse` API route, and a DataBrowser ObjectBrowser UI with tabular preview and notebook seeding. Includes an objectBrowse conformance contract and MinIO live tests.