### PR TITLE
feat(dev): improve local development experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ coverage
 .vite-hooks
 *.tsbuildinfo
 .context
+.conductor/
 pnpm-debug.log*
 
 # Playwright e2e artifacts

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ parallel. It skips the production server build. The local stack uses:
 - `memory` storage, which is non-durable
 - `local` compute, which starts `uv run marimo edit`
 - `dev` auth, which signs everyone in as a fixed local super admin
-- integrations and the metadata data browser, with one org-wide sample integration
+- integrations and metadata browsing, with a welcome notebook and sample environment
+
+Set `MARIMOHUB_DEV_PERSIST=true` to keep local state in the Git-ignored
+`.context/dev-storage` directory. Run `pnpm dev:reset` after stopping the dev
+stack to clear it.
 
 See [Testing locally](./docs/testing-locally.md) for the full local path and the
 production swaps for each backend.

--- a/apps/server/src/bootstrap.test.ts
+++ b/apps/server/src/bootstrap.test.ts
@@ -248,8 +248,8 @@ describe('bootstrap', () => {
 
 	it('disposes compute during drain', async () => {
 		const dispose = vi.fn().mockResolvedValue(undefined);
-		deps.compute[Symbol.asyncDispose] = dispose;
-		const harness = makeHarness(deps);
+		const compute = { ...deps.compute, [Symbol.asyncDispose]: dispose };
+		const harness = makeHarness({ ...deps, compute });
 		const handle = await bootstrap(BASE_ENV, harness.overrides);
 
 		await handle?.drain();

--- a/apps/server/src/bootstrap.test.ts
+++ b/apps/server/src/bootstrap.test.ts
@@ -246,6 +246,18 @@ describe('bootstrap', () => {
 		expect(harness.exit).toHaveBeenCalledWith(0);
 	});
 
+	it('disposes compute during drain', async () => {
+		const dispose = vi.fn().mockResolvedValue(undefined);
+		deps.compute[Symbol.asyncDispose] = dispose;
+		const harness = makeHarness(deps);
+		const handle = await bootstrap(BASE_ENV, harness.overrides);
+
+		await handle?.drain();
+		await handle?.drain();
+
+		expect(dispose).toHaveBeenCalledOnce();
+	});
+
 	it.each([
 		['starts', 'true', 1],
 		['does not start', undefined, 0],

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -163,17 +163,19 @@ export async function bootstrap(
 				dataBrowserClose ??= deps.dataBrowser?.close?.() ?? Promise.resolve();
 				return dataBrowserClose;
 			};
+			const disposeCompute = deps.compute[Symbol.asyncDispose];
+			const shutdowns: PromiseLike<unknown>[] = [
+				closed,
+				...(deps.dataBrowser?.close ? [closed.then(closeDataBrowser)] : []),
+			];
+			if (disposeCompute) {
+				shutdowns.push(Promise.resolve().then(() => disposeCompute.call(deps.compute)));
+			}
+			if (otel) shutdowns.push(Promise.resolve().then(() => otel.shutdown()));
 
 			// Long-lived WebSockets can keep close pending indefinitely. Ten seconds stays
 			// below Kubernetes' default 30-second termination grace period.
-			const result = await settleAllWithin(
-				[
-					closed,
-					...(deps.dataBrowser?.close ? [closed.then(closeDataBrowser)] : []),
-					...(otel ? [Promise.resolve().then(() => otel.shutdown())] : []),
-				],
-				DRAIN_TIMEOUT_MS,
-			);
+			const result = await settleAllWithin(shutdowns, DRAIN_TIMEOUT_MS);
 			// A timed-out drain still resolves (settleAllWithin never rejects), so surface it
 			// here or the forced termination looks like a clean shutdown.
 			if (result === 'timed-out') {

--- a/apps/server/src/dev.test.ts
+++ b/apps/server/src/dev.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createApi } from '@marimo-hub/api';
-import { ValidationError } from '@marimo-hub/core';
+import { ensureInitialized, UserId, ValidationError } from '@marimo-hub/core';
 import type { OrgIntegrationsService } from '@marimo-hub/core';
 import { createFromEnv } from '@marimo-hub/config';
 import { localDevEnv, seedLocalDev } from './devSetup';
@@ -68,6 +68,28 @@ describe('local development setup', () => {
 				scope: 'org',
 			}),
 		]);
+	});
+
+	it('does not mutate storage when integrations are unavailable', async () => {
+		const deps = createDevDeps();
+
+		await expect(seedLocalDev({ ...deps, orgIntegrations: undefined })).rejects.toThrow(
+			'Local development integrations are not enabled.',
+		);
+
+		expect((await deps.bucket.list()).objects).toEqual([]);
+	});
+
+	it('creates one welcome notebook across concurrent startups', async () => {
+		const deps = createDevDeps();
+		await ensureInitialized(deps.bucket, UserId.parse('user'));
+		const createNotebook = vi.spyOn(deps.services.notebooks, 'createNotebook');
+
+		await Promise.all([seedLocalDev(deps), seedLocalDev(deps)]);
+
+		expect(createNotebook).toHaveBeenCalledOnce();
+		const [project] = await deps.services.projects.listProjects();
+		expect(await deps.services.notebooks.listNotebooks(project.id)).toHaveLength(1);
 	});
 
 	it('ignores an atomic name conflict from another startup', async () => {

--- a/apps/server/src/dev.test.ts
+++ b/apps/server/src/dev.test.ts
@@ -5,6 +5,14 @@ import type { OrgIntegrationsService } from '@marimo-hub/core';
 import { createFromEnv } from '@marimo-hub/config';
 import { localDevEnv, seedLocalDev } from './devSetup';
 
+function deferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
 describe('local development setup', () => {
 	const createDevDeps = () => createFromEnv(localDevEnv({ PORT: '4321' }));
 	const nameConflict = () =>
@@ -88,6 +96,56 @@ describe('local development setup', () => {
 		await Promise.all([seedLocalDev(deps), seedLocalDev(deps)]);
 
 		expect(createNotebook).toHaveBeenCalledOnce();
+		const [project] = await deps.services.projects.listProjects();
+		expect(await deps.services.notebooks.listNotebooks(project.id)).toHaveLength(1);
+	});
+
+	it('retries the notebook seed when the concurrent holder fails', async () => {
+		const deps = createDevDeps();
+		await ensureInitialized(deps.bucket, UserId.parse('user'));
+		const originalCreate = deps.services.notebooks.createNotebook.bind(deps.services.notebooks);
+		const firstCanFail = deferred();
+		const firstDidStart = deferred();
+		const secondSawClaim = deferred();
+		const originalGet = deps.bucket.get.bind(deps.bucket);
+		vi.spyOn(deps.bucket, 'get').mockImplementation(async (key) => {
+			const object = await originalGet(key);
+			if (key === '_system/dev/local-notebook-seed.json' && object) secondSawClaim.resolve();
+			return object;
+		});
+		const createNotebook = vi
+			.spyOn(deps.services.notebooks, 'createNotebook')
+			.mockImplementationOnce(async () => {
+				firstDidStart.resolve();
+				await firstCanFail.promise;
+				throw new Error('first seed failed');
+			})
+			.mockImplementation(originalCreate);
+
+		const first = seedLocalDev(deps);
+		await firstDidStart.promise;
+		const second = seedLocalDev(deps);
+		await secondSawClaim.promise;
+		expect(createNotebook).toHaveBeenCalledOnce();
+
+		firstCanFail.resolve();
+		await expect(first).rejects.toThrow('first seed failed');
+		await expect(second).resolves.toBeUndefined();
+
+		expect(createNotebook).toHaveBeenCalledTimes(2);
+		const [project] = await deps.services.projects.listProjects();
+		expect(await deps.services.notebooks.listNotebooks(project.id)).toHaveLength(1);
+	});
+
+	it('reclaims an expired seed claim even when its PID is live', async () => {
+		const deps = createDevDeps();
+		await deps.bucket.put(
+			'_system/dev/local-notebook-seed.json',
+			JSON.stringify({ holder: `${process.pid}:${Date.now() - 60_000}:previous-process` }),
+		);
+
+		await seedLocalDev(deps);
+
 		const [project] = await deps.services.projects.listProjects();
 		expect(await deps.services.notebooks.listNotebooks(project.id)).toHaveLength(1);
 	});

--- a/apps/server/src/dev.test.ts
+++ b/apps/server/src/dev.test.ts
@@ -100,6 +100,44 @@ describe('local development setup', () => {
 		expect(await deps.services.notebooks.listNotebooks(project.id)).toHaveLength(1);
 	});
 
+	it('renews the seed claim while notebook creation is in progress', async () => {
+		const deps = createDevDeps();
+		await ensureInitialized(deps.bucket, UserId.parse('user'));
+		const originalCreate = deps.services.notebooks.createNotebook.bind(deps.services.notebooks);
+		const createDidStart = deferred();
+		const createCanFinish = deferred();
+		const createNotebook = vi
+			.spyOn(deps.services.notebooks, 'createNotebook')
+			.mockImplementationOnce(async (...args) => {
+				createDidStart.resolve();
+				await createCanFinish.promise;
+				return originalCreate(...args);
+			});
+
+		vi.useFakeTimers();
+		try {
+			const first = seedLocalDev(deps);
+			await createDidStart.promise;
+			await vi.advanceTimersByTimeAsync(31_000);
+
+			const second = seedLocalDev(deps);
+			await vi.advanceTimersByTimeAsync(25);
+			expect(createNotebook).toHaveBeenCalledOnce();
+
+			createCanFinish.resolve();
+			await first;
+			await vi.advanceTimersByTimeAsync(25);
+			await second;
+
+			expect(createNotebook).toHaveBeenCalledOnce();
+			const [project] = await deps.services.projects.listProjects();
+			expect(await deps.services.notebooks.listNotebooks(project.id)).toHaveLength(1);
+		} finally {
+			createCanFinish.resolve();
+			vi.useRealTimers();
+		}
+	});
+
 	it('retries the notebook seed when the concurrent holder fails', async () => {
 		const deps = createDevDeps();
 		await ensureInitialized(deps.bucket, UserId.parse('user'));

--- a/apps/server/src/dev.test.ts
+++ b/apps/server/src/dev.test.ts
@@ -38,11 +38,27 @@ describe('local development setup', () => {
 		});
 	});
 
-	it('seeds one org-wide integration once', async () => {
+	it('uses filesystem storage only when persistence is requested', () => {
+		const env = localDevEnv({ MARIMOHUB_DEV_PERSIST: 'true' });
+
+		expect(env).toMatchObject({
+			MARIMOHUB_STORAGE_BACKEND: 'fs',
+			MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: 'false',
+		});
+		expect(env.MARIMOHUB_STORAGE_FS_ROOT).toMatch(/\.context\/dev-storage$/);
+	});
+
+	it('seeds a welcome notebook and one org-wide integration once', async () => {
 		const deps = createDevDeps();
 
 		await seedLocalDev(deps);
 		await seedLocalDev(deps);
+
+		const projects = await deps.services.projects.listProjects();
+		expect(projects).toHaveLength(1);
+		expect(await deps.services.notebooks.listNotebooks(projects[0].id)).toEqual([
+			expect.objectContaining({ title: 'Welcome to marimohub', tags: ['example'] }),
+		]);
 
 		expect(await deps.orgIntegrations?.list()).toEqual([
 			expect.objectContaining({
@@ -61,9 +77,13 @@ describe('local development setup', () => {
 			.mockResolvedValueOnce([])
 			.mockResolvedValueOnce([{ name: 'local-development', kind: 'custom_env' }]);
 		const orgIntegrations = { list, create };
+		const deps = createDevDeps();
 
 		await expect(
-			seedLocalDev({ orgIntegrations: orgIntegrations as unknown as OrgIntegrationsService }),
+			seedLocalDev({
+				...deps,
+				orgIntegrations: orgIntegrations as unknown as OrgIntegrationsService,
+			}),
 		).resolves.toBeUndefined();
 		expect(create).toHaveBeenCalledOnce();
 	});
@@ -75,9 +95,13 @@ describe('local development setup', () => {
 			list: vi.fn().mockResolvedValue([{ name: 'local-development', kind: 'postgres' }]),
 			create,
 		};
+		const deps = createDevDeps();
 
 		await expect(
-			seedLocalDev({ orgIntegrations: orgIntegrations as unknown as OrgIntegrationsService }),
+			seedLocalDev({
+				...deps,
+				orgIntegrations: orgIntegrations as unknown as OrgIntegrationsService,
+			}),
 		).rejects.toBe(conflict);
 
 		expect(create).toHaveBeenCalledWith(

--- a/apps/server/src/devSetup.ts
+++ b/apps/server/src/devSetup.ts
@@ -1,9 +1,17 @@
+import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import type { ApiDeps } from '@marimo-hub/api';
-import { ensureInitialized, UserId, ValidationError } from '@marimo-hub/core';
+import {
+	acquireSingletonClaim,
+	ensureInitialized,
+	releaseSingletonClaim,
+	UserId,
+	ValidationError,
+} from '@marimo-hub/core';
 import type { CreateIntegrationInput, CreateNotebookInput } from '@marimo-hub/core';
 
 const DEV_STORAGE_ROOT = fileURLToPath(new URL('../../../.context/dev-storage', import.meta.url));
+const DEV_NOTEBOOK_SEED_CLAIM = '_system/dev/local-notebook-seed.json';
 
 const DEV_USER = {
 	id: UserId.parse('user'),
@@ -61,6 +69,52 @@ async function hasDevIntegration(integrations: NonNullable<ApiDeps['orgIntegrati
 	);
 }
 
+function parseSeedClaim(raw: unknown): string | null {
+	if (typeof raw !== 'object' || raw === null || !('holder' in raw)) {
+		throw new Error('Invalid local development seed claim');
+	}
+	const holder = raw.holder;
+	if (holder === null || typeof holder === 'string') return holder;
+	throw new Error('Invalid local development seed claim');
+}
+
+async function isSeedProcessLive(holder: string): Promise<boolean> {
+	const match = /^(\d+):/.exec(holder);
+	const pid = Number(match?.[1]);
+	if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return !(error instanceof Error && 'code' in error && error.code === 'ESRCH');
+	}
+}
+
+async function seedWelcomeNotebook(deps: Pick<ApiDeps, 'bucket' | 'services'>): Promise<void> {
+	const holder = `${process.pid}:${randomUUID()}`;
+	const claim = {
+		bucket: deps.bucket,
+		key: DEV_NOTEBOOK_SEED_CLAIM,
+		serialize: (value: string | null) => JSON.stringify({ holder: value }),
+		parseHolder: parseSeedClaim,
+		isHolderLive: isSeedProcessLive,
+	};
+	const { acquired } = await acquireSingletonClaim(claim, holder);
+	if (!acquired) return;
+
+	try {
+		const projects = await deps.services.projects.listProjects();
+		const project = projects.find(({ name }) => name === 'My Projects') ?? projects[0];
+		if (!project) return;
+		const notebooks = await deps.services.notebooks.listNotebooks(project.id);
+		if (!notebooks.some(({ title }) => title === DEV_NOTEBOOK.title)) {
+			await deps.services.notebooks.createNotebook(project.id, DEV_NOTEBOOK, DEV_USER.id);
+		}
+	} finally {
+		await releaseSingletonClaim(claim, holder);
+	}
+}
+
 export function localDevEnv(
 	env: Record<string, string | undefined>,
 ): Record<string, string | undefined> {
@@ -85,18 +139,11 @@ export function localDevEnv(
 export async function seedLocalDev(
 	deps: Pick<ApiDeps, 'bucket' | 'orgIntegrations' | 'services'>,
 ): Promise<void> {
-	await ensureInitialized(deps.bucket, DEV_USER.id);
-	const projects = await deps.services.projects.listProjects();
-	const project = projects.find(({ name }) => name === 'My Projects') ?? projects[0];
-	if (project) {
-		const notebooks = await deps.services.notebooks.listNotebooks(project.id);
-		if (!notebooks.some(({ title }) => title === DEV_NOTEBOOK.title)) {
-			await deps.services.notebooks.createNotebook(project.id, DEV_NOTEBOOK, DEV_USER.id);
-		}
-	}
-
 	const integrations = deps.orgIntegrations;
 	if (!integrations) throw new Error('Local development integrations are not enabled.');
+
+	await ensureInitialized(deps.bucket, DEV_USER.id);
+	await seedWelcomeNotebook(deps);
 	if (await hasDevIntegration(integrations)) return;
 
 	try {

--- a/apps/server/src/devSetup.ts
+++ b/apps/server/src/devSetup.ts
@@ -5,6 +5,7 @@ import {
 	acquireSingletonClaim,
 	ensureInitialized,
 	releaseSingletonClaim,
+	sleep,
 	UserId,
 	ValidationError,
 } from '@marimo-hub/core';
@@ -12,6 +13,9 @@ import type { CreateIntegrationInput, CreateNotebookInput } from '@marimo-hub/co
 
 const DEV_STORAGE_ROOT = fileURLToPath(new URL('../../../.context/dev-storage', import.meta.url));
 const DEV_NOTEBOOK_SEED_CLAIM = '_system/dev/local-notebook-seed.json';
+const DEV_NOTEBOOK_SEED_LEASE_MS = 30_000;
+const DEV_NOTEBOOK_SEED_WAIT_MS = DEV_NOTEBOOK_SEED_LEASE_MS + 5_000;
+const DEV_NOTEBOOK_SEED_POLL_MS = 25;
 
 const DEV_USER = {
 	id: UserId.parse('user'),
@@ -79,9 +83,18 @@ function parseSeedClaim(raw: unknown): string | null {
 }
 
 async function isSeedProcessLive(holder: string): Promise<boolean> {
-	const match = /^(\d+):/.exec(holder);
+	const match = /^(\d+):(\d+):/.exec(holder);
 	const pid = Number(match?.[1]);
-	if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+	const claimedAt = Number(match?.[2]);
+	const age = Date.now() - claimedAt;
+	if (
+		!Number.isSafeInteger(pid) ||
+		pid <= 0 ||
+		!Number.isSafeInteger(claimedAt) ||
+		age < 0 ||
+		age >= DEV_NOTEBOOK_SEED_LEASE_MS
+	)
+		return false;
 	try {
 		process.kill(pid, 0);
 		return true;
@@ -90,8 +103,22 @@ async function isSeedProcessLive(holder: string): Promise<boolean> {
 	}
 }
 
+async function acquireSeedClaim(
+	claim: Parameters<typeof acquireSingletonClaim>[0],
+	holder: string,
+): Promise<void> {
+	const deadline = Date.now() + DEV_NOTEBOOK_SEED_WAIT_MS;
+	for (;;) {
+		if ((await acquireSingletonClaim(claim, holder)).acquired) return;
+		const remaining = deadline - Date.now();
+		if (remaining <= 0)
+			throw new Error('Timed out waiting to seed the local development notebook.');
+		await sleep(Math.min(DEV_NOTEBOOK_SEED_POLL_MS, remaining));
+	}
+}
+
 async function seedWelcomeNotebook(deps: Pick<ApiDeps, 'bucket' | 'services'>): Promise<void> {
-	const holder = `${process.pid}:${randomUUID()}`;
+	const holder = `${process.pid}:${Date.now()}:${randomUUID()}`;
 	const claim = {
 		bucket: deps.bucket,
 		key: DEV_NOTEBOOK_SEED_CLAIM,
@@ -99,8 +126,7 @@ async function seedWelcomeNotebook(deps: Pick<ApiDeps, 'bucket' | 'services'>): 
 		parseHolder: parseSeedClaim,
 		isHolderLive: isSeedProcessLive,
 	};
-	const { acquired } = await acquireSingletonClaim(claim, holder);
-	if (!acquired) return;
+	await acquireSeedClaim(claim, holder);
 
 	try {
 		const projects = await deps.services.projects.listProjects();

--- a/apps/server/src/devSetup.ts
+++ b/apps/server/src/devSetup.ts
@@ -4,6 +4,7 @@ import type { ApiDeps } from '@marimo-hub/api';
 import {
 	acquireSingletonClaim,
 	ensureInitialized,
+	mutateObjectWithOutcome,
 	releaseSingletonClaim,
 	sleep,
 	UserId,
@@ -14,6 +15,7 @@ import type { CreateIntegrationInput, CreateNotebookInput } from '@marimo-hub/co
 const DEV_STORAGE_ROOT = fileURLToPath(new URL('../../../.context/dev-storage', import.meta.url));
 const DEV_NOTEBOOK_SEED_CLAIM = '_system/dev/local-notebook-seed.json';
 const DEV_NOTEBOOK_SEED_LEASE_MS = 30_000;
+const DEV_NOTEBOOK_SEED_RENEW_MS = DEV_NOTEBOOK_SEED_LEASE_MS / 3;
 const DEV_NOTEBOOK_SEED_WAIT_MS = DEV_NOTEBOOK_SEED_LEASE_MS + 5_000;
 const DEV_NOTEBOOK_SEED_POLL_MS = 25;
 
@@ -82,6 +84,11 @@ function parseSeedClaim(raw: unknown): string | null {
 	throw new Error('Invalid local development seed claim');
 }
 
+function renewSeedHolder(holder: string): string | null {
+	const match = /^(\d+):\d+:(.+)$/.exec(holder);
+	return match ? `${match[1]}:${Date.now()}:${match[2]}` : null;
+}
+
 async function isSeedProcessLive(holder: string): Promise<boolean> {
 	const match = /^(\d+):(\d+):/.exec(holder);
 	const pid = Number(match?.[1]);
@@ -117,8 +124,23 @@ async function acquireSeedClaim(
 	}
 }
 
+async function renewSeedClaim(
+	deps: Pick<ApiDeps, 'bucket'>,
+	holder: string,
+): Promise<string | null> {
+	const renewed = renewSeedHolder(holder);
+	if (!renewed) return null;
+	const result = await mutateObjectWithOutcome(
+		deps.bucket,
+		DEV_NOTEBOOK_SEED_CLAIM,
+		(raw) => ({ holder: parseSeedClaim(raw) }),
+		(current) => (current.holder === holder ? { holder: renewed } : null),
+	);
+	return result.written ? renewed : null;
+}
+
 async function seedWelcomeNotebook(deps: Pick<ApiDeps, 'bucket' | 'services'>): Promise<void> {
-	const holder = `${process.pid}:${Date.now()}:${randomUUID()}`;
+	let holder = `${process.pid}:${Date.now()}:${randomUUID()}`;
 	const claim = {
 		bucket: deps.bucket,
 		key: DEV_NOTEBOOK_SEED_CLAIM,
@@ -127,6 +149,26 @@ async function seedWelcomeNotebook(deps: Pick<ApiDeps, 'bucket' | 'services'>): 
 		isHolderLive: isSeedProcessLive,
 	};
 	await acquireSeedClaim(claim, holder);
+	let renewal: Promise<void> | undefined;
+	let renewalError: Error | undefined;
+	const renew = (): Promise<void> => {
+		if (renewal) return renewal;
+		const pending = renewSeedClaim(deps, holder).then((next) => {
+			if (!next) throw new Error('Lost the local development notebook seed lease.');
+			holder = next;
+		});
+		const tracked = pending
+			.catch((error: unknown) => {
+				renewalError = error instanceof Error ? error : new Error(String(error));
+				throw renewalError;
+			})
+			.finally(() => {
+				if (renewal === tracked) renewal = undefined;
+			});
+		renewal = tracked;
+		return tracked;
+	};
+	const renewalTimer = setInterval(() => void renew().catch(() => {}), DEV_NOTEBOOK_SEED_RENEW_MS);
 
 	try {
 		const projects = await deps.services.projects.listProjects();
@@ -134,9 +176,14 @@ async function seedWelcomeNotebook(deps: Pick<ApiDeps, 'bucket' | 'services'>): 
 		if (!project) return;
 		const notebooks = await deps.services.notebooks.listNotebooks(project.id);
 		if (!notebooks.some(({ title }) => title === DEV_NOTEBOOK.title)) {
+			await renew();
 			await deps.services.notebooks.createNotebook(project.id, DEV_NOTEBOOK, DEV_USER.id);
 		}
+		await renewal;
+		if (renewalError) throw renewalError;
 	} finally {
+		clearInterval(renewalTimer);
+		await renewal?.catch(() => {});
 		await releaseSingletonClaim(claim, holder);
 	}
 }

--- a/apps/server/src/devSetup.ts
+++ b/apps/server/src/devSetup.ts
@@ -1,6 +1,9 @@
+import { fileURLToPath } from 'node:url';
 import type { ApiDeps } from '@marimo-hub/api';
-import { UserId, ValidationError } from '@marimo-hub/core';
-import type { CreateIntegrationInput } from '@marimo-hub/core';
+import { ensureInitialized, UserId, ValidationError } from '@marimo-hub/core';
+import type { CreateIntegrationInput, CreateNotebookInput } from '@marimo-hub/core';
+
+const DEV_STORAGE_ROOT = fileURLToPath(new URL('../../../.context/dev-storage', import.meta.url));
 
 const DEV_USER = {
 	id: UserId.parse('user'),
@@ -17,6 +20,41 @@ const DEV_INTEGRATION = {
 
 const DEV_INTEGRATION_CONFLICT = `An integration named "${DEV_INTEGRATION.name}" already exists at the org level.`;
 
+const DEV_NOTEBOOK = {
+	title: 'Welcome to marimohub',
+	description: 'A small notebook for trying the local development stack.',
+	code: `import marimo
+
+__generated_with = "0.16.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    slider = mo.ui.slider(1, 10, value=5, label="Pick a number")
+    slider
+    return (slider,)
+
+
+@app.cell
+def _(mo, slider):
+    mo.md(f"Your number squared is **{slider.value ** 2}**.")
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+`,
+	tags: ['example'],
+	readme: '# Welcome to marimohub\n\nEdit and run this notebook with the local compute backend.\n',
+} satisfies CreateNotebookInput;
+
 async function hasDevIntegration(integrations: NonNullable<ApiDeps['orgIntegrations']>) {
 	return (await integrations.list()).some(
 		({ kind, name }) => kind === DEV_INTEGRATION.kind && name === DEV_INTEGRATION.name,
@@ -26,10 +64,12 @@ async function hasDevIntegration(integrations: NonNullable<ApiDeps['orgIntegrati
 export function localDevEnv(
 	env: Record<string, string | undefined>,
 ): Record<string, string | undefined> {
+	const durableStorage = env.MARIMOHUB_DEV_PERSIST === 'true';
 	return {
 		...env,
-		MARIMOHUB_STORAGE_BACKEND: 'memory',
-		MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: 'true',
+		MARIMOHUB_STORAGE_BACKEND: durableStorage ? 'fs' : 'memory',
+		MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: durableStorage ? 'false' : 'true',
+		MARIMOHUB_STORAGE_FS_ROOT: durableStorage ? DEV_STORAGE_ROOT : undefined,
 		MARIMOHUB_COMPUTE_BACKEND: 'local',
 		MARIMOHUB_AUTH_BACKEND: 'dev',
 		MARIMOHUB_AUTH_DEV_USER_ID: DEV_USER.id,
@@ -42,7 +82,19 @@ export function localDevEnv(
 	};
 }
 
-export async function seedLocalDev(deps: Pick<ApiDeps, 'orgIntegrations'>): Promise<void> {
+export async function seedLocalDev(
+	deps: Pick<ApiDeps, 'bucket' | 'orgIntegrations' | 'services'>,
+): Promise<void> {
+	await ensureInitialized(deps.bucket, DEV_USER.id);
+	const projects = await deps.services.projects.listProjects();
+	const project = projects.find(({ name }) => name === 'My Projects') ?? projects[0];
+	if (project) {
+		const notebooks = await deps.services.notebooks.listNotebooks(project.id);
+		if (!notebooks.some(({ title }) => title === DEV_NOTEBOOK.title)) {
+			await deps.services.notebooks.createNotebook(project.id, DEV_NOTEBOOK, DEV_USER.id);
+		}
+	}
+
 	const integrations = deps.orgIntegrations;
 	if (!integrations) throw new Error('Local development integrations are not enabled.');
 	if (await hasDevIntegration(integrations)) return;

--- a/development_docs/technologies.md
+++ b/development_docs/technologies.md
@@ -155,7 +155,7 @@ classes rather than plain CSS.
 ### Vite + vite-plus
 
 Build tool and dev server. The web app builds with `vite-plus` (`vp`), using
-`@vitejs/plugin-react-swc` for fast JSX transforms and `@tailwindcss/vite` for
+`@vitejs/plugin-react` for JSX transforms and `@tailwindcss/vite` for
 Tailwind. The SPA dev server runs on port **5175** and proxies `/api/*` to the
 local Node server (`apps/server`, port 3000); the Cloudflare vite-plugin is
 intentionally absent — the SPA is a pure consumer of the API, served as static
@@ -251,7 +251,7 @@ Shared primitives in `packages/web/src/components/ui/`, built with
 | `lucide-react`                      | Icon set                   | Frontend     |
 | `sonner`                            | Toast notifications        | Frontend     |
 | `vite` / `vite-plus`                | Build tool & dev server    | Dev          |
-| `@vitejs/plugin-react-swc`          | Fast JSX transform         | Dev          |
+| `@vitejs/plugin-react`              | JSX transform              | Dev          |
 | `@cloudflare/workers-types`         | Worker API types           | Dev          |
 | `typescript`                        | Type checking              | Dev          |
 | `oxlint` / `oxfmt`                  | Lint & format (oxc)        | Dev          |

--- a/docs/testing-locally.md
+++ b/docs/testing-locally.md
@@ -53,6 +53,14 @@ Startup is ready when the `server` process is listening on port `3000` and the
 `web` process prints a Vite local URL on port `5175`. The server owns the API;
 the web dev server proxies `/api` requests to it.
 
+`PORT` overrides the API port and `WEB_PORT` overrides the Vite port. For
+parallel worktrees, set `DEV_PORT_BASE`; the API uses that port and the web app
+uses the next port. Explicit `PORT` and `WEB_PORT` values take precedence:
+
+```bash
+DEV_PORT_BASE=4100 pnpm dev
+```
+
 ## What the local backends mean
 
 | Part    | Local backend           | Production swap                                                         |
@@ -61,10 +69,24 @@ the web dev server proxies `/api` requests to it.
 | Compute | `local`, host process   | CoreWeave, Modal, Kubernetes, Docker, Podman -> [Compute](./compute.md) |
 | Auth    | `dev`, fixed local user | OIDC or Cloudflare Access -> [Auth](./auth.md)                          |
 
-The local stack stores nothing durably. It starts kernels on your machine and
-authenticates every request as a fixed super admin. It enables integrations and
-metadata browsing, then seeds an org-wide `local-development` integration. The
-development entrypoint does not change deployed defaults.
+By default, state is held in memory and disappears on restart. The stack starts
+kernels on your machine, signs every request in as a fixed super admin, enables
+integrations and metadata browsing, and seeds a welcome notebook plus an
+org-wide `local-development` environment. Browsing requires a live Trino,
+ClickHouse, or Iceberg REST service. None of this changes deployed defaults.
+
+To keep projects and notebooks across restarts, opt into filesystem storage:
+
+```bash
+MARIMOHUB_DEV_PERSIST=true pnpm dev
+```
+
+This stores local state in `.context/dev-storage`, which is ignored by Git. Stop
+the dev stack before clearing it:
+
+```bash
+pnpm dev:reset
+```
 
 ## Run the server manually
 
@@ -75,8 +97,10 @@ the example when you want persistent local overrides:
 cp apps/server/.env.example apps/server/.env
 ```
 
-The development entrypoint overrides its storage, compute, auth, access, and
-feature values. The file can set other values, such as `PORT`.
+The development entrypoint overrides storage, compute, auth, access, and feature
+values. The file can set other values such as `MARIMOHUB_DEV_PERSIST=true`.
+Set port overrides on the root command so the server and web proxy receive the
+same values.
 
 ## Validate the local run
 
@@ -89,15 +113,13 @@ curl --fail --silent http://localhost:3000/api/health
 It should return `{"status":"ok"}`. Then:
 
 1. Open `http://localhost:5175`.
-2. Create a project.
-3. Create or upload a notebook.
-4. Start a kernel. If `uv` and Python are unavailable, stop after step 3.
-5. Stop and restart `pnpm dev`.
+2. Open the seeded welcome notebook, or create a project and notebook.
+3. Start a kernel. If `uv` and Python are unavailable, stop after step 2.
+4. Stop and restart `pnpm dev`.
 
-The project will disappear after restart when you use memory storage. That is
-expected. The local trial succeeded if the health check passed, the web app
-loaded, and you could create a project. Switch to a durable storage backend
-before keeping real notebooks.
+Projects disappear after restart when you use the default memory storage. That
+is expected. Set `MARIMOHUB_DEV_PERSIST=true` for durable local state; deployed
+environments should use a production storage configuration.
 
 ## Next
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"license": "Apache-2.0",
 	"type": "module",
 	"scripts": {
-		"dev": "if [ -n \"$DEV_PORT_BASE\" ]; then [ -n \"$PORT\" ] || export PORT=\"$DEV_PORT_BASE\"; [ -n \"$WEB_PORT\" ] || export WEB_PORT=\"$((DEV_PORT_BASE + 1))\"; fi; exec vp run --filter @marimo-hub/server --filter @marimo-hub/web --parallel --log labeled dev",
+		"dev": "node scripts/dev-ports.mjs",
 		"dev:reset": "node scripts/reset-dev-storage.mjs",
 		"ready": "vp fmt && vp lint && pnpm typecheck && vp run -r test && vp run -r build",
 		"check": "vp check",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"license": "Apache-2.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vp run --filter @marimo-hub/server --filter @marimo-hub/web --parallel --log labeled dev",
+		"dev": "if [ -n \"$DEV_PORT_BASE\" ]; then [ -n \"$PORT\" ] || export PORT=\"$DEV_PORT_BASE\"; [ -n \"$WEB_PORT\" ] || export WEB_PORT=\"$((DEV_PORT_BASE + 1))\"; fi; exec vp run --filter @marimo-hub/server --filter @marimo-hub/web --parallel --log labeled dev",
+		"dev:reset": "node scripts/reset-dev-storage.mjs",
 		"ready": "vp fmt && vp lint && pnpm typecheck && vp run -r test && vp run -r build",
 		"check": "vp check",
 		"typecheck": "vp run -r typecheck",

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -167,6 +167,27 @@ describe('LocalCompute file ops', () => {
 		expect(list.files.map((f) => f.name)).toContain('notebook.py');
 	});
 
+	it('waits for active writes before destroying and rejects later writes', async () => {
+		const id = `sb-write-destroy-${Math.random().toString(36).slice(2, 10)}` as SandboxId;
+		created.push(id);
+		const sb = compute.create(id);
+		const root = path.join(os.tmpdir(), `marimohub-sandbox-${id}`);
+		const writes = Array.from({ length: 100 }, (_, index) => ({
+			path: `/workspace/${index}/file.txt`,
+			content: 'content',
+		}));
+
+		const writing = sb.writeFiles(writes);
+		const destroying = sb.destroy();
+		await expect(writing).resolves.toBeUndefined();
+		await expect(destroying).resolves.toBeUndefined();
+
+		await expect(access(root)).rejects.toThrow();
+		await expect(sb.writeFiles([{ path: '/workspace/late.txt', content: 'late' }])).rejects.toThrow(
+			/destroyed/,
+		);
+	});
+
 	it('returns NOT_FOUND reading a missing file', async () => {
 		const sb = newSandbox();
 		const read = await sb.readFile('/workspace/nope.py');
@@ -406,25 +427,29 @@ describe('LocalCompute registry & teardown', () => {
 
 	it('disposes every sandbox and rejects later creates', async () => {
 		const local = new LocalCompute();
-		const first = local.create('sb-dispose-first' as SandboxId);
-		const second = local.create('sb-dispose-second' as SandboxId);
-		const firstProcess = await first.startProcess(SERVER_CMD, { cwd: '/workspace' });
-		const secondProcess = await second.startProcess(SERVER_CMD, { cwd: '/workspace' });
-		await Promise.all([
-			firstProcess.waitForPort(2718, { timeout: 15_000 }),
-			secondProcess.waitForPort(2718, { timeout: 15_000 }),
-		]);
-		const urls = await Promise.all([
-			first.exposePort(2718, { hostname: '' }),
-			second.exposePort(2718, { hostname: '' }),
-		]);
+		try {
+			const first = local.create('sb-dispose-first' as SandboxId);
+			const second = local.create('sb-dispose-second' as SandboxId);
+			const firstProcess = await first.startProcess(SERVER_CMD, { cwd: '/workspace' });
+			const secondProcess = await second.startProcess(SERVER_CMD, { cwd: '/workspace' });
+			await Promise.all([
+				firstProcess.waitForPort(2718, { timeout: 15_000 }),
+				secondProcess.waitForPort(2718, { timeout: 15_000 }),
+			]);
+			const urls = await Promise.all([
+				first.exposePort(2718, { hostname: '' }),
+				second.exposePort(2718, { hostname: '' }),
+			]);
 
-		await local[Symbol.asyncDispose]();
-		await expect(local[Symbol.asyncDispose]()).resolves.toBeUndefined();
+			await local[Symbol.asyncDispose]();
+			await expect(local[Symbol.asyncDispose]()).resolves.toBeUndefined();
 
-		for (const { url } of urls) await expect(fetch(url)).rejects.toThrow();
-		await expect(first.startProcess(SERVER_CMD)).rejects.toThrow(/destroyed/);
-		expect(() => local.create('sb-after-dispose' as SandboxId)).toThrow(/disposed/);
+			for (const { url } of urls) await expect(fetch(url)).rejects.toThrow();
+			await expect(first.startProcess(SERVER_CMD)).rejects.toThrow(/destroyed/);
+			expect(() => local.create('sb-after-dispose' as SandboxId)).toThrow(/disposed/);
+		} finally {
+			await local[Symbol.asyncDispose]();
+		}
 	});
 });
 

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -403,6 +403,29 @@ describe('LocalCompute registry & teardown', () => {
 	it('proxy is a no-op', async () => {
 		expect(await compute.proxy()).toBeNull();
 	});
+
+	it('disposes every sandbox and rejects later creates', async () => {
+		const local = new LocalCompute();
+		const first = local.create('sb-dispose-first' as SandboxId);
+		const second = local.create('sb-dispose-second' as SandboxId);
+		const firstProcess = await first.startProcess(SERVER_CMD, { cwd: '/workspace' });
+		const secondProcess = await second.startProcess(SERVER_CMD, { cwd: '/workspace' });
+		await Promise.all([
+			firstProcess.waitForPort(2718, { timeout: 15_000 }),
+			secondProcess.waitForPort(2718, { timeout: 15_000 }),
+		]);
+		const urls = await Promise.all([
+			first.exposePort(2718, { hostname: '' }),
+			second.exposePort(2718, { hostname: '' }),
+		]);
+
+		await local[Symbol.asyncDispose]();
+		await expect(local[Symbol.asyncDispose]()).resolves.toBeUndefined();
+
+		for (const { url } of urls) await expect(fetch(url)).rejects.toThrow();
+		await expect(first.startProcess(SERVER_CMD)).rejects.toThrow(/destroyed/);
+		expect(() => local.create('sb-after-dispose' as SandboxId)).toThrow(/disposed/);
+	});
 });
 
 describe('LocalCompute listActive', () => {

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -219,6 +219,7 @@ class LocalSandboxInstance implements SandboxInstance {
 	private readonly portMap = new Map<number, number>();
 	private env: Record<string, string> = {};
 	private envDefaults: Record<string, string> = {};
+	private destroyPromise?: Promise<void>;
 	/** ISO timestamp the instance was constructed — surfaced via listActive(). */
 	readonly createdAt = new Date().toISOString();
 
@@ -270,13 +271,20 @@ class LocalSandboxInstance implements SandboxInstance {
 	}
 
 	private async ensureRoot(): Promise<void> {
+		this.assertActive();
 		await mkdir(this.root, { recursive: true });
+		this.assertActive();
+	}
+
+	private assertActive(): void {
+		if (this.destroyPromise) throw new Error('local sandbox has been destroyed');
 	}
 
 	private spawnShell(
 		command: string,
 		options: { cwd?: string; env?: NodeJS.ProcessEnv; detached?: boolean } = {},
 	): ChildProcess {
+		this.assertActive();
 		// Spawn env entries are forced; guarded defaults defer to the inherited host env.
 		return spawn('sh', ['-c', withEnvPrefix(command, {}, this.envDefaults)], {
 			cwd: options.cwd ?? this.root,
@@ -285,31 +293,35 @@ class LocalSandboxInstance implements SandboxInstance {
 		});
 	}
 
+	private trackChild(child: ChildProcess): ChildProcess {
+		this.children.add(child);
+		const forget = () => this.children.delete(child);
+		child.once('exit', forget);
+		child.once('error', forget);
+		return child;
+	}
+
 	async exec(cmd: string): Promise<ExecResult> {
 		await this.ensureRoot();
 		return new Promise((resolve) => {
-			const child = this.spawnShell(this.rewriteCmd(cmd));
+			const child = this.trackChild(this.spawnShell(this.rewriteCmd(cmd), { detached: true }));
 			const { stdout, stderr } = captureOutput(child);
-			child.on('error', (err) =>
+			child.on('error', (err) => {
 				resolve(
 					execResult(false, stdout.toString(), stderr.toString() + String(err), 'SPAWN_FAILED'),
-				),
-			);
-			child.on('close', (code) =>
-				resolve(execResult(code === 0, stdout.toString(), stderr.toString())),
-			);
+				);
+			});
+			child.on('close', (code) => {
+				resolve(execResult(code === 0, stdout.toString(), stderr.toString()));
+			});
 		});
 	}
 
 	async execStream(cmd: string, _options?: ExecStreamOptions): Promise<ReadableStream> {
 		await this.ensureRoot();
-		const child = this.spawnShell(this.rewriteCmd(cmd), { detached: true });
-		this.children.add(child);
+		const child = this.trackChild(this.spawnShell(this.rewriteCmd(cmd), { detached: true }));
 		// An undrained stderr pipe can fill and block the child before stdout completes.
 		child.stderr?.resume();
-		const forget = () => this.children.delete(child);
-		child.once('exit', forget);
-		child.once('error', forget);
 		const stdout = child.stdout ?? Readable.from([]);
 		stdout.once('close', () => {
 			if (stdout.readableAborted) killProcessGroup(child, 'SIGKILL');
@@ -416,20 +428,21 @@ class LocalSandboxInstance implements SandboxInstance {
 
 		const cwd = options?.cwd ? this.mapPath(options.cwd) : this.root;
 		await mkdir(cwd, { recursive: true });
+		this.assertActive();
 
-		const child = this.spawnShell(command, {
-			cwd,
-			env: options?.env,
-			detached: true,
-		});
-		this.children.add(child);
+		const child = this.trackChild(
+			this.spawnShell(command, {
+				cwd,
+				env: options?.env,
+				detached: true,
+			}),
+		);
 
 		const { stdout, stderr } = captureOutput(child);
 
 		let exitInfo: { code: number | null; signal: NodeJS.Signals | null } | null = null;
 		child.on('exit', (code, signal) => {
 			exitInfo = { code, signal };
-			this.children.delete(child);
 		});
 
 		const portMap = this.portMap;
@@ -476,13 +489,14 @@ class LocalSandboxInstance implements SandboxInstance {
 	}
 
 	async destroy(): Promise<void> {
-		for (const child of this.children) {
-			killProcessGroup(child, 'SIGKILL');
-		}
+		if (this.destroyPromise) return this.destroyPromise;
+		for (const child of this.children) killProcessGroup(child, 'SIGKILL');
 		this.children.clear();
 		this.portMap.clear();
-		await rm(this.root, { recursive: true, force: true });
-		this.onDestroyed?.();
+		this.destroyPromise = rm(this.root, { recursive: true, force: true }).then(() => {
+			this.onDestroyed?.();
+		});
+		return this.destroyPromise;
 	}
 }
 
@@ -493,6 +507,7 @@ export class LocalCompute implements SandboxProvider {
 	// Re-resolution must return the same live instance so teardown can find its
 	// child process; destroy evicts it so a later create gets fresh state.
 	private readonly instances = new Map<SandboxId, LocalSandboxInstance>();
+	private disposePromise?: Promise<void>;
 
 	constructor(options?: LocalComputeOptions) {
 		this.host = options?.host || 'localhost';
@@ -501,6 +516,7 @@ export class LocalCompute implements SandboxProvider {
 	}
 
 	create(id: SandboxId): SandboxInstance {
+		if (this.disposePromise) throw new Error('local compute has been disposed');
 		let instance = this.instances.get(id);
 		if (!instance) {
 			const next = new LocalSandboxInstance(
@@ -536,5 +552,13 @@ export class LocalCompute implements SandboxProvider {
 			}
 		}
 		return active;
+	}
+
+	private async destroyInstances(): Promise<void> {
+		await Promise.all([...this.instances.values()].map((instance) => instance.destroy()));
+	}
+
+	[Symbol.asyncDispose](): Promise<void> {
+		return (this.disposePromise ??= this.destroyInstances());
 	}
 }

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -217,6 +217,7 @@ class LocalSandboxInstance implements SandboxInstance {
 	private readonly children = new Set<ChildProcess>();
 	/** Logical port (as named in core, e.g. 2718) → real allocated host port. */
 	private readonly portMap = new Map<number, number>();
+	private readonly pendingWrites = new Set<Promise<unknown>>();
 	private env: Record<string, string> = {};
 	private envDefaults: Record<string, string> = {};
 	private destroyPromise?: Promise<void>;
@@ -374,8 +375,9 @@ class LocalSandboxInstance implements SandboxInstance {
 	}
 
 	async writeFiles(files: readonly SandboxFileWrite[]): Promise<void> {
+		this.assertActive();
 		// Local writes are cheap (no round-trip), so a plain bounded loop is enough.
-		await mapWithConcurrency(files, WRITE_CONCURRENCY, async (f) => {
+		const pending = mapWithConcurrency(files, WRITE_CONCURRENCY, async (f) => {
 			const abs = this.resolveContained(f.path);
 			if (abs === null) {
 				console.warn(`writeFiles: skipping path outside sandbox root: ${f.path}`);
@@ -385,6 +387,12 @@ class LocalSandboxInstance implements SandboxInstance {
 			// `encoding` applies to string content only; bytes are written verbatim.
 			await writeFile(abs, f.content, typeof f.content === 'string' ? 'utf-8' : null);
 		});
+		this.pendingWrites.add(pending);
+		try {
+			await pending;
+		} finally {
+			this.pendingWrites.delete(pending);
+		}
 	}
 
 	async gitCheckout(repo: string, options?: GitCheckoutOptions): Promise<void> {
@@ -493,9 +501,11 @@ class LocalSandboxInstance implements SandboxInstance {
 		for (const child of this.children) killProcessGroup(child, 'SIGKILL');
 		this.children.clear();
 		this.portMap.clear();
-		this.destroyPromise = rm(this.root, { recursive: true, force: true }).then(() => {
-			this.onDestroyed?.();
-		});
+		this.destroyPromise = Promise.allSettled(this.pendingWrites)
+			.then(() => rm(this.root, { recursive: true, force: true }))
+			.then(() => {
+				this.onDestroyed?.();
+			});
 		return this.destroyPromise;
 	}
 }

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -237,6 +237,7 @@ export interface SandboxProvider {
 	 * provider sandbox back to its record (or detect that none exists).
 	 */
 	listActive?(): Promise<ActiveSandbox[]>;
+	[Symbol.asyncDispose]?(): PromiseLike<void>;
 }
 
 /**

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -24,6 +24,7 @@ export { MaintenanceService } from './catalog/MaintenanceService';
 export type { ExpireSnapshotsOptions, PruneEventsOptions } from './catalog/MaintenanceService';
 export { MaintenanceLock } from './catalog/MaintenanceLock';
 export { MAX_VERSIONS, NotebookService } from './content/NotebookService';
+export type { CreateNotebookInput } from './content/NotebookService';
 export type {
 	CreateSyncedNotebookInput,
 	SyncNotebookInput,

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -133,8 +133,10 @@ export type { CreatedToken, CreateTokenInput } from './tokens/TokenService';
 export { composeAuthenticators } from './tokens/composeAuthenticators';
 export { listAllKeys } from './catalog/storage';
 export {
+	acquireSingletonClaim,
 	mutateObject,
 	mutateObjectWithOutcome,
+	releaseSingletonClaim,
 	withCasRetry,
 	type CasRetryOptions,
 	type CasWriter,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,6 @@
 	"license": "Apache-2.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vp dev",
 		"test": "vp test",
 		"preview": "vp preview",
 		"typecheck": "tsc --noEmit"

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -4,8 +4,13 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, lazyPlugins } from 'vite-plus';
 
-const apiPort = Number(process.env.PORT ?? 3000);
-const webPort = Number(process.env.WEB_PORT ?? 5175);
+function envPort(value: string | undefined, fallback: number): number {
+	const port = Number(value);
+	return Number.isInteger(port) && port >= 1 && port <= 65_535 ? port : fallback;
+}
+
+const apiPort = envPort(process.env.PORT, 3000);
+const webPort = envPort(process.env.WEB_PORT, 5175);
 
 // React SPA. The Cloudflare vite-plugin is intentionally absent — the SPA is a
 // pure consumer of the /api/* surface and is served as static assets by whatever

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig, lazyPlugins } from 'vite-plus';
 
+const apiPort = Number(process.env.PORT ?? 3000);
+const webPort = Number(process.env.WEB_PORT ?? 5175);
+
 // React SPA. The Cloudflare vite-plugin is intentionally absent — the SPA is a
 // pure consumer of the /api/* surface and is served as static assets by whatever
 // fronts the deployment (apps/server in Node, or Cloudflare in the reference).
@@ -16,17 +19,15 @@ export default defineConfig({
 		},
 	},
 	server: {
-		port: 5175,
+		port: webPort,
+		strictPort: true,
 		open: true,
 		// Proxy API calls to the local Node server (apps/server) so the SPA dev
 		// server can reach the /api/* surface during development.
 		proxy: {
 			'/api': {
-				target: 'http://localhost:3000',
-				// Keep the browser's Host header (localhost:5175) instead of rewriting it
-				// to the target. The API's CSRF guard compares the full request origin;
-				// with changeOrigin the proxied Host becomes
-				// localhost:3000 while Origin stays localhost:5175, tripping the guard.
+				target: `http://localhost:${apiPort}`,
+				// Rewriting Host would make it differ from Origin and trip the CSRF guard.
 				changeOrigin: false,
 			},
 		},
@@ -37,6 +38,10 @@ export default defineConfig({
 	// Cached build task: `output` archives/restores dist/ on a hit (a script can't).
 	run: {
 		tasks: {
+			dev: {
+				command: 'vp dev',
+				untrackedEnv: ['PORT', 'WEB_PORT'],
+			},
 			build: { command: 'vp build', output: ['dist/**'] },
 		},
 	},

--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -35,9 +35,11 @@ if (process.exitCode === undefined) {
 		env,
 		stdio: 'inherit',
 	});
-	const signals = ['SIGINT', 'SIGTERM'];
+	const signals = useProcessGroup
+		? ['SIGHUP', 'SIGINT', 'SIGQUIT', 'SIGTERM']
+		: ['SIGINT', 'SIGTERM'];
 	const signalHandlers = new Map();
-	const signalChildTree = (signal) => {
+	const signalChildTree = (signal, groupMayBeGone = false) => {
 		if (!useProcessGroup || child.pid === undefined) {
 			child.kill(signal);
 			return;
@@ -46,7 +48,7 @@ if (process.exitCode === undefined) {
 		try {
 			process.kill(-child.pid, signal);
 		} catch (error) {
-			if (error.code !== 'ESRCH') {
+			if (error.code !== 'ESRCH' && !(groupMayBeGone && error.code === 'EPERM')) {
 				throw error;
 			}
 		}
@@ -60,7 +62,7 @@ if (process.exitCode === undefined) {
 	for (const signal of signals) {
 		const handler = () => signalChildTree(signal);
 		signalHandlers.set(signal, handler);
-		process.once(signal, handler);
+		process.on(signal, handler);
 	}
 
 	child.on('error', (error) => {
@@ -69,10 +71,10 @@ if (process.exitCode === undefined) {
 		process.exitCode = 1;
 	});
 	child.on('exit', (code, signal) => {
-		removeSignalHandlers();
 		if (useProcessGroup) {
-			signalChildTree('SIGTERM');
+			signalChildTree('SIGTERM', true);
 		}
+		removeSignalHandlers();
 		if (signal) {
 			process.kill(process.pid, signal);
 		} else {

--- a/scripts/dev-ports.mjs
+++ b/scripts/dev-ports.mjs
@@ -1,0 +1,82 @@
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const vpBin = fileURLToPath(new URL('./bin/vp', import.meta.resolve('vite-plus/package.json')));
+const args = [
+	'run',
+	'--filter',
+	'@marimo-hub/server',
+	'--filter',
+	'@marimo-hub/web',
+	'--parallel',
+	'--log',
+	'labeled',
+	'dev',
+];
+
+const env = { ...process.env };
+const base = env.DEV_PORT_BASE;
+
+if (base !== undefined && base !== '') {
+	const basePort = Number(base);
+	if (!Number.isInteger(basePort) || basePort < 1 || basePort >= 65_535) {
+		console.error('DEV_PORT_BASE must be an integer between 1 and 65534.');
+		process.exitCode = 1;
+	} else {
+		env.PORT ||= String(basePort);
+		env.WEB_PORT ||= String(basePort + 1);
+	}
+}
+
+if (process.exitCode === undefined) {
+	const useProcessGroup = process.platform !== 'win32';
+	const child = spawn(process.execPath, [vpBin, ...args], {
+		detached: useProcessGroup,
+		env,
+		stdio: 'inherit',
+	});
+	const signals = ['SIGINT', 'SIGTERM'];
+	const signalHandlers = new Map();
+	const signalChildTree = (signal) => {
+		if (!useProcessGroup || child.pid === undefined) {
+			child.kill(signal);
+			return;
+		}
+
+		try {
+			process.kill(-child.pid, signal);
+		} catch (error) {
+			if (error.code !== 'ESRCH') {
+				throw error;
+			}
+		}
+	};
+	const removeSignalHandlers = () => {
+		for (const [signal, handler] of signalHandlers) {
+			process.removeListener(signal, handler);
+		}
+	};
+
+	for (const signal of signals) {
+		const handler = () => signalChildTree(signal);
+		signalHandlers.set(signal, handler);
+		process.once(signal, handler);
+	}
+
+	child.on('error', (error) => {
+		removeSignalHandlers();
+		console.error(error);
+		process.exitCode = 1;
+	});
+	child.on('exit', (code, signal) => {
+		removeSignalHandlers();
+		if (useProcessGroup) {
+			signalChildTree('SIGTERM');
+		}
+		if (signal) {
+			process.kill(process.pid, signal);
+		} else {
+			process.exitCode = code ?? 1;
+		}
+	});
+}

--- a/scripts/reset-dev-storage.mjs
+++ b/scripts/reset-dev-storage.mjs
@@ -1,0 +1,7 @@
+import { rm } from 'node:fs/promises';
+import path from 'node:path';
+
+const storageRoot = path.resolve(import.meta.dirname, '../.context/dev-storage');
+
+await rm(storageRoot, { recursive: true, force: true });
+console.log(`Removed local development state from ${storageRoot}`);


### PR DESCRIPTION
Tightens the local dev stack for a smoother first run and parallel worktrees.

## Changes
- **Durable local state (opt-in):** `MARIMOHUB_DEV_PERSIST=true` switches storage to `fs` under the Git-ignored `.context/dev-storage`; `pnpm dev:reset` clears it. Default remains in-memory.
- **Seeded welcome notebook:** local dev seeds a small notebook alongside the sample org integration so there's something to open immediately.
- **Parallel worktree ports:** `DEV_PORT_BASE` sets the API port and the web app takes the next one; explicit `PORT`/`WEB_PORT` still win. The Vite proxy targets the matching API port and uses `strictPort`.
- **Clean compute shutdown:** `LocalCompute` implements `Symbol.asyncDispose` (kills child processes, removes sandbox roots); the server drains it on shutdown.
- Docs (`README`, `testing-locally.md`) and `technologies.md` updated to match.

Note: this branch was cut before the recent `main` cleanup commits; the PR diffs cleanly via merge-base.