### PR TITLE
fix(data-browser): harden S3 object browser and add metrics

### DIFF
--- a/.github/workflows/object-browser-conformance.yml
+++ b/.github/workflows/object-browser-conformance.yml
@@ -43,3 +43,9 @@ jobs:
           MARIMOHUB_TEST_S3_ACCESS_KEY: minioadmin
           MARIMOHUB_TEST_S3_SECRET_KEY: minioadmin
         run: vp test packages/object-browser-s3/src/minio.live.test.ts
+      - name: Run config-to-API smoke test
+        env:
+          MARIMOHUB_TEST_S3_ENDPOINT: http://127.0.0.1:19000
+          MARIMOHUB_TEST_S3_ACCESS_KEY: minioadmin
+          MARIMOHUB_TEST_S3_SECRET_KEY: minioadmin
+        run: vp test packages/config/src/objectBrowser.minio.live.test.ts

--- a/apps/server/src/metrics.test.ts
+++ b/apps/server/src/metrics.test.ts
@@ -24,6 +24,17 @@ describe('WideEventMetrics', () => {
 		expect(metrics.collect()).toMatchObject({ 'gauge.live_sessions': 8 });
 	});
 
+	it('summarizes histogram observations', () => {
+		const metrics = new WideEventMetrics();
+		metrics.histogram('object_browser.latency_ms', 4);
+		metrics.histogram('object_browser.latency_ms', 10);
+		expect(metrics.collect()).toMatchObject({
+			'histogram.object_browser.latency_ms.count': 2,
+			'histogram.object_browser.latency_ms.sum': 14,
+			'histogram.object_browser.latency_ms.max': 10,
+		});
+	});
+
 	it('flattens counters and gauges under prefixed keys', () => {
 		const metrics = new WideEventMetrics();
 		metrics.increment('a');
@@ -74,6 +85,18 @@ describe('OtelMetrics', () => {
 
 		const byName = await collect(provider, exporter);
 		expect(byName.get('sessions.live')?.dataPoints[0]?.value).toBe(2);
+		await provider.shutdown();
+	});
+
+	it('records histogram distributions with tags', async () => {
+		const { exporter, provider, metrics } = setup();
+		metrics.histogram('object_browser.s3.latency_ms', 12, { operation: 'list_objects' });
+		metrics.histogram('object_browser.s3.latency_ms', 20, { operation: 'list_objects' });
+
+		const byName = await collect(provider, exporter);
+		const point = byName.get('object_browser.s3.latency_ms')?.dataPoints[0];
+		expect(point?.attributes).toEqual({ operation: 'list_objects' });
+		expect(point?.value).toMatchObject({ count: 2, sum: 32 });
 		await provider.shutdown();
 	});
 });

--- a/apps/server/src/metrics.test.ts
+++ b/apps/server/src/metrics.test.ts
@@ -102,6 +102,12 @@ describe('OtelMetrics', () => {
 });
 
 describe('fanoutMetrics', () => {
+	it('omits histogram support when no target implements it', () => {
+		const target: Metrics = { increment: vi.fn(), gauge: vi.fn() };
+
+		expect(fanoutMetrics(target).histogram).toBeUndefined();
+	});
+
 	it('forwards every call to all targets', () => {
 		const target: Metrics = { increment: vi.fn(), gauge: vi.fn() };
 		const wide = new WideEventMetrics();
@@ -109,12 +115,16 @@ describe('fanoutMetrics', () => {
 
 		fan.increment('catalog.cas.conflict', 2, { source: 'test' });
 		fan.gauge('sessions.live', 7);
+		fan.histogram?.('object_browser.latency_ms', 12, { operation: 'list_objects' });
 
 		expect(target.increment).toHaveBeenCalledWith('catalog.cas.conflict', 2, { source: 'test' });
 		expect(target.gauge).toHaveBeenCalledWith('sessions.live', 7, undefined);
 		expect(wide.collect()).toEqual({
 			'counter.catalog.cas.conflict': 2,
 			'gauge.sessions.live': 7,
+			'histogram.object_browser.latency_ms.count': 1,
+			'histogram.object_browser.latency_ms.max': 12,
+			'histogram.object_browser.latency_ms.sum': 12,
 		});
 	});
 });

--- a/apps/server/src/metrics.ts
+++ b/apps/server/src/metrics.ts
@@ -1,4 +1,4 @@
-import type { Counter, Gauge, MeterProvider } from '@opentelemetry/api';
+import type { Counter, Gauge, Histogram, MeterProvider } from '@opentelemetry/api';
 import { metrics as metricsApi } from '@opentelemetry/api';
 import type { Metrics, MetricTags } from '@marimo-hub/core';
 
@@ -16,6 +16,7 @@ import type { Metrics, MetricTags } from '@marimo-hub/core';
 export class WideEventMetrics implements Metrics {
 	private counters = new Map<string, number>();
 	private gauges = new Map<string, number>();
+	private histograms = new Map<string, { count: number; sum: number; max: number }>();
 
 	increment(name: string, value = 1): void {
 		this.counters.set(name, (this.counters.get(name) ?? 0) + value);
@@ -25,11 +26,25 @@ export class WideEventMetrics implements Metrics {
 		this.gauges.set(name, value);
 	}
 
+	histogram(name: string, value: number): void {
+		const current = this.histograms.get(name);
+		this.histograms.set(name, {
+			count: (current?.count ?? 0) + 1,
+			sum: (current?.sum ?? 0) + value,
+			max: Math.max(current?.max ?? Number.NEGATIVE_INFINITY, value),
+		});
+	}
+
 	/** Snapshot current totals + latest gauges as flat fields for a wide event. */
 	collect(): Record<string, number> {
 		const out: Record<string, number> = {};
 		for (const [k, v] of this.counters) out[`counter.${k}`] = v;
 		for (const [k, v] of this.gauges) out[`gauge.${k}`] = v;
+		for (const [k, v] of this.histograms) {
+			out[`histogram.${k}.count`] = v.count;
+			out[`histogram.${k}.sum`] = v.sum;
+			out[`histogram.${k}.max`] = v.max;
+		}
 		return out;
 	}
 }
@@ -44,6 +59,7 @@ export class OtelMetrics implements Metrics {
 	private readonly meter;
 	private readonly counters = new Map<string, Counter>();
 	private readonly gauges = new Map<string, Gauge>();
+	private readonly histograms = new Map<string, Histogram>();
 
 	constructor(provider: MeterProvider = metricsApi.getMeterProvider()) {
 		this.meter = provider.getMeter('@marimo-hub/server');
@@ -66,6 +82,15 @@ export class OtelMetrics implements Metrics {
 		}
 		gauge.record(value, tags);
 	}
+
+	histogram(name: string, value: number, tags?: MetricTags): void {
+		let histogram = this.histograms.get(name);
+		if (!histogram) {
+			histogram = this.meter.createHistogram(name);
+			this.histograms.set(name, histogram);
+		}
+		histogram.record(value, tags);
+	}
 }
 
 /** Emit every signal to all targets (e.g. wide-event flush + OTEL export). */
@@ -76,6 +101,9 @@ export function fanoutMetrics(...targets: Metrics[]): Metrics {
 		},
 		gauge(name, value, tags) {
 			for (const t of targets) t.gauge(name, value, tags);
+		},
+		histogram(name, value, tags) {
+			for (const t of targets) t.histogram?.(name, value, tags);
 		},
 	};
 }

--- a/apps/server/src/metrics.ts
+++ b/apps/server/src/metrics.ts
@@ -95,15 +95,20 @@ export class OtelMetrics implements Metrics {
 
 /** Emit every signal to all targets (e.g. wide-event flush + OTEL export). */
 export function fanoutMetrics(...targets: Metrics[]): Metrics {
-	return {
+	const fanout: Metrics = {
 		increment(name, value, tags) {
 			for (const t of targets) t.increment(name, value, tags);
 		},
 		gauge(name, value, tags) {
 			for (const t of targets) t.gauge(name, value, tags);
 		},
-		histogram(name, value, tags) {
-			for (const t of targets) t.histogram?.(name, value, tags);
-		},
 	};
+
+	if (targets.some((target) => target.histogram !== undefined)) {
+		fanout.histogram = (name, value, tags) => {
+			for (const t of targets) t.histogram?.(name, value, tags);
+		};
+	}
+
+	return fanout;
 }

--- a/development_docs/operations.md
+++ b/development_docs/operations.md
@@ -204,14 +204,24 @@ rates from deltas between lines.
 
 Signals emitted today:
 
-| Signal                                               | Type    | Source                          |
-| ---------------------------------------------------- | ------- | ------------------------------- |
-| `catalog.cas.attempt` / `.conflict` / `.exhausted`   | counter | `CatalogService.mutateSnapshot` |
-| `sessions.live`                                      | gauge   | `SessionService.expireStale`    |
-| `sessions.expired` / `sessions.reaped`               | counter | `SessionService`                |
-| `snapshots.count` / `snapshots.bytes`                | gauge   | `MaintenanceService`            |
-| `maintenance.snapshots_pruned` / `.events_pruned`    | counter | `MaintenanceService`            |
-| Per-cycle: `sessions_expired`, `snapshots_pruned`, … | fields  | the `maintenance_cycle` event   |
+| Signal                                                              | Type      | Source                          |
+| ------------------------------------------------------------------- | --------- | ------------------------------- |
+| `catalog.cas.attempt` / `.conflict` / `.exhausted`                  | counter   | `CatalogService.mutateSnapshot` |
+| `sessions.live`                                                     | gauge     | `SessionService.expireStale`    |
+| `sessions.expired` / `sessions.reaped`                              | counter   | `SessionService`                |
+| `snapshots.count` / `snapshots.bytes`                               | gauge     | `MaintenanceService`            |
+| `maintenance.snapshots_pruned` / `.events_pruned`                   | counter   | `MaintenanceService`            |
+| `object_browser.s3.operations` / `.failures`                        | counter   | `S3ObjectBrowser`               |
+| `object_browser.s3.latency_ms`                                      | histogram | `S3ObjectBrowser`               |
+| `object_browser.s3.bytes_read` / `.keys_scanned`                    | counter   | `S3ObjectBrowser`               |
+| `object_browser.cache.requests`                                     | counter   | object browse API cache         |
+| `object_browser.download.active`                                    | gauge     | object download gate            |
+| `object_browser.download.rejected` / `.timeouts` / `.cancellations` | counter   | object download API             |
+| Per-cycle: `sessions_expired`, `snapshots_pruned`, …                | fields    | the `maintenance_cycle` event   |
+
+Object-browser metric attributes are deliberately low-cardinality: operation,
+mode, outcome, and sanitized error code only. Never add bucket names, keys,
+queries, integration IDs, project IDs, or user IDs as metric attributes.
 
 What to watch / alert on:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -144,9 +144,13 @@ The server records RED metrics per request — the `http.server.request.duration
 histogram (labelled by route, method, and status code) and the
 `http.server.active_requests` gauge — plus domain signals: catalog CAS
 contention (`catalog.cas.*`), session and reaper activity (`sessions.*`), and
-snapshot growth (`snapshots.*`, `maintenance.*`), which also still flush as one
-wide-event log line per maintenance cycle. `OTEL_METRICS_EXPORTER` selects the
-mode:
+snapshot growth (`snapshots.*`, `maintenance.*`). Object browsing adds operation
+counts and latency (`object_browser.s3.*`), bytes read, keys scanned, metadata
+cache outcomes, and active/rejected download signals (`object_browser.download.*`).
+Their attributes are limited to fixed operation, mode, outcome, and error-code
+values; bucket names, object keys, queries, integration IDs, and user IDs are
+never metric attributes. These signals also still flush as one wide-event log
+line per maintenance cycle. `OTEL_METRICS_EXPORTER` selects the mode:
 
 - **`otlp`** (default): push over OTLP/HTTP whenever
   `OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`) is

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -13,6 +13,7 @@ import type {
 	ProjectIntegrationsService,
 	KernelProbe,
 	Millis,
+	Metrics,
 	Notifier,
 	OrgIntegrationsService,
 	PreflightReport,
@@ -266,6 +267,8 @@ export interface BackgroundTaskScheduler {
  */
 export interface ApiDeps {
 	services: Services;
+	/** Operational signals shared by domain services and API-owned resource guards. */
+	metrics?: Metrics;
 	/** Raw bucket handle (used by ensureInitialized + the sandbox copy fallback). */
 	bucket: Bucket;
 	compute: SandboxProvider;

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -356,6 +356,35 @@ describe('Data browser routes', () => {
 		expect(versions.items).toEqual([expect.objectContaining({ version_id: 'v1' })]);
 	});
 
+	it('reports low-cardinality object metadata cache outcomes', async () => {
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		(deps as typeof deps & { metrics: typeof metrics }).metrics = metrics;
+		request = createTestApi({ bucket, userId: ACTOR, deps }).request;
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		const url = `/projects/${pid}/integrations/${created.id}/browse/objects?bucket=lake`;
+
+		await expectOk(await request('GET', url));
+		await expectOk(await request('GET', url));
+		await expectOk(await request('GET', `${url}&fresh=true`));
+
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.cache.requests', 1, {
+			operation: 'list_objects',
+			outcome: 'miss',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.cache.requests', 1, {
+			operation: 'list_objects',
+			outcome: 'hit',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.cache.requests', 1, {
+			operation: 'list_objects',
+			outcome: 'refresh',
+		});
+		for (const call of metrics.increment.mock.calls) {
+			expect(JSON.stringify(call[2])).not.toMatch(/lake|proj-|intg-|user-/);
+		}
+	});
+
 	it('reports bounded search progress and rejects inconsistent filters', async () => {
 		const pid = await createProject();
 		const created = await createObjectStore(pid);
@@ -525,6 +554,34 @@ describe('Data browser routes', () => {
 		const afterCancel = await request('GET', url);
 		expect(afterCancel.status).toBe(200);
 		expect(await afterCancel.text()).toBe('hello object');
+	});
+
+	it('reports download timeouts separately from downstream cancellations', async () => {
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		(deps as typeof deps & { metrics: typeof metrics }).metrics = metrics;
+		request = createTestApi({ bucket, userId: ACTOR, deps }).request;
+		const pid = await createProject();
+		const created = await createObjectStore(pid);
+		deps.dataBrowser.objectBrowser.downloadTimeoutMs = Millis.of(5);
+		const url = `/projects/${pid}/integrations/${created.id}/browse/objects/content?bucket=lake&key=events.jsonl`;
+
+		const timedOut = await request('GET', url);
+		await vi.waitFor(() =>
+			expect(metrics.increment).toHaveBeenCalledWith('object_browser.download.timeouts', 1, {
+				operation: 'download',
+			}),
+		);
+		expect(metrics.increment).not.toHaveBeenCalledWith('object_browser.download.cancellations', 1, {
+			operation: 'download',
+		});
+		await timedOut.body?.cancel().catch(() => {});
+
+		deps.dataBrowser.objectBrowser.downloadTimeoutMs = Millis.of(60_000);
+		const canceled = await request('GET', url);
+		await canceled.body?.cancel();
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.download.cancellations', 1, {
+			operation: 'download',
+		});
 	});
 
 	it('rejects malformed ranges and overlong keys before opening content', async () => {

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -560,6 +560,15 @@ describe('Data browser routes', () => {
 		const metrics = { increment: vi.fn(), gauge: vi.fn() };
 		(deps as typeof deps & { metrics: typeof metrics }).metrics = metrics;
 		request = createTestApi({ bucket, userId: ACTOR, deps }).request;
+		const canceledWith = vi.fn();
+		vi.spyOn(objectBrowser, 'openObject').mockResolvedValueOnce({
+			body: new ReadableStream({ cancel: canceledWith }),
+			status: 200,
+			content_type: 'text/plain',
+			content_length: 12,
+			total_size: 12,
+			close: () => {},
+		});
 		const pid = await createProject();
 		const created = await createObjectStore(pid);
 		deps.dataBrowser.objectBrowser.downloadTimeoutMs = Millis.of(5);
@@ -570,6 +579,9 @@ describe('Data browser routes', () => {
 			expect(metrics.increment).toHaveBeenCalledWith('object_browser.download.timeouts', 1, {
 				operation: 'download',
 			}),
+		);
+		await vi.waitFor(() =>
+			expect(canceledWith).toHaveBeenCalledWith(expect.objectContaining({ name: 'TimeoutError' })),
 		);
 		expect(metrics.increment).not.toHaveBeenCalledWith('object_browser.download.cancellations', 1, {
 			operation: 'download',

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -1882,7 +1882,7 @@ app.get('/projects/:pid/integrations/:iid/browse/objects/content', async (c) => 
 	c.req.raw.signal.addEventListener('abort', abort, { once: true });
 	const timeout = setTimeout(() => {
 		deps.metrics?.increment('object_browser.download.timeouts', 1, { operation });
-		controller.abort();
+		controller.abort(new DOMException('The object download timed out.', 'TimeoutError'));
 	}, deps.dataBrowser!.objectBrowser!.downloadTimeoutMs);
 	const finish = () => {
 		clearTimeout(timeout);

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -1149,16 +1149,29 @@ async function cachedBrowse<T>(
 	fresh: boolean,
 	charge: () => void,
 	load: () => Promise<T>,
+	observation?: { metrics: ApiDeps['metrics']; operation: string },
 ): Promise<T> {
+	const record = (outcome: 'hit' | 'miss' | 'coalesced' | 'refresh') =>
+		observation?.metrics?.increment('object_browser.cache.requests', 1, {
+			operation: observation.operation,
+			outcome,
+		});
 	const now = Date.now();
 	const hit = fresh ? undefined : browseCache.get(key);
-	if (hit && hit.expiresAt > now) return hit.value as T;
+	if (hit && hit.expiresAt > now) {
+		record('hit');
+		return hit.value as T;
+	}
 	// Every consumer of a miss pays its own budget BEFORE creating or joining
 	// the shared load: an exhausted user 429s alone (never poisoning the shared
 	// promise for others), and piggybacking on someone else's load is not free.
 	charge();
 	const pending = fresh ? undefined : inflightBrowse.get(key);
-	if (pending) return pending as Promise<T>;
+	if (pending) {
+		record('coalesced');
+		return pending as Promise<T>;
+	}
+	record(fresh ? 'refresh' : 'miss');
 	const promise = (async () => {
 		const value = await load();
 		if (browseCache.size >= BROWSE_CACHE_MAX_ENTRIES) {
@@ -1650,6 +1663,7 @@ app.openapi(browseObjectBuckets, async (c) => {
 		fresh === 'true',
 		() => assertBrowseBudget(user.id),
 		() => runObjectBrowse(() => integrations.browseObjectBuckets(pid, iid, context, request)),
+		{ metrics: deps.metrics, operation: 'list_buckets' },
 	);
 	return c.json({ success: true, data }, 200);
 });
@@ -1680,6 +1694,7 @@ app.openapi(browseObjects, async (c) => {
 		fresh === 'true',
 		() => assertBrowseBudget(user.id),
 		() => runObjectBrowse(() => integrations.browseObjects(pid, iid, context, request)),
+		{ metrics: deps.metrics, operation: 'list_objects' },
 	);
 	return c.json({ success: true, data }, 200);
 });
@@ -1851,11 +1866,24 @@ app.get('/projects/:pid/integrations/:iid/browse/objects/content', async (c) => 
 	const { bucket, key, version_id, inline, etag } = parsed.data;
 	const { integrations } = requireDataBrowser(deps);
 	const project = await assertProjectRole(deps.services.projects, pid, user, 'editor', deps.policy);
-	const release = acquireDownload(deps, user.id);
+	const operation = inline === 'true' ? 'inline' : 'download';
+	const release = acquireDownload(deps, user.id, operation);
 	const controller = new AbortController();
-	const abort = () => controller.abort();
+	let cancellationRecorded = false;
+	const recordCancellation = () => {
+		if (cancellationRecorded) return;
+		cancellationRecorded = true;
+		deps.metrics?.increment('object_browser.download.cancellations', 1, { operation });
+	};
+	const abort = () => {
+		recordCancellation();
+		controller.abort();
+	};
 	c.req.raw.signal.addEventListener('abort', abort, { once: true });
-	const timeout = setTimeout(abort, deps.dataBrowser!.objectBrowser!.downloadTimeoutMs);
+	const timeout = setTimeout(() => {
+		deps.metrics?.increment('object_browser.download.timeouts', 1, { operation });
+		controller.abort();
+	}, deps.dataBrowser!.objectBrowser!.downloadTimeoutMs);
 	const finish = () => {
 		clearTimeout(timeout);
 		c.req.raw.signal.removeEventListener('abort', abort);
@@ -1914,10 +1942,13 @@ app.get('/projects/:pid/integrations/:iid/browse/objects/content', async (c) => 
 		if (object.content_range) headers.set('Content-Range', object.content_range);
 		if (object.etag) headers.set('ETag', object.etag);
 		if (object.version_id) headers.set('X-Marimohub-Object-Version', object.version_id);
-		return new Response(streamObjectBody(object, release, finish, controller.signal), {
-			status: object.status,
-			headers,
-		});
+		return new Response(
+			streamObjectBody(object, release, finish, controller.signal, recordCancellation),
+			{
+				status: object.status,
+				headers,
+			},
+		);
 	} catch (error) {
 		finish();
 		release();

--- a/packages/api/src/routes/objectBrowse.test.ts
+++ b/packages/api/src/routes/objectBrowse.test.ts
@@ -286,6 +286,28 @@ describe('object content response helpers', () => {
 		]);
 	});
 
+	it('uses the current metrics emitter when limits are shared', () => {
+		const firstDeps = wifDeps(async () => ({ accessKeyId: 'unused', secretAccessKey: 'unused' }));
+		const firstMetrics = { increment: vi.fn(), gauge: vi.fn() };
+		const secondMetrics = { increment: vi.fn(), gauge: vi.fn() };
+		firstDeps.metrics = firstMetrics;
+		const secondDeps = { ...firstDeps, metrics: secondMetrics };
+
+		const releaseFirst = acquireDownload(firstDeps, 'user-a');
+		releaseFirst();
+		const releaseSecond = acquireDownload(secondDeps, 'user-b');
+		releaseSecond();
+
+		expect(firstMetrics.gauge.mock.calls).toEqual([
+			['object_browser.download.active', 1],
+			['object_browser.download.active', 0],
+		]);
+		expect(secondMetrics.gauge.mock.calls).toEqual([
+			['object_browser.download.active', 1],
+			['object_browser.download.active', 0],
+		]);
+	});
+
 	it('reports downstream stream cancellation once', async () => {
 		const cancel = vi.fn();
 		const stream = streamObjectBody(

--- a/packages/api/src/routes/objectBrowse.test.ts
+++ b/packages/api/src/routes/objectBrowse.test.ts
@@ -242,6 +242,8 @@ describe('object content response helpers', () => {
 
 	it('enforces both per-user and process download limits with idempotent release', () => {
 		const deps = wifDeps(async () => ({ accessKeyId: 'unused', secretAccessKey: 'unused' }));
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		deps.metrics = metrics;
 		deps.dataBrowser!.objectBrowser!.maxConcurrentDownloads = 3;
 		deps.dataBrowser!.objectBrowser!.maxConcurrentDownloadsPerUser = 2;
 		const first = acquireDownload(deps, 'user-a');
@@ -256,6 +258,45 @@ describe('object content response helpers', () => {
 		second();
 		otherUser();
 		third();
+		expect(metrics.increment).toHaveBeenCalledTimes(2);
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.download.rejected', 1, {
+			operation: 'download',
+		});
+		expect(metrics.gauge).toHaveBeenCalledWith('object_browser.download.active', 3);
+		expect(metrics.gauge).toHaveBeenLastCalledWith('object_browser.download.active', 0);
+	});
+
+	it('reports a global active-download gauge across operation types', () => {
+		const deps = wifDeps(async () => ({ accessKeyId: 'unused', secretAccessKey: 'unused' }));
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		deps.metrics = metrics;
+		deps.dataBrowser!.objectBrowser!.maxConcurrentDownloads = 3;
+		deps.dataBrowser!.objectBrowser!.maxConcurrentDownloadsPerUser = 2;
+
+		const releaseDownload = acquireDownload(deps, 'user-a', 'download');
+		const releaseInline = acquireDownload(deps, 'user-b', 'inline');
+		releaseDownload();
+		releaseInline();
+
+		expect(metrics.gauge.mock.calls).toEqual([
+			['object_browser.download.active', 1],
+			['object_browser.download.active', 2],
+			['object_browser.download.active', 1],
+			['object_browser.download.active', 0],
+		]);
+	});
+
+	it('reports downstream stream cancellation once', async () => {
+		const cancel = vi.fn();
+		const stream = streamObjectBody(
+			body(new ReadableStream({ pull() {} }), vi.fn()),
+			vi.fn(),
+			vi.fn(),
+			undefined,
+			cancel,
+		);
+		await stream.cancel('gone');
+		expect(cancel).toHaveBeenCalledOnce();
 	});
 
 	it('closes the object and releases its permit after a stream error', async () => {

--- a/packages/api/src/routes/objectBrowse.ts
+++ b/packages/api/src/routes/objectBrowse.ts
@@ -166,30 +166,32 @@ class DownloadGate {
 	private active = 0;
 	private readonly activeByUser = new Map<string, number>();
 
-	constructor(
-		private readonly limits: DownloadLimits,
-		private readonly metrics: ApiDeps['metrics'],
-	) {}
+	constructor(private readonly limits: DownloadLimits) {}
 
-	acquire(userId: string, operation: 'download' | 'inline'): () => void {
+	acquire(
+		userId: string,
+		operation: 'download' | 'inline',
+		metrics: ApiDeps['metrics'],
+	): () => void {
 		const tags = { operation };
+		const emitter = metrics ?? noopMetrics;
 		const userActive = this.activeByUser.get(userId) ?? 0;
 		if (
 			this.active >= this.limits.maxConcurrentDownloads ||
 			userActive >= this.limits.maxConcurrentDownloadsPerUser
 		) {
-			(this.metrics ?? noopMetrics).increment('object_browser.download.rejected', 1, tags);
+			emitter.increment('object_browser.download.rejected', 1, tags);
 			throw new ResourceExhaustedError('Too many object downloads are active — try again later.');
 		}
 		this.active += 1;
 		this.activeByUser.set(userId, userActive + 1);
-		(this.metrics ?? noopMetrics).gauge('object_browser.download.active', this.active);
+		emitter.gauge('object_browser.download.active', this.active);
 		let released = false;
 		return () => {
 			if (released) return;
 			released = true;
 			this.active -= 1;
-			(this.metrics ?? noopMetrics).gauge('object_browser.download.active', this.active);
+			emitter.gauge('object_browser.download.active', this.active);
 			const remaining = (this.activeByUser.get(userId) ?? 1) - 1;
 			if (remaining === 0) this.activeByUser.delete(userId);
 			else this.activeByUser.set(userId, remaining);
@@ -208,10 +210,10 @@ export function acquireDownload(
 	if (!limits) throw new NotFoundError('Object downloads are not enabled on this deployment.');
 	let gate = downloadGates.get(limits);
 	if (!gate) {
-		gate = new DownloadGate(limits, deps.metrics);
+		gate = new DownloadGate(limits);
 		downloadGates.set(limits, gate);
 	}
-	return gate.acquire(userId, operation);
+	return gate.acquire(userId, operation, deps.metrics);
 }
 
 export function streamObjectBody(

--- a/packages/api/src/routes/objectBrowse.ts
+++ b/packages/api/src/routes/objectBrowse.ts
@@ -3,6 +3,7 @@ import {
 	createSessionId,
 	exchangeFederatedStorageCredentials,
 	ForbiddenError,
+	noopMetrics,
 	NotFoundError,
 	ObjectBrowseError,
 	PreconditionFailedError,
@@ -165,23 +166,30 @@ class DownloadGate {
 	private active = 0;
 	private readonly activeByUser = new Map<string, number>();
 
-	constructor(private readonly limits: DownloadLimits) {}
+	constructor(
+		private readonly limits: DownloadLimits,
+		private readonly metrics: ApiDeps['metrics'],
+	) {}
 
-	acquire(userId: string): () => void {
+	acquire(userId: string, operation: 'download' | 'inline'): () => void {
+		const tags = { operation };
 		const userActive = this.activeByUser.get(userId) ?? 0;
 		if (
 			this.active >= this.limits.maxConcurrentDownloads ||
 			userActive >= this.limits.maxConcurrentDownloadsPerUser
 		) {
+			(this.metrics ?? noopMetrics).increment('object_browser.download.rejected', 1, tags);
 			throw new ResourceExhaustedError('Too many object downloads are active — try again later.');
 		}
 		this.active += 1;
 		this.activeByUser.set(userId, userActive + 1);
+		(this.metrics ?? noopMetrics).gauge('object_browser.download.active', this.active);
 		let released = false;
 		return () => {
 			if (released) return;
 			released = true;
 			this.active -= 1;
+			(this.metrics ?? noopMetrics).gauge('object_browser.download.active', this.active);
 			const remaining = (this.activeByUser.get(userId) ?? 1) - 1;
 			if (remaining === 0) this.activeByUser.delete(userId);
 			else this.activeByUser.set(userId, remaining);
@@ -191,15 +199,19 @@ class DownloadGate {
 
 const downloadGates = new WeakMap<object, DownloadGate>();
 
-export function acquireDownload(deps: ApiDeps, userId: string): () => void {
+export function acquireDownload(
+	deps: ApiDeps,
+	userId: string,
+	operation: 'download' | 'inline' = 'download',
+): () => void {
 	const limits = deps.dataBrowser?.objectBrowser;
 	if (!limits) throw new NotFoundError('Object downloads are not enabled on this deployment.');
 	let gate = downloadGates.get(limits);
 	if (!gate) {
-		gate = new DownloadGate(limits);
+		gate = new DownloadGate(limits, deps.metrics);
 		downloadGates.set(limits, gate);
 	}
-	return gate.acquire(userId);
+	return gate.acquire(userId, operation);
 }
 
 export function streamObjectBody(
@@ -207,6 +219,7 @@ export function streamObjectBody(
 	release: () => void,
 	onFinish: () => void,
 	signal?: AbortSignal,
+	onCancel?: () => void,
 ): ReadableStream<Uint8Array> {
 	const reader = object.body.getReader();
 	let finished = false;
@@ -263,6 +276,7 @@ export function streamObjectBody(
 		},
 		async cancel(reason) {
 			try {
+				onCancel?.();
 				await reader.cancel(reason);
 			} finally {
 				close();

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -45,6 +45,7 @@
 		"hono": "catalog:"
 	},
 	"devDependencies": {
+		"@aws-sdk/client-s3": "catalog:",
 		"@marimo-hub/tsconfig": "workspace:*",
 		"@types/node": "catalog:",
 		"typescript": "catalog:",

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -376,6 +376,7 @@ export function createFromEnv(
 	const sandboxPreview = dataPreviewFromEnv(env, compute, computeBackendValue);
 	const deps: ApiDeps = {
 		services,
+		metrics,
 		bucket,
 		notifier: makeNotifier(env, metrics),
 		projectAlerts,

--- a/packages/config/src/integrations.ts
+++ b/packages/config/src/integrations.ts
@@ -57,6 +57,7 @@ export function makeIntegrations(
 					return {
 						s3: new S3ObjectBrowser({
 							mode: dataBrowser,
+							metrics,
 							resolveHost: createGuardedHostResolver({
 								allowPrivate: policy === 'private',
 								timeoutMs: deadlines.resolveTimeoutMs,

--- a/packages/config/src/objectBrowser.minio.live.test.ts
+++ b/packages/config/src/objectBrowser.minio.live.test.ts
@@ -1,0 +1,133 @@
+import {
+	CreateBucketCommand,
+	DeleteBucketCommand,
+	DeleteObjectCommand,
+	PutObjectCommand,
+	S3Client,
+} from '@aws-sdk/client-s3';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createApi } from '@marimo-hub/api';
+import { createFromEnv } from './index';
+
+const endpoint = process.env.MARIMOHUB_TEST_S3_ENDPOINT;
+const accessKeyId = process.env.MARIMOHUB_TEST_S3_ACCESS_KEY ?? 'minioadmin';
+const secretAccessKey = process.env.MARIMOHUB_TEST_S3_SECRET_KEY ?? 'minioadmin';
+const bucket = `marimohub-vertical-${process.pid}-${Date.now()}`;
+const key = 'smoke/reports.csv';
+const body = 'name,value\nfirst,1\nsecond,2\n';
+
+if (endpoint) {
+	describe('MinIO object browser vertical smoke', () => {
+		const client = new S3Client({
+			endpoint,
+			region: 'us-east-1',
+			forcePathStyle: true,
+			credentials: { accessKeyId, secretAccessKey },
+		});
+
+		beforeAll(async () => {
+			await client.send(new CreateBucketCommand({ Bucket: bucket }));
+			await client.send(
+				new PutObjectCommand({
+					Bucket: bucket,
+					Key: key,
+					Body: body,
+					ContentType: 'text/csv',
+				}),
+			);
+		}, 30_000);
+
+		afterAll(async () => {
+			await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+			await client.send(new DeleteBucketCommand({ Bucket: bucket }));
+			client.destroy();
+		}, 30_000);
+
+		it('wires config through API routes to the production S3 browser', async () => {
+			const app = createApi(
+				createFromEnv({
+					MARIMOHUB_STORAGE_BACKEND: 'memory',
+					MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: 'true',
+					MARIMOHUB_COMPUTE_BACKEND: 'none',
+					MARIMOHUB_AUTH_BACKEND: 'dev',
+					MARIMOHUB_AUTH_DEV_USER_ID: 'minio-smoke',
+					MARIMOHUB_AUTH_DEV_EMAIL: 'minio-smoke@example.com',
+					MARIMOHUB_INTEGRATIONS: 'on',
+					MARIMOHUB_DATA_BROWSER: 'full',
+					MARIMOHUB_INTEGRATIONS_PROBE: 'private',
+					MARIMOHUB_SECRETS_KEK: '/ECMzY/eM7nlHPPNu+OM2wv0lWiFuHUScSJxNmh64N8=',
+				}),
+			);
+			const request = (method: string, path: string, requestBody?: unknown) =>
+				app.request(`/api/v1${path}`, {
+					method,
+					...(requestBody === undefined
+						? {}
+						: {
+								headers: { 'Content-Type': 'application/json' },
+								body: JSON.stringify(requestBody),
+							}),
+				});
+
+			const project = await expectOk<{ id: string }>(
+				await request('POST', '/projects', { name: 'MinIO smoke', description: '' }),
+				201,
+			);
+			const integration = await expectOk<{ id: string }>(
+				await request('POST', `/projects/${project.id}/integrations`, {
+					kind: 's3',
+					name: 'minio-smoke',
+					config: {
+						bucket,
+						region: 'us-east-1',
+						endpoint_url: endpoint,
+						path_style: true,
+						ambient_env: false,
+						auth: {
+							method: 'static',
+							access_key_id: accessKeyId,
+							secret_access_key: secretAccessKey,
+						},
+					},
+				}),
+				201,
+			);
+			const base = `/projects/${project.id}/integrations/${integration.id}/browse`;
+
+			expect(await expectOk(await request('GET', base))).toMatchObject({
+				surfaces: { objects: { available: true, preview: true, download: true } },
+			});
+			const listed = await expectOk<{ items: { kind: string; key: string }[] }>(
+				await request(
+					'GET',
+					`${base}/objects?bucket=${encodeURIComponent(bucket)}&prefix=${encodeURIComponent('smoke/')}`,
+				),
+			);
+			expect(listed.items).toEqual(
+				expect.arrayContaining([expect.objectContaining({ kind: 'object', key })]),
+			);
+			expect(
+				await expectOk(await request('POST', `${base}/objects/preview`, { bucket, key, limit: 1 })),
+			).toMatchObject({ kind: 'tabular', format: 'csv', truncated: true });
+
+			const content = await app.request(
+				`/api/v1${base}/objects/content?bucket=${encodeURIComponent(bucket)}&key=${encodeURIComponent(key)}`,
+				{ headers: { Range: 'bytes=0-3' } },
+			);
+			expect(content.status).toBe(206);
+			expect(content.headers.get('content-range')).toBe(`bytes 0-3/${Buffer.byteLength(body)}`);
+			expect(await content.text()).toBe('name');
+		}, 30_000);
+	});
+} else {
+	describe.skip('MinIO object browser vertical smoke', () => {
+		it('requires MARIMOHUB_TEST_S3_ENDPOINT', () => {});
+	});
+}
+
+async function expectOk<T>(response: Response, status = 200): Promise<T> {
+	expect(response.status).toBe(status);
+	const envelope = (await response.json()) as { success: boolean; data: T };
+	expect(envelope.success).toBe(true);
+	return envelope.data;
+}

--- a/packages/config/src/objectBrowser.minio.live.test.ts
+++ b/packages/config/src/objectBrowser.minio.live.test.ts
@@ -24,9 +24,11 @@ if (endpoint) {
 			forcePathStyle: true,
 			credentials: { accessKeyId, secretAccessKey },
 		});
+		let bucketCreated = false;
 
 		beforeAll(async () => {
 			await client.send(new CreateBucketCommand({ Bucket: bucket }));
+			bucketCreated = true;
 			await client.send(
 				new PutObjectCommand({
 					Bucket: bucket,
@@ -38,9 +40,30 @@ if (endpoint) {
 		}, 30_000);
 
 		afterAll(async () => {
-			await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
-			await client.send(new DeleteBucketCommand({ Bucket: bucket }));
-			client.destroy();
+			const cleanupErrors: unknown[] = [];
+			try {
+				if (!bucketCreated) {
+					return;
+				}
+
+				try {
+					await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+				} catch (error) {
+					cleanupErrors.push(error);
+				}
+
+				try {
+					await client.send(new DeleteBucketCommand({ Bucket: bucket }));
+				} catch (error) {
+					cleanupErrors.push(error);
+				}
+
+				if (cleanupErrors.length > 0) {
+					throw new AggregateError(cleanupErrors, `Failed to remove MinIO smoke bucket ${bucket}`);
+				}
+			} finally {
+				client.destroy();
+			}
 		}, 30_000);
 
 		it('wires config through API routes to the production S3 browser', async () => {

--- a/packages/core/src/ports/metrics.ts
+++ b/packages/core/src/ports/metrics.ts
@@ -4,9 +4,10 @@
  * CAS contention, reaper activity, snapshot growth, live session count — without
  * the core depending on any concrete metrics backend.
  *
- * Two primitives cover the need:
+ * Three primitives cover the need:
  * - `increment` for counters (rates: CAS conflicts, snapshots pruned, …).
  * - `gauge` for point-in-time values (snapshot count/size, live sessions, …).
+ * - `histogram` for distributions (operation latency, payload sizes, …).
  *
  * The default is `noopMetrics`; entrypoints inject a real emitter (e.g. the
  * wide-event canonical-log emitter in `apps/server`, or a Prometheus adapter).
@@ -18,10 +19,13 @@ export interface Metrics {
 	increment(name: string, value?: number, tags?: MetricTags): void;
 	/** Record a point-in-time value. */
 	gauge(name: string, value: number, tags?: MetricTags): void;
+	/** Record a value in a distribution, such as operation latency. */
+	histogram?(name: string, value: number, tags?: MetricTags): void;
 }
 
 /** No-op default — used everywhere a real emitter isn't wired (tests, library mode). */
 export const noopMetrics: Metrics = {
 	increment() {},
 	gauge() {},
+	histogram() {},
 };

--- a/packages/object-browser-s3/src/index.test.ts
+++ b/packages/object-browser-s3/src/index.test.ts
@@ -554,7 +554,8 @@ describe('S3ObjectBrowser listing and metadata', () => {
 
 describe('S3ObjectBrowser previews and streams', () => {
 	it('aborts a preview when its request deadline is exhausted', async () => {
-		vi.useFakeTimers();
+		const deadline = new AbortController();
+		const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(deadline.signal);
 		try {
 			const test = harness(
 				(sent) =>
@@ -574,11 +575,12 @@ describe('S3ObjectBrowser previews and streams', () => {
 				content_url: '/content',
 			});
 			const rejected = expect(operation).rejects.toMatchObject({ code: 'aborted' });
-			await vi.advanceTimersByTimeAsync(25);
+			deadline.abort(new DOMException('deadline exceeded', 'TimeoutError'));
 			await rejected;
+			expect(timeout).toHaveBeenCalledWith(25);
 			expect(test.destroyed()).toBe(1);
 		} finally {
-			vi.useRealTimers();
+			timeout.mockRestore();
 		}
 	});
 

--- a/packages/object-browser-s3/src/index.test.ts
+++ b/packages/object-browser-s3/src/index.test.ts
@@ -193,6 +193,45 @@ describe('S3ObjectBrowser listing and metadata', () => {
 		expect(second.sent[0].input.ContinuationToken).toBe('next');
 	});
 
+	it('stops a large multi-page scan exactly at the configured key budget', async () => {
+		const objects = (offset: number, count: number) =>
+			Array.from({ length: count }, (_, index) => ({
+				Key: `events/${String(offset + index).padStart(5, '0')}.json`,
+			}));
+		const test = harness(
+			[
+				{
+					Contents: objects(0, 1_000),
+					IsTruncated: true,
+					NextContinuationToken: 'page-2',
+				},
+				{
+					Contents: objects(1_000, 1_000),
+					IsTruncated: true,
+					NextContinuationToken: 'page-3',
+				},
+				{
+					Contents: objects(2_000, 500),
+					IsTruncated: true,
+					NextContinuationToken: 'page-4',
+				},
+			],
+			{ limits: { searchMaxKeys: 2_500 } },
+		);
+		const page = await test.browser.searchObjects(source, context, {
+			bucket: 'lake',
+			query: 'missing',
+			limit: 10,
+		});
+		expect(page).toMatchObject({
+			items: [],
+			scanned: 2_500,
+			complete: false,
+			next_cursor: expect.any(String),
+		});
+		expect(test.sent.map((call) => call.input.MaxKeys)).toEqual([1_000, 1_000, 500]);
+	});
+
 	it('scans in batches independent of the requested result count', async () => {
 		const test = harness([
 			{
@@ -286,6 +325,47 @@ describe('S3ObjectBrowser listing and metadata', () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it('propagates caller cancellation to an in-flight metadata request', async () => {
+		const parent = new AbortController();
+		const test = harness(
+			(sent) =>
+				new Promise((_resolve, reject) => {
+					sent.options?.abortSignal?.addEventListener(
+						'abort',
+						() => reject(new DOMException('aborted', 'AbortError')),
+						{ once: true },
+					);
+				}),
+		);
+		const operation = test.browser.listObjects(
+			source,
+			{ ...context, signal: parent.signal },
+			{
+				bucket: 'lake',
+				limit: 10,
+			},
+		);
+		parent.abort();
+		await expect(operation).rejects.toMatchObject({ code: 'aborted' });
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it('sanitizes malformed provider response shapes', async () => {
+		const test = harness([{ Contents: { private_detail: 'signed request secret' } }]);
+		let error: unknown;
+		try {
+			await test.browser.listObjects(source, context, { bucket: 'lake', limit: 10 });
+		} catch (caught) {
+			error = caught;
+		}
+		expect(error).toMatchObject({
+			code: 'unavailable',
+			message: 'The object-store request failed.',
+		});
+		expect((error as Error).message).not.toContain('signed request secret');
+		expect(test.destroyed()).toBe(1);
 	});
 
 	it('fails a non-advancing provider cursor', async () => {
@@ -473,6 +553,35 @@ describe('S3ObjectBrowser listing and metadata', () => {
 });
 
 describe('S3ObjectBrowser previews and streams', () => {
+	it('aborts a preview when its request deadline is exhausted', async () => {
+		vi.useFakeTimers();
+		try {
+			const test = harness(
+				(sent) =>
+					new Promise((_resolve, reject) => {
+						sent.options?.abortSignal?.addEventListener(
+							'abort',
+							() => reject(new DOMException('aborted', 'AbortError')),
+							{ once: true },
+						);
+					}),
+				{ limits: { previewTimeoutMs: 25 } },
+			);
+			const operation = test.browser.previewObject(source, context, {
+				bucket: 'lake',
+				key: 'slow.csv',
+				limit: 20,
+				content_url: '/content',
+			});
+			const rejected = expect(operation).rejects.toMatchObject({ code: 'aborted' });
+			await vi.advanceTimersByTimeAsync(25);
+			await rejected;
+			expect(test.destroyed()).toBe(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it('previews quoted CSV explicitly within row limits', async () => {
 		const csv = new TextEncoder().encode('name,note\nAda,"hello, world"\nLin,"multi\nline"\n');
 		const test = harness([
@@ -709,10 +818,12 @@ describe('S3ObjectBrowser previews and streams', () => {
 		expect(test.destroyed()).toBe(1);
 	});
 
-	it('releases the client when the returned stream fails', async () => {
+	it('sanitizes a mid-stream provider disconnect and releases the client', async () => {
 		const failing = new ReadableStream<Uint8Array>({
 			pull(controller) {
-				controller.error(new Error('stream failed'));
+				controller.error(
+					Object.assign(new Error('private socket and request detail'), { name: 'InternalError' }),
+				);
 			},
 		});
 		const test = harness([{ Body: failing, ContentLength: 1 }]);
@@ -720,7 +831,43 @@ describe('S3ObjectBrowser previews and streams', () => {
 			bucket: 'lake',
 			key: 'data.bin',
 		});
-		await expect(new Response(opened.body).arrayBuffer()).rejects.toThrow('stream failed');
+		await expect(new Response(opened.body).arrayBuffer()).rejects.toMatchObject({
+			code: 'unavailable',
+			message: 'The object-store request failed.',
+		});
+		expect(test.destroyed()).toBe(1);
+	});
+
+	it('errors a partially-read streaming download when the caller disconnects', async () => {
+		const parent = new AbortController();
+		const cancel = vi.fn();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array([1, 2, 3]));
+			},
+			cancel,
+		});
+		const test = harness([{ Body: stream, ContentLength: 1 }]);
+		const opened = await test.browser.openObject(
+			source,
+			{ ...context, signal: parent.signal },
+			{
+				bucket: 'lake',
+				key: 'slow.bin',
+			},
+		);
+		const reader = opened.body.getReader();
+		await expect(reader.read()).resolves.toEqual({
+			done: false,
+			value: new Uint8Array([1, 2, 3]),
+		});
+		const pendingRead = reader.read();
+		parent.abort();
+		await expect(pendingRead).rejects.toMatchObject({
+			code: 'aborted',
+			message: 'The request was canceled.',
+		});
+		await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
 		expect(test.destroyed()).toBe(1);
 	});
 
@@ -825,7 +972,7 @@ describe('capabilities and metadata-only mode', () => {
 		});
 	});
 
-	it('advertises and enforces metadata-only operation boundaries', () => {
+	it('advertises and enforces metadata-only operation boundaries', async () => {
 		const test = harness([], { mode: 'metadata' });
 		expect(test.browser.capability(source, context)).toMatchObject({
 			available: true,
@@ -833,17 +980,28 @@ describe('capabilities and metadata-only mode', () => {
 			download: false,
 			preview_formats: [],
 		});
-		expect(() =>
+		await expect(
 			test.browser.previewObject(source, context, {
 				bucket: 'lake',
 				key: 'a.txt',
 				limit: 20,
 				content_url: '/content',
 			}),
-		).toThrow(expect.objectContaining({ code: 'access_denied' }));
-		expect(() =>
+		).rejects.toMatchObject({ code: 'access_denied' });
+		await expect(
 			test.browser.openObject(source, context, { bucket: 'lake', key: 'a.txt' }),
-		).toThrow(expect.objectContaining({ code: 'access_denied' }));
+		).rejects.toMatchObject({ code: 'access_denied' });
+		expect(test.sent).toEqual([]);
+	});
+
+	it('advertises preview formats and downloads only in full mode', () => {
+		const test = harness([], { mode: 'full' });
+		expect(test.browser.capability(source, context)).toMatchObject({
+			available: true,
+			preview: true,
+			download: true,
+			preview_formats: expect.arrayContaining(['csv', 'json', 'parquet']),
+		});
 	});
 });
 

--- a/packages/object-browser-s3/src/index.ts
+++ b/packages/object-browser-s3/src/index.ts
@@ -25,8 +25,9 @@ import type {
 	ObjectStoreSource,
 	ObjectVersion,
 	ObjectVersionRequest,
+	Metrics,
 } from '@marimo-hub/core';
-import { ObjectBrowseError } from '@marimo-hub/core';
+import { noopMetrics, ObjectBrowseError } from '@marimo-hub/core';
 import { createS3ClientFactory, credentialsFor } from './client';
 import type { GuardedHostResolver, S3ClientFactory } from './client';
 import { decodeCursor, encodeCursor } from './cursors';
@@ -48,6 +49,7 @@ export interface S3ObjectBrowserLimits {
 
 export interface S3ObjectBrowserOptions {
 	mode: 'metadata' | 'full';
+	metrics?: Metrics;
 	limits?: Partial<S3ObjectBrowserLimits>;
 	resolveHost?: GuardedHostResolver;
 	clientFactory?: S3ClientFactory;
@@ -68,9 +70,11 @@ export class S3ObjectBrowser implements ObjectBrowser {
 	private readonly mode: 'metadata' | 'full';
 	private readonly limits: S3ObjectBrowserLimits;
 	private readonly clientFactory: S3ClientFactory;
+	private readonly metrics: Metrics;
 
 	constructor(options: S3ObjectBrowserOptions) {
 		this.mode = options.mode;
+		this.metrics = options.metrics ?? noopMetrics;
 		this.limits = { ...DEFAULT_S3_OBJECT_BROWSER_LIMITS, ...options.limits };
 		if (options.clientFactory) this.clientFactory = options.clientFactory;
 		else if (options.resolveHost) {
@@ -118,43 +122,45 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		context: ObjectBrowseContext,
 		request: ObjectPageRequest,
 	): Promise<ObjectPage<ObjectBucket>> {
-		if (source.configured_bucket) {
-			if (request.cursor) throw new ObjectBrowseError('invalid_cursor', 'The cursor is invalid.');
-			return {
-				items: [{ name: source.configured_bucket, configured: true }],
-				next_cursor: null,
-			};
-		}
-		const cursor = decodeCursor(request.cursor, ['token']);
-		return this.metadataOperation(context, (scopedContext) =>
-			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
-				const output = await sendS3<{
-					Buckets?: { Name?: string; CreationDate?: Date }[];
-					ContinuationToken?: string;
-				}>(
-					client,
-					new ListBucketsCommand({
-						MaxBuckets: request.limit,
-						ContinuationToken: cursor.token,
-					}),
-					scopedContext.signal,
-				);
+		return this.observe('list_buckets', context, async () => {
+			if (source.configured_bucket) {
+				if (request.cursor) throw new ObjectBrowseError('invalid_cursor', 'The cursor is invalid.');
 				return {
-					items: (output.Buckets ?? [])
-						.filter((bucket): bucket is { Name: string; CreationDate?: Date } =>
-							Boolean(bucket.Name),
-						)
-						.map((bucket) => ({
-							name: bucket.Name,
-							created_at: bucket.CreationDate?.toISOString(),
-							configured: false,
-						})),
-					next_cursor: output.ContinuationToken
-						? encodeCursor({ token: output.ContinuationToken })
-						: null,
+					items: [{ name: source.configured_bucket, configured: true }],
+					next_cursor: null,
 				};
-			}),
-		);
+			}
+			const cursor = decodeCursor(request.cursor, ['token']);
+			return this.metadataOperation(context, (scopedContext) =>
+				withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+					const output = await sendS3<{
+						Buckets?: { Name?: string; CreationDate?: Date }[];
+						ContinuationToken?: string;
+					}>(
+						client,
+						new ListBucketsCommand({
+							MaxBuckets: request.limit,
+							ContinuationToken: cursor.token,
+						}),
+						scopedContext.signal,
+					);
+					return {
+						items: (output.Buckets ?? [])
+							.filter((bucket): bucket is { Name: string; CreationDate?: Date } =>
+								Boolean(bucket.Name),
+							)
+							.map((bucket) => ({
+								name: bucket.Name,
+								created_at: bucket.CreationDate?.toISOString(),
+								configured: false,
+							})),
+						next_cursor: output.ContinuationToken
+							? encodeCursor({ token: output.ContinuationToken })
+							: null,
+					};
+				}),
+			);
+		});
 	}
 
 	async listObjects(
@@ -162,43 +168,45 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		context: ObjectBrowseContext,
 		request: ObjectListRequest,
 	): Promise<ObjectPage<ObjectEntry>> {
-		assertBucket(source, request.bucket);
-		const prefix = request.prefix ?? '';
-		const cursor = decodeCursor(request.cursor, ['token']);
-		return this.metadataOperation(context, (scopedContext) =>
-			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
-				const output = await sendS3<ListObjectsOutput>(
-					client,
-					new ListObjectsV2Command({
-						Bucket: request.bucket,
-						Prefix: prefix,
-						Delimiter: '/',
-						MaxKeys: request.limit,
-						ContinuationToken: cursor.token,
-					}),
-					scopedContext.signal,
-				);
-				const prefixes = new Set(
-					(output.CommonPrefixes ?? []).flatMap(({ Prefix }) => (Prefix ? [Prefix] : [])),
-				);
-				const items: ObjectEntry[] = [
-					...prefixes.values().map((key) => ({
-						kind: 'prefix' as const,
-						key,
-						name: key.slice(prefix.length).replace(/\/$/, ''),
-					})),
-					...(output.Contents ?? [])
-						.filter(({ Key, Size }) => Key && !(Size === 0 && prefixes.has(Key)))
-						.map((object) => objectEntry(object, prefix)),
-				].sort((left, right) => left.key.localeCompare(right.key));
-				return {
-					items,
-					next_cursor: output.NextContinuationToken
-						? encodeCursor({ token: output.NextContinuationToken })
-						: null,
-				};
-			}),
-		);
+		return this.observe('list_objects', context, async () => {
+			assertBucket(source, request.bucket);
+			const prefix = request.prefix ?? '';
+			const cursor = decodeCursor(request.cursor, ['token']);
+			return this.metadataOperation(context, (scopedContext) =>
+				withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+					const output = await sendS3<ListObjectsOutput>(
+						client,
+						new ListObjectsV2Command({
+							Bucket: request.bucket,
+							Prefix: prefix,
+							Delimiter: '/',
+							MaxKeys: request.limit,
+							ContinuationToken: cursor.token,
+						}),
+						scopedContext.signal,
+					);
+					const prefixes = new Set(
+						(output.CommonPrefixes ?? []).flatMap(({ Prefix }) => (Prefix ? [Prefix] : [])),
+					);
+					const items: ObjectEntry[] = [
+						...prefixes.values().map((key) => ({
+							kind: 'prefix' as const,
+							key,
+							name: key.slice(prefix.length).replace(/\/$/, ''),
+						})),
+						...(output.Contents ?? [])
+							.filter(({ Key, Size }) => Key && !(Size === 0 && prefixes.has(Key)))
+							.map((object) => objectEntry(object, prefix)),
+					].sort((left, right) => left.key.localeCompare(right.key));
+					return {
+						items,
+						next_cursor: output.NextContinuationToken
+							? encodeCursor({ token: output.NextContinuationToken })
+							: null,
+					};
+				}),
+			);
+		});
 	}
 
 	async searchObjects(
@@ -206,80 +214,87 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		context: ObjectBrowseContext,
 		request: ObjectSearchRequest,
 	): Promise<ObjectSearchPage> {
-		assertBucket(source, request.bucket);
-		const prefix = request.prefix ?? '';
-		const cursor = decodeCursor(request.cursor, ['token', 'start_after']);
-		if (cursor.token && cursor.start_after) {
-			throw new ObjectBrowseError('invalid_cursor', 'The object-browser cursor is invalid.');
-		}
-		const query = request.query.toLocaleLowerCase();
-		return this.metadataOperation(context, (scopedContext) =>
-			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
-				const items: ObjectEntry[] = [];
-				let scanned = 0;
-				let token = cursor.token;
-				let startAfter = cursor.start_after;
-				let complete = false;
-				let nextCursor: string | null = null;
-				while (scanned < this.limits.searchMaxKeys && items.length < request.limit) {
-					const remainingScan = this.limits.searchMaxKeys - scanned;
-					const requestToken = token;
-					const output = await sendS3<ListObjectsOutput>(
-						client,
-						new ListObjectsV2Command({
-							Bucket: request.bucket,
-							Prefix: prefix,
-							MaxKeys: Math.min(remainingScan, SEARCH_BATCH_SIZE),
-							ContinuationToken: token,
-							StartAfter: token ? undefined : startAfter,
-						}),
-						scopedContext.signal,
-					);
-					const contents = (output.Contents ?? []).filter(
-						(object): object is typeof object & { Key: string } => object.Key !== undefined,
-					);
-					for (let index = 0; index < contents.length; index += 1) {
-						const object = contents[index];
-						scanned += 1;
-						if (object.Key.slice(prefix.length).toLocaleLowerCase().includes(query)) {
-							const entry = objectEntry(object, prefix);
-							if (matchesFilters(entry, request)) items.push(entry);
-						}
-						if (scanned < this.limits.searchMaxKeys && items.length < request.limit) {
-							continue;
-						}
-						if (index < contents.length - 1) {
-							nextCursor = encodeCursor({ start_after: object.Key });
-						} else if (output.IsTruncated && output.NextContinuationToken) {
-							nextCursor = encodeCursor({ token: output.NextContinuationToken });
-						} else {
-							complete = true;
-						}
-						break;
-					}
-					if (items.length >= request.limit || scanned >= this.limits.searchMaxKeys) break;
-					if (!output.IsTruncated) {
-						complete = true;
-						break;
-					}
-					token = output.NextContinuationToken;
-					startAfter = undefined;
-					if (!token || token === requestToken) {
-						throw new ObjectBrowseError(
-							'invalid_cursor',
-							'The object-store cursor did not advance.',
+		return this.observe('search_objects', context, async () => {
+			assertBucket(source, request.bucket);
+			const prefix = request.prefix ?? '';
+			const cursor = decodeCursor(request.cursor, ['token', 'start_after']);
+			if (cursor.token && cursor.start_after) {
+				throw new ObjectBrowseError('invalid_cursor', 'The object-browser cursor is invalid.');
+			}
+			const query = request.query.toLocaleLowerCase();
+			const result = await this.metadataOperation(context, (scopedContext) =>
+				withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+					const items: ObjectEntry[] = [];
+					let scanned = 0;
+					let token = cursor.token;
+					let startAfter = cursor.start_after;
+					let complete = false;
+					let nextCursor: string | null = null;
+					while (scanned < this.limits.searchMaxKeys && items.length < request.limit) {
+						const remainingScan = this.limits.searchMaxKeys - scanned;
+						const requestToken = token;
+						const output = await sendS3<ListObjectsOutput>(
+							client,
+							new ListObjectsV2Command({
+								Bucket: request.bucket,
+								Prefix: prefix,
+								MaxKeys: Math.min(remainingScan, SEARCH_BATCH_SIZE),
+								ContinuationToken: token,
+								StartAfter: token ? undefined : startAfter,
+							}),
+							scopedContext.signal,
 						);
+						const contents = (output.Contents ?? []).filter(
+							(object): object is typeof object & { Key: string } => object.Key !== undefined,
+						);
+						for (let index = 0; index < contents.length; index += 1) {
+							const object = contents[index];
+							scanned += 1;
+							if (object.Key.slice(prefix.length).toLocaleLowerCase().includes(query)) {
+								const entry = objectEntry(object, prefix);
+								if (matchesFilters(entry, request)) items.push(entry);
+							}
+							if (scanned < this.limits.searchMaxKeys && items.length < request.limit) {
+								continue;
+							}
+							if (index < contents.length - 1) {
+								nextCursor = encodeCursor({ start_after: object.Key });
+							} else if (output.IsTruncated && output.NextContinuationToken) {
+								nextCursor = encodeCursor({ token: output.NextContinuationToken });
+							} else {
+								complete = true;
+							}
+							break;
+						}
+						if (items.length >= request.limit || scanned >= this.limits.searchMaxKeys) break;
+						if (!output.IsTruncated) {
+							complete = true;
+							break;
+						}
+						token = output.NextContinuationToken;
+						startAfter = undefined;
+						if (!token || token === requestToken) {
+							throw new ObjectBrowseError(
+								'invalid_cursor',
+								'The object-store cursor did not advance.',
+							);
+						}
 					}
-				}
-				if (!complete && !nextCursor && token) nextCursor = encodeCursor({ token });
-				return {
-					items,
-					scanned,
-					complete,
-					next_cursor: complete ? null : nextCursor,
-				};
-			}),
-		);
+					if (!complete && !nextCursor && token) nextCursor = encodeCursor({ token });
+					return {
+						items,
+						scanned,
+						complete,
+						next_cursor: complete ? null : nextCursor,
+					};
+				}),
+			);
+			this.metrics.increment('object_browser.s3.keys_scanned', result.scanned, {
+				operation: 'search_objects',
+				mode: this.mode,
+			});
+			return result;
+		});
 	}
 
 	async headObject(
@@ -287,54 +302,57 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		context: ObjectBrowseContext,
 		request: ObjectIdentity,
 	): Promise<ObjectDetail> {
-		assertObjectIdentity(source, request);
-		return this.metadataOperation(context, (scopedContext) =>
-			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
-				const input = {
-					Bucket: request.bucket,
-					Key: request.key,
-					VersionId: request.version_id,
-				};
-				let head: HeadOutput;
-				try {
-					head = await sendS3<HeadOutput>(
-						client,
-						new HeadObjectCommand({ ...input, ChecksumMode: 'ENABLED' }),
-						scopedContext.signal,
-					);
-				} catch (error) {
-					if (!(error instanceof ObjectBrowseError) || error.code !== 'access_denied') throw error;
-					head = await sendS3<HeadOutput>(
-						client,
-						new HeadObjectCommand(input),
-						scopedContext.signal,
-					);
-				}
-				let tags: { key: string; value: string }[] | undefined;
-				let tagsAvailable = false;
-				try {
-					const tagged = await sendS3<{ TagSet?: { Key?: string; Value?: string }[] }>(
-						client,
-						new GetObjectTaggingCommand({
-							Bucket: request.bucket,
-							Key: request.key,
-							VersionId: request.version_id,
-						}),
-						scopedContext.signal,
-					);
-					tags = (tagged.TagSet ?? []).flatMap((tag) =>
-						tag.Key !== undefined && tag.Value !== undefined
-							? [{ key: tag.Key, value: tag.Value }]
-							: [],
-					);
-					tagsAvailable = true;
-				} catch (error) {
-					const mapped = mapS3Error(error);
-					if (mapped.code !== 'access_denied' && mapped.code !== 'unsupported') throw mapped;
-				}
-				return detailFromHead(request, head, tags, tagsAvailable);
-			}),
-		);
+		return this.observe('head_object', context, async () => {
+			assertObjectIdentity(source, request);
+			return this.metadataOperation(context, (scopedContext) =>
+				withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+					const input = {
+						Bucket: request.bucket,
+						Key: request.key,
+						VersionId: request.version_id,
+					};
+					let head: HeadOutput;
+					try {
+						head = await sendS3<HeadOutput>(
+							client,
+							new HeadObjectCommand({ ...input, ChecksumMode: 'ENABLED' }),
+							scopedContext.signal,
+						);
+					} catch (error) {
+						if (!(error instanceof ObjectBrowseError) || error.code !== 'access_denied')
+							throw error;
+						head = await sendS3<HeadOutput>(
+							client,
+							new HeadObjectCommand(input),
+							scopedContext.signal,
+						);
+					}
+					let tags: { key: string; value: string }[] | undefined;
+					let tagsAvailable = false;
+					try {
+						const tagged = await sendS3<{ TagSet?: { Key?: string; Value?: string }[] }>(
+							client,
+							new GetObjectTaggingCommand({
+								Bucket: request.bucket,
+								Key: request.key,
+								VersionId: request.version_id,
+							}),
+							scopedContext.signal,
+						);
+						tags = (tagged.TagSet ?? []).flatMap((tag) =>
+							tag.Key !== undefined && tag.Value !== undefined
+								? [{ key: tag.Key, value: tag.Value }]
+								: [],
+						);
+						tagsAvailable = true;
+					} catch (error) {
+						const mapped = mapS3Error(error);
+						if (mapped.code !== 'access_denied' && mapped.code !== 'unsupported') throw mapped;
+					}
+					return detailFromHead(request, head, tags, tagsAvailable);
+				}),
+			);
+		});
 	}
 
 	async listVersions(
@@ -342,44 +360,46 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		context: ObjectBrowseContext,
 		request: ObjectVersionRequest,
 	): Promise<ObjectPage<ObjectVersion>> {
-		assertObjectIdentity(source, request);
-		const cursor = decodeCursor(request.cursor, ['key', 'version']);
-		return this.metadataOperation(context, (scopedContext) =>
-			withS3Client(this.clientFactory, source, scopedContext, async (client) => {
-				const output = await sendS3<VersionsOutput>(
-					client,
-					new ListObjectVersionsCommand({
-						Bucket: request.bucket,
-						Prefix: request.key,
-						MaxKeys: request.limit,
-						KeyMarker: cursor.key,
-						VersionIdMarker: cursor.version,
-					}),
-					scopedContext.signal,
-				);
-				const versions: ObjectVersion[] = [
-					...(output.Versions ?? []).flatMap((version) =>
-						version.Key === request.key && version.VersionId
-							? [versionEntry(request.bucket, version, 'version')]
-							: [],
-					),
-					...(output.DeleteMarkers ?? []).flatMap((version) =>
-						version.Key === request.key && version.VersionId
-							? [versionEntry(request.bucket, version, 'delete-marker')]
-							: [],
-					),
-				].sort((left, right) =>
-					(right.last_modified ?? '').localeCompare(left.last_modified ?? ''),
-				);
-				return {
-					items: versions,
-					next_cursor:
-						output.IsTruncated && output.NextKeyMarker
-							? encodeCursor({ key: output.NextKeyMarker, version: output.NextVersionIdMarker })
-							: null,
-				};
-			}),
-		);
+		return this.observe('list_versions', context, async () => {
+			assertObjectIdentity(source, request);
+			const cursor = decodeCursor(request.cursor, ['key', 'version']);
+			return this.metadataOperation(context, (scopedContext) =>
+				withS3Client(this.clientFactory, source, scopedContext, async (client) => {
+					const output = await sendS3<VersionsOutput>(
+						client,
+						new ListObjectVersionsCommand({
+							Bucket: request.bucket,
+							Prefix: request.key,
+							MaxKeys: request.limit,
+							KeyMarker: cursor.key,
+							VersionIdMarker: cursor.version,
+						}),
+						scopedContext.signal,
+					);
+					const versions: ObjectVersion[] = [
+						...(output.Versions ?? []).flatMap((version) =>
+							version.Key === request.key && version.VersionId
+								? [versionEntry(request.bucket, version, 'version')]
+								: [],
+						),
+						...(output.DeleteMarkers ?? []).flatMap((version) =>
+							version.Key === request.key && version.VersionId
+								? [versionEntry(request.bucket, version, 'delete-marker')]
+								: [],
+						),
+					].sort((left, right) =>
+						(right.last_modified ?? '').localeCompare(left.last_modified ?? ''),
+					);
+					return {
+						items: versions,
+						next_cursor:
+							output.IsTruncated && output.NextKeyMarker
+								? encodeCursor({ key: output.NextKeyMarker, version: output.NextVersionIdMarker })
+								: null,
+					};
+				}),
+			);
+		});
 	}
 
 	previewObject(
@@ -387,11 +407,24 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		context: ObjectBrowseContext,
 		request: ObjectPreviewRequest,
 	): Promise<ObjectPreview> {
-		if (this.mode !== 'full') {
-			throw new ObjectBrowseError('access_denied', 'Object previews are disabled.');
-		}
-		assertObjectIdentity(source, request);
-		return previewS3Object(this.clientFactory, this.limits, source, context, request);
+		return this.observe('preview_object', context, async () => {
+			if (this.mode !== 'full') {
+				throw new ObjectBrowseError('access_denied', 'Object previews are disabled.');
+			}
+			assertObjectIdentity(source, request);
+			const result = await previewS3Object(
+				this.clientFactory,
+				this.limits,
+				source,
+				context,
+				request,
+			);
+			this.metrics.increment('object_browser.s3.bytes_read', this.previewBytesRead(result), {
+				operation: 'preview_object',
+				mode: this.mode,
+			});
+			return result;
+		});
 	}
 
 	openObject(
@@ -399,11 +432,106 @@ export class S3ObjectBrowser implements ObjectBrowser {
 		context: ObjectBrowseContext,
 		request: ObjectOpenRequest,
 	): Promise<ObjectBody> {
-		if (this.mode !== 'full') {
-			throw new ObjectBrowseError('access_denied', 'Object downloads are disabled.');
+		return this.observe('open_object', context, async () => {
+			if (this.mode !== 'full') {
+				throw new ObjectBrowseError('access_denied', 'Object downloads are disabled.');
+			}
+			assertObjectIdentity(source, request);
+			const object = await openS3Object(this.clientFactory, this.limits, source, context, request);
+			return this.observeBody(object, request.inline ? Math.min(object.total_size, 16) : 0);
+		});
+	}
+
+	private async observe<T>(
+		operation: string,
+		context: ObjectBrowseContext,
+		run: () => Promise<T>,
+	): Promise<T> {
+		const tags = { operation, mode: this.mode };
+		const startedAt = performance.now();
+		this.metrics.increment('object_browser.s3.operations', 1, tags);
+		try {
+			return await run();
+		} catch (error) {
+			this.metrics.increment('object_browser.s3.failures', 1, {
+				...tags,
+				code: error instanceof ObjectBrowseError ? error.code : 'unavailable',
+			});
+			if (error instanceof ObjectBrowseError && error.code === 'aborted') {
+				this.metrics.increment(
+					context.signal?.aborted
+						? 'object_browser.s3.cancellations'
+						: 'object_browser.s3.timeouts',
+					1,
+					tags,
+				);
+			}
+			throw error;
+		} finally {
+			const latency = performance.now() - startedAt;
+			if (this.metrics.histogram) {
+				this.metrics.histogram('object_browser.s3.latency_ms', latency, tags);
+			} else {
+				this.metrics.gauge('object_browser.s3.latency_ms', latency, tags);
+			}
 		}
-		assertObjectIdentity(source, request);
-		return openS3Object(this.clientFactory, this.limits, source, context, request);
+	}
+
+	private observeBody(object: ObjectBody, probeBytes: number): ObjectBody {
+		const reader = object.body.getReader();
+		let bytesRead = probeBytes;
+		let finished = false;
+		const tags = { operation: 'open_object', mode: this.mode };
+		const metrics = this.metrics;
+		const finish = () => {
+			if (finished) return;
+			finished = true;
+			this.metrics.increment('object_browser.s3.bytes_read', bytesRead, tags);
+		};
+		return {
+			...object,
+			body: new ReadableStream<Uint8Array>({
+				async pull(controller) {
+					try {
+						const next = await reader.read();
+						if (next.done) {
+							finish();
+							controller.close();
+						} else {
+							bytesRead += next.value.byteLength;
+							controller.enqueue(next.value);
+						}
+					} catch (error) {
+						finish();
+						metrics.increment('object_browser.s3.failures', 1, {
+							...tags,
+							code: error instanceof ObjectBrowseError ? error.code : 'unavailable',
+						});
+						controller.error(error);
+					}
+				},
+				async cancel(reason) {
+					metrics.increment('object_browser.s3.cancellations', 1, tags);
+					try {
+						await reader.cancel(reason);
+					} finally {
+						finish();
+					}
+				},
+			}),
+			close() {
+				finish();
+				object.close();
+			},
+		};
+	}
+
+	private previewBytesRead(result: ObjectPreview): number {
+		const probeBytes = Math.min(result.total_bytes ?? 0, this.limits.previewMaxBytes);
+		if (!('bytes_read' in result) || result.bytes_read === undefined) return probeBytes;
+		return result.kind === 'tabular' && result.format === 'parquet'
+			? result.bytes_read + probeBytes
+			: result.bytes_read;
 	}
 
 	private metadataOperation<T>(

--- a/packages/object-browser-s3/src/index.ts
+++ b/packages/object-browser-s3/src/index.ts
@@ -145,7 +145,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 						scopedContext.signal,
 					);
 					return {
-						items: (output.Buckets ?? [])
+						items: providerArray(output.Buckets)
 							.filter((bucket): bucket is { Name: string; CreationDate?: Date } =>
 								Boolean(bucket.Name),
 							)
@@ -186,7 +186,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 						scopedContext.signal,
 					);
 					const prefixes = new Set(
-						(output.CommonPrefixes ?? []).flatMap(({ Prefix }) => (Prefix ? [Prefix] : [])),
+						providerArray(output.CommonPrefixes).flatMap(({ Prefix }) => (Prefix ? [Prefix] : [])),
 					);
 					const items: ObjectEntry[] = [
 						...prefixes.values().map((key) => ({
@@ -194,7 +194,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 							key,
 							name: key.slice(prefix.length).replace(/\/$/, ''),
 						})),
-						...(output.Contents ?? [])
+						...providerArray(output.Contents)
 							.filter(({ Key, Size }) => Key && !(Size === 0 && prefixes.has(Key)))
 							.map((object) => objectEntry(object, prefix)),
 					].sort((left, right) => left.key.localeCompare(right.key));
@@ -244,7 +244,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 							}),
 							scopedContext.signal,
 						);
-						const contents = (output.Contents ?? []).filter(
+						const contents = providerArray(output.Contents).filter(
 							(object): object is typeof object & { Key: string } => object.Key !== undefined,
 						);
 						for (let index = 0; index < contents.length; index += 1) {
@@ -339,7 +339,7 @@ export class S3ObjectBrowser implements ObjectBrowser {
 							}),
 							scopedContext.signal,
 						);
-						tags = (tagged.TagSet ?? []).flatMap((tag) =>
+						tags = providerArray(tagged.TagSet).flatMap((tag) =>
 							tag.Key !== undefined && tag.Value !== undefined
 								? [{ key: tag.Key, value: tag.Value }]
 								: [],
@@ -377,12 +377,12 @@ export class S3ObjectBrowser implements ObjectBrowser {
 						scopedContext.signal,
 					);
 					const versions: ObjectVersion[] = [
-						...(output.Versions ?? []).flatMap((version) =>
+						...providerArray(output.Versions).flatMap((version) =>
 							version.Key === request.key && version.VersionId
 								? [versionEntry(request.bucket, version, 'version')]
 								: [],
 						),
-						...(output.DeleteMarkers ?? []).flatMap((version) =>
+						...providerArray(output.DeleteMarkers).flatMap((version) =>
 							version.Key === request.key && version.VersionId
 								? [versionEntry(request.bucket, version, 'delete-marker')]
 								: [],
@@ -511,7 +511,11 @@ export class S3ObjectBrowser implements ObjectBrowser {
 					}
 				},
 				async cancel(reason) {
-					metrics.increment('object_browser.s3.cancellations', 1, tags);
+					const metric =
+						(reason as { name?: unknown } | null)?.name === 'TimeoutError'
+							? 'object_browser.s3.timeouts'
+							: 'object_browser.s3.cancellations';
+					metrics.increment(metric, 1, tags);
 					try {
 						await reader.cancel(reason);
 					} finally {
@@ -553,6 +557,12 @@ interface ListObjectsOutput {
 	CommonPrefixes?: { Prefix?: string }[];
 	IsTruncated?: boolean;
 	NextContinuationToken?: string;
+}
+
+function providerArray<T>(value: T[] | undefined): T[] {
+	if (value === undefined) return [];
+	if (Array.isArray(value)) return value;
+	throw new ObjectBrowseError('unavailable', 'The object-store request failed.');
 }
 
 interface HeadOutput {

--- a/packages/object-browser-s3/src/metrics.test.ts
+++ b/packages/object-browser-s3/src/metrics.test.ts
@@ -151,6 +151,27 @@ describe('S3 object browser metrics', () => {
 		});
 	});
 
+	it('records a timed-out download separately from caller cancellation', async () => {
+		const metrics = mockMetrics();
+		const browser = harness([{ Body: body('partial'), ContentLength: 7 }], metrics);
+		const opened = await browser.openObject(source, context, {
+			bucket: 'private-bucket',
+			key: 'secret.bin',
+		});
+		const reader = opened.body.getReader();
+		await reader.read();
+		await reader.cancel(new DOMException('deadline exceeded', 'TimeoutError'));
+
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.timeouts', 1, {
+			operation: 'open_object',
+			mode: 'full',
+		});
+		expect(metrics.increment).not.toHaveBeenCalledWith('object_browser.s3.cancellations', 1, {
+			operation: 'open_object',
+			mode: 'full',
+		});
+	});
+
 	it('records failures that happen after download headers arrive', async () => {
 		const metrics = mockMetrics();
 		const failing = new ReadableStream<Uint8Array>({

--- a/packages/object-browser-s3/src/metrics.test.ts
+++ b/packages/object-browser-s3/src/metrics.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createProjectId, UserId } from '@marimo-hub/core';
+import type { Metrics, ObjectBrowseContext, ObjectStoreSource } from '@marimo-hub/core';
+import type { S3ClientLike } from './client';
+import { S3ObjectBrowser } from './index';
+
+const source: ObjectStoreSource = {
+	provider: 's3',
+	configured_bucket: 'private-bucket',
+	region: 'us-east-1',
+	endpoint: 'https://s3.example.com',
+	path_style: true,
+	auth: { method: 'static', access_key_id: 'access', secret_access_key: 'secret' },
+};
+
+const context: ObjectBrowseContext = {
+	project_id: createProjectId(),
+	user_id: UserId.parse('user-metrics'),
+	user_email: 'metrics@example.com',
+	allow_server_ambient: false,
+};
+
+describe('S3 object browser metrics', () => {
+	it('records operations, latency, failures, scanned keys, and bytes without sensitive tags', async () => {
+		const metrics = mockMetrics();
+		const browser = harness(
+			[
+				{ Contents: [{ Key: 'secret/report.csv', Size: 3 }], IsTruncated: false },
+				{ ContentLength: 3, ContentType: 'text/csv', ETag: 'etag' },
+				{ Body: body('a,b'), ContentLength: 3 },
+				Object.assign(new Error('provider detail'), { name: 'InternalError' }),
+			],
+			metrics,
+		);
+
+		await browser.searchObjects(source, context, {
+			bucket: 'private-bucket',
+			query: 'report',
+			limit: 10,
+		});
+		await browser.previewObject(source, context, {
+			bucket: 'private-bucket',
+			key: 'secret/report.csv',
+			limit: 10,
+			content_url: '/content',
+		});
+		await expect(
+			browser.listObjects(source, context, { bucket: 'private-bucket', limit: 10 }),
+		).rejects.toMatchObject({ code: 'unavailable' });
+
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.keys_scanned', 1, {
+			operation: 'search_objects',
+			mode: 'full',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.bytes_read', 3, {
+			operation: 'preview_object',
+			mode: 'full',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.failures', 1, {
+			operation: 'list_objects',
+			mode: 'full',
+			code: 'unavailable',
+		});
+		expect(metrics.histogram).toHaveBeenCalledWith(
+			'object_browser.s3.latency_ms',
+			expect.any(Number),
+			expect.any(Object),
+		);
+		for (const call of [...metrics.increment.mock.calls, ...metrics.histogram.mock.calls]) {
+			const tags = call[2];
+			expect(Object.keys(tags ?? {}).sort()).toEqual(expect.arrayContaining(['mode', 'operation']));
+			expect(JSON.stringify(tags)).not.toMatch(/private-bucket|secret|report|metrics@example/);
+		}
+	});
+
+	it('distinguishes metadata deadlines from caller cancellations', async () => {
+		vi.useFakeTimers();
+		try {
+			const metrics = mockMetrics();
+			const browser = new S3ObjectBrowser({
+				mode: 'full',
+				limits: { metadataTimeoutMs: 10 },
+				metrics,
+				clientFactory: () => stalledClient(),
+			});
+			const timedOut = browser.listObjects(source, context, {
+				bucket: 'private-bucket',
+				limit: 1,
+			});
+			const timedOutExpectation = expect(timedOut).rejects.toMatchObject({ code: 'aborted' });
+			await vi.advanceTimersByTimeAsync(10);
+			await timedOutExpectation;
+			expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.timeouts', 1, {
+				operation: 'list_objects',
+				mode: 'full',
+			});
+
+			const caller = new AbortController();
+			const canceled = browser.listObjects(
+				source,
+				{ ...context, signal: caller.signal },
+				{
+					bucket: 'private-bucket',
+					limit: 1,
+				},
+			);
+			const canceledExpectation = expect(canceled).rejects.toMatchObject({ code: 'aborted' });
+			caller.abort();
+			await canceledExpectation;
+			expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.cancellations', 1, {
+				operation: 'list_objects',
+				mode: 'full',
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('counts downloaded bytes when a stream completes or is canceled', async () => {
+		const metrics = mockMetrics();
+		const browser = harness(
+			[
+				{ Body: body('hello'), ContentLength: 5 },
+				{ Body: body('partial'), ContentLength: 7 },
+			],
+			metrics,
+		);
+		const complete = await browser.openObject(source, context, {
+			bucket: 'private-bucket',
+			key: 'secret.bin',
+		});
+		expect(await new Response(complete.body).text()).toBe('hello');
+		const partial = await browser.openObject(source, context, {
+			bucket: 'private-bucket',
+			key: 'secret.bin',
+		});
+		const reader = partial.body.getReader();
+		await reader.read();
+		await reader.cancel();
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.bytes_read', 5, {
+			operation: 'open_object',
+			mode: 'full',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.bytes_read', 7, {
+			operation: 'open_object',
+			mode: 'full',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.cancellations', 1, {
+			operation: 'open_object',
+			mode: 'full',
+		});
+	});
+
+	it('records failures that happen after download headers arrive', async () => {
+		const metrics = mockMetrics();
+		const failing = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				controller.error(Object.assign(new Error('provider detail'), { name: 'InternalError' }));
+			},
+		});
+		const browser = harness([{ Body: failing, ContentLength: 1 }], metrics);
+		const opened = await browser.openObject(source, context, {
+			bucket: 'private-bucket',
+			key: 'secret.bin',
+		});
+		await expect(new Response(opened.body).arrayBuffer()).rejects.toMatchObject({
+			code: 'unavailable',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('object_browser.s3.failures', 1, {
+			operation: 'open_object',
+			mode: 'full',
+			code: 'unavailable',
+		});
+	});
+
+	it('includes the raster safety probe in inline download bytes', async () => {
+		const metrics = mockMetrics();
+		const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+		const browser = harness(
+			[
+				{ ContentLength: png.byteLength, ETag: 'etag' },
+				{ Body: new Blob([png]).stream(), ContentLength: png.byteLength },
+				{ Body: new Blob([png]).stream(), ContentLength: png.byteLength },
+			],
+			metrics,
+		);
+		const opened = await browser.openObject(source, context, {
+			bucket: 'private-bucket',
+			key: 'secret.png',
+			inline: true,
+		});
+		await new Response(opened.body).arrayBuffer();
+		expect(metrics.increment).toHaveBeenCalledWith(
+			'object_browser.s3.bytes_read',
+			png.byteLength * 2,
+			{ operation: 'open_object', mode: 'full' },
+		);
+	});
+});
+
+function harness(responses: unknown[], metrics: Metrics): S3ObjectBrowser {
+	const queue = [...responses];
+	const client: S3ClientLike = {
+		async send() {
+			const response = queue.shift();
+			if (response instanceof Error) throw response;
+			return response;
+		},
+		destroy() {},
+	};
+	return new S3ObjectBrowser({ mode: 'full', metrics, clientFactory: () => client });
+}
+
+function stalledClient(): S3ClientLike {
+	return {
+		send(_command, options) {
+			return new Promise((_resolve, reject) => {
+				options?.abortSignal?.addEventListener(
+					'abort',
+					() => reject(new DOMException('aborted', 'AbortError')),
+					{ once: true },
+				);
+			});
+		},
+		destroy() {},
+	};
+}
+
+function mockMetrics() {
+	return {
+		increment: vi.fn<Metrics['increment']>(),
+		gauge: vi.fn<Metrics['gauge']>(),
+		histogram: vi.fn<NonNullable<Metrics['histogram']>>(),
+	};
+}
+
+function body(value: string): ReadableStream<Uint8Array> {
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(value));
+			controller.close();
+		},
+	});
+}

--- a/packages/object-browser-s3/src/open.ts
+++ b/packages/object-browser-s3/src/open.ts
@@ -76,17 +76,37 @@ export async function openS3Object(
 		if (!output.Body) throw new ObjectBrowseError('unavailable', 'The object body was empty.');
 		const upstream = toWebStream(output.Body).getReader();
 		let upstreamClosed = false;
+		let aborted = context.signal?.aborted ?? false;
+		const abortedError = () => new ObjectBrowseError('aborted', 'The request was canceled.');
 		const cancelUpstream = (reason?: unknown): Promise<void> => {
 			if (upstreamClosed) return Promise.resolve();
 			upstreamClosed = true;
+			context.signal?.removeEventListener('abort', abortStream);
 			return upstream.cancel(reason);
 		};
+		function abortStream() {
+			aborted = true;
+			const cancellation = cancelUpstream(context.signal?.reason);
+			release();
+			void cancellation.catch(() => {});
+		}
+		if (context.signal?.aborted) abortStream();
+		else context.signal?.addEventListener('abort', abortStream, { once: true });
 		const body = new ReadableStream<Uint8Array>({
 			async pull(controller) {
+				if (aborted) {
+					controller.error(abortedError());
+					return;
+				}
 				try {
 					const next = await upstream.read();
+					if (aborted) {
+						controller.error(abortedError());
+						return;
+					}
 					if (next.done) {
 						upstreamClosed = true;
+						context.signal?.removeEventListener('abort', abortStream);
 						controller.close();
 						release();
 					} else {
@@ -94,7 +114,8 @@ export async function openS3Object(
 					}
 				} catch (error) {
 					upstreamClosed = true;
-					controller.error(error);
+					context.signal?.removeEventListener('abort', abortStream);
+					controller.error(aborted ? abortedError() : mapS3Error(error));
 					release();
 				}
 			},

--- a/packages/object-browser-s3/src/s3Request.test.ts
+++ b/packages/object-browser-s3/src/s3Request.test.ts
@@ -47,8 +47,24 @@ describe('S3 request utilities', () => {
 					throw new Error('failed');
 				},
 			),
-		).rejects.toThrow('failed');
+		).rejects.toMatchObject({
+			code: 'unavailable',
+			message: 'The object-store request failed.',
+		});
 		expect(failure.destroy).toHaveBeenCalledOnce();
+	});
+
+	it('maps client construction failures without attempting cleanup', async () => {
+		await expect(
+			withS3Client(
+				() => {
+					throw Object.assign(new Error('private credential detail'), { name: 'AccessDenied' });
+				},
+				source,
+				context,
+				async () => 'unreachable',
+			),
+		).rejects.toMatchObject({ code: 'access_denied' });
 	});
 
 	it('releases a client at most once', () => {

--- a/packages/object-browser-s3/src/s3Request.test.ts
+++ b/packages/object-browser-s3/src/s3Request.test.ts
@@ -38,19 +38,17 @@ describe('S3 request utilities', () => {
 		expect(success.destroy).toHaveBeenCalledOnce();
 
 		const failure = mockClient();
+		const programmingError = new Error('failed');
 		await expect(
 			withS3Client(
 				() => failure,
 				source,
 				context,
 				async () => {
-					throw new Error('failed');
+					throw programmingError;
 				},
 			),
-		).rejects.toMatchObject({
-			code: 'unavailable',
-			message: 'The object-store request failed.',
-		});
+		).rejects.toBe(programmingError);
 		expect(failure.destroy).toHaveBeenCalledOnce();
 	});
 

--- a/packages/object-browser-s3/src/s3Request.ts
+++ b/packages/object-browser-s3/src/s3Request.ts
@@ -27,11 +27,14 @@ export async function withS3Client<T>(
 	context: ObjectBrowseContext,
 	run: (client: S3ClientLike) => Promise<T>,
 ): Promise<T> {
-	const client = clientFactory(source, context);
+	let client: S3ClientLike | undefined;
 	try {
+		client = clientFactory(source, context);
 		return await run(client);
+	} catch (error) {
+		throw mapS3Error(error);
 	} finally {
-		client.destroy();
+		client?.destroy();
 	}
 }
 

--- a/packages/object-browser-s3/src/s3Request.ts
+++ b/packages/object-browser-s3/src/s3Request.ts
@@ -27,14 +27,16 @@ export async function withS3Client<T>(
 	context: ObjectBrowseContext,
 	run: (client: S3ClientLike) => Promise<T>,
 ): Promise<T> {
-	let client: S3ClientLike | undefined;
+	let client: S3ClientLike;
 	try {
 		client = clientFactory(source, context);
-		return await run(client);
 	} catch (error) {
 		throw mapS3Error(error);
+	}
+	try {
+		return await run(client);
 	} finally {
-		client?.destroy();
+		client.destroy();
 	}
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,6 +852,9 @@ importers:
         specifier: 4.12.34
         version: 4.12.34
     devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: 'catalog:'
+        version: 3.1066.0
       '@marimo-hub/tsconfig':
         specifier: workspace:*
         version: link:../ts-config
@@ -1479,72 +1482,36 @@ packages:
     resolution: {integrity: sha512-N6azFky/nhHaBfLxza6fMnLbOCgqO12StpCgMDVzx43W7phexcWT61r2mHWrVK6VA6TU+Bze12ZQUb017+VWpw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.20':
-    resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/core@3.974.24':
     resolution: {integrity: sha512-vWB/qJl21vxGKBkBN8fKPTVXgm14v/bUQWTtR5oikrfAZbIN2bxuSiCY5rRAMR4gs3vtR2Vw0aTfVDU4tdfIPg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-env@3.972.46':
-    resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.50':
     resolution: {integrity: sha512-l8bWzhPFTi9tDcvtURxeMlfsboul5/0sEN3SwwXxdpYudVB9+EuQcxo2pwlTzXwDo4Gm2VLGyiZ8zti3nfdOLw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.48':
-    resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-http@3.972.52':
     resolution: {integrity: sha512-FjAlnsIvemWzO3JTM3ObuuxpqCyrqkXOewlYY2+NiR1MYO1JuFYSIJ8SJN5Q2KD1jkL5lIuab8awjb/AxsvjiQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.57':
     resolution: {integrity: sha512-8qwNhQ0sK/1KaOpVEFC7TFxrWP3fxzJV1K049MzjouiMIbvTDvIGDEUtj5ND5aTmlHVK/YZxjoYnLCeV/GZU0w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.52':
-    resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-login@3.972.56':
     resolution: {integrity: sha512-S36dCrDaafakFMlaCVGAF4advbQKoJuMcyMtNWVBpUz65uqhbIAsUfvAyp+djA+jkzaEfgZGd+AELjIGzTqyhw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-node@3.972.55':
-    resolution: {integrity: sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.59':
     resolution: {integrity: sha512-LkczBXaEsdManijlEZwbKfEoo1C98Yri3LHF8gQI7CYWv+uFkmpS3OZH3BSew8g1A2ppKsScdPUSlhI6NV7a9g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.46':
-    resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-process@3.972.50':
     resolution: {integrity: sha512-ARBEVkOQzmowTU0a35smGVyldJ9FN/f57XIGrPatrul4mYN+vvOKxoc1njDOX3nugVze+0sHzQZWJ8kPARAtUA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-sso@3.972.56':
     resolution: {integrity: sha512-LvbWiFcLI/D5RPaT68TrpLLHyv7x5X+dm59wJ5dFizyGPZggBC7OdgJTlP0X1bVjiSSAgE1u1oxxcBps0GCEnA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.56':
@@ -1559,32 +1526,16 @@ packages:
     resolution: {integrity: sha512-keQgcIUTcHL0Qn7guhsuLaxQU36r9norCrxgaPH4DNCwon4TPtXdI/UdYuycl9vj3Dlwc3YR1dfL3U+6iIwJ6w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.20':
-    resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/nested-clients@3.997.24':
     resolution: {integrity: sha512-+wFVfVofxeiXdRhUjRwYISB2mVfBCdiCq1wThkRipTeOc10Kyr+LS9QJTjgZuhWsna7jyLMPndrCnzLGWWvZXg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/signature-v4-multi-region@3.996.34':
-    resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.36':
     resolution: {integrity: sha512-VSOWIPkI+g3a7NkxIBCO24HnsR0BZXJAi3wrKaGIZwVKyrMtNRdHxPrQI/igazgla5J9FhDzmg4RgnOSr6UQBw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1066.0':
-    resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/token-providers@3.1076.0':
     resolution: {integrity: sha512-4rTHETRKe2JWAsFUMo5ENmlzc3i9FD4KqBVXgoaF8DLTADjGid8SA+1LR2nJWjefoafvKAHcQH9F2iKa8uHc6Q==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.12':
-    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.14':
@@ -1593,10 +1544,6 @@ packages:
 
   '@aws-sdk/util-locate-window@3.965.7':
     resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/xml-builder@3.972.29':
-    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.32':
@@ -3028,24 +2975,12 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@smithy/core@3.24.6':
-    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.28.0':
     resolution: {integrity: sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.3.8':
-    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/credential-provider-imds@4.4.4':
     resolution: {integrity: sha512-jT0WrDaM88L5na9FX1xRNywCS3B1n75wPY5Ksasjo0PHUtuI7d8FclksN1BbOSYTiaiKxUDqU23nUymH/V+AaQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/fetch-http-handler@5.4.6':
-    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.1':
@@ -3060,16 +2995,8 @@ packages:
     resolution: {integrity: sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.4.6':
-    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/signature-v4@5.6.0':
     resolution: {integrity: sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.14.3':
-    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.15.0':
@@ -5626,20 +5553,20 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.14
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.14
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.14
       '@aws-sdk/util-locate-window': 3.965.7
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -5666,7 +5593,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.14
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -5675,8 +5602,8 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.24
+      '@aws-sdk/types': 3.973.14
       '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
@@ -5686,16 +5613,16 @@ snapshots:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-node': 3.972.55
+      '@aws-sdk/core': 3.974.24
+      '@aws-sdk/credential-provider-node': 3.972.59
       '@aws-sdk/middleware-flexible-checksums': 3.974.30
       '@aws-sdk/middleware-sdk-s3': 3.972.51
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
+      '@aws-sdk/signature-v4-multi-region': 3.996.36
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/fetch-http-handler': 5.6.1
       '@smithy/node-http-handler': 4.9.1
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/client-secrets-manager@3.1076.0':
@@ -5711,17 +5638,6 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.20':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@aws-sdk/xml-builder': 3.972.29
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.28.0
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.15.0
-      bowser: 2.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/core@3.974.24':
     dependencies:
       '@aws-sdk/types': 3.973.14
@@ -5733,29 +5649,11 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-env@3.972.50':
     dependencies:
       '@aws-sdk/core': 3.974.24
       '@aws-sdk/types': 3.973.14
       '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-http@3.972.48':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.28.0
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5766,22 +5664,6 @@ snapshots:
       '@smithy/core': 3.28.0
       '@smithy/fetch-http-handler': 5.6.1
       '@smithy/node-http-handler': 4.9.1
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-ini@3.972.53':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-login': 3.972.52
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.28.0
-      '@smithy/credential-provider-imds': 4.3.8
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5801,35 +5683,12 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-login@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-login@3.972.56':
     dependencies:
       '@aws-sdk/core': 3.974.24
       '@aws-sdk/nested-clients': 3.997.24
       '@aws-sdk/types': 3.973.14
       '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-node@3.972.55':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.46
-      '@aws-sdk/credential-provider-http': 3.972.48
-      '@aws-sdk/credential-provider-ini': 3.972.53
-      '@aws-sdk/credential-provider-process': 3.972.46
-      '@aws-sdk/credential-provider-sso': 3.972.52
-      '@aws-sdk/credential-provider-web-identity': 3.972.52
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.28.0
-      '@smithy/credential-provider-imds': 4.3.8
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5847,28 +5706,10 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-process@3.972.46':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-process@3.972.50':
     dependencies:
       '@aws-sdk/core': 3.974.24
       '@aws-sdk/types': 3.973.14
-      '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/token-providers': 3.1066.0
-      '@aws-sdk/types': 3.973.12
       '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
@@ -5879,15 +5720,6 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.24
       '@aws-sdk/token-providers': 3.1076.0
       '@aws-sdk/types': 3.973.14
-      '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-web-identity@3.972.52':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
       '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
@@ -5908,23 +5740,10 @@ snapshots:
 
   '@aws-sdk/middleware-sdk-s3@3.972.51':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.24
+      '@aws-sdk/signature-v4-multi-region': 3.996.36
+      '@aws-sdk/types': 3.973.14
       '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.997.20':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.28.0
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5941,26 +5760,10 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.34':
-    dependencies:
-      '@aws-sdk/types': 3.973.12
-      '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.996.36':
     dependencies:
       '@aws-sdk/types': 3.973.14
       '@smithy/signature-v4': 5.6.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1066.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
-      '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5973,11 +5776,6 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@aws-sdk/types@3.973.12':
-    dependencies:
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@aws-sdk/types@3.973.14':
     dependencies:
       '@smithy/types': 4.15.0
@@ -5985,12 +5783,6 @@ snapshots:
 
   '@aws-sdk/util-locate-window@3.965.7':
     dependencies:
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.29':
-    dependencies:
-      '@smithy/types': 4.15.0
-      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.32':
@@ -7099,30 +6891,12 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@smithy/core@3.24.6':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@smithy/core@3.28.0':
     dependencies:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.3.8':
-    dependencies:
-      '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@smithy/credential-provider-imds@4.4.4':
-    dependencies:
-      '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@smithy/fetch-http-handler@5.4.6':
     dependencies:
       '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
@@ -7144,20 +6918,10 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.4.6':
-    dependencies:
-      '@smithy/core': 3.28.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
   '@smithy/signature-v4@5.6.0':
     dependencies:
       '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@smithy/types@4.14.3':
-    dependencies:
       tslib: 2.8.1
 
   '@smithy/types@4.15.0':


### PR DESCRIPTION
Wraps object-browser operations in observability spans that emit a metrics counter and latency histogram, threads an optional `Metrics` port through the S3 browser and its config wiring, and adds a MinIO live conformance test.