### PR TITLE
fix(auth-oidc): let trusted-issuer cover email_verified omission for domain allowlist

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
@@ -23,8 +23,8 @@ or more domains, or set <code>*</code> to allow all.</p>
 UserInfo must have the same <code>sub</code> as the validated ID token. Email verification
 is required by default. If a trusted issuer omits <code>email_verified</code>, use
 <code>MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION=trusted-issuer</code>. Any present value other
-than boolean <code>true</code> is invalid. A domain allowlist always requires boolean
-<code>true</code>, even under <code>trusted-issuer</code>.</p>
+than boolean <code>true</code> is invalid. This policy also applies when a domain allowlist
+is active.</p>
 <p>The signed session JWT has a 3,800-byte limit. If necessary, marimohub omits the
 profile picture first and the display name second. Required identity and
 authorization claims are never omitted. Login fails if they exceed the limit.</p>

--- a/development_docs/auth.md
+++ b/development_docs/auth.md
@@ -62,8 +62,9 @@ provider logout endpoint.
 register byte-for-byte. The issuer, redirect URI, and discovered authorization
 and logout endpoints must use HTTPS and cannot contain credentials.
 
-`trusted-issuer` applies only when all email domains are allowed. A domain
-allowlist always requires `email_verified: true`.
+`trusted-issuer` permits an omitted `email_verified` claim, including when a
+domain allowlist is active. Any present value other than boolean `true` is
+rejected.
 
 **Cookies**: `mh_session` is an issuer-, audience-, and type-bound HS256 JWT.
 It is HttpOnly, Secure, and SameSite=Lax. Its default lifetime is 8 hours, or

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -108,8 +108,8 @@ revokes their access.
 
 The login email grants access, so OIDC requires `email_verified: true` by
 default. `trusted-issuer` permits an enterprise issuer to omit the claim. Any
-present value other than boolean `true` is rejected. A domain allowlist always
-requires boolean `true`, even under `trusted-issuer`.
+present value other than boolean `true` is rejected. This policy also applies
+when a domain allowlist is active.
 
 Invite emails are PII of people who never signed in: the members list and
 project detail show them only to project managers (and to the invitee themself).

--- a/docs/setup/auth/oidc.md
+++ b/docs/setup/auth/oidc.md
@@ -26,8 +26,8 @@ If the provider publishes UserInfo, marimohub uses it for profile claims.
 UserInfo must have the same `sub` as the validated ID token. Email verification
 is required by default. If a trusted issuer omits `email_verified`, use
 `MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION=trusted-issuer`. Any present value other
-than boolean `true` is invalid. A domain allowlist always requires boolean
-`true`, even under `trusted-issuer`.
+than boolean `true` is invalid. This policy also applies when a domain allowlist
+is active.
 
 The signed session JWT has a 3,800-byte limit. If necessary, marimohub omits the
 profile picture first and the display name second. Required identity and

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -828,7 +828,7 @@ describe('OIDC routes', () => {
 		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
 	});
 
-	it('requires email_verified when a domain allowlist is active under trusted-issuer', async () => {
+	it('allows an omitted ID-token email_verified with a domain allowlist under trusted-issuer', async () => {
 		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
 			sub: 'user-1',
 			email: 'user@example.com',
@@ -843,11 +843,10 @@ describe('OIDC routes', () => {
 			headers: { cookie: txn },
 		});
 
-		expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
-		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
 	});
 
-	it('requires UserInfo email_verified with a domain allowlist under trusted-issuer', async () => {
+	it('allows an omitted UserInfo email_verified with a domain allowlist under trusted-issuer', async () => {
 		oauthMock.processDiscoveryResponse.mockReturnValue({
 			issuer: 'https://issuer.example.com',
 			authorization_endpoint: 'https://issuer.example.com/authorize',
@@ -869,17 +868,19 @@ describe('OIDC routes', () => {
 			headers: { cookie: txn },
 		});
 
-		expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
-		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
 	});
 
-	it('rejects explicit false even with the trusted-issuer compatibility policy', async () => {
+	it('rejects explicit false with a domain allowlist under trusted-issuer', async () => {
 		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
 			sub: 'user-1',
 			email: 'user@example.com',
 			email_verified: false,
 		});
-		const { routes } = makeOidc({ emailVerification: 'trusted-issuer' });
+		const { routes } = makeOidc({
+			emailVerification: 'trusted-issuer',
+			allowedEmailDomains: ['example.com'],
+		});
 		const txn = await beginOidcTransaction(routes);
 
 		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -846,6 +846,25 @@ describe('OIDC routes', () => {
 		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
 	});
 
+	it('rejects an omitted email_verified when the email domain is not allowed', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.org',
+		});
+		const { routes } = makeOidc({
+			emailVerification: 'trusted-issuer',
+			allowedEmailDomains: ['example.com'],
+		});
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=domain_not_allowed');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
+	});
+
 	it('allows an omitted UserInfo email_verified with a domain allowlist under trusted-issuer', async () => {
 		oauthMock.processDiscoveryResponse.mockReturnValue({
 			issuer: 'https://issuer.example.com',
@@ -869,6 +888,37 @@ describe('OIDC routes', () => {
 		});
 
 		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('rejects ID-token email_verified false when UserInfo omits the claim', async () => {
+		oauthMock.processDiscoveryResponse.mockReturnValue({
+			issuer: 'https://issuer.example.com',
+			authorization_endpoint: 'https://issuer.example.com/authorize',
+			token_endpoint: 'https://issuer.example.com/token',
+			jwks_uri: 'https://issuer.example.com/jwks',
+			userinfo_endpoint: 'https://issuer.example.com/userinfo',
+		});
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: false,
+		});
+		oauthMock.processUserInfoResponse.mockResolvedValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+		});
+		const { routes } = makeOidc({
+			emailVerification: 'trusted-issuer',
+			allowedEmailDomains: ['example.com'],
+		});
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.headers.get('location')).toBe('/?auth_error=email_not_verified');
+		expect(res.headers.get('set-cookie') ?? '').not.toMatch(/mh_session=[^;,]+/);
 	});
 
 	it('rejects explicit false with a domain allowlist under trusted-issuer', async () => {

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -68,9 +68,9 @@ export interface OidcConfig {
 	/**
 	 * Lowercase email domains allowed to sign in (e.g. `['marimo.io']`). When set
 	 * and non-empty, the callback rejects any user whose `email` is not under one
-	 * of these domains, and additionally requires the `email_verified` claim to be
-	 * true (so a domain can't be spoofed via an unverified address). When exactly
-	 * one domain is configured, it is also passed to the provider as the `hd`
+	 * of these domains. Email verification follows `emailVerification`: a present
+	 * claim must be true, while `trusted-issuer` permits omission. When exactly one
+	 * domain is configured, it is also passed to the provider as the `hd`
 	 * (hosted-domain) hint — a Google UX nudge, NOT a security boundary; the
 	 * callback check is what actually enforces the restriction. Empty/undefined
 	 * means any successfully-authenticated account is accepted.
@@ -678,7 +678,7 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		if (emailVerified !== undefined && emailVerified !== true) {
 			return callbackError(c, 'email_not_verified', returnTo);
 		}
-		if ((emailVerification === 'required' || restrictDomains) && emailVerified !== true) {
+		if (emailVerification === 'required' && emailVerified !== true) {
 			return callbackError(c, 'email_not_verified', returnTo);
 		}
 

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -672,10 +672,15 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 		if (!validEmail(identityClaims.email)) return callbackError(c, 'auth_failed', returnTo);
 		const email = identityClaims.email;
 		const emailVerified = identityClaims.email_verified;
+		const emailVerificationClaims = [claims.email_verified, userInfo?.email_verified];
 
-		// Email participates in project authorization, so a present verification
-		// claim must be exactly true. Only omission is covered by trusted-issuer.
-		if (emailVerified !== undefined && emailVerified !== true) {
+		// Email participates in project authorization, so every validated source
+		// that provides a verification claim must set it to exactly true.
+		if (
+			emailVerificationClaims.some(
+				(verification) => verification !== undefined && verification !== true,
+			)
+		) {
 			return callbackError(c, 'email_not_verified', returnTo);
 		}
 		if (emailVerification === 'required' && emailVerified !== true) {


### PR DESCRIPTION
A configured domain allowlist forced `required` email-verification semantics even under `trusted-issuer`, so issuers that verify email upstream and omit the claim (e.g. Cloudflare Access for SaaS) made the allowlist unusable — every login ended at `/?auth_error=email_not_verified`, forcing operators to set `ALLOWED_EMAIL_DOMAINS=*` and move domain enforcement into the IdP.

Now `trusted-issuer` permits an omitted `email_verified` claim regardless of whether a domain allowlist is active; a present non-true value is still rejected, and the default `required` policy keeps today's strictness. Updates docs to match.

Fixes #152