### PR TITLE
feat(compute): pass gpu key from compute profiles through to Modal

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -59,18 +59,22 @@ model.
 
 ## Compute profiles
 
-Operators can define named CPU and memory profiles in an ordered list:
+Operators can define named CPU, memory, and GPU profiles in an ordered list:
 
 ```bash
-MARIMOHUB_COMPUTE_PROFILES="small:cpu=1;mem=2Gi,large:cpu=8;mem=32Gi"
+MARIMOHUB_COMPUTE_PROFILES="small:cpu=1;mem=2Gi,gpu-large:cpu=8;mem=32Gi;gpu=A100"
 # Optional: let editors choose a profile per notebook.
 MARIMOHUB_COMPUTE_PROFILE_OVERRIDE="editors"
 ```
 
 - The first profile is the default and applies to every new sandbox. Reordering
   the list changes the default.
-- Profile names are stable identifiers. Renaming is remove-and-add; CPU and
-  memory values under an existing name can be changed freely.
+- GPU values use Modal's `<type>[:<count>]` syntax, such as `A100`, `T4:2`, or
+  `A100-80GB:4`. Modal applies them when creating a sandbox. Other backends
+  ignore GPU values and log a startup warning while continuing to apply CPU and
+  memory values when supported.
+- Profile names are stable identifiers. Renaming is remove-and-add; CPU, memory,
+  and GPU values under an existing name can be changed freely.
 - Changes apply on the next session start. Running kernels keep their current
   resources. The session details show both the running and selected profile
   until the restart.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,7 +101,7 @@ Read regardless of the selected compute backend.
 | Variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
 | `MARIMOHUB_COMPUTE_IMAGE` | Container image with marimo + uv + python, or a comma-separated list of such images: the first is the default and the rest are selectable per notebook as base images. Required by the `modal` backend; recommended for `coreweave`. | — | — | `ghcr.io/orgname/marimo-sandbox:latest` |
-| `MARIMOHUB_COMPUTE_PROFILES` | Ordered named CPU/memory profiles (`name:cpu=<cores>;mem=<Mi\|Gi\|Ti>`). The first is the default; supported backends apply the notebook choice when overrides are enabled. | — | — | `small:cpu=1;mem=2Gi,large:cpu=8;mem=32Gi` |
+| `MARIMOHUB_COMPUTE_PROFILES` | Ordered named CPU, memory, and optional GPU profiles (`name:cpu=<cores>;mem=<Mi\|Gi\|Ti>;gpu=<type>[:<count>]`). The first is the default; supported backends apply the notebook choice when overrides are enabled. Modal applies GPU requests; other backends ignore them with a startup warning. | — | — | `small:cpu=1;mem=2Gi,gpu-large:cpu=8;mem=32Gi;gpu=A100` |
 | `MARIMOHUB_COMPUTE_PROFILE_OVERRIDE` | Whether editors may choose a non-default compute profile per notebook (`none` or `editors`). | — | `none` | `editors` |
 | `MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME` | Public hostname used to expose kernel ports. | — | `'' (empty)` | `hub.example.com` |
 | `MARIMOHUB_COMPUTE_WORKDIR` | Working directory inside the sandbox where notebook files land and marimo runs. | — | `/workspace` | — |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,7 +101,7 @@ Read regardless of the selected compute backend.
 | Variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
 | `MARIMOHUB_COMPUTE_IMAGE` | Container image with marimo + uv + python, or a comma-separated list of such images: the first is the default and the rest are selectable per notebook as base images. Required by the `modal` backend; recommended for `coreweave`. | — | — | `ghcr.io/orgname/marimo-sandbox:latest` |
-| `MARIMOHUB_COMPUTE_PROFILES` | Ordered named CPU, memory, and optional GPU profiles (`name:cpu=<cores>;mem=<Mi\|Gi\|Ti>;gpu=<type>[:<count>]`). The first is the default; supported backends apply the notebook choice when overrides are enabled. Modal applies GPU requests; other backends ignore them with a startup warning. | — | — | `small:cpu=1;mem=2Gi,gpu-large:cpu=8;mem=32Gi;gpu=A100` |
+| `MARIMOHUB_COMPUTE_PROFILES` | Ordered named CPU, memory, and optional GPU profiles (`name:cpu=<cores>;mem=<Mi\|Gi\|Ti>;gpu=<type>[:<count>]`, with a maximum GPU count of 8). The first is the default; supported backends apply the notebook choice when overrides are enabled. Modal applies GPU requests; other backends ignore them with a startup warning. | — | — | `small:cpu=1;mem=2Gi,gpu-large:cpu=8;mem=32Gi;gpu=A100` |
 | `MARIMOHUB_COMPUTE_PROFILE_OVERRIDE` | Whether editors may choose a non-default compute profile per notebook (`none` or `editors`). | — | `none` | `editors` |
 | `MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME` | Public hostname used to expose kernel ports. | — | `'' (empty)` | `hub.example.com` |
 | `MARIMOHUB_COMPUTE_WORKDIR` | Working directory inside the sandbox where notebook files land and marimo runs. | — | `/workspace` | — |

--- a/docs/setup/compute/modal.md
+++ b/docs/setup/compute/modal.md
@@ -20,10 +20,10 @@ running kernels. The easiest path if you don't already run a cluster.
 :::
 
 The adapter creates and reconnects to sandboxes through Modal's supported
-JavaScript SDK. Compute profiles are passed as the SDK's `cpu` and `memoryMiB`
-sandbox options. The adapter sets Modal's provider-side idle timeout to 1.5 times
-`MARIMOHUB_SESSION_IDLE_TIMEOUT_SECONDS`. This leaves time for the hub to save
-and stop the session first.
+JavaScript SDK. Compute profiles are passed as the SDK's `cpu`, `memoryMiB`, and
+`gpu` sandbox options. The adapter sets Modal's provider-side idle timeout to 1.5
+times `MARIMOHUB_SESSION_IDLE_TIMEOUT_SECONDS`. This leaves time for the hub to
+save and stop the session first.
 
 ::: warning Cold starts & shared workspaces
 A freshly-started kernel can take a few seconds to boot; a warm sandbox image

--- a/internal/schemas/bucket.yml
+++ b/internal/schemas/bucket.yml
@@ -1199,6 +1199,8 @@ components:
               type: number
             memory_bytes:
               type: number
+            gpu:
+              type: string
         owner_user_id:
           type: string
       required:
@@ -1391,6 +1393,8 @@ components:
               type: number
             memory_bytes:
               type: number
+            gpu:
+              type: string
         compute_from_snapshot:
           type: boolean
         sandbox_origin_url:

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -288,6 +288,8 @@ components:
           type: number
         memory_bytes:
           type: number
+        gpu:
+          type: string
     ProjectPage:
       type: object
       properties:

--- a/packages/api/src/capabilities.test.ts
+++ b/packages/api/src/capabilities.test.ts
@@ -160,14 +160,14 @@ describe('GET /api/v1/capabilities', () => {
 		const deps = makeTestDeps(new MemoryBucket(), { authenticator: authed });
 		deps.sandbox.computeProfiles = [
 			{ name: 'small', resources: { cpu: 1, memoryBytes: 2 * 1024 ** 3 } },
-			{ name: 'large', resources: { cpu: 8 } },
+			{ name: 'large', resources: { cpu: 8, gpu: 'A100:2' } },
 		];
 		deps.sandbox.computeProfileOverride = 'editors';
 
 		expect(await expectOk(await createApi(deps).request('/api/v1/capabilities'))).toMatchObject({
 			compute_profiles: [
 				{ name: 'small', cpu: 1, memory_bytes: 2 * 1024 ** 3 },
-				{ name: 'large', cpu: 8 },
+				{ name: 'large', cpu: 8, gpu: 'A100:2' },
 			],
 			compute_profile_override: 'editors',
 		});

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -805,7 +805,7 @@ describe('Session routes', () => {
 			compute,
 			deps: {
 				sandbox: sandboxConfig({
-					resources: { cpu: 0.5, memoryBytes: 512 * 1024 ** 2 },
+					resources: { cpu: 0.5, memoryBytes: 512 * 1024 ** 2, gpu: 'T4' },
 					computeProfile: 'small',
 				}),
 			},
@@ -815,11 +815,13 @@ describe('Session routes', () => {
 		expect(compute.lastCreateOptions?.resources).toEqual({
 			cpu: 0.5,
 			memoryBytes: 512 * 1024 ** 2,
+			gpu: 'T4',
 		});
 		expect(data.compute_profile).toBe('small');
 		expect(data.compute_resources).toEqual({
 			cpu: 0.5,
 			memory_bytes: 512 * 1024 ** 2,
+			gpu: 'T4',
 		});
 		expect(data.compute_from_snapshot).toBeUndefined();
 		const stored = await createServices(bucket).sessions.getSession(pid, data.session_id);
@@ -827,6 +829,7 @@ describe('Session routes', () => {
 		expect(stored.compute_resources).toEqual({
 			cpu: 0.5,
 			memory_bytes: 512 * 1024 ** 2,
+			gpu: 'T4',
 		});
 	});
 

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -726,6 +726,7 @@ export const ComputeResourcesResponseSchema = z
 	.object({
 		cpu: z.number().optional(),
 		memory_bytes: z.number().optional(),
+		gpu: z.string().optional(),
 	})
 	.openapi('ComputeResources');
 
@@ -736,6 +737,7 @@ export function toComputeResourcesResponse(
 	return {
 		cpu: resources.cpu,
 		memory_bytes: resources.memoryBytes,
+		gpu: resources.gpu,
 	};
 }
 

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -8771,6 +8771,7 @@ export interface components {
 		ComputeResources: {
 			cpu?: number;
 			memory_bytes?: number;
+			gpu?: string;
 		};
 		ProjectPage: {
 			items: components['schemas']['SnapshotProjectEntry'][];

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -183,7 +183,7 @@ describe('ModalCompute', () => {
 		await makeCompute(world)
 			.create(SANDBOX_ID, {
 				reuse: false,
-				resources: { cpu: 1.5, memoryBytes: 2 * 1024 ** 3 },
+				resources: { cpu: 1.5, memoryBytes: 2 * 1024 ** 3, gpu: 'A100:2' },
 			})
 			.exec('true');
 
@@ -192,6 +192,7 @@ describe('ModalCompute', () => {
 			name: SANDBOX_ID,
 			cpu: 1.5,
 			memoryMiB: 2048,
+			gpu: 'A100:2',
 			encryptedPorts: [2718],
 			idleTimeoutMs: 45 * 60_000,
 			timeoutMs: 24 * 60 * 60_000,
@@ -216,11 +217,13 @@ describe('ModalCompute', () => {
 			cpu: 0.5,
 			memoryMiB: 512,
 		});
+		expect(modalProfileResources({ gpu: 'T4:2' })).toEqual({ gpu: 'T4:2' });
 
 		const world = makeWorld();
 		await makeCompute(world).create(SANDBOX_ID, { reuse: false }).exec('true');
 		expect(world.created[0].options).not.toHaveProperty('cpu');
 		expect(world.created[0].options).not.toHaveProperty('memoryMiB');
+		expect(world.created[0].options).not.toHaveProperty('gpu');
 	});
 
 	it('reattaches by sandbox name when reuse is enabled', async () => {

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -101,6 +101,7 @@ export interface ModalClientLike {
 				idleTimeoutMs?: number;
 				cpu?: number;
 				memoryMiB?: number;
+				gpu?: string;
 			},
 		): Promise<ModalSandboxLike>;
 		fromName(appName: string, name: string): Promise<ModalSandboxLike>;
@@ -117,12 +118,14 @@ const SANDBOX_ID_TAG = 'marimohub.sandbox-id';
 export function modalProfileResources(resources: ComputeResources | undefined): {
 	cpu?: number;
 	memoryMiB?: number;
+	gpu?: string;
 } {
 	return {
 		...(resources?.cpu !== undefined ? { cpu: resources.cpu } : {}),
 		...(resources?.memoryBytes !== undefined
 			? { memoryMiB: Math.ceil(resources.memoryBytes / 1024 ** 2) }
 			: {}),
+		...(resources?.gpu !== undefined ? { gpu: resources.gpu } : {}),
 	};
 }
 

--- a/packages/config/src/computeProfiles.test.ts
+++ b/packages/config/src/computeProfiles.test.ts
@@ -103,8 +103,8 @@ describe('parseComputeProfiles', () => {
 
 	it('accepts exact numeric resource boundaries', () => {
 		expect(
-			parseComputeProfiles('max:cpu=4096;mem=64Ti;gpu=A100:4294967295').defaultProfile?.resources,
-		).toEqual({ cpu: 4096, memoryBytes: 64 * 1024 ** 4, gpu: 'A100:4294967295' });
+			parseComputeProfiles('max:cpu=4096;mem=64Ti;gpu=A100:8').defaultProfile?.resources,
+		).toEqual({ cpu: 4096, memoryBytes: 64 * 1024 ** 4, gpu: 'A100:8' });
 	});
 
 	const fatal = (raw: string, messagePart: string) => {
@@ -144,8 +144,10 @@ describe('parseComputeProfiles', () => {
 		]) {
 			fatal(`gpu:gpu=${value}`, 'gpu must match');
 		}
-		fatal('gpu:gpu=A100:4294967296', 'transport limit');
-		fatal('gpu:gpu=A100:999999999999999999999999999999999999', 'transport limit');
+		fatal('gpu:gpu=A100:9', 'sanity limit of 8');
+		fatal('gpu:gpu=A100:100000', 'sanity limit of 8');
+		fatal('gpu:gpu=A100:4294967295', 'sanity limit of 8');
+		fatal('gpu:gpu=A100:999999999999999999999999999999999999', 'sanity limit of 8');
 	});
 
 	it('rejects unsupported or missing memory units', () => {

--- a/packages/config/src/computeProfiles.test.ts
+++ b/packages/config/src/computeProfiles.test.ts
@@ -5,7 +5,9 @@ import {
 	parseComputeProfiles,
 	parseComputeProfileOverride,
 	resolveResources,
+	profilesForBackend,
 	supportsComputeProfiles,
+	supportsGpuProfiles,
 	unsupportedBackendNotice,
 } from './computeProfiles';
 import { isConfigError } from './errors';
@@ -34,11 +36,31 @@ describe('parseComputeProfiles', () => {
 		expect(resolveResources(parseComputeProfiles('large:cpu=8,small:cpu=1')).cpu).toBe(8);
 	});
 
+	it('preserves profile order and accepts every resource-key ordering', () => {
+		const keyOrderings = [
+			'cpu=8;mem=32Gi;gpu=A100',
+			'cpu=8;gpu=A100;mem=32Gi',
+			'mem=32Gi;cpu=8;gpu=A100',
+			'mem=32Gi;gpu=A100;cpu=8',
+			'gpu=A100;cpu=8;mem=32Gi',
+			'gpu=A100;mem=32Gi;cpu=8',
+		];
+		for (const body of keyOrderings) {
+			expect(parseComputeProfiles(`first:${body},second:gpu=T4`).profiles).toEqual([
+				{ name: 'first', resources: { cpu: 8, memoryBytes: 32 * Gi, gpu: 'A100' } },
+				{ name: 'second', resources: { gpu: 'T4' } },
+			]);
+		}
+	});
+
 	it('tolerates whitespace and trailing semicolons', () => {
-		const config = parseComputeProfiles('  small : cpu = 0.5 ; mem = 512Mi ; , large:cpu=2 ');
+		const config = parseComputeProfiles(
+			'  small : gpu = a100:2 ; mem = 512Mi ; cpu = 0.5 ; , large:cpu=2 ',
+		);
 		expect(config.profiles[0].resources).toEqual({
 			cpu: 0.5,
 			memoryBytes: 512 * Mi,
+			gpu: 'A100:2',
 		});
 		expect(config.profiles[1].resources).toEqual({ cpu: 2 });
 	});
@@ -57,6 +79,34 @@ describe('parseComputeProfiles', () => {
 		expect(config.profiles[2].resources.memoryBytes).toBe(2 * 1024 ** 4);
 	});
 
+	it('parses and canonicalizes GPU types with optional counts', () => {
+		const config = parseComputeProfiles(
+			'gpu-a100:cpu=8;mem=32Gi;gpu=a100,gpu-t4:gpu=t4:2,gpu-large:gpu=A100-80gb:4',
+		);
+		expect(config.profiles).toEqual([
+			{ name: 'gpu-a100', resources: { cpu: 8, memoryBytes: 32 * Gi, gpu: 'A100' } },
+			{ name: 'gpu-t4', resources: { gpu: 'T4:2' } },
+			{ name: 'gpu-large', resources: { gpu: 'A100-80GB:4' } },
+		]);
+		expect(resolveResources(config)).toEqual({ cpu: 8, memoryBytes: 32 * Gi, gpu: 'A100' });
+		expect(hasConfiguredResources(config)).toBe(true);
+		expect(profilesForBackend('modal', config)).toBe(config);
+		const dockerConfig = profilesForBackend('docker', config);
+		expect(dockerConfig.profiles).toEqual([
+			{ name: 'gpu-a100', resources: { cpu: 8, memoryBytes: 32 * Gi } },
+			{ name: 'gpu-t4', resources: {} },
+			{ name: 'gpu-large', resources: {} },
+		]);
+		expect(dockerConfig.defaultProfile).toBe(dockerConfig.profiles[0]);
+		expect(config.profiles[0].resources.gpu).toBe('A100');
+	});
+
+	it('accepts exact numeric resource boundaries', () => {
+		expect(
+			parseComputeProfiles('max:cpu=4096;mem=64Ti;gpu=A100:4294967295').defaultProfile?.resources,
+		).toEqual({ cpu: 4096, memoryBytes: 64 * 1024 ** 4, gpu: 'A100:4294967295' });
+	});
+
 	const fatal = (raw: string, messagePart: string) => {
 		let error: unknown;
 		try {
@@ -72,8 +122,30 @@ describe('parseComputeProfiles', () => {
 	it('rejects unknown keys', () => {
 		fatal('small:cpus=1', 'unknown key');
 		fatal('small:memory=2Gi', 'unknown key');
-		fatal('gpu-a100:cpu=8;gpu=A100:1', 'unknown key');
 		fatal('big:disk=10Gi', 'unknown key');
+	});
+
+	it('rejects malformed GPU requests', () => {
+		for (const value of [
+			'A100:',
+			'A100:0',
+			'A100:01',
+			'A100:+1',
+			'A100:-1',
+			'A100:1.5',
+			'A100:1e2',
+			'A100::2',
+			'A100:2:3',
+			'A100 80GB',
+			'A100-',
+			'-A100',
+			':1',
+			'A100=2',
+		]) {
+			fatal(`gpu:gpu=${value}`, 'gpu must match');
+		}
+		fatal('gpu:gpu=A100:4294967296', 'transport limit');
+		fatal('gpu:gpu=A100:999999999999999999999999999999999999', 'transport limit');
 	});
 
 	it('rejects unsupported or missing memory units', () => {
@@ -84,14 +156,16 @@ describe('parseComputeProfiles', () => {
 	});
 
 	it('rejects malformed and non-positive values', () => {
-		fatal('small:cpu=abc', 'positive decimal');
-		fatal('small:cpu=0', 'at least 0.001');
-		fatal('small:cpu=0.0004', 'at least 0.001');
-		fatal('small:cpu=-1', 'positive decimal');
-		fatal('small:mem=0Gi', 'at least 1Mi');
-		fatal('small:mem=0.0000001Mi', 'at least 1Mi');
-		fatal('small:mem=0.5Mi', 'at least 1Mi');
-		fatal('small:mem=abcGi', 'must match');
+		for (const value of ['abc', '-1', '+1', '.5', '1.', '1e2', 'Infinity', 'NaN']) {
+			fatal(`small:cpu=${value}`, 'positive decimal');
+		}
+		for (const value of ['abcGi', '-1Gi', '+1Gi', '.5Gi', '1.Gi', '1e2Gi']) {
+			fatal(`small:mem=${value}`, 'mem');
+		}
+		for (const value of ['0', '0.0004']) fatal(`small:cpu=${value}`, 'at least 0.001');
+		for (const value of ['0Gi', '0.0000001Mi', '0.5Mi']) {
+			fatal(`small:mem=${value}`, 'at least 1Mi');
+		}
 	});
 
 	it('accepts the smallest provider-representable values', () => {
@@ -108,13 +182,17 @@ describe('parseComputeProfiles', () => {
 
 	it('rejects duplicate keys and names', () => {
 		fatal('small:cpu=1;cpu=2', 'duplicate key');
+		fatal('small:gpu=A100;gpu=T4', 'duplicate key');
 		fatal('small:cpu=1,small:cpu=2', 'duplicate profile name');
+		fatal(' small:cpu=1 , small:cpu=2 ', 'duplicate profile name');
 	});
 
 	it('rejects invalid names', () => {
+		const maxName = 'a'.repeat(32);
+		expect(parseComputeProfiles(`${maxName}:gpu=A100`).profiles[0].name).toBe(maxName);
 		fatal('Small:cpu=1', 'invalid profile name');
 		fatal('has_underscore:cpu=1', 'invalid profile name');
-		fatal('way-too-long-name-way-too-long-name-x:cpu=1', 'invalid profile name');
+		fatal(`${'a'.repeat(33)}:cpu=1`, 'invalid profile name');
 		fatal(':cpu=1', 'empty name');
 		fatal('small:cpu=1,,large:cpu=2', 'position 2 has an empty name');
 		fatal(',small:cpu=1', 'position 1 has an empty name');
@@ -124,6 +202,16 @@ describe('parseComputeProfiles', () => {
 	it('rejects missing keys or values', () => {
 		fatal('small:cpu', 'expected key=value');
 		fatal('small:cpu=', 'empty value');
+		fatal('small:=1', 'unknown key');
+		fatal('small:gpu=A100=2', 'gpu must match');
+		fatal('small:GPU=A100', 'unknown key');
+	});
+
+	it('allows one trailing separator but rejects empty resource entries elsewhere', () => {
+		expect(parseComputeProfiles('small:cpu=1;').defaultProfile?.resources).toEqual({ cpu: 1 });
+		fatal('small:;cpu=1', 'empty resource entry');
+		fatal('small:cpu=1;;gpu=A100', 'empty resource entry');
+		fatal('small:cpu=1;;', 'empty resource entry');
 	});
 
 	it('names the offending profile and key in the error', () => {
@@ -165,6 +253,16 @@ describe('unsupportedBackendNotice', () => {
 		expect(notice).toContain('MARIMOHUB_COMPUTE_PROFILE_OVERRIDE');
 		expect(notice).toContain('ignored');
 	});
+
+	it('warns when a profile-aware backend ignores only GPU values', () => {
+		const configured = parseComputeProfiles('gpu:cpu=8;gpu=A100');
+		expect(unsupportedBackendNotice('docker', configured)).toContain('profile GPUs');
+		expect(unsupportedBackendNotice('docker', configured)).toContain(
+			'CPU and memory values still apply',
+		);
+		expect(unsupportedBackendNotice('modal', configured)).toBeUndefined();
+		expect(unsupportedBackendNotice('docker', parseComputeProfiles('small:cpu=1'))).toBeUndefined();
+	});
 });
 
 describe('supportsComputeProfiles', () => {
@@ -174,6 +272,22 @@ describe('supportsComputeProfiles', () => {
 		}
 		for (const backend of ['e2b', 'cloudflare', 'local', 'none', 'noop', 'unknown']) {
 			expect(supportsComputeProfiles(backend), backend).toBe(false);
+		}
+	});
+
+	it('only maps profile GPUs on Modal', () => {
+		expect(supportsGpuProfiles('modal')).toBe(true);
+		for (const backend of [
+			'coreweave',
+			'wandb',
+			'docker',
+			'podman',
+			'kubernetes',
+			'e2b',
+			'cloudflare',
+			'local',
+		]) {
+			expect(supportsGpuProfiles(backend), backend).toBe(false);
 		}
 	});
 });

--- a/packages/config/src/computeProfiles.ts
+++ b/packages/config/src/computeProfiles.ts
@@ -49,8 +49,8 @@ const MAX_CPU_CORES = 4096;
 const MAX_MEMORY_BYTES = 64 * 1024 ** 4;
 const MIN_CPU_CORES = 0.001;
 const MIN_MEMORY_BYTES = 1024 ** 2;
-// Modal serializes the count as protobuf uint32.
-const MAX_GPU_COUNT = 0xffff_ffff;
+// Modal currently schedules at most eight GPUs in one container.
+const MAX_GPU_COUNT = 8;
 const COMPUTE_BACKENDS =
 	CONFIG_SPEC.find((group) => group.selector === 'MARIMOHUB_COMPUTE_BACKEND')?.backends ?? [];
 
@@ -159,7 +159,7 @@ function parseGpu(value: string, profile: string): string {
 	const count = match[2] === undefined ? undefined : Number(match[2]);
 	if (count !== undefined && (!Number.isSafeInteger(count) || count > MAX_GPU_COUNT)) {
 		throw new ComputeProfileConfigError(
-			`gpu count exceeds transport limit of ${MAX_GPU_COUNT}, got ${JSON.stringify(match[2])}`,
+			`gpu count exceeds sanity limit of ${MAX_GPU_COUNT}, got ${JSON.stringify(match[2])}`,
 			profile,
 			'gpu',
 		);

--- a/packages/config/src/computeProfiles.ts
+++ b/packages/config/src/computeProfiles.ts
@@ -28,7 +28,8 @@ export class ComputeProfileConfigError extends ConfigError {
 				: '';
 		super(`MARIMOHUB_COMPUTE_PROFILES: ${message}${where}`, {
 			variable: 'MARIMOHUB_COMPUTE_PROFILES',
-			remediation: 'Use name:cpu=<cores>;mem=<Mi|Gi|Ti>, with lowercase names and unique keys.',
+			remediation:
+				'Use name:cpu=<cores>;mem=<Mi|Gi|Ti>;gpu=<type>[:<count>], with lowercase names and unique keys.',
 			docs: 'docs/configuration.md#compute',
 		});
 		this.name = 'ComputeProfileConfigError';
@@ -36,8 +37,9 @@ export class ComputeProfileConfigError extends ConfigError {
 }
 
 const NAME_RE = /^[a-z0-9-]{1,32}$/;
-const KNOWN_KEYS = new Set(['cpu', 'mem']);
+const KNOWN_KEYS = new Set(['cpu', 'mem', 'gpu']);
 const MEM_RE = /^(\d+(?:\.\d+)?)(Mi|Gi|Ti)$/;
+const GPU_RE = /^([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)(?::([1-9]\d*))?$/;
 const MEM_MULTIPLIER: Record<string, number> = {
 	Mi: 1024 ** 2,
 	Gi: 1024 ** 3,
@@ -47,6 +49,8 @@ const MAX_CPU_CORES = 4096;
 const MAX_MEMORY_BYTES = 64 * 1024 ** 4;
 const MIN_CPU_CORES = 0.001;
 const MIN_MEMORY_BYTES = 1024 ** 2;
+// Modal serializes the count as protobuf uint32.
+const MAX_GPU_COUNT = 0xffff_ffff;
 const COMPUTE_BACKENDS =
 	CONFIG_SPEC.find((group) => group.selector === 'MARIMOHUB_COMPUTE_BACKEND')?.backends ?? [];
 
@@ -55,6 +59,25 @@ export function supportsComputeProfiles(backend: string): boolean {
 		COMPUTE_BACKENDS.find((candidate) => candidate.selectorValue === backend)
 			?.supportsComputeProfiles === true
 	);
+}
+
+export function supportsGpuProfiles(backend: string): boolean {
+	return (
+		COMPUTE_BACKENDS.find((candidate) => candidate.selectorValue === backend)
+			?.supportsGpuProfiles === true
+	);
+}
+
+export function profilesForBackend(
+	backend: string,
+	config: ComputeProfilesConfig,
+): ComputeProfilesConfig {
+	if (supportsGpuProfiles(backend)) return config;
+	const profiles = config.profiles.map((profile) => {
+		const { gpu: _gpu, ...resources } = profile.resources;
+		return { name: profile.name, resources };
+	});
+	return { profiles, defaultProfile: profiles[0] };
 }
 
 function parseCpu(value: string, profile: string): number {
@@ -124,6 +147,26 @@ function parseMem(value: string, profile: string): number {
 	return Math.round(bytes);
 }
 
+function parseGpu(value: string, profile: string): string {
+	const match = GPU_RE.exec(value);
+	if (!match) {
+		throw new ComputeProfileConfigError(
+			`gpu must match <type>[:<positive integer count>], got ${JSON.stringify(value)}`,
+			profile,
+			'gpu',
+		);
+	}
+	const count = match[2] === undefined ? undefined : Number(match[2]);
+	if (count !== undefined && (!Number.isSafeInteger(count) || count > MAX_GPU_COUNT)) {
+		throw new ComputeProfileConfigError(
+			`gpu count exceeds transport limit of ${MAX_GPU_COUNT}, got ${JSON.stringify(match[2])}`,
+			profile,
+			'gpu',
+		);
+	}
+	return `${match[1].toUpperCase()}${count === undefined ? '' : `:${count}`}`;
+}
+
 function parseOneProfile(chunk: string, index: number): ComputeProfile {
 	const colon = chunk.indexOf(':');
 	const name = (colon === -1 ? chunk : chunk.slice(0, colon)).trim();
@@ -141,11 +184,16 @@ function parseOneProfile(chunk: string, index: number): ComputeProfile {
 
 	let cpu: number | undefined;
 	let memoryBytes: number | undefined;
+	let gpu: string | undefined;
 	const seen = new Set<string>();
 	if (body.length > 0) {
-		for (const rawPair of body.split(';')) {
+		const pairs = body.split(';');
+		for (const [pairIndex, rawPair] of pairs.entries()) {
 			const pair = rawPair.trim();
-			if (pair.length === 0) continue;
+			if (pair.length === 0) {
+				if (pairIndex === pairs.length - 1) continue;
+				throw new ComputeProfileConfigError('empty resource entry', name);
+			}
 			const equals = pair.indexOf('=');
 			if (equals === -1) {
 				throw new ComputeProfileConfigError(
@@ -167,6 +215,7 @@ function parseOneProfile(chunk: string, index: number): ComputeProfile {
 			if (value.length === 0) throw new ComputeProfileConfigError('empty value', name, key);
 			if (key === 'cpu') cpu = parseCpu(value, name);
 			if (key === 'mem') memoryBytes = parseMem(value, name);
+			if (key === 'gpu') gpu = parseGpu(value, name);
 		}
 	}
 
@@ -175,6 +224,7 @@ function parseOneProfile(chunk: string, index: number): ComputeProfile {
 		resources: {
 			...(cpu !== undefined ? { cpu } : {}),
 			...(memoryBytes !== undefined ? { memoryBytes } : {}),
+			...(gpu !== undefined ? { gpu } : {}),
 		},
 	};
 }
@@ -219,8 +269,15 @@ export function parseComputeProfileOverride(raw: string | undefined): ComputePro
 
 export function hasConfiguredResources(config: ComputeProfilesConfig): boolean {
 	return config.profiles.some(
-		(profile) => profile.resources.cpu !== undefined || profile.resources.memoryBytes !== undefined,
+		(profile) =>
+			profile.resources.cpu !== undefined ||
+			profile.resources.memoryBytes !== undefined ||
+			profile.resources.gpu !== undefined,
 	);
+}
+
+function hasConfiguredGpu(config: ComputeProfilesConfig): boolean {
+	return config.profiles.some((profile) => profile.resources.gpu !== undefined);
 }
 
 export function unsupportedBackendNotice(
@@ -230,7 +287,14 @@ export function unsupportedBackendNotice(
 ): string | undefined {
 	const profilesConfigured = hasConfiguredResources(config);
 	const overrideConfigured = override !== 'none';
-	if (supportsComputeProfiles(backend) || (!profilesConfigured && !overrideConfigured)) {
+	if (supportsComputeProfiles(backend)) {
+		if (!hasConfiguredGpu(config) || supportsGpuProfiles(backend)) return undefined;
+		return (
+			`MARIMOHUB_COMPUTE_PROFILES includes gpu values but the ${JSON.stringify(backend)} ` +
+			'compute backend does not apply profile GPUs; gpu values are ignored while CPU and memory values still apply.'
+		);
+	}
+	if (!profilesConfigured && !overrideConfigured) {
 		return undefined;
 	}
 	const backendConfigHint =

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -69,6 +69,29 @@ describe('createFromEnv auth backend selection', () => {
 		expect(deps.sandbox.computeProfileOverride).toBe('none');
 	});
 
+	it('wires GPU profiles through for Modal', () => {
+		const deps = createFromEnv({
+			...baseEnv,
+			MARIMOHUB_AUTH_BACKEND: 'dev',
+			MARIMOHUB_COMPUTE_BACKEND: 'modal',
+			MARIMOHUB_COMPUTE_IMAGE: 'ghcr.io/acme/marimo:latest',
+			MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: 'token-id',
+			MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: 'token-secret',
+			MARIMOHUB_COMPUTE_PROFILES: 'gpu:cpu=8;mem=32Gi;gpu=A100:2',
+		});
+		expect(deps.sandbox.resources).toEqual({
+			cpu: 8,
+			memoryBytes: 32 * 1024 ** 3,
+			gpu: 'A100:2',
+		});
+		expect(deps.sandbox.computeProfiles).toEqual([
+			{
+				name: 'gpu',
+				resources: { cpu: 8, memoryBytes: 32 * 1024 ** 3, gpu: 'A100:2' },
+			},
+		]);
+	});
+
 	it('wires a preview service only when an executor is configured', () => {
 		const env = {
 			...baseEnv,
@@ -203,6 +226,23 @@ describe('createFromEnv auth backend selection', () => {
 					String(call[0]).includes('MARIMOHUB_COMPUTE_PROFILE_OVERRIDE'),
 				),
 			).toBe(true);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it('warns when a profile-aware backend ignores GPU values', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		try {
+			const deps = createFromEnv({
+				...baseEnv,
+				MARIMOHUB_AUTH_BACKEND: 'dev',
+				MARIMOHUB_COMPUTE_BACKEND: 'docker',
+				MARIMOHUB_COMPUTE_PROFILES: 'gpu:cpu=8;gpu=A100',
+			});
+			expect(warn.mock.calls.some((call) => String(call[0]).includes('profile GPUs'))).toBe(true);
+			expect(deps.sandbox.resources).toEqual({ cpu: 8 });
+			expect(deps.sandbox.computeProfiles).toEqual([{ name: 'gpu', resources: { cpu: 8 } }]);
 		} finally {
 			warn.mockRestore();
 		}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -44,6 +44,7 @@ import { computeBackend, makeCompute, resolveSandboxImages } from './compute';
 import {
 	parseComputeProfileOverride,
 	parseComputeProfiles,
+	profilesForBackend,
 	resolveResources,
 	supportsComputeProfiles,
 	unsupportedBackendNotice,
@@ -71,8 +72,10 @@ export {
 	hasConfiguredResources,
 	parseComputeProfileOverride,
 	parseComputeProfiles,
+	profilesForBackend,
 	resolveResources,
 	supportsComputeProfiles,
+	supportsGpuProfiles,
 	unsupportedBackendNotice,
 } from './computeProfiles';
 export type {
@@ -395,7 +398,8 @@ export function createFromEnv(
 	const computeProfiles = parseComputeProfiles(env.MARIMOHUB_COMPUTE_PROFILES);
 	const computeBackendValue = computeBackend(env) ?? 'unset';
 	const profilesSupported = supportsComputeProfiles(computeBackendValue);
-	const computeResources = profilesSupported ? resolveResources(computeProfiles) : {};
+	const appliedComputeProfiles = profilesForBackend(computeBackendValue, computeProfiles);
+	const computeResources = profilesSupported ? resolveResources(appliedComputeProfiles) : {};
 	const computeProfileOverride = parseComputeProfileOverride(
 		env.MARIMOHUB_COMPUTE_PROFILE_OVERRIDE,
 	);
@@ -443,8 +447,8 @@ export function createFromEnv(
 			sessionLifetime,
 			images: sandboxImages,
 			resources: computeResources,
-			computeProfile: profilesSupported ? computeProfiles.defaultProfile?.name : undefined,
-			computeProfiles: profilesSupported ? [...computeProfiles.profiles] : [],
+			computeProfile: profilesSupported ? appliedComputeProfiles.defaultProfile?.name : undefined,
+			computeProfiles: profilesSupported ? [...appliedComputeProfiles.profiles] : [],
 			computeProfileOverride: profilesSupported ? computeProfileOverride : 'none',
 			userHome,
 		},

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -36,6 +36,8 @@ export interface ConfigBackend {
 	description?: string;
 	/** Whether this compute backend applies per-sandbox CPU and memory requests. */
 	supportsComputeProfiles?: boolean;
+	/** Whether this compute backend applies GPU requests from compute profiles. */
+	supportsGpuProfiles?: boolean;
 	vars: ConfigVar[];
 }
 
@@ -236,8 +238,8 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						id: 'MARIMOHUB_COMPUTE_PROFILES',
 						name: 'Compute profiles',
 						description:
-							'Ordered named CPU/memory profiles (`name:cpu=<cores>;mem=<Mi|Gi|Ti>`). The first is the default; supported backends apply the notebook choice when overrides are enabled.',
-						example: 'small:cpu=1;mem=2Gi,large:cpu=8;mem=32Gi',
+							'Ordered named CPU, memory, and optional GPU profiles (`name:cpu=<cores>;mem=<Mi|Gi|Ti>;gpu=<type>[:<count>]`). The first is the default; supported backends apply the notebook choice when overrides are enabled. Modal applies GPU requests; other backends ignore them with a startup warning.',
+						example: 'small:cpu=1;mem=2Gi,gpu-large:cpu=8;mem=32Gi;gpu=A100',
 						optIn: true,
 					},
 					{
@@ -437,6 +439,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 				name: 'Modal',
 				selectorValue: 'modal',
 				supportsComputeProfiles: true,
+				supportsGpuProfiles: true,
 				description: 'Modal sandboxes.',
 				vars: [
 					{

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -238,7 +238,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						id: 'MARIMOHUB_COMPUTE_PROFILES',
 						name: 'Compute profiles',
 						description:
-							'Ordered named CPU, memory, and optional GPU profiles (`name:cpu=<cores>;mem=<Mi|Gi|Ti>;gpu=<type>[:<count>]`). The first is the default; supported backends apply the notebook choice when overrides are enabled. Modal applies GPU requests; other backends ignore them with a startup warning.',
+							'Ordered named CPU, memory, and optional GPU profiles (`name:cpu=<cores>;mem=<Mi|Gi|Ti>;gpu=<type>[:<count>]`, with a maximum GPU count of 8). The first is the default; supported backends apply the notebook choice when overrides are enabled. Modal applies GPU requests; other backends ignore them with a startup warning.',
 						example: 'small:cpu=1;mem=2Gi,gpu-large:cpu=8;mem=32Gi;gpu=A100',
 						optIn: true,
 					},

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -190,6 +190,8 @@ export interface ComputeResources {
 	cpu?: number;
 	/** Memory in bytes. */
 	memoryBytes?: number;
+	/** Provider GPU type, optionally suffixed with a count (for example, `A100:2`). */
+	gpu?: string;
 }
 
 /** A per-user directory selected before the sandbox Pod is created. */

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -517,6 +517,7 @@ export function toPublicVersion(version: Version): PublicVersion {
 export const ComputeResourceRecordSchema = z.object({
 	cpu: z.number().optional(),
 	memory_bytes: z.number().optional(),
+	gpu: z.string().optional(),
 });
 
 export type ComputeResourceRecord = z.infer<typeof ComputeResourceRecordSchema>;

--- a/packages/core/src/services/content/filesystemSnapshots.test.ts
+++ b/packages/core/src/services/content/filesystemSnapshots.test.ts
@@ -214,13 +214,13 @@ describe('filesystemSnapshots', () => {
 
 			await captureFilesystemSnapshot(provider, env.notebooks, instance, project.id, nb.id, {
 				compute_profile: 'large',
-				compute_resources: { cpu: 8, memory_bytes: 32 * 1024 ** 3 },
+				compute_resources: { cpu: 8, memory_bytes: 32 * 1024 ** 3, gpu: 'A100' },
 			});
 
 			expect(await env.notebooks.getFsSnapshot(project.id, nb.id)).toMatchObject({
 				snapshot_id: 'snap_new',
 				compute_profile: 'large',
-				compute_resources: { cpu: 8, memory_bytes: 32 * 1024 ** 3 },
+				compute_resources: { cpu: 8, memory_bytes: 32 * 1024 ** 3, gpu: 'A100' },
 			});
 		});
 

--- a/packages/web/src/components/Notebook/computeProfiles.test.tsx
+++ b/packages/web/src/components/Notebook/computeProfiles.test.tsx
@@ -20,6 +20,9 @@ const profiles = [
 describe('compute profile presentation', () => {
 	it('formats resources and the concrete default label', () => {
 		expect(computeProfileResources(profiles[0])).toBe('1 CPU · 2 Gi');
+		expect(computeProfileResources({ cpu: 8, memory_bytes: 32 * 1024 ** 3, gpu: 'A100:2' })).toBe(
+			'8 CPU · 32 Gi · A100:2 GPU',
+		);
 		expect(computeProfileResources({})).toBe('platform default');
 		expect(computeProfileLabel(profiles[0], true)).toBe('Default (small) — 1 CPU · 2 Gi');
 	});
@@ -33,6 +36,8 @@ describe('compute profile presentation', () => {
 	it('keeps unknown resources distinct from equality', () => {
 		expect(compareComputeResources({ cpu: 1 }, { cpu: 1 })).toBe('same');
 		expect(compareComputeResources({ cpu: 1 }, { cpu: 2 })).toBe('different');
+		expect(compareComputeResources({ gpu: 'A100' }, { gpu: 'A100:2' })).toBe('different');
+		expect(compareComputeResources({}, { gpu: 'A100' })).toBe('different');
 		expect(compareComputeResources(undefined, { cpu: 2 })).toBe('unknown');
 	});
 

--- a/packages/web/src/components/Notebook/computeProfiles.ts
+++ b/packages/web/src/components/Notebook/computeProfiles.ts
@@ -29,11 +29,12 @@ function formatMemory(bytes: number): string {
 }
 
 export function computeProfileResources(
-	profile: Pick<ComputeProfile, 'cpu' | 'memory_bytes'> | ComputeProfileResources,
+	profile: Pick<ComputeProfile, 'cpu' | 'memory_bytes' | 'gpu'> | ComputeProfileResources,
 ): string {
 	const resources = [
 		profile.cpu === undefined ? undefined : `${profile.cpu} CPU`,
 		profile.memory_bytes === undefined ? undefined : formatMemory(profile.memory_bytes),
+		profile.gpu === undefined ? undefined : `${profile.gpu} GPU`,
 	].filter((value): value is string => value !== undefined);
 	return resources.length > 0 ? resources.join(' · ') : 'platform default';
 }
@@ -94,7 +95,11 @@ export function compareComputeResources(
 	right: ComputeProfileResources | undefined,
 ): ComputeResourceComparison {
 	if (!left || !right) return 'unknown';
-	return left.cpu === right.cpu && left.memory_bytes === right.memory_bytes ? 'same' : 'different';
+	return left.cpu === right.cpu &&
+		left.memory_bytes === right.memory_bytes &&
+		left.gpu === right.gpu
+		? 'same'
+		: 'different';
 }
 
 export function computeSessionPresentation(


### PR DESCRIPTION
Adds an optional `gpu=<type>[:<count>]` key to `MARIMOHUB_COMPUTE_PROFILES` (e.g. `gpu-large:cpu=8;mem=32Gi;gpu=A100`), giving editors a per-notebook GPU selector for free via the existing profile picker.

- New `gpu` field on `ComputeResources` and `ComputeResourceRecordSchema`, parsed and validated in `computeProfiles` (`<type>[:<count>]`, count bounded by the protobuf uint32 transport limit).
- `compute-modal` maps `gpu` onto the Modal SDK's sandbox `gpu` create option.
- Backends without a GPU mapping (`supportsGpuProfiles`) strip gpu values and emit a startup warning while still applying CPU and memory.
- Docs and config spec updated.

Closes #150.