### PR TITLE
feat(compute-modal): support named Modal environment

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -203,6 +203,7 @@ MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{
 MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_MODAL_TOKEN_ID=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=_replace_me_  # required, secret
+MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT=notebooks
 MARIMOHUB_COMPUTE_MODAL_APP_NAME=marimohub
 
 # --- Auth ---
@@ -246,6 +247,7 @@ exports[`config -> code generators > default-prod (s3 + modal + oidc) > compose 
       MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: _replace_me_
+      MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: notebooks
       MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
       MARIMOHUB_AUTH_BACKEND: oidc
       MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
@@ -275,6 +277,7 @@ config:
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
   MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
+  MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: notebooks
   MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
   MARIMOHUB_AUTH_BACKEND: oidc
   MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
@@ -1462,6 +1465,7 @@ MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{
 MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_MODAL_TOKEN_ID=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=_replace_me_  # required, secret
+MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT=notebooks
 MARIMOHUB_COMPUTE_MODAL_APP_NAME=marimohub
 
 # --- Auth ---
@@ -1513,6 +1517,7 @@ exports[`config -> code generators > s3 + modal + oidc, managed ai > compose 1`]
       MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: _replace_me_
+      MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: notebooks
       MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
       MARIMOHUB_AUTH_BACKEND: oidc
       MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
@@ -1550,6 +1555,7 @@ config:
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
   MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
+  MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: notebooks
   MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
   MARIMOHUB_AUTH_BACKEND: oidc
   MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
@@ -1657,6 +1663,7 @@ MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{
 MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
 MARIMOHUB_COMPUTE_MODAL_TOKEN_ID=_replace_me_  # required, secret
 MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=_replace_me_  # required, secret
+MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT=notebooks
 MARIMOHUB_COMPUTE_MODAL_APP_NAME=marimohub
 
 # --- Auth ---
@@ -1700,6 +1707,7 @@ exports[`config -> code generators > s3 + modal + oidc, value overrides > compos
       MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
       MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: _replace_me_
       MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: _replace_me_
+      MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: notebooks
       MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
       MARIMOHUB_AUTH_BACKEND: oidc
       MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
@@ -1729,6 +1737,7 @@ config:
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
   MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
+  MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: notebooks
   MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
   MARIMOHUB_AUTH_BACKEND: oidc
   MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com

--- a/development_docs/architecture.md
+++ b/development_docs/architecture.md
@@ -375,6 +375,7 @@ adapter-specific settings.
 | `MARIMOHUB_COMPUTE_IMAGE`                       | Sandbox image reference                                                                          |
 | `MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME`            | Public hostname used when exposing kernel ports                                                  |
 | `MARIMOHUB_COMPUTE_MODAL_TOKEN_ID` / `_SECRET`  | Modal credentials (secret)                                                                       |
+| `MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT`           | `modal` backend: named Modal environment (defaults to the workspace environment)                 |
 | `MARIMOHUB_COMPUTE_COREWEAVE_API_KEY`           | `coreweave` backend: CoreWeave Sandbox API key (secret)                                          |
 | `MARIMOHUB_COMPUTE_COREWEAVE_HOSTNAME_TEMPLATE` | `coreweave` backend: public kernel URL scheme (`{sandboxId}`/`{port}`/`{host}`)                  |
 | `MARIMOHUB_COMPUTE_LOCAL_HOST`                  | `local` backend: host for the kernel URL (default `localhost`)                                   |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,7 @@ Modal sandboxes.
 | --- | --- | --- | --- | --- |
 | `MARIMOHUB_COMPUTE_MODAL_TOKEN_ID` 🔒 | Modal API token id. | Yes | — | — |
 | `MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET` 🔒 | Modal API token secret. | Yes | — | — |
+| `MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT` | Runs Modal apps and sandboxes in this named environment instead of the workspace default. | — | — | `notebooks` |
 | `MARIMOHUB_COMPUTE_MODAL_APP_NAME` | Limits cleanup to sandboxes this deployment created, so it never stops others sharing the same Modal workspace. | — | — | `marimohub` |
 
 ### Docker

--- a/docs/setup/compute/modal.md
+++ b/docs/setup/compute/modal.md
@@ -10,6 +10,7 @@
 MARIMOHUB_COMPUTE_BACKEND=modal
 MARIMOHUB_COMPUTE_MODAL_TOKEN_ID=…              # secret
 MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=…          # secret
+MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT=notebooks   # optional named environment
 MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_SESSION_IDLE_TIMEOUT_SECONDS=1800     # save and stop after 30 idle minutes
 ```
@@ -20,10 +21,11 @@ running kernels. The easiest path if you don't already run a cluster.
 :::
 
 The adapter creates and reconnects to sandboxes through Modal's supported
-JavaScript SDK. Compute profiles are passed as the SDK's `cpu`, `memoryMiB`, and
-`gpu` sandbox options. The adapter sets Modal's provider-side idle timeout to 1.5
-times `MARIMOHUB_SESSION_IDLE_TIMEOUT_SECONDS`. This leaves time for the hub to
-save and stop the session first.
+JavaScript SDK. When `MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT` is set, apps and
+sandboxes are isolated in that Modal environment. Compute profiles are passed as
+the SDK's `cpu`, `memoryMiB`, and `gpu` sandbox options. The adapter sets Modal's
+provider-side idle timeout to 1.5 times `MARIMOHUB_SESSION_IDLE_TIMEOUT_SECONDS`.
+This leaves time for the hub to save and stop the session first.
 
 ::: warning Cold starts & shared workspaces
 A freshly-started kernel can take a few seconds to boot; a warm sandbox image

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -178,6 +178,18 @@ function makeCompute(world: ReturnType<typeof makeWorld>, overrides = {}) {
 }
 
 describe('ModalCompute', () => {
+	it('configures the SDK client for the selected Modal environment', () => {
+		const compute = new ModalCompute({
+			tokenId: 'token-id',
+			tokenSecret: 'token-secret',
+			image: 'ghcr.io/acme/marimo:latest',
+			environment: 'notebooks',
+		});
+		const client = Reflect.get(compute, 'client') as { profile: { environment?: string } };
+
+		expect(client.profile.environment).toBe('notebooks');
+	});
+
 	it('creates fresh sandboxes through the supported SDK with profile resources', async () => {
 		const world = makeWorld();
 		await makeCompute(world)

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -40,6 +40,8 @@ export interface ModalConfig {
 	image: string;
 	/** Modal API endpoint override. */
 	apiBase?: string;
+	/** Modal environment that contains the app and sandboxes. */
+	environment?: string;
 	/** Modal app name that owns the sandboxes. */
 	appName?: string;
 	/** Provider-side fallback, set later than marimohub's graceful idle deadline. */
@@ -453,6 +455,7 @@ export class ModalCompute implements SandboxProvider {
 			(new ModalClient({
 				tokenId: config.tokenId,
 				tokenSecret: config.tokenSecret,
+				environment: config.environment,
 				...(config.apiBase ? { endpoint: config.apiBase } : {}),
 			}) as unknown as ModalClientLike);
 	}

--- a/packages/config/src/compute.test.ts
+++ b/packages/config/src/compute.test.ts
@@ -30,6 +30,7 @@ const configOf = (provider: unknown) =>
 		provider as {
 			config: {
 				image?: string;
+				environment?: string;
 				template?: string;
 				host?: string;
 				bindHost?: string;
@@ -72,6 +73,17 @@ describe('makeCompute backend selection', () => {
 		expect(
 			configOf(makeCompute(modalEnv, { sessionIdleTimeoutMs: Millis.minutes(30) })).idleFallbackMs,
 		).toBe(Millis.minutes(45));
+	});
+
+	it('forwards the selected Modal environment', () => {
+		expect(
+			configOf(
+				makeCompute({
+					...modalEnv,
+					MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: 'notebooks',
+				}),
+			).environment,
+		).toBe('notebooks');
 	});
 
 	it('selects docker', () => {

--- a/packages/config/src/compute.ts
+++ b/packages/config/src/compute.ts
@@ -186,6 +186,7 @@ export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 				tokenId,
 				tokenSecret,
 				image: defaultImage,
+				environment: env.MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT,
 				// App name scopes reconciler enumeration (listActive) to sandboxes this
 				// deployment owns, so it never reaps co-tenant sandboxes in the workspace.
 				appName: env.MARIMOHUB_COMPUTE_MODAL_APP_NAME,

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -457,6 +457,13 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						secret: true,
 					},
 					{
+						id: 'MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT',
+						name: 'Modal environment',
+						description:
+							'Runs Modal apps and sandboxes in this named environment instead of the workspace default.',
+						example: 'notebooks',
+					},
+					{
 						id: 'MARIMOHUB_COMPUTE_MODAL_APP_NAME',
 						name: 'Modal app name',
 						description:


### PR DESCRIPTION
Adds an optional `MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT` setting that runs Modal apps and sandboxes in a named environment instead of the workspace default. Threaded through config → `ModalConfig` → `ModalClient`, with spec entry and docs.

Closes #151