### PR TITLE
feat(git-sync): support marimo markdown notebooks as entry_notebook

### DIFF
--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -60,13 +60,13 @@ Content-Type: application/json
 }
 ```
 
-| Field            | Required | Notes                                                                       |
-| ---------------- | -------- | --------------------------------------------------------------------------- |
-| `provider`       | no       | `github` or `gitlab`. Usually derived from `repo`; see below.               |
-| `repo`           | yes      | `owner/name` or a repository URL. Informational + matched on each push.     |
-| `branch`         | yes      | Branch this notebook tracks.                                                |
-| `root_path`      | no       | Repo subdirectory whose tree is mirrored. Defaults to the repo root (`""`). |
-| `entry_notebook` | yes      | The `.py` notebook to open, **relative to `root_path`**.                    |
+| Field            | Required | Notes                                                                                     |
+| ---------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `provider`       | no       | `github` or `gitlab`. Usually derived from `repo`; see below.                             |
+| `repo`           | yes      | `owner/name` or a repository URL. Informational + matched on each push.                   |
+| `branch`         | yes      | Branch this notebook tracks.                                                              |
+| `root_path`      | no       | Repo subdirectory whose tree is mirrored. Defaults to the repo root (`""`).               |
+| `entry_notebook` | yes      | The notebook to open (`.py`, `.md`, `.markdown`, or `.qmd`), **relative to `root_path`**. |
 
 `repo` accepts `owner/repo` (GitHub shorthand; gitlab.com when `provider` is
 `gitlab`) or a repository URL such as

--- a/packages/api/src/routes/gitSync.test.ts
+++ b/packages/api/src/routes/gitSync.test.ts
@@ -147,6 +147,149 @@ describe('Git sync routes', () => {
 		expect(versions.items[0]?.commit).toBe('abc123');
 	});
 
+	it('syncs a markdown entry notebook end to end', async () => {
+		const markdown = '# Report\n\n```python {.marimo}\nx = 1\n```\n';
+		const { notebook, sync_token } = await expectOk<{
+			notebook: { id: string };
+			sync_token: string;
+		}>(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Markdown app',
+				description: 'Synced',
+				repo: 'org/repo',
+				branch: 'main',
+				entry_notebook: 'docs/page.md',
+			}),
+			201,
+		);
+
+		const response = await app.request(
+			`/api/sync/git/v1/projects/${projectId}/notebooks/${notebook.id}`,
+			{
+				method: 'POST',
+				body: zipSync({ 'docs/page.md': new TextEncoder().encode(markdown) }),
+				headers: { 'Content-Type': 'application/zip', ...requiredHeaders(sync_token) },
+			},
+		);
+		await expectOk(response);
+
+		const content = await expectOk<{ code: string }>(
+			await request('GET', `/projects/${projectId}/notebooks/${notebook.id}/content`),
+		);
+		expect(content.code).toBe(markdown);
+	});
+
+	// `.ipynb` isn't in NOTEBOOK_FILE_EXTENSIONS yet; a bare `.md` has no stem, so
+	// marimo would refuse to open it.
+	for (const entry of ['notes.ipynb', 'notes.txt', '.md', 'docs/.qmd', 'page.MD']) {
+		it(`rejects creating a synced notebook with entry_notebook ${JSON.stringify(entry)} (400)`, async () => {
+			await expectError(
+				await request('POST', `/projects/${projectId}/notebooks/git`, {
+					title: 'Bad entry',
+					description: 'd',
+					repo: 'org/repo',
+					branch: 'main',
+					entry_notebook: entry,
+				}),
+				400,
+				'BAD_REQUEST',
+			);
+		});
+	}
+
+	it('syncs a prose-only markdown notebook (no code fences)', async () => {
+		// marimo compiles prose into mo.md cells, so a page with zero code fences is
+		// still a real notebook — the sync path must not gate on "has Python".
+		const prose = '# Quarterly report\n\nAll numbers are up and to the right.\n';
+		const { notebook, sync_token } = await expectOk<{
+			notebook: { id: string };
+			sync_token: string;
+		}>(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Prose page',
+				description: 'Synced',
+				repo: 'org/repo',
+				branch: 'main',
+				entry_notebook: 'report.md',
+			}),
+			201,
+		);
+
+		await expectOk(
+			await app.request(`/api/sync/git/v1/projects/${projectId}/notebooks/${notebook.id}`, {
+				method: 'POST',
+				body: zipSync({ 'report.md': new TextEncoder().encode(prose) }),
+				headers: { 'Content-Type': 'application/zip', ...requiredHeaders(sync_token) },
+			}),
+		);
+
+		const content = await expectOk<{ code: string }>(
+			await request('GET', `/projects/${projectId}/notebooks/${notebook.id}/content`),
+		);
+		expect(content.code).toBe(prose);
+	});
+
+	it('rejects a sync whose archive is missing the markdown entry notebook (422)', async () => {
+		const { notebook, sync_token } = await expectOk<{
+			notebook: { id: string };
+			sync_token: string;
+		}>(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Markdown app',
+				description: 'Synced',
+				repo: 'org/repo',
+				branch: 'main',
+				entry_notebook: 'page.md',
+			}),
+			201,
+		);
+
+		const error = await expectError(
+			await app.request(`/api/sync/git/v1/projects/${projectId}/notebooks/${notebook.id}`, {
+				method: 'POST',
+				body: zipSync({ 'other.md': new TextEncoder().encode('# not the entry') }),
+				headers: { 'Content-Type': 'application/zip', ...requiredHeaders(sync_token) },
+			}),
+			422,
+			'VALIDATION_ERROR',
+		);
+		expect(error.message).toContain('page.md');
+	});
+
+	it('switches a synced notebook from a .py to a .md entry via pending config', async () => {
+		const { notebookId, syncToken } = await createSyncedNotebook();
+		await expectOk(await syncRequest({ notebookId, headers: requiredHeaders(syncToken) }));
+
+		// Staged (not applied) until an archive matching the new config arrives.
+		const patched = await expectOk<{ source: { entry_notebook: string } }>(
+			await request('PATCH', `/projects/${projectId}/notebooks/${notebookId}/source`, {
+				repo: 'org/repo',
+				branch: 'main',
+				root_path: '',
+				entry_notebook: 'page.md',
+			}),
+		);
+		expect(patched.source.entry_notebook).toBe('app.py');
+
+		const markdown = '# Ported\n\n```python {.marimo}\ny = 2\n```\n';
+		await expectOk(
+			await app.request(`/api/sync/git/v1/projects/${projectId}/notebooks/${notebookId}`, {
+				method: 'POST',
+				body: zipSync({ 'page.md': new TextEncoder().encode(markdown) }),
+				headers: { 'Content-Type': 'application/zip', ...requiredHeaders(syncToken) },
+			}),
+		);
+
+		const detail = await expectOk<{ source: { entry_notebook: string } }>(
+			await request('GET', `/projects/${projectId}/notebooks/${notebookId}`),
+		);
+		expect(detail.source.entry_notebook).toBe('page.md');
+		const content = await expectOk<{ code: string }>(
+			await request('GET', `/projects/${projectId}/notebooks/${notebookId}/content`),
+		);
+		expect(content.code).toBe(markdown);
+	});
+
 	it('does not perform alert metadata reads before a successful sync', async () => {
 		const { notebookId, syncToken } = await createSyncedNotebook();
 		const services = createServices(bucket);

--- a/packages/core/src/integrations/remoteWorkspace.test.ts
+++ b/packages/core/src/integrations/remoteWorkspace.test.ts
@@ -56,6 +56,9 @@ describe('remote workspace helpers', () => {
 		expect(normalizeWorkspaceRootPath(' apps/ ')).toBe('apps');
 		expect(normalizeWorkspaceRootPath(undefined)).toBe('');
 		expect(normalizeEntryNotebook(' apps/main.py ')).toBe('apps/main.py');
+		expect(normalizeEntryNotebook('docs/page.md')).toBe('docs/page.md');
+		expect(normalizeEntryNotebook('docs/page.markdown')).toBe('docs/page.markdown');
+		expect(normalizeEntryNotebook('docs/page.qmd')).toBe('docs/page.qmd');
 
 		expect(isSafeWorkspacePath('data/cars.csv')).toBe(true);
 		expect(isSafeWorkspacePath('', true)).toBe(true);
@@ -86,9 +89,30 @@ describe('remote workspace helpers', () => {
 		expect(isSafeWorkspacePath('.')).toBe(false);
 	});
 
-	it('normalizeEntryNotebook rejects a non-.py path', () => {
+	it('normalizeEntryNotebook rejects a non-notebook path', () => {
 		expect(() => normalizeEntryNotebook('apps/main.txt')).toThrow(BadRequestError);
 		expect(() => normalizeEntryNotebook('apps/main')).toThrow(BadRequestError);
+		expect(() => normalizeEntryNotebook('apps/main.md.bak')).toThrow(BadRequestError);
+		// Not in NOTEBOOK_FILE_EXTENSIONS yet — the runtime can't open it.
+		expect(() => normalizeEntryNotebook('apps/main.ipynb')).toThrow(BadRequestError);
+	});
+
+	it('normalizeEntryNotebook matches marimo suffix semantics on dotfiles and case', () => {
+		// `Path('.md').suffix` is empty — marimo refuses a stemless dotfile.
+		expect(() => normalizeEntryNotebook('.md')).toThrow(BadRequestError);
+		expect(() => normalizeEntryNotebook('docs/.qmd')).toThrow(BadRequestError);
+		// `Path('..md').suffix` is `.md` (stem `.`), so marimo accepts it.
+		expect(normalizeEntryNotebook('..md')).toBe('..md');
+		// Suffix matching is case-sensitive, as in `Path.suffix`.
+		expect(() => normalizeEntryNotebook('page.MD')).toThrow(BadRequestError);
+		expect(() => normalizeEntryNotebook('page.Py')).toThrow(BadRequestError);
+	});
+
+	it('normalizeEntryNotebook rejects traversal even with a notebook extension', () => {
+		expect(() => normalizeEntryNotebook('../page.md')).toThrow(BadRequestError);
+		expect(() => normalizeEntryNotebook('docs/../page.md')).toThrow(BadRequestError);
+		expect(() => normalizeEntryNotebook('/docs/page.md')).toThrow(BadRequestError);
+		expect(() => normalizeEntryNotebook('docs\\page.md')).toThrow(BadRequestError);
 	});
 
 	it('toSyncedWorkspaceFileMap rejects an empty archive', () => {

--- a/packages/core/src/integrations/remoteWorkspace.ts
+++ b/packages/core/src/integrations/remoteWorkspace.ts
@@ -41,10 +41,26 @@ export function normalizeWorkspaceRootPath(path: string | undefined): string {
 	return normalized;
 }
 
+/**
+ * Extensions marimo treats as first-class notebooks (mirrors marimo's
+ * `MarimoPath.is_valid`, minus `.ipynb` which the runtime can't open yet).
+ * Extend this list to admit new formats everywhere at once.
+ */
+export const NOTEBOOK_FILE_EXTENSIONS = ['.py', '.md', '.markdown', '.qmd'] as const;
+
+export function isNotebookFilePath(path: string): boolean {
+	const name = path.slice(path.lastIndexOf('/') + 1);
+	// Require a non-empty stem: to `Path.suffix` a dotfile like `.md` has NO
+	// extension, so marimo would refuse to open it.
+	return NOTEBOOK_FILE_EXTENSIONS.some((ext) => name.endsWith(ext) && name.length > ext.length);
+}
+
 export function normalizeEntryNotebook(path: string): string {
 	const normalized = path.trim().replace(/\/+$/, '');
-	if (!isSafeWorkspacePath(normalized) || !normalized.endsWith('.py')) {
-		throw new BadRequestError('entry_notebook must be a relative .py file path');
+	if (!isSafeWorkspacePath(normalized) || !isNotebookFilePath(normalized)) {
+		throw new BadRequestError(
+			`entry_notebook must be a relative notebook file path (${NOTEBOOK_FILE_EXTENSIONS.join(', ')})`,
+		);
 	}
 	return normalized;
 }

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -24,6 +24,21 @@ describe('buildMarimoLaunch', () => {
 		expect(start).toContain('--base-url="/proxy/tok"');
 	});
 
+	// --convert's fallback can rewrite a file as Python, so it must never reach a
+	// markdown-family notebook.
+	for (const file of ['docs/page.md', 'page.markdown', 'reports/q3.qmd']) {
+		it(`edit drops --convert for ${file}`, () => {
+			const { start } = buildMarimoLaunch({ ...BASE, mode: 'edit', notebookFile: file });
+			expect(start).toContain('marimo edit');
+			expect(start).not.toContain('--convert');
+		});
+	}
+
+	it('edit keeps --convert for a nested .py entry (synced sources set entryNotebook)', () => {
+		const { start } = buildMarimoLaunch({ ...BASE, mode: 'edit', notebookFile: 'apps/main.py' });
+		expect(start).toContain('--convert');
+	});
+
 	it('app drops --convert but keeps host/port/asset-url/base-url', () => {
 		const { start } = buildMarimoLaunch({ ...BASE, mode: 'app' });
 		expect(start).toContain('marimo run');

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -55,9 +55,10 @@ interface ModeLaunch {
 const LAUNCH_MODES: Record<SessionMode, ModeLaunch> = {
 	edit: {
 		subcommand: 'edit',
-		// --convert opens a non-marimo file (e.g. a plain script); no-op on real
-		// marimo notebooks, so it's safe to always pass.
-		flags: (p) => `--convert ${commonFlags(p)}`,
+		// --convert opens a non-marimo .py file (e.g. a plain script); no-op on real
+		// marimo notebooks, so it's safe to always pass for .py. Its fallback can
+		// rewrite the file as Python, so never pass it for md/qmd notebooks.
+		flags: (p) => `${p.notebookFile.endsWith('.py') ? '--convert ' : ''}${commonFlags(p)}`,
 	},
 	app: {
 		subcommand: 'run',

--- a/packages/web/src/components/Notebook/SyncSettingsDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncSettingsDialog.tsx
@@ -18,7 +18,12 @@ import {
 	WriteOnceWarning,
 } from '@/components/ui';
 import { useNotebookQuery, useRotateSyncToken, useUpdateGitSource } from '@/api/hooks';
-import { isRepoInput, REPO_INPUT_HINT } from '@/lib/git';
+import {
+	ENTRY_NOTEBOOK_HINT,
+	ENTRY_NOTEBOOK_PATTERN,
+	isRepoInput,
+	REPO_INPUT_HINT,
+} from '@/lib/git';
 import { DOCS_SYNCING_URL } from '@/lib/links';
 import { formatRelative } from '@/lib/time';
 
@@ -37,10 +42,7 @@ const settingsSchema = z.object({
 	repo: requiredText('Repository').refine(isRepoInput, REPO_INPUT_HINT),
 	branch: requiredText('Branch'),
 	rootPath: optionalText(),
-	entryNotebook: requiredText('Notebook file').regex(
-		/\.py$/,
-		'Must point to a .py file, e.g. dashboard.py',
-	),
+	entryNotebook: requiredText('Notebook file').regex(ENTRY_NOTEBOOK_PATTERN, ENTRY_NOTEBOOK_HINT),
 });
 
 const EMPTY = { repo: '', branch: '', rootPath: '', entryNotebook: '' };

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
@@ -9,7 +9,12 @@ import {
 	useSeedOnOpen,
 } from '@/components/form';
 import { useCreateSyncedNotebook } from '@/api/hooks';
-import { isRepoInput, REPO_INPUT_HINT } from '@/lib/git';
+import {
+	ENTRY_NOTEBOOK_HINT,
+	ENTRY_NOTEBOOK_PATTERN,
+	isRepoInput,
+	REPO_INPUT_HINT,
+} from '@/lib/git';
 
 export interface SyncedNotebookCreated {
 	notebookId: string;
@@ -31,10 +36,7 @@ const syncedSchema = z.object({
 	repo: requiredText('Repository').refine(isRepoInput, REPO_INPUT_HINT),
 	branch: requiredText('Branch'),
 	rootPath: optionalText(),
-	entryNotebook: requiredText('Notebook file').regex(
-		/\.py$/,
-		'Must point to a .py file, e.g. dashboard.py',
-	),
+	entryNotebook: requiredText('Notebook file').regex(ENTRY_NOTEBOOK_PATTERN, ENTRY_NOTEBOOK_HINT),
 });
 
 const EMPTY = { title: '', repo: '', branch: 'main', rootPath: '', entryNotebook: '' };

--- a/packages/web/src/lib/git.test.ts
+++ b/packages/web/src/lib/git.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { NotebookDetail } from '@/types';
 import {
+	ENTRY_NOTEBOOK_PATTERN,
 	gitBranchUrl,
 	gitCommitUrl,
 	gitCoords,
@@ -188,6 +189,20 @@ describe('isRepoInput', () => {
 describe('shortCommit', () => {
 	it('abbreviates commits to 7 characters', () => {
 		expect(shortCommit('abc123def4567890')).toBe('abc123d');
+	});
+});
+
+describe('ENTRY_NOTEBOOK_PATTERN', () => {
+	it('accepts every marimo notebook extension, at the root or nested', () => {
+		for (const path of ['app.py', 'docs/page.md', 'page.markdown', 'reports/q3.qmd']) {
+			expect(path).toMatch(ENTRY_NOTEBOOK_PATTERN);
+		}
+	});
+
+	it('rejects other extensions, stemless dotfiles, and case mismatches (server parity)', () => {
+		for (const path of ['app.txt', 'notes.ipynb', 'app', '.md', 'docs/.qmd', 'page.MD']) {
+			expect(path).not.toMatch(ENTRY_NOTEBOOK_PATTERN);
+		}
 	});
 });
 

--- a/packages/web/src/lib/git.ts
+++ b/packages/web/src/lib/git.ts
@@ -183,3 +183,10 @@ export function isRepoInput(input: string): boolean {
 
 export const REPO_INPUT_HINT =
 	'Use owner/repo or a repository URL, e.g. acme/analytics or https://gitlab.example.com/group/project';
+
+// Mirrors the server's notebook-extension gate (core `isNotebookFilePath`),
+// including its non-empty-stem rule: a bare dotfile like `.md` is not a notebook.
+export const ENTRY_NOTEBOOK_PATTERN = /[^/]\.(py|md|markdown|qmd)$/;
+
+export const ENTRY_NOTEBOOK_HINT =
+	'Must point to a marimo notebook (.py, .md, .markdown, or .qmd), e.g. dashboard.py';


### PR DESCRIPTION
Git-synced sources now accept marimo's markdown notebooks (`.md`, `.markdown`, `.qmd`) as the `entry_notebook`, end to end from create/update through sync push and session launch. Closes #143.

The gate is a single extension list in core (`NOTEBOOK_FILE_EXTENSIONS`) so future formats (e.g. `.ipynb`) are a one-entry change. Validation mirrors marimo's `Path.suffix` semantics: case-sensitive, and stemless dotfiles like `.md` are rejected since marimo can't open them. `marimo edit`'s `--convert` flag is now passed only for `.py` entries — its fallback rewrites a file's contents as Python on a parse failure, so it must never reach a markdown notebook. The web sync dialogs mirror the same gate.

The other `notebook.py` hardcodings (paths, sandbox capture, provisioner default) are local-source-only and untouched; git sources carry their stored entry filename through the workspace policy and never persist session edits.

Tests cover the validator edges (dotfiles, case, traversal, `.ipynb`), `--convert` gating per extension, and end-to-end syncs: markdown with code fences, prose-only pages (no code fences), a missing entry in the archive, and switching a synced notebook from `.py` to `.md` via pending config.