### PR TITLE
fix(duckdb-wasm-runtime): resolve the Node worker file by existence

### DIFF
--- a/packages/duckdb-wasm-runtime/src/node.ts
+++ b/packages/duckdb-wasm-runtime/src/node.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';
 import type {
 	DataQueryExecution,
@@ -97,12 +99,7 @@ class WorkerRuntime implements DuckDBWasmRuntime {
 	private closed = false;
 
 	constructor() {
-		const source = import.meta.url.endsWith('.ts')
-			? './worker.ts'
-			: import.meta.url.includes('/apps/server/dist/')
-				? './duckdbWorker.mjs'
-				: './worker.mjs';
-		this.worker = new Worker(new URL(source, import.meta.url), {
+		this.worker = new Worker(resolveWorkerUrl(), {
 			resourceLimits: DUCKDB_WORKER_RESOURCE_LIMITS,
 		});
 		this.worker.on('message', (response: RuntimeResponse) => this.onResponse(response));
@@ -200,6 +197,22 @@ function assertSupported(program: DuckDBPreviewProgram): void {
 			`DuckDB-Wasm runtime does not support required feature ${feature}.${reason ? ` ${reason}` : ''}`,
 		);
 	}
+}
+
+/**
+ * The worker filename depends on who built us: the server bundle emits the
+ * entry as duckdbWorker.mjs next to the main bundle; the package's own build
+ * emits worker.mjs. Resolve by existence — sniffing import.meta.url for a repo
+ * path fails in the Docker image, where the bundle lives at /app/dist and the
+ * missing file otherwise only surfaces as an async worker "error" event.
+ */
+function resolveWorkerUrl(): URL {
+	if (import.meta.url.endsWith('.ts')) return new URL('./worker.ts', import.meta.url);
+	for (const candidate of ['./duckdbWorker.mjs', './worker.mjs']) {
+		const url = new URL(candidate, import.meta.url);
+		if (existsSync(fileURLToPath(url))) return url;
+	}
+	throw new Error('DuckDB-Wasm worker file not found next to the runtime module.');
 }
 
 function isStructuralWorkerError(error: unknown): boolean {


### PR DESCRIPTION
## Bug

`WorkerRuntime` picks its worker file by sniffing `import.meta.url` for `/apps/server/dist/`. That's true in the repo layout, but false in the server Docker image, where the bundle lives at `/app/dist`. There it loads `./worker.mjs`, which the server bundle does not emit (`vp pack` emits the entry as `duckdbWorker.mjs`).

The missing file surfaces only as an async worker `error` event — not a synchronous throw — so `auto` mode's structural-error fallback to the inline runtime never triggers either. Net effect on a deployed hub with `duckdb-wasm-preview` enabled: every runtime check rejects and startup preflight logs

```
integrations.data-preview: Data-preview runtime unavailable: No data-preview runtime is available.
```

This also blocks the `duckdb-wasm-sql` execution path (`createNodeDataQueryExecutorFactory` always uses `WorkerRuntime`) in any containerized deployment.

## Fix

Resolve the worker URL by file existence: `./worker.ts` in source, else the first of `./duckdbWorker.mjs` / `./worker.mjs` that exists next to the executing module. The two names never coexist (server bundle vs package build), so ordering is just a preference.

Found while dogfooding #161 on the CoreWeave stack; verified there that `/app/dist` contains `duckdbWorker.mjs` only.

## Testing

- `pnpm --filter @marimo-hub/duckdb-wasm-runtime test` (60 passed)
- `vp fmt` + package typecheck clean