### PR TITLE
fix(marimo-sandbox): keep the venv on PATH in login shells

### DIFF
--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -70,7 +70,7 @@ ENV VIRTUAL_ENV=/opt/venv \
 # /etc/profile resets PATH — dropping the venv set by ENV above. profile.d runs
 # after that reset, so login shells keep python3/pyarrow/pyiceberg resolvable
 # (the data-preview preflight depends on it).
-RUN echo 'export PATH=/opt/venv/bin:$PATH' > /etc/profile.d/venv-path.sh
+RUN echo 'export PATH=$VIRTUAL_ENV/bin:$PATH' > /etc/profile.d/venv-path.sh
 
 USER appuser
 WORKDIR /workspace

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -66,6 +66,12 @@ RUN python3 -m compileall -j 0 -q /usr/local/lib/python3.13 || true
 ENV VIRTUAL_ENV=/opt/venv \
     PATH=/opt/venv/bin:$PATH
 
+# The hub's compute adapters exec commands via a login shell (`sh -lc`), and
+# /etc/profile resets PATH — dropping the venv set by ENV above. profile.d runs
+# after that reset, so login shells keep python3/pyarrow/pyiceberg resolvable
+# (the data-preview preflight depends on it).
+RUN echo 'export PATH=/opt/venv/bin:$PATH' > /etc/profile.d/venv-path.sh
+
 USER appuser
 WORKDIR /workspace
 


### PR DESCRIPTION
## Bug

The hub's compute adapters exec sandbox commands via a login shell (`sh -lc`, see `packages/compute-coreweave`). Debian's `/etc/profile` resets `PATH`, dropping the `/opt/venv/bin` entry set by Docker `ENV` — so `python3` resolves to the bare system interpreter without the venv packages.

Concretely, with `MARIMOHUB_DATA_PREVIEW_IMAGE` pointed at this image, `SandboxDataPreview`'s preflight `python3 -c 'import pyarrow, pyiceberg'` fails with `ModuleNotFoundError: No module named 'pyarrow'` even though the image ships both — the hub then reports "No data-preview runtime is available" and iceberg REST previews never run.

Reproduce:

```
docker run --rm --entrypoint /bin/sh ghcr.io/marimo-team/marimo-sandbox:py3.13-marimo0.23.16 \
  -c "sh -lc 'python3 -c \"import pyarrow, pyiceberg\"'"
# ModuleNotFoundError: No module named 'pyarrow'
```

## Fix

`/etc/profile` sources `/etc/profile.d/*.sh` after resetting PATH, so persist the venv there. Verified in the published image: with the snippet in place, `sh -lc 'which python3'` → `/opt/venv/bin/python3` and the preflight import succeeds.

Same class of issue we previously hit with E2B (profile.d env).

Found while dogfooding #161 previews on the CoreWeave stack; companion to #164.