### PR TITLE
feat(integrations): probe object-store connectivity in test endpoint

### DIFF
--- a/development_docs/duckdb_wasm_iceberg_broker.md
+++ b/development_docs/duckdb_wasm_iceberg_broker.md
@@ -1,0 +1,94 @@
+# DuckDB-Wasm Iceberg HTTP broker mock
+
+## Status
+
+The repository contains a parent-side broker policy mock in
+`packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts`. It is deliberately not connected to the
+DuckDB-Wasm worker. The runtime must continue to omit `iceberg-http` until the transport and worker
+bridge described below exist and pass live conformance tests.
+
+## Boundary
+
+```text
+API request
+  -> resolve one integration version and its ephemeral credentials
+  -> open broker capability in the server parent
+  -> start disposable DuckDB-Wasm worker with only the capability ID
+  -> worker asks the parent to perform HTTP requests
+  -> broker authorizes and executes each request
+  -> close capability and terminate worker
+```
+
+Credentials remain in the parent-side route records. The worker may supply safe protocol headers,
+such as `Range` and `If-None-Match`, but cannot supply `Authorization`, cookies, proxy headers, or
+arbitrary destinations. This first contract is read-only: catalog routes accept `GET`, and storage
+routes accept `GET` or `HEAD`. OAuth exchanges happen in trusted parent code before the capability is
+opened.
+
+An execution capability contains:
+
+- an expiry;
+- catalog and storage URL scopes;
+- methods allowed for each scope;
+- parent-owned headers for each scope;
+- request, redirect, and response-byte budgets.
+
+For example, the parent might open this read-only capability after resolving one stored integration:
+
+```ts
+const capabilityId = broker.open({
+	expiresAtMs: Date.now() + 30_000,
+	routes: [
+		{
+			kind: 'catalog',
+			url: 'https://catalog.example.com/iceberg',
+			match: 'prefix',
+			methods: ['GET'],
+			headers: { authorization: `Bearer ${catalogToken}` },
+		},
+		{
+			kind: 'storage',
+			url: 'https://storage.example.com/warehouse',
+			match: 'prefix',
+			methods: ['GET', 'HEAD'],
+			headers: { authorization: `Bearer ${storageToken}` },
+		},
+	],
+	limits: {
+		maxRequests: 256,
+		maxRedirects: 8,
+		maxResponseBytes: 64 * 1024 * 1024,
+	},
+});
+```
+
+This example is illustrative. Storage routes must come from validated integration configuration or
+trusted parsing of catalog responses; they must not be copied from untrusted worker requests.
+
+Redirects are not followed by the transport. The broker resolves each `Location`, authorizes the new
+target, and applies credentials belonging to that target. A catalog credential therefore cannot ride
+a redirect to object storage or an unapproved host. Requests are serialized within one capability so
+concurrent reads cannot oversubscribe its cumulative response-byte budget.
+
+## Missing implementation
+
+The following work is required before advertising `iceberg-http`:
+
+1. Implement a Node transport that resolves once, rejects forbidden addresses, pins the socket to the
+   validated address set, does not follow redirects, supports byte ranges and binary bodies, and
+   respects cancellation and response limits.
+2. Bridge blocking DuckDB-Wasm HTTP callbacks to the asynchronous parent broker. Candidate designs
+   are a per-execution loopback proxy or a shared-memory worker bridge. The capability ID must be
+   bound to that worker and never accepted from an API client.
+3. Derive initial routes from the resolved integration. Add storage routes only from configured
+   locations or catalog responses parsed by trusted parent code. Do not let worker SQL add routes.
+4. Serve pinned `iceberg` and `httpfs` Wasm extensions locally. Extension downloads must not share
+   the data-egress capability.
+5. Add live tests whose fixture records every catalog, redirect, metadata, manifest, and Parquet
+   request. Tests must also cover DNS rebinding, private addresses, redirect credential separation,
+   expired capabilities, cancellation, and concurrent budget exhaustion.
+6. Only after those tests pass, enable external access for the brokered runtime and advertise the
+   `iceberg-http` feature.
+
+The broker mock is not itself a network sandbox. Its transport contract requires address validation
+and pinning because an origin allowlist alone does not prevent DNS rebinding.

--- a/development_docs/integrations.md
+++ b/development_docs/integrations.md
@@ -175,7 +175,8 @@ A positive live scan suite must be added with the broker API so its fixture can
 assert that every catalog, redirect, and vended object request crossed the
 parent probe. Until then, conformance asserts the negative contract: both Node
 runtime modes omit `iceberg-http` and reject a program that requires it before
-executing setup.
+executing setup. See [the broker policy mock](./duckdb_wasm_iceberg_broker.md)
+for the proposed capability boundary and remaining transport work.
 
 The sandbox adapter renders only the selected integration. It uses the image
 from `MARIMOHUB_DATA_PREVIEW_IMAGE` after a PyIceberg and PyArrow preflight. It

--- a/docs/partials/integrations/azure_blob.md
+++ b/docs/partials/integrations/azure_blob.md
@@ -1,6 +1,6 @@
 <!-- GENERATED from internal/schemas/integrations.yml — do not edit; run `pnpm schemas:generate`. -->
 
-<span style="display:inline-block;width:12px;height:12px;border-radius:9999px;background:#0078D4;vertical-align:-1px"></span> `azure_blob` · storage · config schema v1
+<span style="display:inline-block;width:12px;height:12px;border-radius:9999px;background:#0078D4;vertical-align:-1px"></span> `azure_blob` · storage · config schema v1 · connection test supported
 
 **Notebook packages:** `adlfs>=2024.7`, `azure-storage-blob>=12.22`, `azure-identity>=1.17`
 

--- a/docs/partials/integrations/gcs.md
+++ b/docs/partials/integrations/gcs.md
@@ -1,6 +1,6 @@
 <!-- GENERATED from internal/schemas/integrations.yml — do not edit; run `pnpm schemas:generate`. -->
 
-<span style="display:inline-block;padding:3px;border-radius:6px;background:var(--vp-c-default-soft);vertical-align:-7px"><svg role="img" aria-label="Google Cloud Storage logo" viewBox="0 0 24 24" width="18" height="18" fill="#AECBFA"><path d="M24 2.4v8.4h-2.4V2.4H24zM0 10.8h2.4V2.4H0v8.4zm3-8.4h18v8.4H3V2.4zm12.6 4.2a1.8 1.8 0 1 0 3.6 0 1.8 1.8 0 0 0-3.6 0zm-10.8.6H12V6H4.8v1.2zm16.8 14.4H24v-8.4h-2.4v8.4zM0 21.6h2.4v-8.4H0v8.4zm3-8.4h18v8.4H3v-8.4zm12.6 4.2a1.8 1.8 0 1 0 3.6 0 1.8 1.8 0 0 0-3.6 0zM4.8 18H12v-1.2H4.8V18z"/></svg></span> `gcs` · storage · config schema v1
+<span style="display:inline-block;padding:3px;border-radius:6px;background:var(--vp-c-default-soft);vertical-align:-7px"><svg role="img" aria-label="Google Cloud Storage logo" viewBox="0 0 24 24" width="18" height="18" fill="#AECBFA"><path d="M24 2.4v8.4h-2.4V2.4H24zM0 10.8h2.4V2.4H0v8.4zm3-8.4h18v8.4H3V2.4zm12.6 4.2a1.8 1.8 0 1 0 3.6 0 1.8 1.8 0 0 0-3.6 0zm-10.8.6H12V6H4.8v1.2zm16.8 14.4H24v-8.4h-2.4v8.4zM0 21.6h2.4v-8.4H0v8.4zm3-8.4h18v8.4H3v-8.4zm12.6 4.2a1.8 1.8 0 1 0 3.6 0 1.8 1.8 0 0 0-3.6 0zM4.8 18H12v-1.2H4.8V18z"/></svg></span> `gcs` · storage · config schema v1 · connection test supported
 
 **Notebook packages:** `gcsfs>=2024.6`, `google-cloud-storage>=2.18`
 

--- a/docs/partials/integrations/s3.md
+++ b/docs/partials/integrations/s3.md
@@ -1,6 +1,6 @@
 <!-- GENERATED from internal/schemas/integrations.yml — do not edit; run `pnpm schemas:generate`. -->
 
-<span style="display:inline-block;width:12px;height:12px;border-radius:9999px;background:#569A31;vertical-align:-1px"></span> `s3` · storage · config schema v1
+<span style="display:inline-block;width:12px;height:12px;border-radius:9999px;background:#569A31;vertical-align:-1px"></span> `s3` · storage · config schema v1 · connection test supported
 
 **Notebook packages:** `boto3>=1.35`, `s3fs>=2024.6`
 

--- a/internal/schemas/integrations.yml
+++ b/internal/schemas/integrations.yml
@@ -57,7 +57,7 @@ paths:
       - auth.sas_token
       - auth.connection_string
       - auth.client_secret
-    x-supports-test: false
+    x-supports-test: true
     x-requirements:
       - adlfs>=2024.7
       - azure-storage-blob>=12.22
@@ -245,7 +245,7 @@ paths:
     x-brand-icon: googlecloudstorage
     x-secret-paths:
       - auth.credentials_json
-    x-supports-test: false
+    x-supports-test: true
     x-requirements:
       - gcsfs>=2024.6
       - google-cloud-storage>=2.18
@@ -834,7 +834,7 @@ paths:
       - auth.access_key_id
       - auth.secret_access_key
       - auth.session_token
-    x-supports-test: false
+    x-supports-test: true
     x-requirements:
       - boto3>=1.35
       - s3fs>=2024.6

--- a/packages/api/src/routes/integrationBrowse.ts
+++ b/packages/api/src/routes/integrationBrowse.ts
@@ -29,7 +29,7 @@ import {
 	ProjectIdParam,
 } from '../shared';
 import type { ApiDeps } from '../shared';
-import { appendAudit } from '../log';
+import { appendAudit, logEvent } from '../log';
 import {
 	acquireDownload,
 	makeObjectBrowseContext,
@@ -1188,6 +1188,16 @@ app.openapi(browseCapability, async (c) => {
 		iid,
 		c.req.raw.signal,
 	);
+	const querySurface = capability.surfaces.query;
+	if (deps.dataBrowser?.query === true && querySurface?.available === false) {
+		logEvent({
+			level: 'warn',
+			event: 'integration_query_unavailable',
+			project_id: pid,
+			integration_id: iid,
+			reason: querySurface.reason ?? 'No reason provided.',
+		});
+	}
 	const tablePreview = preview && capability.metadata && capability.hub_preview;
 	return c.json(
 		{

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -47,7 +47,14 @@ const browsyKind = defineIntegration({
 	}),
 	render: () => ({}),
 	query: {
-		available: () => ({ ok: true }),
+		available: (config) =>
+			config.mode === 'open'
+				? { ok: true }
+				: {
+						ok: false,
+						reason:
+							'guarded catalog and object-store HTTP brokering is not available in DuckDB-Wasm',
+					},
 		plan: () => ({ setup: [] }),
 	},
 	browse: {
@@ -428,6 +435,33 @@ describe('Data browser routes', () => {
 					reason: 'Run SQL is not enabled on this deployment.',
 				},
 			},
+		});
+	});
+
+	it('logs a server warning when Run SQL is unavailable', async () => {
+		const pid = await createProject();
+		const created = await expectOk<{ id: string }>(
+			await request('POST', `/projects/${pid}/integrations`, {
+				kind: 'browsy',
+				name: 'blocked-query',
+				config: { mode: 'sandbox_only', token: 'tok' },
+			}),
+			201,
+		);
+		const queryDeps = browserDeps(bucket, undefined, queryService([]));
+		queryDeps.dataBrowser.query = true;
+		const query = createTestApi({ bucket, userId: ACTOR, deps: queryDeps }).request;
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+		await expectOk(await query('GET', `/projects/${pid}/integrations/${created.id}/browse`));
+
+		expect(log).toHaveBeenCalledOnce();
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			level: 'warn',
+			event: 'integration_query_unavailable',
+			project_id: pid,
+			integration_id: created.id,
+			reason: 'guarded catalog and object-store HTTP brokering is not available in DuckDB-Wasm',
 		});
 	});
 

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -11,6 +11,7 @@ import {
 import type {
 	IntegrationDetail,
 	IntegrationEntry,
+	ObjectBrowseContext,
 	ProjectIntegrationsService,
 	OrgIntegrationsService,
 	SlidingWindowBudget,
@@ -43,6 +44,7 @@ import {
 } from '../pagination';
 import { appendAudit } from '../log';
 import integrationBrowseApp from './integrationBrowse';
+import { makeObjectBrowseContext } from './objectBrowse';
 
 export { clearIntegrationBrowseStateForTests } from './integrationBrowse';
 
@@ -727,10 +729,22 @@ app.openapi(testIntegration, async (c) => {
 	const user = c.get('user');
 	const { pid } = c.req.valid('param');
 	const integrations = requireIntegrations(deps);
-	await assertProjectRole(deps.services.projects, pid, user, 'manager', deps.policy);
+	const project = await assertProjectRole(
+		deps.services.projects,
+		pid,
+		user,
+		'manager',
+		deps.policy,
+	);
 	assertTestBudget(user.id);
 	const body = c.req.valid('json') as TestIntegrationRequest;
-	return c.json({ success: true, data: await integrations.test(pid, body) }, 200);
+	const objectContext = await objectTestContext(
+		integrations.listKinds(),
+		body,
+		(id) => integrations.get(pid, id),
+		() => makeObjectBrowseContext(deps, project, user, c.req.raw.signal),
+	);
+	return c.json({ success: true, data: await integrations.test(pid, body, objectContext) }, 200);
 });
 
 app.route('/', integrationBrowseApp);
@@ -850,7 +864,36 @@ app.openapi(testOrgIntegration, async (c) => {
 	assertSuperAdmin(user, deps.policy);
 	assertTestBudget(user.id);
 	const body = c.req.valid('json') as TestIntegrationRequest;
-	return c.json({ success: true, data: await integrations.test(body) }, 200);
+	const objectContext = await objectTestContext(
+		integrations.listKinds(),
+		body,
+		(id) => integrations.get(id),
+		() =>
+			Promise.resolve({
+				user_id: user.id,
+				user_email: user.email,
+				allow_server_ambient: {
+					s3: deps.dataBrowser?.objectBrowser?.allowServerAmbientCredentials ?? false,
+					gcs: deps.dataBrowser?.objectBrowser?.allowServerAmbientCredentials ?? false,
+					azure_blob: deps.dataBrowser?.objectBrowser?.allowServerAmbientCredentials ?? false,
+				},
+				signal: c.req.raw.signal,
+			}),
+	);
+	return c.json({ success: true, data: await integrations.test(body, objectContext) }, 200);
 });
+
+async function objectTestContext(
+	kinds: ReturnType<ProjectIntegrationsService['listKinds']>,
+	request: TestIntegrationRequest,
+	getStored: (id: IntegrationId) => Promise<IntegrationDetail>,
+	makeContext: () => Promise<ObjectBrowseContext>,
+): Promise<ObjectBrowseContext | undefined> {
+	const kind = request.source === 'draft' ? request.kind : (await getStored(request.id)).kind;
+	if (!kinds.find((item) => item.kind === kind)?.browse_surfaces.includes('objects')) {
+		return undefined;
+	}
+	return makeContext();
+}
 
 export default app;

--- a/packages/config/src/integrations.test.ts
+++ b/packages/config/src/integrations.test.ts
@@ -135,6 +135,7 @@ describe('makeIntegrations data browser', () => {
 		});
 		expect(wired.integrations?.listKinds().some((k) => k.supports_browse)).toBe(true);
 		expect(wired.integrations?.listKinds().find((kind) => kind.kind === 's3')).toMatchObject({
+			supports_test: true,
 			supports_browse: true,
 			browse_surfaces: ['objects'],
 		});

--- a/packages/core/src/ports/objectBrowser.ts
+++ b/packages/core/src/ports/objectBrowser.ts
@@ -63,7 +63,7 @@ export interface S3FederationContext {
 }
 
 export interface ObjectBrowseContext {
-	project_id: ProjectId;
+	project_id?: ProjectId;
 	user_id: UserId;
 	user_email: string;
 	federation?: S3FederationContext;

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.test.ts
@@ -12,6 +12,7 @@ import { createIntegrationId, createProjectId, createSessionId } from '../../ids
 import type { ProjectId, SessionId } from '../../ids';
 import { paths } from '../../paths';
 import type { Bucket, BucketListOptions } from '../../ports/bucket';
+import { ObjectBrowseError } from '../../ports/objectBrowser';
 import type { ObjectBrowseContext, ObjectBrowser } from '../../ports/objectBrowser';
 import { SecretResolutionError } from '../../ports/secrets';
 import type { SecretResolver } from '../../ports/secrets';
@@ -2108,13 +2109,13 @@ describe('data browsing', () => {
 		category: 'storage',
 		brand: { color: '#000000' },
 		schemaVersion: 1,
-		configSchema: z.object({ token: zSecret() }),
+		configSchema: z.object({ discover: z.boolean().default(false), token: zSecret() }),
 		render: () => ({}),
 		objectBrowse: {
 			provider: 's3',
 			source: (config) => ({
 				provider: 's3',
-				configured_bucket: 'lake',
+				configured_bucket: config.discover ? undefined : 'lake',
 				path_style: true,
 				auth: {
 					method: 'static',
@@ -2294,6 +2295,61 @@ describe('data browsing', () => {
 		await expect(
 			bare.browseObjectBuckets(pid, created.id, objectContext(), { limit: 10 }),
 		).rejects.toThrow(/not enabled/);
+	});
+
+	it('probes a configured object-store bucket through its guarded browser', async () => {
+		const listBuckets = vi.fn(async () => ({ items: [], next_cursor: null }));
+		const listObjects = vi.fn(objectBrowser.listObjects);
+		const registry = new IntegrationRegistry();
+		registry.register(objectKind);
+		const probeStore = new ProjectIntegrationsStore({
+			bucket,
+			registry,
+			codec,
+			probe: stubProbe,
+			objectBrowsers: { s3: { ...objectBrowser, listBuckets, listObjects } },
+		});
+
+		expect(probeStore.listKinds().find(({ kind }) => kind === 'objecty')?.supports_test).toBe(true);
+		await expect(
+			probeStore.test(
+				pid,
+				{ source: 'draft', kind: 'objecty', config: { token: 'provider-secret' } },
+				objectContext(),
+			),
+		).resolves.toMatchObject({ ok: true, details: 'bucket reachable' });
+		expect(listObjects).toHaveBeenCalledWith(
+			expect.objectContaining({ configured_bucket: 'lake' }),
+			objectContext(),
+			{ bucket: 'lake', limit: 1 },
+		);
+		await expect(
+			probeStore.test(
+				pid,
+				{
+					source: 'draft',
+					kind: 'objecty',
+					config: { discover: true, token: 'provider-secret' },
+				},
+				objectContext(),
+			),
+		).resolves.toMatchObject({ ok: true, details: 'bucket discovery succeeded' });
+		expect(listBuckets).toHaveBeenCalledWith(
+			expect.objectContaining({ configured_bucket: undefined }),
+			objectContext(),
+			{ limit: 1 },
+		);
+
+		listObjects.mockRejectedValueOnce(
+			new ObjectBrowseError('not_found', 'provider-secret must never reach the response'),
+		);
+		await expect(
+			probeStore.test(
+				pid,
+				{ source: 'draft', kind: 'objecty', config: { token: 'provider-secret' } },
+				objectContext(),
+			),
+		).resolves.toMatchObject({ ok: false, details: 'bucket not found' });
 	});
 
 	it('does not expose provider exceptions containing resolved object credentials', async () => {

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -279,7 +279,8 @@ class ScopedIntegrationsStore {
 		const tableBrowsable = this.browseProbe !== undefined;
 		const secret_sources = this.secretSources();
 		return this.registry.describeAll().map((descriptor) => {
-			const objectProvider = this.registry.get(descriptor.kind).objectBrowse?.provider;
+			const def = this.registry.get(descriptor.kind);
+			const objectProvider = def.objectBrowse?.provider;
 			const browse_surfaces = descriptor.browse_surfaces.filter(
 				(surface) =>
 					(surface === 'tables' && tableBrowsable) ||
@@ -287,9 +288,14 @@ class ScopedIntegrationsStore {
 						objectProvider !== undefined &&
 						this.objectBrowsers[objectProvider]?.provider === objectProvider),
 			);
+			const supportsTest =
+				descriptor.supports_test &&
+				(def.testConnection !== undefined ||
+					(objectProvider !== undefined &&
+						this.objectBrowsers[objectProvider]?.provider === objectProvider));
 			return {
 				...descriptor,
-				supports_test: testable && descriptor.supports_test,
+				supports_test: testable && supportsTest,
 				supports_browse: browse_surfaces.length > 0,
 				browse_surfaces,
 				secret_sources,
@@ -710,7 +716,11 @@ class ScopedIntegrationsStore {
 		);
 	}
 
-	async test(scope: IntegrationScope, request: TestIntegrationRequest): Promise<TestResult> {
+	async test(
+		scope: IntegrationScope,
+		request: TestIntegrationRequest,
+		objectContext?: ObjectBrowseContext,
+	): Promise<TestResult> {
 		let def: IntegrationDefinition;
 		let resolved: Record<string, unknown>;
 		if (request.source === 'stored') {
@@ -750,7 +760,7 @@ class ScopedIntegrationsStore {
 				});
 			}
 		}
-		if (!def.testConnection) {
+		if (!def.testConnection && !def.objectBrowse) {
 			throw new ValidationError(`Integration kind "${def.kind}" does not support testing.`);
 		}
 		const probe = this.probe;
@@ -764,7 +774,51 @@ class ScopedIntegrationsStore {
 				`Stored config no longer matches kind "${def.kind}" — edit and re-save it.`,
 			);
 		}
-		return def.testConnection(parsed.data, probe);
+		if (def.testConnection) return def.testConnection(parsed.data, probe);
+		if (!objectContext) {
+			throw new ValidationError('Object-store connection testing requires a user context.');
+		}
+		const objectBrowse = def.objectBrowse!;
+		const source = objectBrowse.source(parsed.data);
+		const browser = this.browserFor(source);
+		if (!browser) {
+			throw new ValidationError(
+				'Object-store connection testing is not enabled on this deployment.',
+			);
+		}
+		const startedAt = performance.now();
+		const metadata = OBJECT_BROWSE_PROVIDER_METADATA[source.provider];
+		try {
+			const capability = await browser.capability(source, objectContext);
+			if (!capability.available) {
+				return {
+					ok: false,
+					latency_ms: Math.round(performance.now() - startedAt),
+					details: capability.reason ?? 'object-store access is unavailable',
+				};
+			}
+			if (source.configured_bucket) {
+				await browser.listObjects(source, objectContext, {
+					bucket: source.configured_bucket,
+					limit: 1,
+				});
+			} else {
+				await browser.listBuckets(source, objectContext, { limit: 1 });
+			}
+			return {
+				ok: true,
+				latency_ms: Math.round(performance.now() - startedAt),
+				details: source.configured_bucket
+					? `${metadata.root_kind} reachable`
+					: `${metadata.root_kind} discovery succeeded`,
+			};
+		} catch (error) {
+			return {
+				ok: false,
+				latency_ms: Math.round(performance.now() - startedAt),
+				details: objectTestFailure(error, metadata.root_kind),
+			};
+		}
 	}
 
 	/**
@@ -1658,8 +1712,12 @@ export class ProjectIntegrationsStore implements ProjectIntegrationsService {
 		return this.store.listVersions(projectScope(projectId), id, page);
 	}
 
-	test(projectId: ProjectId, request: TestIntegrationRequest): Promise<TestResult> {
-		return this.store.test(projectScope(projectId), request);
+	test(
+		projectId: ProjectId,
+		request: TestIntegrationRequest,
+		objectContext?: ObjectBrowseContext,
+	): Promise<TestResult> {
+		return this.store.test(projectScope(projectId), request, objectContext);
 	}
 
 	copy(
@@ -1936,8 +1994,26 @@ export class OrgIntegrationsStore implements OrgIntegrationsService {
 		return this.store.listVersions(ORG_SCOPE, id, page);
 	}
 
-	test(request: TestIntegrationRequest): Promise<TestResult> {
-		return this.store.test(ORG_SCOPE, request);
+	test(request: TestIntegrationRequest, objectContext?: ObjectBrowseContext): Promise<TestResult> {
+		return this.store.test(ORG_SCOPE, request, objectContext);
+	}
+}
+
+function objectTestFailure(error: unknown, rootKind: 'bucket' | 'container'): string {
+	if (!(error instanceof ObjectBrowseError)) return 'object-store request failed';
+	switch (error.code) {
+		case 'access_denied':
+			return 'access denied';
+		case 'not_found':
+			return `${rootKind} not found`;
+		case 'aborted':
+			return 'object-store request timed out';
+		case 'invalid_cursor':
+		case 'precondition_failed':
+		case 'range_not_satisfiable':
+		case 'unavailable':
+		case 'unsupported':
+			return 'object store unavailable';
 	}
 }
 

--- a/packages/core/src/services/integrations/contracts.ts
+++ b/packages/core/src/services/integrations/contracts.ts
@@ -67,7 +67,11 @@ export interface ProjectIntegrationsService {
 		id: IntegrationId,
 		page?: IntegrationVersionPageRequest,
 	): Promise<IntegrationVersionPage>;
-	test(projectId: ProjectId, request: TestIntegrationRequest): Promise<TestResult>;
+	test(
+		projectId: ProjectId,
+		request: TestIntegrationRequest,
+		objectContext?: ObjectBrowseContext,
+	): Promise<TestResult>;
 	/**
 	 * Read-only catalog browsing. Unlike `get`/`test`, the id resolves
 	 * project-first, then the inherited org tier (shadowed org instances read
@@ -188,5 +192,5 @@ export interface OrgIntegrationsService {
 		id: IntegrationId,
 		page?: IntegrationVersionPageRequest,
 	): Promise<IntegrationVersionPage>;
-	test(request: TestIntegrationRequest): Promise<TestResult>;
+	test(request: TestIntegrationRequest, objectContext?: ObjectBrowseContext): Promise<TestResult>;
 }

--- a/packages/core/src/services/integrations/registry.test.ts
+++ b/packages/core/src/services/integrations/registry.test.ts
@@ -49,6 +49,7 @@ describe('IntegrationRegistry', () => {
 			browse_surfaces: ['tables'],
 		});
 		expect(registry.describe('objects')).toMatchObject({
+			supports_test: true,
 			supports_browse: true,
 			browse_surfaces: ['objects'],
 		});

--- a/packages/core/src/services/integrations/registry.ts
+++ b/packages/core/src/services/integrations/registry.ts
@@ -76,7 +76,7 @@ export class IntegrationRegistry {
 			schema_version: def.schemaVersion,
 			json_schema: this.jsonSchema(kind),
 			ui_hints: def.uiHints ?? {},
-			supports_test: def.testConnection !== undefined,
+			supports_test: def.testConnection !== undefined || def.objectBrowse !== undefined,
 			supports_browse: browse_surfaces.length > 0,
 			browse_surfaces,
 			secret_sources: { inline: false, references: [] },

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it, vi } from 'vitest';
+import { IcebergHttpBroker, IcebergHttpBrokerError } from './icebergHttpBroker';
+import type {
+	IcebergHttpBrokerCapability,
+	IcebergHttpBrokerTransportRequest,
+} from './icebergHttpBroker';
+
+const NOW = Date.parse('2026-08-13T12:00:00Z');
+
+function capability(
+	overrides: Partial<IcebergHttpBrokerCapability> = {},
+): IcebergHttpBrokerCapability {
+	return {
+		expiresAtMs: NOW + 60_000,
+		routes: [
+			{
+				kind: 'catalog',
+				url: 'https://catalog.example.test/iceberg',
+				match: 'prefix',
+				methods: ['GET'],
+				headers: { Authorization: 'Bearer catalog-secret' },
+			},
+			{
+				kind: 'storage',
+				url: 'https://objects.example.test/warehouse',
+				match: 'prefix',
+				methods: ['GET', 'HEAD'],
+				headers: { Authorization: 'Bearer storage-secret' },
+			},
+		],
+		limits: {
+			maxRequests: 8,
+			maxRedirects: 2,
+			maxResponseBytes: 4096,
+		},
+		...overrides,
+	};
+}
+
+function setup(responses?: { status: number; headers?: Record<string, string>; body?: string }[]) {
+	const calls: IcebergHttpBrokerTransportRequest[] = [];
+	const queue = [...(responses ?? [{ status: 200, body: 'ok' }])];
+	const transport = vi.fn(async (request: IcebergHttpBrokerTransportRequest) => {
+		calls.push(request);
+		const response = queue.shift() ?? { status: 200, body: 'ok' };
+		return {
+			status: response.status,
+			headers: response.headers ?? {},
+			body: new TextEncoder().encode(response.body ?? ''),
+		};
+	});
+	const broker = new IcebergHttpBroker(
+		transport,
+		() => NOW,
+		() => 'capability-id',
+	);
+	return { broker, calls, transport };
+}
+
+async function expectCode(promise: Promise<unknown>, code: IcebergHttpBrokerError['code']) {
+	await expect(promise).rejects.toMatchObject({ code });
+}
+
+describe('IcebergHttpBroker', () => {
+	it('rejects incomplete capabilities at the runtime boundary', () => {
+		const { broker } = setup();
+		expect(() =>
+			broker.open({
+				...capability(),
+				limits: { maxRequests: 1 },
+			} as unknown as IcebergHttpBrokerCapability),
+		).toThrow(IcebergHttpBrokerError);
+	});
+
+	it('keeps credentials in the parent and forwards only approved worker headers', async () => {
+		const { broker, calls } = setup([
+			{
+				status: 206,
+				headers: {
+					'Content-Range': 'bytes 0-1/20',
+					'Set-Cookie': 'session=do-not-return',
+				},
+				body: 'ab',
+			},
+		]);
+		const id = broker.open(capability());
+		const response = await broker.fetch(id, {
+			url: 'https://objects.example.test/warehouse/table/data.parquet',
+			method: 'GET',
+			headers: { Range: 'bytes=0-1' },
+		});
+
+		expect(calls[0]).toMatchObject({
+			url: 'https://objects.example.test/warehouse/table/data.parquet',
+			method: 'GET',
+			headers: {
+				range: 'bytes=0-1',
+				authorization: 'Bearer storage-secret',
+			},
+			maxResponseBytes: 4096,
+		});
+		expect(response.headers).toEqual({ 'content-range': 'bytes 0-1/20' });
+	});
+
+	it('rejects targets outside the granted origins and path prefixes', async () => {
+		const { broker, transport } = setup();
+		const id = broker.open(capability());
+
+		await expectCode(
+			broker.fetch(id, { url: 'http://169.254.169.254/latest/meta-data', method: 'GET' }),
+			'target_denied',
+		);
+		await expectCode(
+			broker.fetch(id, { url: 'https://catalog.example.test/admin', method: 'GET' }),
+			'target_denied',
+		);
+		await expectCode(
+			broker.fetch(id, {
+				url: 'https://catalog.example.test/iceberg-other',
+				method: 'GET',
+			}),
+			'target_denied',
+		);
+		expect(transport).not.toHaveBeenCalled();
+	});
+
+	it('rejects worker-supplied credentials and unapproved methods', async () => {
+		const { broker, transport } = setup();
+		const id = broker.open(capability());
+
+		await expectCode(
+			broker.fetch(id, {
+				url: 'https://catalog.example.test/iceberg/v1/config',
+				method: 'GET',
+				headers: { Authorization: 'Bearer forged' },
+			}),
+			'header_denied',
+		);
+		await expectCode(
+			broker.fetch(id, {
+				url: 'https://catalog.example.test/iceberg/v1/namespaces',
+				method: 'HEAD',
+			}),
+			'method_denied',
+		);
+		expect(transport).not.toHaveBeenCalled();
+	});
+
+	it('reauthorizes redirects and switches to credentials for the destination route', async () => {
+		const { broker, calls } = setup([
+			{
+				status: 307,
+				headers: {
+					Location: 'https://objects.example.test/warehouse/table/metadata.json',
+				},
+			},
+			{ status: 200, headers: { ETag: 'snapshot-1' }, body: '{}' },
+		]);
+		const id = broker.open(capability());
+		const response = await broker.fetch(id, {
+			url: 'https://catalog.example.test/iceberg/v1/table',
+			method: 'GET',
+		});
+
+		expect(calls).toHaveLength(2);
+		expect(calls[0].headers).toMatchObject({ authorization: 'Bearer catalog-secret' });
+		expect(calls[1]).toMatchObject({
+			url: 'https://objects.example.test/warehouse/table/metadata.json',
+			headers: { authorization: 'Bearer storage-secret' },
+		});
+		expect(response).toMatchObject({ status: 200, headers: { etag: 'snapshot-1' } });
+	});
+
+	it('does not follow a redirect to an ungranted destination', async () => {
+		const { broker, calls } = setup([
+			{
+				status: 302,
+				headers: { Location: 'http://127.0.0.1:3000/internal' },
+			},
+		]);
+		const id = broker.open(capability());
+
+		await expectCode(
+			broker.fetch(id, {
+				url: 'https://catalog.example.test/iceberg/v1/config',
+				method: 'GET',
+			}),
+			'target_denied',
+		);
+		expect(calls).toHaveLength(1);
+	});
+
+	it('enforces request, response, redirect, expiry, and close boundaries', async () => {
+		const requestLimited = setup();
+		const requestId = requestLimited.broker.open(
+			capability({ limits: { ...capability().limits, maxRequests: 1 } }),
+		);
+		await requestLimited.broker.fetch(requestId, {
+			url: 'https://catalog.example.test/iceberg/v1/config',
+			method: 'GET',
+		});
+		await expectCode(
+			requestLimited.broker.fetch(requestId, {
+				url: 'https://catalog.example.test/iceberg/v1/config',
+				method: 'GET',
+			}),
+			'request_budget_exceeded',
+		);
+
+		const responseLimited = setup([{ status: 200, body: 'too large' }]);
+		const responseId = responseLimited.broker.open(
+			capability({ limits: { ...capability().limits, maxResponseBytes: 2 } }),
+		);
+		await expectCode(
+			responseLimited.broker.fetch(responseId, {
+				url: 'https://catalog.example.test/iceberg/v1/config',
+				method: 'GET',
+			}),
+			'response_budget_exceeded',
+		);
+
+		const redirectLimited = setup([{ status: 302, headers: { Location: '/iceberg/v1/config' } }]);
+		const redirectId = redirectLimited.broker.open(
+			capability({ limits: { ...capability().limits, maxRedirects: 0 } }),
+		);
+		await expectCode(
+			redirectLimited.broker.fetch(redirectId, {
+				url: 'https://catalog.example.test/iceberg/v1/config',
+				method: 'GET',
+			}),
+			'redirect_budget_exceeded',
+		);
+
+		let clock = NOW;
+		const expiring = new IcebergHttpBroker(
+			async () => ({ status: 200, headers: {}, body: new Uint8Array() }),
+			() => clock,
+			() => 'expiring',
+		);
+		const expiringId = expiring.open(capability({ expiresAtMs: NOW + 1 }));
+		clock += 1;
+		await expectCode(
+			expiring.fetch(expiringId, {
+				url: 'https://catalog.example.test/iceberg/v1/config',
+				method: 'GET',
+			}),
+			'capability_expired',
+		);
+
+		const closed = setup();
+		const closedId = closed.broker.open(capability());
+		closed.broker.close(closedId);
+		await expectCode(
+			closed.broker.fetch(closedId, {
+				url: 'https://catalog.example.test/iceberg/v1/config',
+				method: 'GET',
+			}),
+			'capability_unknown',
+		);
+	});
+
+	it('discards an in-flight response when its capability is revoked', async () => {
+		let resolveTransport!: (response: {
+			status: number;
+			headers: Record<string, string>;
+			body: Uint8Array;
+		}) => void;
+		const broker = new IcebergHttpBroker(
+			() =>
+				new Promise((resolve) => {
+					resolveTransport = resolve;
+				}),
+			() => NOW,
+			() => 'revoked',
+		);
+		const id = broker.open(capability());
+		const pending = broker.fetch(id, {
+			url: 'https://catalog.example.test/iceberg/v1/config',
+			method: 'GET',
+		});
+		await vi.waitFor(() => expect(resolveTransport).toBeTypeOf('function'));
+		broker.close(id);
+		resolveTransport({ status: 200, headers: {}, body: new Uint8Array() });
+
+		await expectCode(pending, 'capability_unknown');
+	});
+
+	it('serializes requests so concurrent reads share one exact byte budget', async () => {
+		let releaseFirst!: () => void;
+		let calls = 0;
+		const limits: number[] = [];
+		const broker = new IcebergHttpBroker(
+			async (request) => {
+				calls += 1;
+				limits.push(request.maxResponseBytes);
+				if (calls === 1) {
+					await new Promise<void>((resolve) => {
+						releaseFirst = resolve;
+					});
+				}
+				return { status: 200, headers: {}, body: new Uint8Array(2) };
+			},
+			() => NOW,
+			() => 'serialized',
+		);
+		const id = broker.open(capability({ limits: { ...capability().limits, maxResponseBytes: 4 } }));
+		const first = broker.fetch(id, {
+			url: 'https://objects.example.test/warehouse/one.parquet',
+			method: 'GET',
+		});
+		const second = broker.fetch(id, {
+			url: 'https://objects.example.test/warehouse/two.parquet',
+			method: 'GET',
+		});
+
+		await vi.waitFor(() => expect(calls).toBe(1));
+		releaseFirst();
+		await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+		expect(limits).toEqual([4, 2]);
+	});
+});

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
@@ -72,6 +72,24 @@ describe('IcebergHttpBroker', () => {
 		).toThrow(IcebergHttpBrokerError);
 	});
 
+	it('rejects non-string forwarded header names as an invalid capability', () => {
+		const { broker } = setup();
+		let error: unknown;
+
+		try {
+			broker.open(
+				capability({
+					forwardRequestHeaders: ['range', 42] as unknown as string[],
+				}),
+			);
+		} catch (cause) {
+			error = cause;
+		}
+
+		expect(error).toBeInstanceOf(IcebergHttpBrokerError);
+		expect(error).toMatchObject({ code: 'invalid_capability' });
+	});
+
 	it('keeps credentials in the parent and forwards only approved worker headers', async () => {
 		const { broker, calls } = setup([
 			{
@@ -144,6 +162,37 @@ describe('IcebergHttpBroker', () => {
 			'method_denied',
 		);
 		expect(transport).not.toHaveBeenCalled();
+	});
+
+	it('uses an exact route before an equal-path prefix route', async () => {
+		const { broker, calls } = setup();
+		const url = 'https://objects.example.test/warehouse/table.parquet';
+		const id = broker.open(
+			capability({
+				routes: [
+					{
+						kind: 'storage',
+						url,
+						match: 'prefix',
+						methods: ['GET', 'HEAD'],
+						headers: { Authorization: 'Bearer prefix-secret' },
+					},
+					{
+						kind: 'storage',
+						url,
+						match: 'exact',
+						methods: ['GET'],
+						headers: { Authorization: 'Bearer exact-secret' },
+					},
+				],
+			}),
+		);
+
+		await broker.fetch(id, { url, method: 'GET' });
+		expect(calls[0].headers).toMatchObject({ authorization: 'Bearer exact-secret' });
+
+		await expectCode(broker.fetch(id, { url, method: 'HEAD' }), 'method_denied');
+		expect(calls).toHaveLength(1);
 	});
 
 	it('reauthorizes redirects and switches to credentials for the destination route', async () => {

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
@@ -228,11 +228,12 @@ function normalizeCapability(capability: IcebergHttpBrokerCapability, now: numbe
 	) {
 		throw invalidCapability();
 	}
-	const forwarded = new Set(
-		(capability.forwardRequestHeaders ?? DEFAULT_FORWARDED_REQUEST_HEADERS).map((header) =>
-			normalizeHeaderName(header),
-		),
-	);
+	const rawForwardedHeaders: readonly unknown[] =
+		capability.forwardRequestHeaders ?? DEFAULT_FORWARDED_REQUEST_HEADERS;
+	if (!rawForwardedHeaders.every((header): header is string => typeof header === 'string')) {
+		throw invalidCapability();
+	}
+	const forwarded = new Set(rawForwardedHeaders.map(normalizeHeaderName));
 	if ([...forwarded].some((header) => !header || FORBIDDEN_WORKER_HEADERS.has(header))) {
 		throw invalidCapability();
 	}
@@ -295,15 +296,18 @@ function authorize(session: Session, request: IcebergHttpBrokerRequest): Iceberg
 	const target = new URL(request.url);
 	const candidates = session.routes
 		.filter((route) => routeMatches(route, target))
-		.sort((left, right) => right.url.pathname.length - left.url.pathname.length);
-	if (candidates.length === 0) {
+		.sort((left, right) => {
+			if (left.match !== right.match) return left.match === 'exact' ? -1 : 1;
+			return right.url.pathname.length - left.url.pathname.length;
+		});
+	const route = candidates[0];
+	if (!route) {
 		throw new IcebergHttpBrokerError(
 			'target_denied',
 			'Iceberg HTTP broker target is outside the execution capability.',
 		);
 	}
-	const route = candidates.find((candidate) => candidate.methods.has(request.method));
-	if (!route) {
+	if (!route.methods.has(request.method)) {
 		throw new IcebergHttpBrokerError(
 			'method_denied',
 			'Iceberg HTTP broker method is not allowed for this target.',

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
@@ -1,0 +1,449 @@
+import { randomUUID } from 'node:crypto';
+
+export type IcebergHttpBrokerMethod = 'GET' | 'HEAD';
+
+export interface IcebergHttpBrokerRoute {
+	kind: 'catalog' | 'storage';
+	url: string;
+	match: 'exact' | 'prefix';
+	methods: readonly IcebergHttpBrokerMethod[];
+	/** Parent-owned headers, including credentials. They are never sent by the worker. */
+	headers?: Readonly<Record<string, string>>;
+}
+
+export interface IcebergHttpBrokerCapability {
+	expiresAtMs: number;
+	routes: readonly IcebergHttpBrokerRoute[];
+	limits: {
+		maxRequests: number;
+		maxRedirects: number;
+		maxResponseBytes: number;
+	};
+	forwardRequestHeaders?: readonly string[];
+}
+
+export interface IcebergHttpBrokerRequest {
+	url: string;
+	method: IcebergHttpBrokerMethod;
+	headers?: Readonly<Record<string, string>>;
+}
+
+export interface IcebergHttpBrokerResponse {
+	status: number;
+	headers: Readonly<Record<string, string>>;
+	body: Uint8Array;
+}
+
+export interface IcebergHttpBrokerTransportRequest extends IcebergHttpBrokerRequest {
+	/** The transport must stop reading before this limit and must not follow redirects. */
+	maxResponseBytes: number;
+	signal?: AbortSignal;
+}
+
+export type IcebergHttpBrokerTransport = (
+	request: IcebergHttpBrokerTransportRequest,
+) => Promise<IcebergHttpBrokerResponse>;
+
+export type IcebergHttpBrokerErrorCode =
+	| 'capability_expired'
+	| 'capability_unknown'
+	| 'header_denied'
+	| 'invalid_capability'
+	| 'invalid_request'
+	| 'method_denied'
+	| 'redirect_budget_exceeded'
+	| 'request_budget_exceeded'
+	| 'response_budget_exceeded'
+	| 'target_denied';
+
+export class IcebergHttpBrokerError extends Error {
+	constructor(
+		readonly code: IcebergHttpBrokerErrorCode,
+		message: string,
+	) {
+		super(message);
+		this.name = 'IcebergHttpBrokerError';
+	}
+}
+
+interface NormalizedRoute {
+	kind: IcebergHttpBrokerRoute['kind'];
+	url: URL;
+	match: IcebergHttpBrokerRoute['match'];
+	methods: ReadonlySet<IcebergHttpBrokerMethod>;
+	headers: Readonly<Record<string, string>>;
+}
+
+interface Session {
+	expiresAtMs: number;
+	routes: readonly NormalizedRoute[];
+	limits: IcebergHttpBrokerCapability['limits'];
+	forwardRequestHeaders: ReadonlySet<string>;
+	requests: number;
+	responseBytes: number;
+	tail: Promise<void>;
+}
+
+const DEFAULT_FORWARDED_REQUEST_HEADERS = [
+	'accept',
+	'content-type',
+	'if-match',
+	'if-modified-since',
+	'if-none-match',
+	'if-unmodified-since',
+	'range',
+	'x-iceberg-access-delegation',
+] as const;
+
+const FORBIDDEN_WORKER_HEADERS = new Set([
+	'authorization',
+	'cookie',
+	'host',
+	'proxy-authorization',
+	'proxy-connection',
+	'x-forwarded-for',
+	'x-forwarded-host',
+]);
+
+const RESPONSE_HEADERS = new Set([
+	'accept-ranges',
+	'content-length',
+	'content-range',
+	'content-type',
+	'etag',
+	'last-modified',
+	'location',
+]);
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Parent-side policy mock for a future DuckDB-Wasm HTTP bridge. Opening a capability stores
+ * credentials here; worker requests carry only the opaque ID and unprivileged request fields.
+ */
+export class IcebergHttpBroker {
+	private readonly sessions = new Map<string, Session>();
+
+	constructor(
+		private readonly transport: IcebergHttpBrokerTransport,
+		private readonly now: () => number = Date.now,
+		private readonly createId: () => string = randomUUID,
+	) {}
+
+	open(capability: IcebergHttpBrokerCapability): string {
+		const session = normalizeCapability(capability, this.now());
+		const id = this.createId();
+		if (!id || this.sessions.has(id)) {
+			throw new IcebergHttpBrokerError(
+				'invalid_capability',
+				'Iceberg HTTP broker generated an invalid capability ID.',
+			);
+		}
+		this.sessions.set(id, session);
+		return id;
+	}
+
+	close(id: string): void {
+		this.sessions.delete(id);
+	}
+
+	async fetch(
+		id: string,
+		request: IcebergHttpBrokerRequest,
+		signal?: AbortSignal,
+	): Promise<IcebergHttpBrokerResponse> {
+		const session = this.requireSession(id);
+		return exclusive(session, async () => {
+			if (this.requireSession(id) !== session) throw unknownCapability();
+			let current = normalizeRequest(request);
+			let redirects = 0;
+
+			for (;;) {
+				const authorized = authorize(session, current);
+				const remainingResponseBytes = session.limits.maxResponseBytes - session.responseBytes;
+				const response = await this.transport({
+					...authorized,
+					maxResponseBytes: remainingResponseBytes,
+					signal,
+				});
+				assertResponse(response);
+				if (this.requireSession(id) !== session) throw unknownCapability();
+				session.responseBytes += response.body.byteLength;
+				if (session.responseBytes > session.limits.maxResponseBytes) {
+					throw new IcebergHttpBrokerError(
+						'response_budget_exceeded',
+						'Iceberg HTTP broker response budget exceeded.',
+					);
+				}
+
+				const headers = sanitizeResponseHeaders(response.headers);
+				const location = REDIRECT_STATUSES.has(response.status) ? headers.location : undefined;
+				if (!location) return { status: response.status, headers, body: response.body };
+				if (redirects >= session.limits.maxRedirects) {
+					throw new IcebergHttpBrokerError(
+						'redirect_budget_exceeded',
+						'Iceberg HTTP broker redirect budget exceeded.',
+					);
+				}
+				redirects += 1;
+				current = redirectRequest(current, location, response.status);
+			}
+		});
+	}
+
+	private requireSession(id: string): Session {
+		const session = this.sessions.get(id);
+		if (!session) throw unknownCapability();
+		if (this.now() >= session.expiresAtMs) {
+			this.sessions.delete(id);
+			throw new IcebergHttpBrokerError(
+				'capability_expired',
+				'Iceberg HTTP broker capability expired.',
+			);
+		}
+		return session;
+	}
+}
+
+function normalizeCapability(capability: IcebergHttpBrokerCapability, now: number): Session {
+	const limits = capability.limits;
+	if (
+		!Number.isSafeInteger(capability.expiresAtMs) ||
+		capability.expiresAtMs <= now ||
+		!Array.isArray(capability.routes) ||
+		!limits ||
+		capability.routes.length === 0
+	) {
+		throw invalidCapability();
+	}
+	for (const value of [limits.maxRequests, limits.maxRedirects, limits.maxResponseBytes]) {
+		if (!Number.isSafeInteger(value) || value < 0) throw invalidCapability();
+	}
+	if (limits.maxRequests === 0 || limits.maxResponseBytes === 0) {
+		throw invalidCapability();
+	}
+	if (
+		capability.forwardRequestHeaders !== undefined &&
+		!Array.isArray(capability.forwardRequestHeaders)
+	) {
+		throw invalidCapability();
+	}
+	const forwarded = new Set(
+		(capability.forwardRequestHeaders ?? DEFAULT_FORWARDED_REQUEST_HEADERS).map((header) =>
+			normalizeHeaderName(header),
+		),
+	);
+	if ([...forwarded].some((header) => !header || FORBIDDEN_WORKER_HEADERS.has(header))) {
+		throw invalidCapability();
+	}
+	return {
+		expiresAtMs: capability.expiresAtMs,
+		routes: capability.routes.map(normalizeRoute),
+		limits: { ...limits },
+		forwardRequestHeaders: forwarded,
+		requests: 0,
+		responseBytes: 0,
+		tail: Promise.resolve(),
+	};
+}
+
+function normalizeRoute(route: IcebergHttpBrokerRoute): NormalizedRoute {
+	if (
+		(route.kind !== 'catalog' && route.kind !== 'storage') ||
+		(route.match !== 'exact' && route.match !== 'prefix') ||
+		!Array.isArray(route.methods)
+	) {
+		throw invalidCapability();
+	}
+	const url = parseHttpUrl(route.url, 'invalid_capability');
+	if (url.hash || (route.match === 'prefix' && url.search)) throw invalidCapability();
+	if (route.methods.length === 0) throw invalidCapability();
+	const rawMethods: readonly unknown[] = route.methods;
+	const permittedMethods =
+		route.kind === 'catalog'
+			? new Set<IcebergHttpBrokerMethod>(['GET'])
+			: new Set<IcebergHttpBrokerMethod>(['GET', 'HEAD']);
+	if (rawMethods.some((method) => !permittedMethods.has(method as IcebergHttpBrokerMethod))) {
+		throw invalidCapability();
+	}
+	const methods = new Set(rawMethods as IcebergHttpBrokerMethod[]);
+	if (methods.size !== route.methods.length) throw invalidCapability();
+	const headers = normalizeHeaders(route.headers ?? {}, 'invalid_capability');
+	if (Object.keys(headers).some((header) => header === 'host' || header === 'content-length')) {
+		throw invalidCapability();
+	}
+	return { kind: route.kind, url, match: route.match, methods, headers };
+}
+
+function normalizeRequest(request: IcebergHttpBrokerRequest): IcebergHttpBrokerRequest {
+	const url = parseHttpUrl(request.url, 'invalid_request');
+	if (url.hash) throw invalidRequest('Request URLs must not contain fragments.');
+	return {
+		url: url.toString(),
+		method: request.method,
+		headers: normalizeHeaders(request.headers ?? {}, 'invalid_request'),
+	};
+}
+
+function authorize(session: Session, request: IcebergHttpBrokerRequest): IcebergHttpBrokerRequest {
+	if (session.requests >= session.limits.maxRequests) {
+		throw new IcebergHttpBrokerError(
+			'request_budget_exceeded',
+			'Iceberg HTTP broker request budget exceeded.',
+		);
+	}
+	const target = new URL(request.url);
+	const candidates = session.routes
+		.filter((route) => routeMatches(route, target))
+		.sort((left, right) => right.url.pathname.length - left.url.pathname.length);
+	if (candidates.length === 0) {
+		throw new IcebergHttpBrokerError(
+			'target_denied',
+			'Iceberg HTTP broker target is outside the execution capability.',
+		);
+	}
+	const route = candidates.find((candidate) => candidate.methods.has(request.method));
+	if (!route) {
+		throw new IcebergHttpBrokerError(
+			'method_denied',
+			'Iceberg HTTP broker method is not allowed for this target.',
+		);
+	}
+	const workerHeaders = normalizeHeaders(request.headers ?? {}, 'invalid_request');
+	for (const header of Object.keys(workerHeaders)) {
+		if (FORBIDDEN_WORKER_HEADERS.has(header) || !session.forwardRequestHeaders.has(header)) {
+			throw new IcebergHttpBrokerError(
+				'header_denied',
+				`Iceberg HTTP broker request header "${header}" is not allowed.`,
+			);
+		}
+	}
+	session.requests += 1;
+	return {
+		...request,
+		headers: { ...workerHeaders, ...route.headers },
+	};
+}
+
+function routeMatches(route: NormalizedRoute, target: URL): boolean {
+	if (route.url.origin !== target.origin) return false;
+	if (route.match === 'exact') {
+		return route.url.pathname === target.pathname && route.url.search === target.search;
+	}
+	const prefix = route.url.pathname.replace(/\/$/, '');
+	return target.pathname === prefix || target.pathname.startsWith(`${prefix}/`);
+}
+
+function redirectRequest(
+	request: IcebergHttpBrokerRequest,
+	location: string,
+	status: number,
+): IcebergHttpBrokerRequest {
+	let method = request.method;
+	if (status === 303) {
+		method = 'GET';
+	}
+	return normalizeRequest({
+		url: new URL(location, request.url).toString(),
+		method,
+		headers: request.headers,
+	});
+}
+
+function sanitizeResponseHeaders(
+	headers: Readonly<Record<string, string>>,
+): Record<string, string> {
+	const normalized = normalizeHeaders(headers, 'invalid_request');
+	return Object.fromEntries(
+		Object.entries(normalized).filter(([name]) => RESPONSE_HEADERS.has(name)),
+	);
+}
+
+function normalizeHeaders(
+	headers: Readonly<Record<string, string>>,
+	code: 'invalid_capability' | 'invalid_request',
+): Record<string, string> {
+	const normalized: Record<string, string> = {};
+	for (const [rawName, value] of Object.entries(headers)) {
+		const name = normalizeHeaderName(rawName);
+		if (
+			!name ||
+			typeof value !== 'string' ||
+			/[\r\n]/.test(value) ||
+			Object.hasOwn(normalized, name)
+		) {
+			if (code === 'invalid_capability') throw invalidCapability();
+			throw invalidRequest('Request contains an invalid header.');
+		}
+		normalized[name] = value;
+	}
+	return normalized;
+}
+
+function normalizeHeaderName(name: string): string {
+	const normalized = name.trim().toLowerCase();
+	return /^[!#$%&'*+.^_`|~0-9a-z-]+$/.test(normalized) ? normalized : '';
+}
+
+function parseHttpUrl(value: string, code: 'invalid_capability' | 'invalid_request'): URL {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		if (code === 'invalid_capability') throw invalidCapability();
+		throw invalidRequest('Request contains an invalid URL.');
+	}
+	if (
+		(url.protocol !== 'http:' && url.protocol !== 'https:') ||
+		url.username !== '' ||
+		url.password !== '' ||
+		/%2f|%5c/i.test(url.pathname)
+	) {
+		if (code === 'invalid_capability') throw invalidCapability();
+		throw invalidRequest('Request URL is not allowed.');
+	}
+	return url;
+}
+
+function assertResponse(response: IcebergHttpBrokerResponse): void {
+	if (
+		!Number.isSafeInteger(response.status) ||
+		response.status < 100 ||
+		response.status > 599 ||
+		!(response.body instanceof Uint8Array)
+	) {
+		throw invalidRequest('Iceberg HTTP broker transport returned an invalid response.');
+	}
+}
+
+function invalidCapability(): IcebergHttpBrokerError {
+	return new IcebergHttpBrokerError(
+		'invalid_capability',
+		'Iceberg HTTP broker capability is invalid.',
+	);
+}
+
+function invalidRequest(message: string): IcebergHttpBrokerError {
+	return new IcebergHttpBrokerError('invalid_request', message);
+}
+
+function unknownCapability(): IcebergHttpBrokerError {
+	return new IcebergHttpBrokerError(
+		'capability_unknown',
+		'Iceberg HTTP broker capability is unknown.',
+	);
+}
+
+async function exclusive<T>(session: Session, work: () => Promise<T>): Promise<T> {
+	const previous = session.tail;
+	let release!: () => void;
+	session.tail = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	await previous;
+	try {
+		return await work();
+	} finally {
+		release();
+	}
+}

--- a/packages/duckdb-wasm-runtime/src/node.ts
+++ b/packages/duckdb-wasm-runtime/src/node.ts
@@ -11,6 +11,19 @@ import type {
 import { ICEBERG_HTTP_UNAVAILABLE } from './networkPolicy';
 import type { RuntimeRequestInput, RuntimeResponse } from './protocol';
 
+export {
+	IcebergHttpBroker,
+	IcebergHttpBrokerError,
+	type IcebergHttpBrokerCapability,
+	type IcebergHttpBrokerErrorCode,
+	type IcebergHttpBrokerMethod,
+	type IcebergHttpBrokerRequest,
+	type IcebergHttpBrokerResponse,
+	type IcebergHttpBrokerRoute,
+	type IcebergHttpBrokerTransport,
+	type IcebergHttpBrokerTransportRequest,
+} from './icebergHttpBroker';
+
 export type DuckDBWasmRuntimeMode = 'auto' | 'worker' | 'inline';
 
 export interface NodeDuckDBWasmCapabilities {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -566,7 +566,10 @@ describe('DataBrowserPage', () => {
 		expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/browse/objects'))).toBe(
 			true,
 		);
-		expect(screen.getByRole('group', { name: 'Object filters' })).toHaveClass('grid-cols-2');
+		expect(screen.getByRole('group', { name: 'Object filters' })).toHaveClass(
+			'grid-cols-2',
+			'xl:grid-cols-4',
+		);
 	});
 
 	it('selects among discovered buckets and reports empty or failed discovery', async () => {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -354,18 +354,17 @@ afterEach(() => {
 });
 
 describe('DataBrowserPage', () => {
-	it('renders only supported surface buttons when Query is blocked', async () => {
+	it('hides Query when the server reports it unavailable', async () => {
 		setup(`/projects/${PID}/data/${IID}`, {
 			role: 'manager',
 			querySurface: { available: false, reason: 'Broker unavailable.' },
 		});
 
-		expect(
-			await screen.findByRole('button', { name: 'Tables' }, { timeout: 5000 }),
-		).toBeInTheDocument();
-		expect(screen.getByRole('button', { name: 'Query' })).toBeDisabled();
+		await screen.findByTestId('browse-namespace', undefined, { timeout: 5000 });
+		expect(screen.queryByRole('button', { name: 'Tables' })).not.toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Query' })).not.toBeInTheDocument();
 		expect(screen.queryByRole('button', { name: 'Objects' })).not.toBeInTheDocument();
-		expect(screen.getByText('Run SQL unavailable: Broker unavailable.')).toBeInTheDocument();
+		expect(screen.queryByText(/Run SQL unavailable/)).not.toBeInTheDocument();
 	});
 
 	it('restores a deep link: tree expanded to the namespace, table selected, schema shown', async () => {
@@ -567,6 +566,7 @@ describe('DataBrowserPage', () => {
 		expect(fetchImpl.mock.calls.some(([url]) => String(url).includes('/browse/objects'))).toBe(
 			true,
 		);
+		expect(screen.getByRole('group', { name: 'Object filters' })).toHaveClass('grid-cols-2');
 	});
 
 	it('selects among discovered buckets and reports empty or failed discovery', async () => {
@@ -710,6 +710,8 @@ describe('DataBrowserPage', () => {
 		expect(
 			await screen.findByText('Object listing failed. Check ListBucket access.'),
 		).toBeInTheDocument();
+		expect(screen.queryByLabelText('Filter loaded objects')).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Retry loading objects' })).toBeInTheDocument();
 	});
 
 	it('round-trips object selection in the URL and loads previews only on request', async () => {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -717,6 +717,23 @@ describe('DataBrowserPage', () => {
 		expect(screen.getByRole('button', { name: 'Retry loading objects' })).toBeInTheDocument();
 	});
 
+	it('keeps parent-prefix navigation available when the initial listing fails', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&prefix=daily%2F`, {
+			kind: objectKind,
+			entry: { ...lakeEntry, kind: 's3' },
+			objectFailures: { objects: 'Object listing failed. Check ListBucket access.' },
+		});
+
+		const parentPrefix = await screen.findByRole('button', { name: 'Parent prefix' });
+		expect(
+			await screen.findByRole('button', { name: 'Retry loading objects' }),
+		).toBeInTheDocument();
+		await user.click(parentPrefix);
+
+		await waitFor(() => expect(screen.getByTestId('location')).not.toHaveTextContent('prefix='));
+	});
+
 	it('round-trips object selection in the URL and loads previews only on request', async () => {
 		const user = userEvent.setup();
 		const fetchImpl = setup(

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -258,7 +258,7 @@ export default function DataBrowserPage() {
 				[
 					supportsTableBrowse(selectedKind),
 					supportsObjectBrowse(selectedKind),
-					canManageQueries && querySurface !== undefined,
+					querySurfaceAvailable,
 				].filter(Boolean).length > 1 && (
 					<div
 						className="flex w-fit rounded-md border border-input p-1"
@@ -282,22 +282,17 @@ export default function DataBrowserPage() {
 								Objects
 							</Button>
 						) : null}
-						{canManageQueries && querySurface ? (
+						{querySurfaceAvailable ? (
 							<Button
 								size="sm"
 								variant={selectedSurface === 'query' ? 'primary' : 'ghost'}
 								onPress={() => selectSurface('query')}
-								isDisabled={!querySurface.available}
 							>
 								Query
 							</Button>
 						) : null}
 					</div>
 				)}
-			{canManageQueries && querySurface?.available === false && querySurface.reason ? (
-				<p className="text-xs text-muted-foreground">Run SQL unavailable: {querySurface.reason}</p>
-			) : null}
-
 			{!available ? (
 				<EmptyState
 					icon={<Database />}

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -397,7 +397,7 @@ export function ObjectBrowser({
 							{listError && !initialListError && (
 								<p className="p-3 text-sm text-destructive">{errorMessage(listError)}</p>
 							)}
-							{!initialListError && prefix && !activeSearchQuery && (
+							{prefix && !activeSearchQuery && (
 								<button
 									type="button"
 									onKeyDown={handleListKeyDown}

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -171,6 +171,8 @@ export function ObjectBrowser({
 	const parentPrefix = prefix ? prefix.replace(/[^/]+\/$/, '') : '';
 	const searchSummary = search.data?.pages.at(-1);
 	const listError = activeSearchQuery ? search.error : listing.error;
+	const results = activeSearchQuery ? search : listing;
+	const initialListError = listError && results.data === undefined;
 	const { copy: copySelection } = useCopyToClipboard();
 	const copySelectedUris = () => {
 		const keys = selectedKeys.size > 0 ? [...selectedKeys] : key ? [key] : [];
@@ -308,63 +310,68 @@ export function ObjectBrowser({
 								)}
 							</div>
 						)}
-						<TextField
-							name="loaded-object-filter"
-							autoComplete="off"
-							spellCheck="false"
-							aria-label="Filter loaded objects"
-							placeholder="Filter loaded results…"
-							value={filter}
-							onChange={setFilter}
-						/>
-						<div className="grid grid-cols-2 gap-2 text-xs xl:grid-cols-4">
-							<ObjectFilterSelect
-								label="Type"
-								name="object-format-filter"
-								value={formatFilter}
-								onChange={setFormatFilter}
-							>
-								<option value="all">All loaded types</option>
-								<option value="data">Data</option>
-								<option value="text">Text</option>
-								<option value="image">Images</option>
-								<option value="other">Other</option>
-							</ObjectFilterSelect>
-							<ObjectFilterSelect
-								label="Size"
-								name="object-size-filter"
-								value={sizeFilter}
-								onChange={setSizeFilter}
-							>
-								<option value="all">Any loaded size</option>
-								<option value="small">Under 1 MiB</option>
-								<option value="medium">1–100 MiB</option>
-								<option value="large">100 MiB+</option>
-							</ObjectFilterSelect>
-							<label className="flex flex-col gap-1 text-muted-foreground">
-								Modified after
-								<input
-									type="date"
-									aria-label="Modified after"
-									name="object-modified-after"
-									autoComplete="off"
-									value={modifiedAfter}
-									onChange={(event) => setModifiedAfter(event.target.value)}
-									className="h-9 rounded-md border border-input bg-background px-2 text-foreground"
-								/>
-							</label>
-							<ObjectFilterSelect
-								label="Sort loaded results"
-								name="object-sort"
-								value={sort}
-								onChange={setSort}
-							>
-								<option value="name-asc">Name A–Z</option>
-								<option value="name-desc">Name Z–A</option>
-								<option value="size-desc">Largest first</option>
-								<option value="modified-desc">Newest first</option>
-							</ObjectFilterSelect>
-						</div>
+						{!initialListError && (
+							<TextField
+								name="loaded-object-filter"
+								autoComplete="off"
+								spellCheck="false"
+								aria-label="Filter loaded objects"
+								placeholder="Filter loaded results…"
+								value={filter}
+								onChange={setFilter}
+							/>
+						)}
+						{!initialListError && (
+							<fieldset className="grid grid-cols-2 gap-2 text-xs">
+								<legend className="sr-only">Object filters</legend>
+								<ObjectFilterSelect
+									label="Type"
+									name="object-format-filter"
+									value={formatFilter}
+									onChange={setFormatFilter}
+								>
+									<option value="all">All loaded types</option>
+									<option value="data">Data</option>
+									<option value="text">Text</option>
+									<option value="image">Images</option>
+									<option value="other">Other</option>
+								</ObjectFilterSelect>
+								<ObjectFilterSelect
+									label="Size"
+									name="object-size-filter"
+									value={sizeFilter}
+									onChange={setSizeFilter}
+								>
+									<option value="all">Any loaded size</option>
+									<option value="small">Under 1 MiB</option>
+									<option value="medium">1–100 MiB</option>
+									<option value="large">100 MiB+</option>
+								</ObjectFilterSelect>
+								<label className="flex flex-col gap-1 text-muted-foreground">
+									Modified after
+									<input
+										type="date"
+										aria-label="Modified after"
+										name="object-modified-after"
+										autoComplete="off"
+										value={modifiedAfter}
+										onChange={(event) => setModifiedAfter(event.target.value)}
+										className="h-9 rounded-md border border-input bg-background px-2 text-foreground"
+									/>
+								</label>
+								<ObjectFilterSelect
+									label="Sort loaded results"
+									name="object-sort"
+									value={sort}
+									onChange={setSort}
+								>
+									<option value="name-asc">Name A–Z</option>
+									<option value="name-desc">Name Z–A</option>
+									<option value="size-desc">Largest first</option>
+									<option value="modified-desc">Newest first</option>
+								</ObjectFilterSelect>
+							</fieldset>
+						)}
 						{selectedKeys.size > 0 && (
 							<Button size="sm" onPress={copySelectedUris}>
 								Copy {selectedKeys.size} selected URI{selectedKeys.size === 1 ? '' : 's'}
@@ -377,10 +384,20 @@ export function ObjectBrowser({
 								{searchSummary.complete ? '.' : '; more may exist.'}
 							</output>
 						)}
-						{listError && <p className="text-sm text-destructive">{errorMessage(listError)}</p>}
 						<fieldset className="min-h-0 flex-1 overflow-y-auto">
 							<legend className="sr-only">Objects</legend>
-							{prefix && !activeSearchQuery && (
+							{initialListError && (
+								<div className="flex min-h-40 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-4 text-center">
+									<p className="text-sm text-destructive">{errorMessage(listError)}</p>
+									<Button onPress={() => void results.refetch()}>
+										{activeSearchQuery ? 'Retry search' : 'Retry loading objects'}
+									</Button>
+								</div>
+							)}
+							{listError && !initialListError && (
+								<p className="p-3 text-sm text-destructive">{errorMessage(listError)}</p>
+							)}
+							{!initialListError && prefix && !activeSearchQuery && (
 								<button
 									type="button"
 									onKeyDown={handleListKeyDown}
@@ -390,57 +407,59 @@ export function ObjectBrowser({
 									<ArrowUp className="size-4" aria-hidden /> Parent prefix
 								</button>
 							)}
-							{entries.map((entry) => (
-								<button
-									key={`${entry.kind}:${entry.key}`}
-									data-object-row
-									type="button"
-									aria-pressed={entry.kind === 'object' && selectedKeys.has(entry.key)}
-									onKeyDown={handleListKeyDown}
-									onClick={(event) => selectEntry(entry, event)}
-									className={cn(
-										'grid w-full touch-manipulation grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-md:min-h-11 [content-visibility:auto] [contain-intrinsic-size:auto_44px]',
-										entry.kind === 'object' &&
-											selectedKeys.has(entry.key) &&
-											'bg-primary/10 text-primary',
-									)}
-								>
-									{entry.kind === 'prefix' ? (
-										<Folder className="size-4" aria-hidden />
-									) : (
-										<File className="size-4" aria-hidden />
-									)}
-									<span className="min-w-0">
-										<span className="block truncate">{entry.name}</span>
-										{entry.kind === 'object' && (
-											<span className="block truncate text-[11px] text-muted-foreground">
-												{[objectFormatLabel(entry.name), entry.storage_class, entry.etag]
-													.filter(Boolean)
-													.join(' · ')}
-											</span>
+							{!initialListError &&
+								entries.map((entry) => (
+									<button
+										key={`${entry.kind}:${entry.key}`}
+										data-object-row
+										type="button"
+										aria-pressed={entry.kind === 'object' && selectedKeys.has(entry.key)}
+										onKeyDown={handleListKeyDown}
+										onClick={(event) => selectEntry(entry, event)}
+										className={cn(
+											'grid w-full touch-manipulation grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-2 text-left hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring max-md:min-h-11 [content-visibility:auto] [contain-intrinsic-size:auto_44px]',
+											entry.kind === 'object' &&
+												selectedKeys.has(entry.key) &&
+												'bg-primary/10 text-primary',
 										)}
-									</span>
-									<span className="text-right text-xs text-muted-foreground tabular-nums">
-										{entry.size === undefined ? '' : formatBytes(entry.size)}
-										{entry.last_modified && (
-											<span className="block">{formatDateTime(entry.last_modified)}</span>
+									>
+										{entry.kind === 'prefix' ? (
+											<Folder className="size-4" aria-hidden />
+										) : (
+											<File className="size-4" aria-hidden />
 										)}
-									</span>
-								</button>
-							))}
-							{entries.length === 0 && (listing.data || search.data) && (
+										<span className="min-w-0">
+											<span className="block truncate">{entry.name}</span>
+											{entry.kind === 'object' && (
+												<span className="block truncate text-[11px] text-muted-foreground">
+													{[objectFormatLabel(entry.name), entry.storage_class, entry.etag]
+														.filter(Boolean)
+														.join(' · ')}
+												</span>
+											)}
+										</span>
+										<span className="text-right text-xs text-muted-foreground tabular-nums">
+											{entry.size === undefined ? '' : formatBytes(entry.size)}
+											{entry.last_modified && (
+												<span className="block">{formatDateTime(entry.last_modified)}</span>
+											)}
+										</span>
+									</button>
+								))}
+							{!initialListError && entries.length === 0 && (listing.data || search.data) && (
 								<p className="p-4 text-center text-xs text-muted-foreground">No objects found.</p>
 							)}
-							{(activeSearchQuery ? search.hasNextPage : listing.hasNextPage) && (
-								<Button
-									className="mt-2 w-full"
-									onPress={() =>
-										void (activeSearchQuery ? search.fetchNextPage() : listing.fetchNextPage())
-									}
-								>
-									{activeSearchQuery ? 'Continue search' : 'Load more'}
-								</Button>
-							)}
+							{!initialListError &&
+								(activeSearchQuery ? search.hasNextPage : listing.hasNextPage) && (
+									<Button
+										className="mt-2 w-full"
+										onPress={() =>
+											void (activeSearchQuery ? search.fetchNextPage() : listing.fetchNextPage())
+										}
+									>
+										{activeSearchQuery ? 'Continue search' : 'Load more'}
+									</Button>
+								)}
 						</fieldset>
 					</>
 				)}

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -322,7 +322,7 @@ export function ObjectBrowser({
 							/>
 						)}
 						{!initialListError && (
-							<fieldset className="grid grid-cols-2 gap-2 text-xs">
+							<fieldset className="grid grid-cols-2 gap-2 text-xs xl:grid-cols-4">
 								<legend className="sr-only">Object filters</legend>
 								<ObjectFilterSelect
 									label="Type"


### PR DESCRIPTION
Test connection now works for object-store integrations (S3/GCS/Azure). It probes the object browser's `capability`, then does a minimal `listObjects` (when a bucket is configured) or `listBuckets` call, in addition to the existing `testConnection` path.

- Plumbs `ObjectBrowseContext` through the project and org `test` routes.
- Gates `supports_test` on an actual testable path (`testConnection` or an enabled object browser), rather than the descriptor flag alone.
- Warns (`integration_query_unavailable`) when a query surface is unavailable while the data-browser query flag is on.
- Tightens the `ObjectBrowser` UI.