### PR TITLE
feat(runtime): infer launch strategy per source, honor PEP 723 inline metadata

### DIFF
--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -59,21 +59,21 @@ uv sync --inexact --no-compile-bytecode   # add the notebook's deps to the base 
 uv run --no-sync marimo edit notebook.py --headless --no-token --host 0.0.0.0 --port 2718
 ```
 
-For a git-synced notebook whose entry file declares
-[PEP 723](https://peps.python.org/pep-0723/) inline metadata, two more setup
-commands run between the sync and the launch, installing the declared pins on
-top of the base env:
+If a git-synced notebook's entry file contains
+[PEP 723](https://peps.python.org/pep-0723/) inline metadata, marimohub runs three
+more setup commands. These commands run after the project sync and install the
+inline dependencies into the base environment:
 
 ```sh
-uv export --script notebook.py --format requirements-txt --no-hashes -o /tmp/marimohub-script-requirements.txt
+uv export --script notebook.py --format requirements-txt --no-hashes -o /tmp/marimohub-script-requirements-$$.txt
 [ -d "${UV_PROJECT_ENVIRONMENT:-.venv}" ] || uv venv "${UV_PROJECT_ENVIRONMENT:-.venv}"
-uv pip install --python "${UV_PROJECT_ENVIRONMENT:-.venv}" --no-build -r /tmp/marimohub-script-requirements.txt
+uv pip install --python "${UV_PROJECT_ENVIRONMENT:-.venv}" --no-build -r /tmp/marimohub-script-requirements-$$.txt
 ```
 
-Unlike the lenient pyproject sync, a failed pin install fails the session —
-declared pins are never silently ignored. A notebook pinning `marimo` itself
-replaces the image's pinned marimo for that sandbox, which can mismatch a
-CDN-served frontend (`--asset-url`).
+A failed project sync does not stop the session. In contrast, a failure in these
+three commands stops the session, so marimohub never ignores inline dependencies.
+If the metadata pins `marimo`, it replaces the image's version for that sandbox.
+The replacement can be incompatible with a frontend served through `--asset-url`.
 
 So your image must provide:
 

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -65,9 +65,9 @@ more setup commands. These commands run after the project sync and install the
 inline dependencies into the base environment:
 
 ```sh
-uv export --script notebook.py --format requirements-txt --no-hashes -o /tmp/marimohub-script-requirements-$$.txt
 [ -d "${UV_PROJECT_ENVIRONMENT:-.venv}" ] || uv venv "${UV_PROJECT_ENVIRONMENT:-.venv}"
-uv pip install --python "${UV_PROJECT_ENVIRONMENT:-.venv}" --no-build -r /tmp/marimohub-script-requirements-$$.txt
+uv export --script notebook.py --format requirements-txt --no-hashes -o "${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"
+uv pip install --python "${UV_PROJECT_ENVIRONMENT:-.venv}" --no-build -r "${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"
 ```
 
 A failed project sync does not stop the session. In contrast, a failure in these

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -59,6 +59,22 @@ uv sync --inexact --no-compile-bytecode   # add the notebook's deps to the base 
 uv run --no-sync marimo edit notebook.py --headless --no-token --host 0.0.0.0 --port 2718
 ```
 
+For a git-synced notebook whose entry file declares
+[PEP 723](https://peps.python.org/pep-0723/) inline metadata, two more setup
+commands run between the sync and the launch, installing the declared pins on
+top of the base env:
+
+```sh
+uv export --script notebook.py --format requirements-txt --no-hashes -o /tmp/marimohub-script-requirements.txt
+[ -d "${UV_PROJECT_ENVIRONMENT:-.venv}" ] || uv venv "${UV_PROJECT_ENVIRONMENT:-.venv}"
+uv pip install --python "${UV_PROJECT_ENVIRONMENT:-.venv}" --no-build -r /tmp/marimohub-script-requirements.txt
+```
+
+Unlike the lenient pyproject sync, a failed pin install fails the session —
+declared pins are never silently ignored. A notebook pinning `marimo` itself
+replaces the image's pinned marimo for that sandbox, which can mismatch a
+CDN-served frontend (`--asset-url`).
+
 So your image must provide:
 
 1. **`uv` on `PATH`** — the launch command is `uv sync` + `uv run …`.

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -253,6 +253,23 @@ POST /api/v1/projects/{pid}/notebooks/{nid}/sync-token/rotate
 
 Returns a fresh `sync_url` + `sync_token`.
 
+## Dependencies
+
+A session's environment is built from what the push contained, layered onto the
+sandbox image's pre-installed base:
+
+- A `pyproject.toml` at the synced root is applied with `uv sync --inexact` —
+  its dependencies are added to the base environment. This layer is lenient: a
+  broken pyproject falls back to the base environment.
+- [PEP 723](https://peps.python.org/pep-0723/) inline metadata
+  (`# /// script … # ///`) in the entry notebook is detected automatically and
+  installed on top via `uv export --script` + `uv pip install`. This layer is
+  strict: an unsatisfiable pin fails the session with uv's resolver error
+  (declared pins are never silently ignored).
+
+Both compose — the inline pins are applied last, so they win on conflicts. No
+configuration is needed; the strategy is inferred per notebook at session start.
+
 ## Read-only sessions
 
 Sessions on a synced notebook are **ephemeral**: the sandbox is populated from

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -255,20 +255,20 @@ Returns a fresh `sync_url` + `sync_token`.
 
 ## Dependencies
 
-A session's environment is built from what the push contained, layered onto the
-sandbox image's pre-installed base:
+A session environment starts with the packages in the sandbox image. marimohub
+then applies dependency sources from the pushed archive in this order:
 
-- A `pyproject.toml` at the synced root is applied with `uv sync --inexact` —
-  its dependencies are added to the base environment. This layer is lenient: a
-  broken pyproject falls back to the base environment.
+- If the synced root contains `pyproject.toml`, `uv sync --inexact` adds its
+  dependencies to the base environment. If this command fails, the session
+  continues with the base environment.
 - [PEP 723](https://peps.python.org/pep-0723/) inline metadata
-  (`# /// script … # ///`) in the entry notebook is detected automatically and
-  installed on top via `uv export --script` + `uv pip install`. This layer is
-  strict: an unsatisfiable pin fails the session with uv's resolver error
-  (declared pins are never silently ignored).
+  (`# /// script … # ///`) in the entry notebook adds another dependency layer.
+  marimohub installs these dependencies with `uv export --script` and
+  `uv pip install`. If uv cannot resolve them, the session fails.
 
-Both compose — the inline pins are applied last, so they win on conflicts. No
-configuration is needed; the strategy is inferred per notebook at session start.
+If both sources declare the same package, the inline metadata takes precedence.
+No configuration is necessary. marimohub selects the dependency strategy when
+the session starts.
 
 ## Read-only sessions
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -121,6 +121,22 @@ provide, or the namespace may lack sufficient quota. Check the Pod's
 out-of-memory during dependency installation, use a larger compute profile and
 start a new session.
 
+### Session fails with a uv resolver error
+
+A git-synced notebook declaring [PEP 723](https://peps.python.org/pep-0723/)
+inline metadata has its pins installed at session start, and an unsatisfiable
+pin fails the session **by design** — declared pins are never silently ignored.
+Fix the pins in the repo and push again. Source builds are also disallowed on
+the launch path (`--no-build`): pin versions that ship wheels.
+
+### Git-synced session with heavy inline dependencies times out
+
+Inline pins install before the kernel binds its port, so a large dependency set
+(e.g. torch) can exceed the startup window. Raise
+`MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS`, or pre-install the heavy packages
+in the sandbox image so only the delta installs at launch. See
+[Sandbox image](/sandbox-image).
+
 ## Check a live deployment
 
 `GET /api/health?deep=true` probes every downstream dependency and reports each

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -123,19 +123,18 @@ start a new session.
 
 ### Session fails with a uv resolver error
 
-A git-synced notebook declaring [PEP 723](https://peps.python.org/pep-0723/)
-inline metadata has its pins installed at session start, and an unsatisfiable
-pin fails the session **by design** — declared pins are never silently ignored.
-Fix the pins in the repo and push again. Source builds are also disallowed on
-the launch path (`--no-build`): pin versions that ship wheels.
+When a git-synced notebook contains [PEP 723](https://peps.python.org/pep-0723/)
+inline metadata, marimohub installs its dependencies at session start. If uv
+cannot resolve these dependencies, the session fails. Fix the versions in the
+repository, and then push again. marimohub also disables source builds with
+`--no-build`, so use package versions that provide wheels.
 
 ### Git-synced session with heavy inline dependencies times out
 
-Inline pins install before the kernel binds its port, so a large dependency set
-(e.g. torch) can exceed the startup window. Raise
-`MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS`, or pre-install the heavy packages
-in the sandbox image so only the delta installs at launch. See
-[Sandbox image](/sandbox-image).
+marimohub installs inline dependencies before the kernel binds its port. A large
+package, such as torch, can exceed the startup timeout. Increase
+`MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS`, or pre-install large packages in the
+sandbox image. See [Sandbox image](/sandbox-image).
 
 ## Check a live deployment
 

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -137,6 +137,128 @@ describe('Session routes', () => {
 		expect(await services.sessions.listSessions(meta.id)).toHaveLength(0);
 	});
 
+	describe('launch strategy inference', () => {
+		const enc = (s: string) => new TextEncoder().encode(s);
+		const INLINE_CODE = '# /// script\n# dependencies = ["cowsay==6.1"]\n# ///\nimport cowsay';
+		// Nested on purpose: catches a workspace-relative vs repo-relative join bug.
+		const ENTRY = 'apps/dash.py';
+
+		async function createSyncedNotebook(entryCode: string): Promise<NotebookId> {
+			const services = createServices(bucket);
+			const { meta } = await services.notebooks.synced.create(
+				pid,
+				{
+					title: 'GitHub NB',
+					description: 'd',
+					repo: 'org/repo',
+					branch: 'main',
+					entry_notebook: ENTRY,
+				},
+				ACTOR,
+			);
+			await services.notebooks.synced.sync(pid, meta.id, {
+				repo: 'org/repo',
+				branch: 'main',
+				root_path: '',
+				commit: 'commit-aaaa',
+				files: [{ path: ENTRY, bytes: enc(entryCode) }],
+			});
+			return meta.id;
+		}
+
+		const entryReads = (spy: { mock: { calls: unknown[][] } }) =>
+			spy.mock.calls.filter(([key]) => String(key).endsWith(ENTRY)).length;
+
+		async function startSessionApi(notebookId: NotebookId) {
+			const sb = makeFakeSandbox();
+			const api = createTestApi({
+				bucket,
+				userId: ACTOR,
+				compute: fakeComputeFrom(sb.instance),
+			}).request;
+			return {
+				sb,
+				post: () => api('POST', `/projects/${pid}/notebooks/${notebookId}/sessions`),
+			};
+		}
+
+		it('installs PEP 723 pins for a git-synced entry notebook that declares them', async () => {
+			const synced = await createSyncedNotebook(INLINE_CODE);
+			const { sb, post } = await startSessionApi(synced);
+			await expectOk<ApiSession>(await post());
+			const cmd = sb.calls.startProcess[0].cmd;
+			expect(cmd).toContain("uv export --script 'apps/dash.py'");
+			expect(cmd).toContain('uv pip install');
+			// The repo pyproject layer still applies underneath the pins.
+			expect(cmd).toContain('uv sync --inexact');
+		});
+
+		it('uses the project-managed env for a git-synced notebook without inline metadata', async () => {
+			const synced = await createSyncedNotebook('import marimo');
+			const { sb, post } = await startSessionApi(synced);
+			await expectOk<ApiSession>(await post());
+			expect(sb.calls.startProcess[0].cmd).toContain('uv sync --inexact');
+			expect(sb.calls.startProcess[0].cmd).not.toContain('uv export');
+		});
+
+		it('ignores inline metadata in a local notebook (deps live in pyproject.toml)', async () => {
+			const services = createServices(bucket);
+			const local = await services.notebooks.createNotebook(
+				pid,
+				{ title: 'Local NB', description: 'd', code: INLINE_CODE },
+				ACTOR,
+			);
+			const { sb, post } = await startSessionApi(local.id as NotebookId);
+			await expectOk<ApiSession>(await post());
+			expect(sb.calls.startProcess[0].cmd).toContain('uv sync --inexact');
+			expect(sb.calls.startProcess[0].cmd).not.toContain('uv export');
+		});
+
+		it('does not re-read the entry file when reusing an existing session', async () => {
+			const synced = await createSyncedNotebook(INLINE_CODE);
+			const { post } = await startSessionApi(synced);
+			await expectOk<ApiSession>(await post());
+			const get = vi.spyOn(bucket, 'get');
+			const reused = await expectOk<ApiSession>(await post());
+			expect(reused.reused).toBe(true);
+			expect(entryReads(get)).toBe(0);
+		});
+
+		it('still starts the session with the default strategy when the entry file is unreadable', async () => {
+			const synced = await createSyncedNotebook(INLINE_CODE);
+			// Simulate a torn read of the immutable workspace (object missing).
+			const { objects } = await bucket.list();
+			const entryKey = objects.find((o) => o.key.endsWith(ENTRY))!.key;
+			await bucket.delete(entryKey);
+			const { sb, post } = await startSessionApi(synced);
+			await expectOk<ApiSession>(await post());
+			expect(sb.calls.startProcess[0].cmd).toContain('uv sync --inexact');
+			expect(sb.calls.startProcess[0].cmd).not.toContain('uv export');
+		});
+
+		it('rejects an unsynced notebook before reading any entry file', async () => {
+			const services = createServices(bucket);
+			const { meta } = await services.notebooks.synced.create(
+				pid,
+				{
+					title: 'Unsynced',
+					description: 'd',
+					repo: 'org/repo',
+					branch: 'main',
+					entry_notebook: ENTRY,
+				},
+				ACTOR,
+			);
+			const get = vi.spyOn(bucket, 'get');
+			await expectError(
+				await owner('POST', `/projects/${pid}/notebooks/${meta.id}/sessions`),
+				409,
+				'CONFLICT',
+			);
+			expect(entryReads(get)).toBe(0);
+		});
+	});
+
 	it('POST /sessions as the owner (editor) creates a running session', async () => {
 		const data = await expectOk<ApiSession>(await owner('POST', sessionsPath()));
 		expect(data.session_id).toMatch(/^sess-/);

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1035,13 +1035,6 @@ app.openapi(createSession, async (c) => {
 	// In subdomain mode clientUrl === url and originUrl is unset.
 	let clientUrl = '';
 	let originUrl: string | undefined;
-	// After the reuse/cap short-circuits on purpose: the synced-entry GET is
-	// only worth paying when a sandbox is actually provisioned.
-	const resolvedLaunchStrategy = await resolveLaunchStrategyForSession({
-		entryNotebook: workspacePolicy.entryNotebook,
-		workspacePrefix,
-		bucket: bucketHandle,
-	});
 	const observer = logObserver({
 		event: 'session_provision',
 		sandbox_id: sandboxId,
@@ -1050,8 +1043,6 @@ app.openapi(createSession, async (c) => {
 		user_id: user.id,
 		mode,
 	});
-	observer.tag('launch_strategy', resolvedLaunchStrategy.strategy);
-	observer.tag('launch_strategy_detection_failed', resolvedLaunchStrategy.detectionFailed);
 	try {
 		await saga(observer)
 			.step('session_record', async () => {
@@ -1240,7 +1231,19 @@ app.openapi(createSession, async (c) => {
 					const sessionEnv = resolveSessionEnv();
 					void sessionEnv.catch(() => {});
 
+					// Inside this step on purpose: only a create that survived the reuse
+					// fast path and cap_recheck pays the synced-entry GET. Never rejects
+					// (a failed read falls back to the default strategy).
+					const launchStrategyPromise = resolveLaunchStrategyForSession({
+						entryNotebook: workspacePolicy.entryNotebook,
+						workspacePrefix,
+						bucket: bucketHandle,
+					});
+
 					const { baseUrl } = await sandboxExposure.prepare(exposureCtx);
+					const resolvedLaunchStrategy = await launchStrategyPromise;
+					observer.tag('launch_strategy', resolvedLaunchStrategy.strategy);
+					observer.tag('launch_strategy_detection_failed', resolvedLaunchStrategy.detectionFailed);
 
 					const provisionResult = await provisioner.provision({
 						sandboxId,

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -30,6 +30,7 @@ import {
 	requireRole,
 	roleAtLeast,
 	resolveBaseImage,
+	resolveLaunchStrategyForSession,
 	resolveRestoreSnapshot,
 	recipientFromIdentity,
 	ResourceExhaustedError,
@@ -1034,6 +1035,13 @@ app.openapi(createSession, async (c) => {
 	// In subdomain mode clientUrl === url and originUrl is unset.
 	let clientUrl = '';
 	let originUrl: string | undefined;
+	// After the reuse/cap short-circuits on purpose: the synced-entry GET is
+	// only worth paying when a sandbox is actually provisioned.
+	const resolvedLaunchStrategy = await resolveLaunchStrategyForSession({
+		entryNotebook: workspacePolicy.entryNotebook,
+		workspacePrefix,
+		bucket: bucketHandle,
+	});
 	const observer = logObserver({
 		event: 'session_provision',
 		sandbox_id: sandboxId,
@@ -1042,6 +1050,8 @@ app.openapi(createSession, async (c) => {
 		user_id: user.id,
 		mode,
 	});
+	observer.tag('launch_strategy', resolvedLaunchStrategy.strategy);
+	observer.tag('launch_strategy_detection_failed', resolvedLaunchStrategy.detectionFailed);
 	try {
 		await saga(observer)
 			.step('session_record', async () => {
@@ -1249,6 +1259,7 @@ app.openapi(createSession, async (c) => {
 						userHome,
 						sessionEnv,
 						entryNotebook: workspacePolicy.entryNotebook,
+						launchStrategy: resolvedLaunchStrategy.strategy,
 						launchMode: mode,
 						// Ephemeral and app sandboxes never mount the live workspace: a mount
 						// writes straight through to the bucket (bypassing every persistEdits

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -1,7 +1,9 @@
-import { access, rm } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import type { SandboxId } from '@marimo-hub/core';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
 import type { SandboxInstance } from '@marimo-hub/core/ports';
@@ -13,6 +15,7 @@ import {
 	CONTRACT_SANDBOX_ID,
 	CONTRACT_VISIBLE_FILE,
 } from '@marimo-hub/core/testing/compute-contract';
+import { buildMarimoLaunch } from '@marimo-hub/core';
 import { LocalCompute, prepareMarimoCommand, rewriteWorkspace } from './index';
 
 const compute = new LocalCompute();
@@ -137,6 +140,75 @@ describe('prepareMarimoCommand (pure)', () => {
 		expect(prepareMarimoCommand('uv run marimo edit -c "a && b"', '0.0.0.0')).toBe(
 			'uv run --with marimo marimo edit -c "a && b" --host 0.0.0.0',
 		);
+	});
+
+	it('rewrites only the launch segment of the composed uv-script-pins command', () => {
+		const plan = buildMarimoLaunch(
+			{ notebookFile: 'apps/dash.py', port: 2718, host: '0.0.0.0' },
+			'uv-script-pins',
+		);
+		const command = [...plan.setup, plan.start].join(' && ');
+		const prepared = prepareMarimoCommand(command, '0.0.0.0');
+		expect(prepared.split(' && ').slice(0, -1)).toEqual(command.split(' && ').slice(0, -1));
+		expect(prepared).toContain('uv run --with marimo --no-sync marimo edit');
+		expect(prepared.match(/--with marimo/g)).toHaveLength(1);
+		// The strategy's own --host must not be doubled by the bind-host append.
+		expect(prepared.match(/--host/g)).toHaveLength(1);
+	});
+});
+
+// Runs the real setup commands through `sh` with a logging uv stub — locally
+// (unlike in a sandbox image) UV_PROJECT_ENVIRONMENT and VIRTUAL_ENV are
+// typically unset, and the pin install must fall back to `.venv` rather than
+// expanding to `--python ""`.
+describe('uv-script-pins setup execution', () => {
+	const setup = buildMarimoLaunch(
+		{ notebookFile: 'app.py', port: 2718, host: '127.0.0.1' },
+		'uv-script-pins',
+	).setup.join(' && ');
+
+	async function runSetup(extraEnv: Record<string, string>) {
+		const dir = await mkdtemp(path.join(os.tmpdir(), 'marimohub-uvstub-'));
+		const workdir = path.join(dir, 'work');
+		const logFile = path.join(dir, 'uv.log');
+		await mkdir(workdir);
+		await writeFile(
+			path.join(dir, 'uv'),
+			'#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$UV_LOG"\nif [ "$1" = venv ]; then mkdir -p "$2"; fi\n',
+			{ mode: 0o755 },
+		);
+		const env: NodeJS.ProcessEnv = {
+			...process.env,
+			PATH: `${dir}:${process.env.PATH}`,
+			UV_LOG: logFile,
+		};
+		delete env.UV_PROJECT_ENVIRONMENT;
+		delete env.VIRTUAL_ENV;
+		Object.assign(env, extraEnv);
+		try {
+			await promisify(execFile)('sh', ['-c', setup], { cwd: workdir, env });
+			return { log: await readFile(logFile, 'utf8'), workdir };
+		} finally {
+			await rm(dir, { recursive: true, force: true });
+		}
+	}
+
+	it('creates and targets .venv when UV_PROJECT_ENVIRONMENT and VIRTUAL_ENV are unset', async () => {
+		const { log } = await runSetup({});
+		expect(log).toContain('venv .venv\n');
+		expect(log).toContain('pip install --python .venv --no-build -r');
+		expect(log).not.toMatch(/--python\s+--/);
+	});
+
+	it('targets an existing UV_PROJECT_ENVIRONMENT without recreating it', async () => {
+		const envDir = await mkdtemp(path.join(os.tmpdir(), 'marimohub-envdir-'));
+		try {
+			const { log } = await runSetup({ UV_PROJECT_ENVIRONMENT: envDir });
+			expect(log).not.toContain('venv ');
+			expect(log).toContain(`pip install --python ${envDir} --no-build -r`);
+		} finally {
+			await rm(envDir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -198,6 +198,10 @@ describe('uv-script-pins setup execution', () => {
 		expect(log).toContain('venv .venv\n');
 		expect(log).toContain('pip install --python .venv --no-build -r');
 		expect(log).not.toMatch(/--python\s+--/);
+		// `$$` expanded to a real PID, identically in the export and install lines.
+		const exportPath = /-o (\S+)/.exec(log)?.[1];
+		expect(exportPath).toMatch(/marimohub-script-requirements-\d+\.txt$/);
+		expect(log).toContain(`-r ${exportPath}`);
 	});
 
 	it('targets an existing UV_PROJECT_ENVIRONMENT without recreating it', async () => {

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -198,9 +198,9 @@ describe('uv-script-pins setup execution', () => {
 		expect(log).toContain('venv .venv\n');
 		expect(log).toContain('pip install --python .venv --no-build -r');
 		expect(log).not.toMatch(/--python\s+--/);
-		// `$$` expanded to a real PID, identically in the export and install lines.
+		// The requirements file lands inside the (lifecycle-managed) pin env.
 		const exportPath = /-o (\S+)/.exec(log)?.[1];
-		expect(exportPath).toMatch(/marimohub-script-requirements-\d+\.txt$/);
+		expect(exportPath).toBe('.venv/marimohub-script-requirements.txt');
 		expect(log).toContain(`-r ${exportPath}`);
 	});
 

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -194,6 +194,10 @@ export {
 } from './runtime/sessionAuthz';
 export { signProxyToken, verifyProxyToken } from './runtime/proxyToken';
 export { resolveBaseImage } from './runtime/resolveBaseImage';
+export { resolveLaunchStrategyForSession } from './runtime/launchStrategy';
+export type { ResolvedLaunchStrategy } from './runtime/launchStrategy';
+export { buildMarimoLaunch } from './runtime/marimoLaunch';
+export type { MarimoLaunchStrategyName } from './runtime/marimoLaunch';
 export { probeKernelLiveness } from './runtime/kernelProbe';
 export type { KernelLiveness, KernelProbe, KernelProbeOptions } from './runtime/kernelProbe';
 export { runPreflight } from './runtime/preflight';

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -101,6 +101,50 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess[0].cmd).toContain('--host 0.0.0.0');
 		});
 
+		it('honors a resolved launch strategy, setup layers ordered before the kernel', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			await provisioner.provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				entryNotebook: 'apps/dash.py',
+				launchStrategy: 'uv-script-pins',
+			});
+
+			// Pins apply last so they win: pyproject → export → install → kernel.
+			const cmd = calls.startProcess[0].cmd;
+			const order = [
+				cmd.indexOf('uv sync --inexact'),
+				cmd.indexOf("uv export --script 'apps/dash.py'"),
+				cmd.indexOf('uv pip install'),
+				cmd.indexOf('marimo edit'),
+			];
+			expect(Math.min(...order)).toBeGreaterThanOrEqual(0);
+			expect(order).toEqual([...order].sort((a, b) => a - b));
+		});
+
+		it('defaults to the project-managed env when no launch strategy is given', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			await provisioner.provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+			});
+
+			const cmd = calls.startProcess[0].cmd;
+			expect(cmd).toContain('uv sync --inexact');
+			expect(cmd).not.toContain('uv export');
+			expect(cmd).not.toContain('uv pip install');
+		});
+
 		it('accepts sessionEnv as a promise, injecting it once resolved', async () => {
 			const { instance, calls } = makeFakeSandbox();
 			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -20,6 +20,7 @@ import { Stopwatch } from '../../timing';
 import type { Timings } from '../../timing';
 import { captureFilesystemSnapshot, createOrRestoreSandbox } from '../content/filesystemSnapshots';
 import { buildMarimoLaunch } from './marimoLaunch';
+import type { MarimoLaunchStrategyName } from './marimoLaunch';
 import type { NotebookService } from '../content/NotebookService';
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
 import type { WorkspaceRestoreStats } from './sandboxFiles';
@@ -118,6 +119,8 @@ export interface ProvisionOptions {
 	sessionEnv?: SessionEnv | Promise<SessionEnv | undefined>;
 	/** Workspace-relative notebook file marimo should open. Defaults to `notebook.py`. */
 	entryNotebook?: string;
+	/** Per-source launch strategy (see launchStrategy.ts). Defaults to the project-managed env. */
+	launchStrategy?: MarimoLaunchStrategyName;
 	/**
 	 * How long to wait for the marimo kernel to bind its port before failing the
 	 * provision. Covers setup too (a cold env may install/build first). Defaults
@@ -436,14 +439,17 @@ export class SandboxProvisioner {
 		mountPath: string,
 		sw: Stopwatch,
 	): Promise<void> {
-		const launch = buildMarimoLaunch({
-			notebookFile: options.entryNotebook ?? 'notebook.py',
-			port: MARIMO_PORT,
-			host: '0.0.0.0',
-			mode: options.launchMode,
-			assetUrl: options.assetUrl,
-			baseUrl: options.baseUrl,
-		});
+		const launch = buildMarimoLaunch(
+			{
+				notebookFile: options.entryNotebook ?? 'notebook.py',
+				port: MARIMO_PORT,
+				host: '0.0.0.0',
+				mode: options.launchMode,
+				assetUrl: options.assetUrl,
+				baseUrl: options.baseUrl,
+			},
+			options.launchStrategy,
+		);
 		const startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS;
 		let process: SandboxProcess | undefined;
 		let portWaitStart: number | undefined;

--- a/packages/core/src/services/runtime/launchStrategy.test.ts
+++ b/packages/core/src/services/runtime/launchStrategy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createNotebookId, createProjectId, createVersionId } from '../../ids';
+import { paths } from '../../paths';
+import { MemoryBucket } from '../../testing';
+import { resolveLaunchStrategyForSession } from './launchStrategy';
+
+const INLINE_NOTEBOOK = ['# /// script', '# dependencies = ["cowsay==6.1"]', '# ///', ''].join(
+	'\n',
+);
+const ENTRY = 'apps/dash.py';
+// The real paths helper, so a trailing-slash change in workspacePrefix breaks here.
+const PREFIX = paths
+	.project(createProjectId())
+	.notebook(createNotebookId())
+	.version(createVersionId()).workspacePrefix;
+
+async function seededBucket(entryCode: string): Promise<MemoryBucket> {
+	const bucket = new MemoryBucket();
+	await bucket.put(PREFIX + ENTRY, entryCode);
+	return bucket;
+}
+
+describe('resolveLaunchStrategyForSession', () => {
+	it('uses the default without reading the bucket when there is no synced workspace', async () => {
+		const bucket = new MemoryBucket();
+		const get = vi.spyOn(bucket, 'get');
+		const resolved = await resolveLaunchStrategyForSession({
+			entryNotebook: 'notebook.py',
+			bucket,
+		});
+		expect(resolved).toEqual({ strategy: 'uv-sync-edit', detectionFailed: false });
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	it('detects inline metadata in the synced entry file', async () => {
+		const resolved = await resolveLaunchStrategyForSession({
+			entryNotebook: ENTRY,
+			workspacePrefix: PREFIX,
+			bucket: await seededBucket(INLINE_NOTEBOOK),
+		});
+		expect(resolved).toEqual({ strategy: 'uv-script-pins', detectionFailed: false });
+	});
+
+	it('uses the default when the entry file has no inline metadata', async () => {
+		const resolved = await resolveLaunchStrategyForSession({
+			entryNotebook: ENTRY,
+			workspacePrefix: PREFIX,
+			bucket: await seededBucket('import marimo\n'),
+		});
+		expect(resolved).toEqual({ strategy: 'uv-sync-edit', detectionFailed: false });
+	});
+
+	it('falls back leniently when the entry file is missing', async () => {
+		const resolved = await resolveLaunchStrategyForSession({
+			entryNotebook: ENTRY,
+			workspacePrefix: PREFIX,
+			bucket: new MemoryBucket(),
+		});
+		expect(resolved).toEqual({ strategy: 'uv-sync-edit', detectionFailed: true });
+	});
+
+	it('falls back leniently when the bucket read throws', async () => {
+		const bucket = new MemoryBucket();
+		bucket.get = () => Promise.reject(new Error('boom'));
+		const resolved = await resolveLaunchStrategyForSession({
+			entryNotebook: ENTRY,
+			workspacePrefix: PREFIX,
+			bucket,
+		});
+		expect(resolved).toEqual({ strategy: 'uv-sync-edit', detectionFailed: true });
+	});
+
+	it('falls back leniently when the entry file fails to decode', async () => {
+		const bucket = await seededBucket(INLINE_NOTEBOOK);
+		const object = await bucket.get(PREFIX + ENTRY);
+		vi.spyOn(bucket, 'get').mockResolvedValue({
+			...object!,
+			text: () => Promise.reject(new Error('bad encoding')),
+		});
+		const resolved = await resolveLaunchStrategyForSession({
+			entryNotebook: ENTRY,
+			workspacePrefix: PREFIX,
+			bucket,
+		});
+		expect(resolved).toEqual({ strategy: 'uv-sync-edit', detectionFailed: true });
+	});
+});

--- a/packages/core/src/services/runtime/launchStrategy.ts
+++ b/packages/core/src/services/runtime/launchStrategy.ts
@@ -1,0 +1,44 @@
+import type { Bucket } from '../../ports/bucket';
+import { DEFAULT_LAUNCH_STRATEGY } from './marimoLaunch';
+import type { MarimoLaunchStrategyName } from './marimoLaunch';
+import { hasInlineScriptMetadata } from './pep723';
+
+export interface ResolvedLaunchStrategy {
+	strategy: MarimoLaunchStrategyName;
+	/** The synced entry file could not be read; fell back to the default. */
+	detectionFailed: boolean;
+}
+
+/**
+ * Infers the launch strategy per source — no user-facing configuration. Local
+ * notebooks (no `workspacePrefix`) always use the project-managed env; synced
+ * notebooks get `uv-script-pins` when their entry file declares PEP 723
+ * metadata (one GET of the immutable workspace). Never throws: a failed read
+ * falls back to the default, and the provision itself fails later if the file
+ * truly doesn't exist.
+ *
+ * Future (#143): markdown entries resolve to `uv-sandbox` here — their
+ * metadata lives in YAML frontmatter uv can't parse.
+ */
+export async function resolveLaunchStrategyForSession(opts: {
+	entryNotebook: string;
+	/** Synced sources only: `versions/{vid}/workspace/`. */
+	workspacePrefix?: string;
+	bucket: Bucket;
+}): Promise<ResolvedLaunchStrategy> {
+	if (!opts.workspacePrefix) {
+		return { strategy: DEFAULT_LAUNCH_STRATEGY, detectionFailed: false };
+	}
+	try {
+		const object = await opts.bucket.get(opts.workspacePrefix + opts.entryNotebook);
+		if (!object) return { strategy: DEFAULT_LAUNCH_STRATEGY, detectionFailed: true };
+		return {
+			strategy: hasInlineScriptMetadata(await object.text())
+				? 'uv-script-pins'
+				: DEFAULT_LAUNCH_STRATEGY,
+			detectionFailed: false,
+		};
+	} catch {
+		return { strategy: DEFAULT_LAUNCH_STRATEGY, detectionFailed: true };
+	}
+}

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -85,10 +85,13 @@ describe('buildMarimoLaunch', () => {
 			expect(plan.start).toMatch(/^uv run --no-sync marimo /);
 		});
 
-		it('shares one requirements file, outside the workspace', () => {
+		it('shares one per-launch requirements file, outside the workspace', () => {
 			const [, exportCmd, , installCmd] = plan.setup;
 			const [, exportTarget] = /-o (\S+)/.exec(exportCmd) ?? [];
 			expect(exportTarget).toMatch(/^\/tmp\//);
+			// `$$` (the launch shell's PID) keeps concurrent local sandboxes, which
+			// share the host /tmp, from clobbering each other's export.
+			expect(exportTarget).toContain('$$');
 			expect(installCmd).toContain(`-r ${exportTarget}`);
 		});
 

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -66,4 +66,59 @@ describe('buildMarimoLaunch', () => {
 		expect(setup).toContain('--name notebook');
 		expect(setup).toContain('--description "Built in marimohub"');
 	});
+
+	describe('uv-script-pins', () => {
+		const plan = buildMarimoLaunch({ ...BASE, notebookFile: 'apps/my app.py' }, 'uv-script-pins');
+
+		it('layers pyproject first, then exports and installs the script pins', () => {
+			expect(plan.setup).toHaveLength(4);
+			const [pyproject, exportCmd, ensureEnv, installCmd] = plan.setup;
+			expect(pyproject).toContain('uv sync --inexact');
+			expect(exportCmd).toContain("uv export --script 'apps/my app.py'");
+			expect(exportCmd).toContain('--format requirements-txt');
+			expect(ensureEnv).toContain('uv venv');
+			expect(installCmd).toContain('uv pip install');
+			// The env `uv run --no-sync` resolves — never VIRTUAL_ENV, which uv run
+			// ignores and would leave the pins invisible to the kernel.
+			expect(installCmd).toContain('--python "${UV_PROJECT_ENVIRONMENT:-.venv}"');
+			expect(installCmd).toContain('--no-build');
+			expect(plan.start).toMatch(/^uv run --no-sync marimo /);
+		});
+
+		it('shares one requirements file, outside the workspace', () => {
+			const [, exportCmd, , installCmd] = plan.setup;
+			const [, exportTarget] = /-o (\S+)/.exec(exportCmd) ?? [];
+			expect(exportTarget).toMatch(/^\/tmp\//);
+			expect(installCmd).toContain(`-r ${exportTarget}`);
+		});
+
+		it('keeps the pyproject layer lenient and the pin layers strict', () => {
+			const [pyproject, exportCmd, ensureEnv, installCmd] = plan.setup;
+			expect(pyproject).toContain('|| true');
+			expect(exportCmd).not.toContain('|| true');
+			expect(ensureEnv).not.toContain('|| true');
+			expect(installCmd).not.toContain('|| true');
+		});
+
+		it('reuses the exact uv-sync-edit pyproject layer', () => {
+			expect(plan.setup[0]).toBe(buildMarimoLaunch(BASE, 'uv-sync-edit').setup[0]);
+		});
+
+		it('installs the pins in app mode too (setup is mode-invariant)', () => {
+			const app = buildMarimoLaunch(
+				{ ...BASE, notebookFile: 'apps/my app.py', mode: 'app' },
+				'uv-script-pins',
+			);
+			expect(app.setup).toEqual(plan.setup);
+		});
+
+		it('shell-quotes a hostile notebook filename in the export command', () => {
+			// Filenames come from synced repos and ride a single `&&`-joined shell string.
+			const hostile = buildMarimoLaunch(
+				{ ...BASE, notebookFile: "apps/it's a && b.py" },
+				'uv-script-pins',
+			);
+			expect(hostile.setup[1]).toContain(`--script 'apps/it'\\''s a && b.py'`);
+		});
+	});
 });

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -72,11 +72,11 @@ describe('buildMarimoLaunch', () => {
 
 		it('layers pyproject first, then exports and installs the script pins', () => {
 			expect(plan.setup).toHaveLength(4);
-			const [pyproject, exportCmd, ensureEnv, installCmd] = plan.setup;
+			const [pyproject, ensureEnv, exportCmd, installCmd] = plan.setup;
 			expect(pyproject).toContain('uv sync --inexact');
+			expect(ensureEnv).toContain('uv venv');
 			expect(exportCmd).toContain("uv export --script 'apps/my app.py'");
 			expect(exportCmd).toContain('--format requirements-txt');
-			expect(ensureEnv).toContain('uv venv');
 			expect(installCmd).toContain('uv pip install');
 			// The env `uv run --no-sync` resolves — never VIRTUAL_ENV, which uv run
 			// ignores and would leave the pins invisible to the kernel.
@@ -85,21 +85,22 @@ describe('buildMarimoLaunch', () => {
 			expect(plan.start).toMatch(/^uv run --no-sync marimo /);
 		});
 
-		it('shares one per-launch requirements file, outside the workspace', () => {
-			const [, exportCmd, , installCmd] = plan.setup;
+		it('writes the requirements file inside the pin env', () => {
+			// Per-sandbox and lifecycle-managed on every backend — nothing left on a
+			// shared host /tmp, no clobbering between concurrent local launches.
+			const [, , exportCmd, installCmd] = plan.setup;
 			const [, exportTarget] = /-o (\S+)/.exec(exportCmd) ?? [];
-			expect(exportTarget).toMatch(/^\/tmp\//);
-			// `$$` (the launch shell's PID) keeps concurrent local sandboxes, which
-			// share the host /tmp, from clobbering each other's export.
-			expect(exportTarget).toContain('$$');
+			expect(exportTarget).toBe(
+				'"${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"',
+			);
 			expect(installCmd).toContain(`-r ${exportTarget}`);
 		});
 
 		it('keeps the pyproject layer lenient and the pin layers strict', () => {
-			const [pyproject, exportCmd, ensureEnv, installCmd] = plan.setup;
+			const [pyproject, ensureEnv, exportCmd, installCmd] = plan.setup;
 			expect(pyproject).toContain('|| true');
-			expect(exportCmd).not.toContain('|| true');
 			expect(ensureEnv).not.toContain('|| true');
+			expect(exportCmd).not.toContain('|| true');
 			expect(installCmd).not.toContain('|| true');
 		});
 
@@ -121,7 +122,7 @@ describe('buildMarimoLaunch', () => {
 				{ ...BASE, notebookFile: "apps/it's a && b.py" },
 				'uv-script-pins',
 			);
-			expect(hostile.setup[1]).toContain(`--script 'apps/it'\\''s a && b.py'`);
+			expect(hostile.setup[2]).toContain(`--script 'apps/it'\\''s a && b.py'`);
 		});
 	});
 });

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -80,19 +80,21 @@ function marimoCommand(p: MarimoLaunchParams, extraFlags = ''): string {
 // conflict with --no-compile-bytecode). `|| true` never blocks launch.
 const PYPROJECT_LAYER_SETUP = `if python3 -c "import tomllib,sys;sys.exit(0 if tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies') else 1)" 2>/dev/null; then uv sync --inexact --no-compile-bytecode --no-build || true; elif ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then { rm -f pyproject.toml && uv init --vcs none --name notebook --description "Built in marimohub"; } || true; fi`;
 
-// Outside the workspace (keeps the marimo file browser clean, can't clobber a
-// synced repo's own requirements.txt) and unique per launch shell: `$$` is the
-// PID of the single `sh -c` the setup runs in, so local sandboxes — which
-// share the host /tmp — can't clobber each other between export and install.
-const SCRIPT_REQUIREMENTS = '/tmp/marimohub-script-requirements-$$.txt';
-
 // The env the kernel's `uv run --no-sync` will use — uv resolves the project
 // env as UV_PROJECT_ENVIRONMENT, else `.venv` in the project dir. Deliberately
 // not VIRTUAL_ENV: `uv run` ignores it, so pins installed there would be
 // invisible to the kernel. Local dev (compute-local) has neither var nor an
 // existing env, hence the create-if-missing guard — a no-op on sandbox images,
 // whose contract pre-creates UV_PROJECT_ENVIRONMENT.
-const PIN_ENV = '"${UV_PROJECT_ENVIRONMENT:-.venv}"';
+const PIN_ENV_EXPANSION = '${UV_PROJECT_ENVIRONMENT:-.venv}';
+const PIN_ENV = `"${PIN_ENV_EXPANSION}"`;
+
+// Inside the pin env: per-sandbox on every backend (a container's env dies
+// with it; a local sandbox's .venv is removed with its root), so nothing
+// accumulates on a shared host /tmp and concurrent launches can't clobber
+// each other. Also keeps it out of workspace capture and away from a synced
+// repo's own requirements.txt.
+const SCRIPT_REQUIREMENTS = `"${PIN_ENV_EXPANSION}/marimohub-script-requirements.txt"`;
 
 export const MARIMO_LAUNCH_STRATEGIES = {
 	// marimohub's default. The sandbox image pre-installs marimo (pinned) plus
@@ -116,8 +118,8 @@ export const MARIMO_LAUNCH_STRATEGIES = {
 	'uv-script-pins': (p) => ({
 		setup: [
 			PYPROJECT_LAYER_SETUP,
-			`uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt --no-hashes -o ${SCRIPT_REQUIREMENTS}`,
 			`[ -d ${PIN_ENV} ] || uv venv ${PIN_ENV}`,
+			`uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt --no-hashes -o ${SCRIPT_REQUIREMENTS}`,
 			`uv pip install --python ${PIN_ENV} --no-build -r ${SCRIPT_REQUIREMENTS}`,
 		],
 		start: `uv run --no-sync ${marimoCommand(p)}`,

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -1,6 +1,6 @@
 /**
- * How marimo is launched inside a sandbox. Pick a strategy via ACTIVE_STRATEGY
- * below to experiment with different ways of provisioning the env.
+ * How marimo is launched inside a sandbox. Strategies are inferred per-source
+ * (see launchStrategy.ts); the default is the project-managed env.
  */
 import type { SessionMode } from '../../constants';
 import { shellQuote } from './shell';
@@ -71,45 +71,59 @@ function marimoCommand(p: MarimoLaunchParams, extraFlags = ''): string {
 	return `marimo ${subcommand} ${extraFlags}${shellQuote(p.notebookFile)} ${flags(p)}`;
 }
 
+// Sync only when the notebook declares real deps; an empty one just gets a
+// `[project]` table (so `uv add` works) and runs from the pre-installed
+// /opt/venv via `--no-sync`. --no-compile-bytecode skips ~5s of compiling
+// freshly-added deps on the launch path (lazy-compiled on import instead);
+// --no-build keeps it to wheels so a source build can't run arbitrary code /
+// stall the launch. The image must NOT set UV_COMPILE_BYTECODE (it would
+// conflict with --no-compile-bytecode). `|| true` never blocks launch.
+const PYPROJECT_LAYER_SETUP = `if python3 -c "import tomllib,sys;sys.exit(0 if tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies') else 1)" 2>/dev/null; then uv sync --inexact --no-compile-bytecode --no-build || true; elif ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then { rm -f pyproject.toml && uv init --vcs none --name notebook --description "Built in marimohub"; } || true; fi`;
+
+// Outside the workspace: keeps the marimo file browser clean and can't clobber
+// a synced repo's own requirements.txt.
+const SCRIPT_REQUIREMENTS = '/tmp/marimohub-script-requirements.txt';
+
+// The env the kernel's `uv run --no-sync` will use — uv resolves the project
+// env as UV_PROJECT_ENVIRONMENT, else `.venv` in the project dir. Deliberately
+// not VIRTUAL_ENV: `uv run` ignores it, so pins installed there would be
+// invisible to the kernel. Local dev (compute-local) has neither var nor an
+// existing env, hence the create-if-missing guard — a no-op on sandbox images,
+// whose contract pre-creates UV_PROJECT_ENVIRONMENT.
+const PIN_ENV = '"${UV_PROJECT_ENVIRONMENT:-.venv}"';
+
 export const MARIMO_LAUNCH_STRATEGIES = {
-	// marimohub's strategy. The sandbox image pre-installs marimo (pinned) plus
+	// marimohub's default. The sandbox image pre-installs marimo (pinned) plus
 	// popular libraries into the project env (UV_PROJECT_ENVIRONMENT), so the base
 	// case needs no install and startup is near-instant. A notebook's own deps live
-	// in pyproject.toml (not PEP 723 inline metadata); `uv sync --inexact` adds them
-	// to that env without removing the pre-installed base, then `--no-sync` runs
-	// marimo straight from it. Unlike marimo's `--sandbox` (which force-refreshes
-	// when a notebook declares no inline deps — ours never do), this never refetches.
+	// in pyproject.toml; `uv sync --inexact` adds them to that env without removing
+	// the pre-installed base, then `--no-sync` runs marimo straight from it. Unlike
+	// marimo's `--sandbox` (which force-refreshes when a notebook declares no
+	// inline deps), this never refetches.
 	'uv-sync-edit': (p) => ({
+		setup: [PYPROJECT_LAYER_SETUP],
+		start: `uv run --no-sync ${marimoCommand(p)}`,
+	}),
+
+	// Git-synced notebooks with PEP 723 inline metadata: the pyproject layer runs
+	// first (lenient, as above), then the script's pins install into the same base
+	// env — last, so they win. No `|| true` on the pin steps: declared pins must
+	// fail the launch loudly (uv's error surfaces via the kernel logs), never be
+	// silently ignored. --no-hashes because hash checking rejects the unhashed
+	// base env.
+	'uv-script-pins': (p) => ({
 		setup: [
-			// Sync only when the notebook declares real deps; an empty one just gets a
-			// `[project]` table (so `uv add` works) and runs from the pre-installed
-			// /opt/venv via `--no-sync`. --no-compile-bytecode skips ~5s of compiling
-			// freshly-added deps on the launch path (lazy-compiled on import instead);
-			// --no-build keeps it to wheels so a source build can't run arbitrary code /
-			// stall the launch. The image must NOT set UV_COMPILE_BYTECODE (it would
-			// conflict with --no-compile-bytecode). `|| true` never blocks launch.
-			`if python3 -c "import tomllib,sys;sys.exit(0 if tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies') else 1)" 2>/dev/null; then uv sync --inexact --no-compile-bytecode --no-build || true; elif ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then { rm -f pyproject.toml && uv init --vcs none --name notebook --description "Built in marimohub"; } || true; fi`,
+			PYPROJECT_LAYER_SETUP,
+			`uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt --no-hashes -o ${SCRIPT_REQUIREMENTS}`,
+			`[ -d ${PIN_ENV} ] || uv venv ${PIN_ENV}`,
+			`uv pip install --python ${PIN_ENV} --no-build -r ${SCRIPT_REQUIREMENTS}`,
 		],
 		start: `uv run --no-sync ${marimoCommand(p)}`,
 	}),
 
-	// Project mode without a prior `uv sync` — leaner, but `uv run` doesn't reliably
-	// materialize project deps on first invocation. Prefer `uv-sync-edit`.
-	'uv-run-edit': (p) => ({
-		setup: [],
-		start: `uv run ${marimoCommand(p)}`,
-	}),
-
-	// Export the script's PEP 723 deps to requirements.txt, then run against that.
-	'uv-export-requirements': (p) => ({
-		setup: [
-			`uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt > requirements.txt`,
-		],
-		start: `uv run --with marimo --with-requirements=requirements.txt ${marimoCommand(p)}`,
-	}),
-
-	// marimo builds its own venv from PEP 723 metadata; force-refreshes when the
-	// script declares no deps.
+	// marimo builds its own venv from PEP 723 metadata. Unselected today; kept
+	// as the future path for markdown notebooks, whose metadata lives in YAML
+	// frontmatter that uv can't parse (but marimo --sandbox can).
 	'uv-sandbox': (p) => ({
 		setup: [],
 		start: `uv run --with marimo ${marimoCommand(p, '--sandbox ')}`,
@@ -118,8 +132,11 @@ export const MARIMO_LAUNCH_STRATEGIES = {
 
 export type MarimoLaunchStrategyName = keyof typeof MARIMO_LAUNCH_STRATEGIES;
 
-const ACTIVE_STRATEGY: MarimoLaunchStrategyName = 'uv-sync-edit';
+export const DEFAULT_LAUNCH_STRATEGY: MarimoLaunchStrategyName = 'uv-sync-edit';
 
-export function buildMarimoLaunch(params: MarimoLaunchParams): MarimoLaunchPlan {
-	return MARIMO_LAUNCH_STRATEGIES[ACTIVE_STRATEGY](params);
+export function buildMarimoLaunch(
+	params: MarimoLaunchParams,
+	strategy: MarimoLaunchStrategyName = DEFAULT_LAUNCH_STRATEGY,
+): MarimoLaunchPlan {
+	return MARIMO_LAUNCH_STRATEGIES[strategy](params);
 }

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -80,9 +80,11 @@ function marimoCommand(p: MarimoLaunchParams, extraFlags = ''): string {
 // conflict with --no-compile-bytecode). `|| true` never blocks launch.
 const PYPROJECT_LAYER_SETUP = `if python3 -c "import tomllib,sys;sys.exit(0 if tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies') else 1)" 2>/dev/null; then uv sync --inexact --no-compile-bytecode --no-build || true; elif ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then { rm -f pyproject.toml && uv init --vcs none --name notebook --description "Built in marimohub"; } || true; fi`;
 
-// Outside the workspace: keeps the marimo file browser clean and can't clobber
-// a synced repo's own requirements.txt.
-const SCRIPT_REQUIREMENTS = '/tmp/marimohub-script-requirements.txt';
+// Outside the workspace (keeps the marimo file browser clean, can't clobber a
+// synced repo's own requirements.txt) and unique per launch shell: `$$` is the
+// PID of the single `sh -c` the setup runs in, so local sandboxes — which
+// share the host /tmp — can't clobber each other between export and install.
+const SCRIPT_REQUIREMENTS = '/tmp/marimohub-script-requirements-$$.txt';
 
 // The env the kernel's `uv run --no-sync` will use — uv resolves the project
 // env as UV_PROJECT_ENVIRONMENT, else `.venv` in the project dir. Deliberately

--- a/packages/core/src/services/runtime/pep723.test.ts
+++ b/packages/core/src/services/runtime/pep723.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { hasInlineScriptMetadata } from './pep723';
+
+const CANONICAL = [
+	'# /// script',
+	'# requires-python = ">=3.12"',
+	'# dependencies = [',
+	'#   "cowsay==6.1",',
+	'# ]',
+	'# ///',
+	'',
+	'import cowsay',
+].join('\n');
+
+// Every case verified against `uv export --script`: true = uv sees metadata
+// (exports it, or errors loudly on a malformed block); false = uv reports no
+// metadata tag.
+describe('hasInlineScriptMetadata', () => {
+	it('matches a canonical block', () => {
+		expect(hasInlineScriptMetadata(CANONICAL)).toBe(true);
+	});
+
+	it('matches CRLF line endings', () => {
+		expect(hasInlineScriptMetadata(CANONICAL.replaceAll('\n', '\r\n'))).toBe(true);
+	});
+
+	it('matches a block that is not at the top of the file', () => {
+		expect(hasInlineScriptMetadata(`"""Docstring."""\n\n${CANONICAL}`)).toBe(true);
+	});
+
+	it('matches a closing fence at EOF with no trailing newline', () => {
+		expect(hasInlineScriptMetadata('# /// script\n# dependencies = ["cowsay"]\n# ///')).toBe(true);
+	});
+
+	it('matches a tag at EOF with no trailing newline', () => {
+		expect(hasInlineScriptMetadata('# /// script')).toBe(true);
+	});
+
+	it('matches an empty block (uv exports it fine)', () => {
+		expect(hasInlineScriptMetadata('# /// script\n# ///\nimport os')).toBe(true);
+	});
+
+	it('matches a malformed block — uv errors loudly rather than silently ignoring it', () => {
+		expect(
+			hasInlineScriptMetadata('# /// script\n# dependencies = ["cowsay"]\n\n# ///\nimport os'),
+		).toBe(true);
+		expect(hasInlineScriptMetadata('# /// script\nimport os')).toBe(true);
+	});
+
+	it('ignores a tag with trailing whitespace (uv does too)', () => {
+		expect(hasInlineScriptMetadata('# /// script  \n# dependencies = []\n# ///')).toBe(false);
+		expect(hasInlineScriptMetadata('# /// script\t\n# dependencies = []\n# ///')).toBe(false);
+	});
+
+	it('ignores an indented tag (uv does too)', () => {
+		expect(hasInlineScriptMetadata('  # /// script\n# dependencies = []\n# ///')).toBe(false);
+	});
+
+	it('ignores other metadata types', () => {
+		expect(hasInlineScriptMetadata('# /// pyproject\n# dependencies = ["cowsay"]\n# ///')).toBe(
+			false,
+		);
+	});
+
+	it('ignores a lookalike comment line', () => {
+		expect(hasInlineScriptMetadata('# # /// script\n# ///')).toBe(false);
+	});
+
+	it('ignores an empty file', () => {
+		expect(hasInlineScriptMetadata('')).toBe(false);
+	});
+});

--- a/packages/core/src/services/runtime/pep723.ts
+++ b/packages/core/src/services/runtime/pep723.ts
@@ -1,0 +1,11 @@
+// uv's recognition rule (verified empirically): a column-0 line that is
+// exactly `# /// script` declares metadata; trailing whitespace or indentation
+// means none. Block validity is deliberately unchecked — a malformed block
+// should fail the launch's `uv export` with uv's own diagnostic, not be
+// silently ignored here.
+const SCRIPT_TAG = /^# \/\/\/ script\r?$/m;
+
+/** Whether `code` declares a PEP 723 `# /// script` metadata block. */
+export function hasInlineScriptMetadata(code: string): boolean {
+	return SCRIPT_TAG.test(code);
+}


### PR DESCRIPTION
Fixes #145.

The launch strategy was a compile-time constant (`ACTIVE_STRATEGY = 'uv-sync-edit'`), so a git-synced notebook pinning deps via a PEP 723 `# /// script` block had those pins silently ignored. The strategy is now inferred per source at session start — no configuration.

- Local notebooks (and synced ones without inline metadata) keep the project-managed env: `uv sync --inexact` layered onto the pre-baked base.
- Synced notebooks whose entry file declares a PEP 723 block get the new `uv-script-pins` strategy: the pyproject layer runs first (lenient, unchanged), then `uv export --script` + `uv pip install` into the env `uv run --no-sync` actually resolves (`UV_PROJECT_ENVIRONMENT`, else `.venv`, created if missing — so local dev works with neither var set). Both layers compose; pins apply last and fail loudly rather than being silently ignored.
- Detection mirrors uv's own recognition rule (an exact `# /// script` line, verified empirically against `uv export`), via one bucket GET of the immutable synced entry file. It runs after the reuse fast path so reconnects pay nothing; a failed read falls back leniently and is tagged on the `session_provision` event.
- `uv-run-edit` and `uv-export-requirements` are removed; `uv-sandbox` stays as the seam for markdown notebooks (#143), whose YAML-frontmatter metadata uv can't parse.

Docs updated (sandbox-image contract, syncing, troubleshooting). Coverage includes execution-level tests of the setup commands with `UV_PROJECT_ENVIRONMENT`/`VIRTUAL_ENV` absent, detector cases verified against real uv behavior, and route tests for the reuse path, unreadable entry files, and the 409-before-read ordering.