### PR TITLE
fix(object-browser-commons): clear request timeout once response streams

### DIFF
--- a/packages/duckdb-wasm-runtime/src/node.test.ts
+++ b/packages/duckdb-wasm-runtime/src/node.test.ts
@@ -233,7 +233,7 @@ describe('DuckDB-Wasm worker runtime', () => {
 		await expect(runtime.ping()).rejects.toThrow(/not initialized/i);
 		await expect(runtime.initialize({ memoryLimitMb: 64 })).resolves.toBeUndefined();
 		await expect(runtime.ping()).resolves.toBeUndefined();
-	});
+	}, 15_000);
 
 	it('executes SQL and normalizes Arrow values', async () => {
 		const runtime = await initialized(mode);

--- a/packages/object-browser-commons/src/network.test.ts
+++ b/packages/object-browser-commons/src/network.test.ts
@@ -111,10 +111,10 @@ describe('guarded fetch', () => {
 		try {
 			const port = (server.address() as AddressInfo).port;
 			const guardedFetch = createGuardedFetch(async () => [{ address: '127.0.0.1', family: 4 }], {
-				socketTimeoutMs: 5,
+				socketTimeoutMs: 50,
 			});
 			const response = await guardedFetch(`http://objects.example.test:${port}/`);
-			await expect(response.arrayBuffer()).rejects.toThrow(/timed out/);
+			await expect(response.arrayBuffer()).rejects.toThrow('The object-store response timed out.');
 		} finally {
 			server.closeAllConnections();
 			await new Promise<void>((resolve, reject) =>

--- a/packages/object-browser-commons/src/network.ts
+++ b/packages/object-browser-commons/src/network.ts
@@ -56,6 +56,7 @@ export function createGuardedFetch(
 					signal: effective.signal,
 				},
 				(incoming) => {
+					outgoing.setTimeout(0);
 					incoming.setTimeout(socketTimeoutMs, () => {
 						incoming.destroy(new Error('The object-store response timed out.'));
 					});

--- a/packages/object-browser-commons/src/network.ts
+++ b/packages/object-browser-commons/src/network.ts
@@ -47,6 +47,9 @@ export function createGuardedFetch(
 		const request = url.protocol === 'http:' ? httpRequest : httpsRequest;
 		const body = effective.body ? new Uint8Array(await effective.arrayBuffer()) : undefined;
 		return new Promise<Response>((resolve, reject) => {
+			const onRequestTimeout = () => {
+				outgoing.destroy(new Error('The object-store request timed out.'));
+			};
 			const outgoing = request(
 				url,
 				{
@@ -57,6 +60,7 @@ export function createGuardedFetch(
 				},
 				(incoming) => {
 					outgoing.setTimeout(0);
+					outgoing.removeListener('timeout', onRequestTimeout);
 					incoming.setTimeout(socketTimeoutMs, () => {
 						incoming.destroy(new Error('The object-store response timed out.'));
 					});
@@ -80,9 +84,7 @@ export function createGuardedFetch(
 					);
 				},
 			);
-			outgoing.setTimeout(socketTimeoutMs, () => {
-				outgoing.destroy(new Error('The object-store request timed out.'));
-			});
+			outgoing.setTimeout(socketTimeoutMs, onRequestTimeout);
 			outgoing.on('error', reject);
 			writeBody(outgoing, body);
 		});


### PR DESCRIPTION
The outgoing request's socket timeout kept firing while the response body streamed, so a slow-but-alive response could be destroyed mid-stream. Clear it once headers arrive (`outgoing.setTimeout(0)`) and let the incoming response's own timeout govern the body.

Test updated to assert the exact timeout error message and use a headroom timeout.