### PR TITLE
fix(web): alias node-sql-parser to its PostgreSQL-only build

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
 	resolve: {
 		alias: {
 			'@': path.resolve(fileURLToPath(new URL('.', import.meta.url)), './src'),
+			// codemirror-sql maps its DuckDB dialect onto node-sql-parser's PostgreSQL
+			// grammar, so ship the single-grammar build instead of the ~2.5 MB
+			// all-dialects bundle.
+			'node-sql-parser': 'node-sql-parser/build/postgresql',
 		},
 	},
 	server: {


### PR DESCRIPTION
## Summary

CI's `verify` job has failed on every push to main since the SQL workspace merged (#164) — not a timeout, but the bundle-size budget: js hit **2814 KiB gzipped vs the 2458 KiB budget**, with `node-sql-parser` alone at 426 KiB.

`@marimo-team/codemirror-sql` maps its DuckDB dialect onto node-sql-parser's **PostgreSQL** grammar (`parseWithDuckDBSupport` always passes `database: 'PostgreSQL'`), so the all-dialects bundle ships ~360 KiB of grammars that can never be reached. This aliases `node-sql-parser` → `node-sql-parser/build/postgresql` in the web vite config.

**Result:** parser chunk 426 → 65 KiB gzipped; total js 2814 → **2451.5 KiB**, back under the 2458 KiB budget.

## Verification
- `node scripts/check-bundle-size.mjs` passes after a fresh build
- Confirmed `build/postgresql.js` exports the same `Parser` API and `astify('SELECT …', {database: 'PostgreSQL'})` works
- `pnpm --filter @marimo-hub/web test` — 713 passed (alias applies to vitest too)
- `pnpm check` and web `typecheck` pass