### PR TITLE
feat(compute-local): make local sandbox root configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage
 *.tsbuildinfo
 .context
 .conductor/
+.marimohub/
 pnpm-debug.log*
 
 # Playwright e2e artifacts

--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -832,6 +832,7 @@ MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
 MARIMOHUB_COMPUTE_WORKDIR=/workspace
 MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
 MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
+MARIMOHUB_COMPUTE_LOCAL_ROOT=/var/lib/marimohub/sandboxes
 MARIMOHUB_COMPUTE_LOCAL_HOST=localhost
 MARIMOHUB_COMPUTE_LOCAL_BIND_HOST=127.0.0.1
 MARIMOHUB_COMPUTE_LOCAL_PORTS=2718-2723
@@ -865,6 +866,7 @@ exports[`config -> code generators > memory + local + dev (all-local) > compose 
       MARIMOHUB_COMPUTE_WORKDIR: /workspace
       MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
       MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
+      MARIMOHUB_COMPUTE_LOCAL_ROOT: /var/lib/marimohub/sandboxes
       MARIMOHUB_COMPUTE_LOCAL_HOST: localhost
       MARIMOHUB_COMPUTE_LOCAL_BIND_HOST: 127.0.0.1
       MARIMOHUB_COMPUTE_LOCAL_PORTS: 2718-2723
@@ -888,6 +890,7 @@ config:
   MARIMOHUB_COMPUTE_WORKDIR: /workspace
   MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
   MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
+  MARIMOHUB_COMPUTE_LOCAL_ROOT: /var/lib/marimohub/sandboxes
   MARIMOHUB_COMPUTE_LOCAL_HOST: localhost
   MARIMOHUB_COMPUTE_LOCAL_BIND_HOST: 127.0.0.1
   MARIMOHUB_COMPUTE_LOCAL_PORTS: 2718-2723

--- a/development_docs/architecture.md
+++ b/development_docs/architecture.md
@@ -411,6 +411,7 @@ destinations.
 | `MARIMOHUB_COMPUTE_COREWEAVE_API_KEY`           | `coreweave` backend: CoreWeave Sandbox API key (secret)                                          |
 | `MARIMOHUB_COMPUTE_COREWEAVE_HOSTNAME_TEMPLATE` | `coreweave` backend: public kernel URL scheme (`{sandboxId}`/`{port}`/`{host}`)                  |
 | `MARIMOHUB_COMPUTE_LOCAL_HOST`                  | `local` backend: host for the kernel URL (default `localhost`)                                   |
+| `MARIMOHUB_COMPUTE_LOCAL_ROOT`                  | `local` backend: parent directory for sandboxes (default: OS temporary directory)                |
 
 Modal derives its provider-side idle limit as 1.5 times
 `MARIMOHUB_SESSION_IDLE_TIMEOUT_SECONDS`. The record-driven lifecycle sweep

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,10 +221,11 @@ Native Kubernetes: one keep-alive Pod + Service + Ingress per session via `@kube
 
 `MARIMOHUB_COMPUTE_BACKEND=local`
 
-Spawns `uv run marimo edit` as a host subprocess. Requires `uv` + Python on the host; not for shared/production use.
+Spawns `uv run marimo edit` as a host subprocess. Requires `uv` + Python on the host; not for shared/production use. Set the local root outside the OS temporary directory so marimo saves Hub-managed notebooks in place.
 
 | Variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
+| `MARIMOHUB_COMPUTE_LOCAL_ROOT` | Parent directory for local sandboxes. Set this outside the OS temporary directory to prevent marimo from treating notebooks as temporary files. | — | `OS temporary directory` | `/var/lib/marimohub/sandboxes` |
 | `MARIMOHUB_COMPUTE_LOCAL_HOST` | Host the exposed kernel URL points to. | — | `localhost` | — |
 | `MARIMOHUB_COMPUTE_LOCAL_BIND_HOST` | Interface marimo binds to (set `0.0.0.0` in Docker). | — | `127.0.0.1` | — |
 | `MARIMOHUB_COMPUTE_LOCAL_PORTS` | Published port range (`start-end`). Required in Docker; omit for ephemeral ports. | — | — | `2718-2723` |

--- a/docs/setup/compute/local.md
+++ b/docs/setup/compute/local.md
@@ -5,6 +5,7 @@
 
 ```bash
 MARIMOHUB_COMPUTE_BACKEND=local
+# MARIMOHUB_COMPUTE_LOCAL_ROOT=/var/lib/marimohub/sandboxes # keep notebooks outside /tmp
 # MARIMOHUB_COMPUTE_LOCAL_HOST=localhost      # host the kernel URL points at
 # MARIMOHUB_COMPUTE_LOCAL_BIND_HOST=127.0.0.1 # set 0.0.0.0 when running in Docker
 # MARIMOHUB_COMPUTE_LOCAL_PORTS=2718-2723     # published port range (required in Docker)
@@ -13,6 +14,13 @@ MARIMOHUB_COMPUTE_BACKEND=local
 ::: tip Fastest way to try marimohub
 Spawns `uv run marimo edit` as a subprocess on the host — nothing to provision.
 Great for `pnpm dev` on your laptop.
+:::
+
+::: warning Configure the sandbox root
+marimo treats notebooks under the operating system's temporary directory as
+temporary files and opens **Save As** instead of saving them in place. Set
+`MARIMOHUB_COMPUTE_LOCAL_ROOT` to a writable directory outside the temporary
+directory. Each sandbox gets its own child directory beneath this root.
 :::
 
 ::: danger Development only

--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -17,6 +17,8 @@ open http://localhost:9001        # MinIO console (minioadmin / minioadmin)
   `uv` fetches Python + marimo on the first kernel launch (cached in the
   `uv-cache` volume). Each kernel binds `0.0.0.0` on a port in the published
   `2718-2723` range and is served to the browser at `http://localhost:<port>`.
+  Sandboxes use `/sandboxes` instead of `/tmp`, so marimo saves Hub-managed
+  notebooks in place instead of opening **Save As**.
 
   To use Modal instead, set `MARIMOHUB_COMPUTE_BACKEND=modal` with
   `MARIMOHUB_COMPUTE_MODAL_TOKEN_*` and an image (drop the `local` vars and the

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       # Run marimo kernels as subprocesses inside this container. uv fetches
       # Python + marimo on the first launch (cached in the uv-cache volume).
       MARIMOHUB_COMPUTE_BACKEND: local
+      MARIMOHUB_COMPUTE_LOCAL_ROOT: /sandboxes # avoid marimo treating notebooks as temporary files
       MARIMOHUB_COMPUTE_LOCAL_HOST: localhost # what the browser connects to
       MARIMOHUB_COMPUTE_LOCAL_BIND_HOST: 0.0.0.0 # reachable through published ports
       MARIMOHUB_COMPUTE_LOCAL_PORTS: 2718-2723 # must match the published range above

--- a/examples/env/dev-local.env
+++ b/examples/env/dev-local.env
@@ -6,6 +6,7 @@ MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true
 
 # Runs `uv run marimo edit` as a host subprocess — needs uv + Python on the host.
 MARIMOHUB_COMPUTE_BACKEND=local
+MARIMOHUB_COMPUTE_LOCAL_ROOT=.marimohub/sandboxes
 MARIMOHUB_COMPUTE_LOCAL_PORTS=2718-2723
 
 # Dev bypass: authenticates every request as a fixed user.

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -229,6 +229,26 @@ describe('rewriteWorkspace (pure)', () => {
 });
 
 describe('LocalCompute file ops', () => {
+	it('places sandboxes beneath the configured root', async () => {
+		const root = await mkdtemp(path.join(os.tmpdir(), 'marimohub-local-root-'));
+		const local = new LocalCompute({ root });
+		const id = 'sb-configured-root' as SandboxId;
+		const sandboxRoot = path.join(root, `marimohub-sandbox-${id}`);
+		try {
+			const sb = local.create(id);
+			await sb.writeFiles([{ path: '/workspace/notebook.py', content: 'print(1)' }]);
+
+			await expect(readFile(path.join(sandboxRoot, 'workspace/notebook.py'), 'utf8')).resolves.toBe(
+				'print(1)',
+			);
+			await sb.destroy();
+			await expect(access(sandboxRoot)).rejects.toThrow();
+		} finally {
+			await local[Symbol.asyncDispose]();
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
 	it('round-trips files under the workspace and maps /workspace paths', async () => {
 		const sb = newSandbox();
 		const mkdir = await sb.exec('mkdir -p /workspace');

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -13,7 +13,7 @@
  *
  * Two impedance mismatches with the provider-agnostic core are handled here:
  *  - core hardcodes the workspace at `/workspace`; each sandbox gets a private
- *    temp root and `/workspace` is rewritten to `<root>/workspace`.
+ *    root and `/workspace` is rewritten to `<root>/workspace`.
  *  - core hardcodes `--port 2718`; we allocate a real free port per sandbox and
  *    map the logical port (2718) → the real port so multiple kernels coexist.
  */
@@ -193,6 +193,8 @@ export function prepareMarimoCommand(cmd: string, bindHost: string): string {
 }
 
 export interface LocalComputeOptions {
+	/** Parent directory for local sandbox roots. Defaults to the OS temporary directory. */
+	root?: string;
 	/** Host the exposed kernel URL points at (what the browser hits). Default `localhost`. */
 	host?: string;
 	/**
@@ -231,11 +233,11 @@ class LocalSandboxInstance implements SandboxInstance {
 
 	constructor(
 		id: SandboxId,
-		opts: Required<Pick<LocalComputeOptions, 'host' | 'bindHost'>> &
+		opts: Required<Pick<LocalComputeOptions, 'root' | 'host' | 'bindHost'>> &
 			Pick<LocalComputeOptions, 'ports'>,
 		private readonly onDestroyed?: () => void,
 	) {
-		this.root = path.join(os.tmpdir(), `marimohub-sandbox-${id}`);
+		this.root = path.join(opts.root, `marimohub-sandbox-${id}`);
 		this.host = opts.host;
 		this.bindHost = opts.bindHost;
 		this.ports = opts.ports;
@@ -511,6 +513,7 @@ class LocalSandboxInstance implements SandboxInstance {
 }
 
 export class LocalCompute implements SandboxProvider {
+	private readonly root: string;
 	private readonly host: string;
 	private readonly bindHost: string;
 	private readonly ports?: PortRange;
@@ -520,6 +523,7 @@ export class LocalCompute implements SandboxProvider {
 	private disposePromise?: Promise<void>;
 
 	constructor(options?: LocalComputeOptions) {
+		this.root = path.resolve(options?.root || os.tmpdir());
 		this.host = options?.host || 'localhost';
 		this.bindHost = options?.bindHost || '127.0.0.1';
 		this.ports = options?.ports;
@@ -532,6 +536,7 @@ export class LocalCompute implements SandboxProvider {
 			const next = new LocalSandboxInstance(
 				id,
 				{
+					root: this.root,
 					host: this.host,
 					bindHost: this.bindHost,
 					ports: this.ports,

--- a/packages/config/src/compute.test.ts
+++ b/packages/config/src/compute.test.ts
@@ -115,6 +115,15 @@ describe('makeCompute backend selection', () => {
 		expect(makeCompute({ MARIMOHUB_COMPUTE_BACKEND: 'local' })).toBeInstanceOf(LocalCompute);
 	});
 
+	it('passes the configured sandbox root to local compute', () => {
+		expect(
+			makeCompute({
+				MARIMOHUB_COMPUTE_BACKEND: 'local',
+				MARIMOHUB_COMPUTE_LOCAL_ROOT: '/var/lib/marimohub/sandboxes',
+			}),
+		).toMatchObject({ root: '/var/lib/marimohub/sandboxes' });
+	});
+
 	it('selects wandb (the CoreWeave adapter behind the W&B gateway)', () => {
 		expect(
 			makeCompute({

--- a/packages/config/src/compute.ts
+++ b/packages/config/src/compute.ts
@@ -288,6 +288,7 @@ export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 			// Requires `uv` + Python on the host; not for shared/production use.
 			// In Docker, set BIND_HOST=0.0.0.0 + PORTS to a published range.
 			return new LocalCompute({
+				root: env.MARIMOHUB_COMPUTE_LOCAL_ROOT,
 				host: env.MARIMOHUB_COMPUTE_LOCAL_HOST,
 				bindHost: env.MARIMOHUB_COMPUTE_LOCAL_BIND_HOST,
 				ports: parsePortRange(env.MARIMOHUB_COMPUTE_LOCAL_PORTS),

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -651,8 +651,16 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 				name: 'Local (dev only)',
 				selectorValue: 'local',
 				description:
-					'Spawns `uv run marimo edit` as a host subprocess. Requires `uv` + Python on the host; not for shared/production use.',
+					'Spawns `uv run marimo edit` as a host subprocess. Requires `uv` + Python on the host; not for shared/production use. Set the local root outside the OS temporary directory so marimo saves Hub-managed notebooks in place.',
 				vars: [
+					{
+						id: 'MARIMOHUB_COMPUTE_LOCAL_ROOT',
+						name: 'Local sandbox root',
+						description:
+							'Parent directory for local sandboxes. Set this outside the OS temporary directory to prevent marimo from treating notebooks as temporary files.',
+						example: '/var/lib/marimohub/sandboxes',
+						default: 'OS temporary directory',
+					},
 					{
 						id: 'MARIMOHUB_COMPUTE_LOCAL_HOST',
 						name: 'Local host',


### PR DESCRIPTION
## Summary

With the `local` compute backend, sandboxes were always created under `os.tmpdir()`, producing notebook paths like `/tmp/marimohub-sandbox-<id>/workspace/notebook.py`. marimo treats files under `/tmp/` as temporary and opens its **Save as** dialog on Ctrl+S instead of saving in place, so edits appear to not persist.

This adds `MARIMOHUB_COMPUTE_LOCAL_ROOT` to place local sandbox roots outside the OS temporary directory, resolving the conflict with marimo's temporary-file protection.

Closes #176