### PR TITLE
feat(api): log and count rejected 4xx mutations

### DIFF
--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -119,6 +119,38 @@ describe('createApi rejected request observability', () => {
 		});
 	});
 
+	it('captures resource context when mounted sync middleware rejects the request', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		const { app } = createTestApi({ deps: { metrics } });
+		const pid = createProjectId();
+		const nid = createNotebookId();
+
+		const res = await app.request(`/api/sync/git/v1/projects/${pid}/notebooks/${nid}`, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Basic invalid',
+				'X-Request-Id': 'rejected-sync-request',
+			},
+		});
+
+		expect(res.status).toBe(400);
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			level: 'warn',
+			event: 'request_rejected',
+			route: '/api/sync/git/v1/projects/:pid/notebooks/:nid',
+			status: 400,
+			code: 'BAD_REQUEST',
+			request_id: 'rejected-sync-request',
+			project_id: pid,
+			notebook_id: nid,
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('requests.rejected', 1, {
+			route: '/api/sync/git/v1/projects/:pid/notebooks/:nid',
+			code: 'BAD_REQUEST',
+		});
+	});
+
 	it('observes request-schema 422 responses returned without throwing', async () => {
 		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 		const metrics = { increment: vi.fn(), gauge: vi.fn() };

--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, it, expect, vi } from 'vitest';
 import { HTTPException } from 'hono/http-exception';
 import {
 	ConflictError,
+	createNotebookId,
+	createProjectId,
 	createServices,
 	ForbiddenError,
 	NotFoundError,
@@ -75,6 +77,85 @@ describe('createApi onError mapping', () => {
 		expect(log).toHaveBeenCalledOnce();
 		expect(log.mock.calls[0]?.[0]).toContain('request_error');
 		expect(log.mock.calls[0]?.[0]).not.toContain('do-not-return');
+	});
+});
+
+describe('createApi rejected request observability', () => {
+	it('logs and counts a rejected mutation with route and resource context', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		const { app } = createTestApi({ deps: { metrics } });
+		const pid = createProjectId();
+		const nid = createNotebookId();
+		const route = '/api/v1/projects/:pid/notebooks/:nid/_conflict';
+		app.post(route, () => {
+			throw new ConflictError('The edited notebook is missing from the session');
+		});
+
+		const res = await app.request(`/api/v1/projects/${pid}/notebooks/${nid}/_conflict`, {
+			method: 'POST',
+			headers: { 'X-Request-Id': 'rejected-request-1' },
+		});
+
+		expect(res.status).toBe(409);
+		expect(log).toHaveBeenCalledOnce();
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			level: 'warn',
+			event: 'request_rejected',
+			route,
+			method: 'POST',
+			status: 409,
+			code: 'CONFLICT',
+			message: 'The edited notebook is missing from the session',
+			request_id: 'rejected-request-1',
+			user: ACTOR,
+			project_id: pid,
+			notebook_id: nid,
+		});
+		expect(metrics.increment).toHaveBeenCalledOnce();
+		expect(metrics.increment).toHaveBeenCalledWith('requests.rejected', 1, {
+			route,
+			code: 'CONFLICT',
+		});
+	});
+
+	it('observes request-schema 422 responses returned without throwing', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		const { request } = createTestApi({ deps: { metrics } });
+
+		const res = await request('POST', '/projects', {});
+
+		expect(res.status).toBe(422);
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			level: 'warn',
+			event: 'request_rejected',
+			route: '/api/v1/projects',
+			method: 'POST',
+			status: 422,
+			code: 'VALIDATION_ERROR',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('requests.rejected', 1, {
+			route: '/api/v1/projects',
+			code: 'VALIDATION_ERROR',
+		});
+	});
+
+	it('does not observe read-only or authorization rejections', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		const { app } = createTestApi({ deps: { metrics } });
+		app.get('/api/v1/_conflict', () => {
+			throw new ConflictError('Read rejected');
+		});
+		app.post('/api/v1/_forbidden', () => {
+			throw new ForbiddenError('Mutation forbidden');
+		});
+
+		expect((await app.request('/api/v1/_conflict')).status).toBe(409);
+		expect((await app.request('/api/v1/_forbidden', { method: 'POST' })).status).toBe(403);
+		expect(log).not.toHaveBeenCalled();
+		expect(metrics.increment).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -1,7 +1,9 @@
+import type { MiddlewareHandler } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import { etag } from 'hono/etag';
 import { HTTPException } from 'hono/http-exception';
 import { requestId } from 'hono/request-id';
+import { routePath } from 'hono/route';
 import {
 	DomainError,
 	ensureInitialized,
@@ -12,7 +14,7 @@ import {
 	SubdomainExposure,
 	UnavailableError,
 } from '@marimo-hub/core';
-import type { ApiDeps } from './context';
+import type { ApiDeps, HonoEnv } from './context';
 import { describeError, errorMetadata, logEvent } from './log';
 import adminApp from './routes/admin';
 import { createAiProxy } from './routes/ai';
@@ -29,7 +31,7 @@ import tokensApp from './routes/tokens';
 import usersApp from './routes/users';
 import { createOidcDiscovery } from './oidcDiscovery';
 import { sandboxProxyMiddleware } from './sandboxProxy';
-import { createApp, fail } from './shared';
+import { createApp, ErrorResponseSchema, fail } from './shared';
 import type { ErrorCode } from './shared';
 
 const OPENAPI_DOC = {
@@ -68,6 +70,23 @@ const AI_PROXY_PREFIX = '/api/ai/v1';
 
 /** `/api/v1/*` paths that skip the catalog auto-init — metadata that must render before any catalog exists. */
 const SKIP_INIT_PATHS = new Set([`${API_PREFIX}/version`, `${API_PREFIX}/capabilities`]);
+
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+async function rejectionDetails(response: Response): Promise<{ code: string; message: string }> {
+	try {
+		const result = ErrorResponseSchema.safeParse(await response.clone().json());
+		if (result.success) {
+			return { code: result.data.error.code, message: result.data.error.message };
+		}
+	} catch {
+		// Unknown routes can return Hono's plain-text 404.
+	}
+	return {
+		code: `HTTP_${response.status}`,
+		message: response.statusText || 'Request rejected',
+	};
+}
 
 /**
  * Build the provider-agnostic marimohub API. All external dependencies arrive
@@ -189,6 +208,40 @@ export function createApi(rawDeps: ApiDeps) {
 	// response header, and thread it into error envelopes + logs for tracing.
 	app.use(`${API_PREFIX}/*`, requestId());
 	app.use('/api/sync/*', requestId());
+
+	const observeRejection: MiddlewareHandler<HonoEnv> = async (c, next) => {
+		await next();
+		if (
+			!MUTATING_METHODS.has(c.req.method) ||
+			c.res.status < 400 ||
+			c.res.status >= 500 ||
+			c.res.status === 401 ||
+			c.res.status === 403
+		) {
+			return;
+		}
+
+		const rejection = await rejectionDetails(c.res);
+		const route = routePath(c, -1) || c.req.path;
+		const projectId = c.req.param('pid');
+		const notebookId = c.req.param('nid');
+		deps.metrics?.increment('requests.rejected', 1, { route, code: rejection.code });
+		logEvent({
+			level: 'warn',
+			event: 'request_rejected',
+			route,
+			method: c.req.method,
+			status: c.res.status,
+			code: rejection.code,
+			message: rejection.message,
+			request_id: c.get('requestId') ?? null,
+			user: c.get('user')?.id ?? null,
+			...(projectId ? { project_id: projectId } : {}),
+			...(notebookId ? { notebook_id: notebookId } : {}),
+		});
+	};
+	app.use(`${API_PREFIX}/*`, observeRejection);
+	app.use('/api/sync/*', observeRejection);
 
 	// Body-size cap: the API buffers request bodies in full (Hono parses JSON in
 	// memory), so an unbounded POST could OOM the service. Reject anything past

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -9,8 +9,10 @@ import {
 	ensureInitialized,
 	isPatRequest,
 	MAX_REQUEST_BYTES,
+	NotebookId,
 	noopNotifier,
 	probeKernelLiveness,
+	ProjectId,
 	SubdomainExposure,
 	UnavailableError,
 } from '@marimo-hub/core';
@@ -85,6 +87,16 @@ async function rejectionDetails(response: Response): Promise<{ code: string; mes
 	return {
 		code: `HTTP_${response.status}`,
 		message: response.statusText || 'Request rejected',
+	};
+}
+
+function rejectionResourceContext(path: string) {
+	const match = /\/projects\/([^/]+)(?:\/notebooks\/([^/]+))?/.exec(path);
+	const projectId = match?.[1];
+	const notebookId = match?.[2];
+	return {
+		...(ProjectId.is(projectId) ? { project_id: projectId } : {}),
+		...(NotebookId.is(notebookId) ? { notebook_id: notebookId } : {}),
 	};
 }
 
@@ -223,8 +235,6 @@ export function createApi(rawDeps: ApiDeps) {
 
 		const rejection = await rejectionDetails(c.res);
 		const route = routePath(c, -1) || c.req.path;
-		const projectId = c.req.param('pid');
-		const notebookId = c.req.param('nid');
 		deps.metrics?.increment('requests.rejected', 1, { route, code: rejection.code });
 		logEvent({
 			level: 'warn',
@@ -236,8 +246,7 @@ export function createApi(rawDeps: ApiDeps) {
 			message: rejection.message,
 			request_id: c.get('requestId') ?? null,
 			user: c.get('user')?.id ?? null,
-			...(projectId ? { project_id: projectId } : {}),
-			...(notebookId ? { notebook_id: notebookId } : {}),
+			...rejectionResourceContext(c.req.path),
 		});
 	};
 	app.use(`${API_PREFIX}/*`, observeRejection);


### PR DESCRIPTION
Adds an `observeRejection` middleware that logs a `request_rejected` warn event and increments a `requests.rejected` metric for client-rejected mutations (POST/PUT/PATCH/DELETE returning 4xx). Skips read-only requests and auth rejections (401/403), and captures route, code, message, request id, user, and project/notebook context when present.