### PR TITLE
docs(config): document duckdb-wasm-sql experiment and GitHub App key secret

### DIFF
--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -81,6 +81,7 @@ MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=example.com  # REQUIRED (oidc): comma-separ
 # --- Server ---
 PORT=3000
 MARIMOHUB_STATIC_ROOT=./public               # prebuilt SPA assets
+# MARIMOHUB_EXPERIMENTS=duckdb-wasm-preview,duckdb-wasm-sql
 MARIMOHUB_RUN_MAINTENANCE=true               # run session-maintenance cron on THIS replica only
 MARIMOHUB_MAX_SESSIONS_PER_USER=10           # per-user concurrent session cap (0 = unlimited)
 # MARIMOHUB_EDITOR_SANDBOX_SHARING=shared     # shared: all editors attach to one sandbox

--- a/charts/marimohub/README.md
+++ b/charts/marimohub/README.md
@@ -17,7 +17,8 @@ kubectl -n marimohub create secret generic marimohub-secrets \
   --from-literal=MARIMOHUB_AUTH_SESSION_SECRET="$(openssl rand -hex 32)" \
   --from-literal=MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=... \
   --from-literal=MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID=... \
-  --from-literal=MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY=...
+  --from-literal=MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY=... \
+  --from-file=MARIMOHUB_SOURCE_CONTROL_GITHUB_APP_PRIVATE_KEY=./github-app.pem
 
 helm upgrade --install marimohub oci://ghcr.io/marimo-team/charts/marimohub \
   --version 1.4.2 -n marimohub -f my-values.yaml
@@ -25,6 +26,20 @@ helm upgrade --install marimohub oci://ghcr.io/marimo-team/charts/marimohub \
 
 Start from `ci/example-values.yaml`. The full `MARIMOHUB_*` surface is in
 [`apps/server/.env.example`](../../apps/server/.env.example).
+
+Use `--from-file=KEY=PATH` for PEMs, certificates, and other multiline values;
+Kubernetes preserves their newlines. Set `secrets.existingSecret` to
+`marimohub-secrets` in `my-values.yaml`. For development, `secrets.data` also accepts
+YAML block scalars:
+
+```yaml
+secrets:
+  data:
+    MARIMOHUB_SOURCE_CONTROL_GITHUB_APP_PRIVATE_KEY: |
+      -----BEGIN PRIVATE KEY-----
+      ...
+      -----END PRIVATE KEY-----
+```
 
 ## Update
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -324,7 +324,7 @@ Server-wide settings; no backend selector.
 
 | Variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
-| `MARIMOHUB_EXPERIMENTS` | Comma-separated experimental feature IDs. Unknown IDs are ignored with a startup warning. Current values: `duckdb-wasm-preview`. | — | — | `duckdb-wasm-preview` |
+| `MARIMOHUB_EXPERIMENTS` | Comma-separated experimental feature IDs. Unknown IDs are ignored with a startup warning. Current values: `duckdb-wasm-preview`, `duckdb-wasm-sql`. | — | — | `duckdb-wasm-preview` |
 | `PORT` | Port the HTTP server listens on. | — | `3000` | — |
 | `MARIMOHUB_STATIC_ROOT` | Directory containing the web UI's static files. | — | `./public` | — |
 | `MARIMOHUB_RUN_MAINTENANCE` | Run background maintenance (expiring old sessions, cleaning up sandboxes) on this replica only. | — | `false` | `true` |

--- a/docs/deploying/helm.md
+++ b/docs/deploying/helm.md
@@ -23,7 +23,8 @@ kubectl -n marimohub create secret generic marimohub-secrets \
   --from-literal=MARIMOHUB_AUTH_SESSION_SECRET="$(openssl rand -hex 32)" \
   --from-literal=MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=... \
   --from-literal=MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID=... \
-  --from-literal=MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY=...
+  --from-literal=MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY=... \
+  --from-file=MARIMOHUB_SOURCE_CONTROL_GITHUB_APP_PRIVATE_KEY=./github-app.pem
 
 helm upgrade --install marimohub oci://ghcr.io/marimo-team/charts/marimohub \
   --version <VERSION> -n marimohub -f values.yaml
@@ -34,6 +35,10 @@ Replace `<VERSION>` with a tag from
 the leading `v`. Start from
 [`charts/marimohub/ci/example-values.yaml`](https://github.com/marimo-team/marimohub/blob/main/charts/marimohub/ci/example-values.yaml).
 Reference the secret you created with `secrets.existingSecret: marimohub-secrets`.
+Use `--from-file=KEY=PATH` for PEMs, certificates, and other multiline values;
+Kubernetes preserves their newlines. The chart's development-only `secrets.data`
+alternative also accepts YAML block scalars, but places the values in the Helm
+release metadata.
 The full `MARIMOHUB_*` surface is in [Configuration](../configuration.md).
 Set `config.MARIMOHUB_EDITOR_SANDBOX_SHARING` to `shared` or `exclusive`. Before
 you change it in an existing deployment, follow the required drain procedure in

--- a/packages/config/src/experiments.test.ts
+++ b/packages/config/src/experiments.test.ts
@@ -18,15 +18,18 @@ describe('parseExperiments', () => {
 		]).toEqual(['duckdb-wasm-preview']);
 	});
 
-	it('ignores unknown IDs with a warning', () => {
+	it('warns and ignores unknown IDs without throwing', () => {
 		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 		expect([
 			...parseExperiments({ MARIMOHUB_EXPERIMENTS: 'duckdb-wasm-preveiw,duckdb-wasm-preview' }),
 		]).toEqual(['duckdb-wasm-preview']);
 		expect(warn).toHaveBeenCalledOnce();
-		expect(warn.mock.calls[0]?.[0]).toContain(
-			'Unknown MARIMOHUB_EXPERIMENTS value: duckdb-wasm-preveiw',
-		);
+		expect(JSON.parse(warn.mock.calls[0]?.[0] as string)).toEqual({
+			ts: expect.any(String),
+			event: 'experiment_unknown',
+			id: 'duckdb-wasm-preveiw',
+			known: ['duckdb-wasm-preview', 'duckdb-wasm-sql'],
+		});
 	});
 
 	it.each(['constructor', 'toString', 'hasOwnProperty', '__proto__'])(

--- a/packages/config/src/experiments.ts
+++ b/packages/config/src/experiments.ts
@@ -14,19 +14,17 @@ export type Experiment = keyof typeof EXPERIMENTS;
 
 export function parseExperiments(env: Env): ReadonlySet<Experiment> {
 	const enabled = new Set<Experiment>();
+	const known = Object.keys(EXPERIMENTS);
 	for (const raw of env.MARIMOHUB_EXPERIMENTS?.split(',') ?? []) {
 		const id = raw.trim().toLowerCase();
 		if (!id) continue;
-		// An experiment id from a newer or older deployment must not brick boot;
-		// ignore it so config stays forward- and backward-compatible.
 		if (!Object.hasOwn(EXPERIMENTS, id)) {
 			console.warn(
 				JSON.stringify({
 					ts: new Date().toISOString(),
-					event: 'unknown_experiment_ignored',
-					message:
-						`Unknown MARIMOHUB_EXPERIMENTS value: ${id}. ` +
-						`Known experiments: ${Object.keys(EXPERIMENTS).join(', ')}.`,
+					event: 'experiment_unknown',
+					id,
+					known,
 				}),
 			);
 			continue;

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -916,7 +916,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						id: 'MARIMOHUB_EXPERIMENTS',
 						name: 'Experiments',
 						description:
-							'Comma-separated experimental feature IDs. Unknown IDs are ignored with a startup warning. Current values: `duckdb-wasm-preview`.',
+							'Comma-separated experimental feature IDs. Unknown IDs are ignored with a startup warning. Current values: `duckdb-wasm-preview`, `duckdb-wasm-sql`.',
 						example: 'duckdb-wasm-preview',
 					},
 					{


### PR DESCRIPTION
Adds `duckdb-wasm-sql` to the experiments list across docs and the config spec, documents `--from-file`/YAML block scalars for supplying the GitHub App private key in the Helm charts, and switches the unknown-experiment warning to a structured log line.