### PR TITLE
perf(runtime): faster provisioning

### DIFF
--- a/packages/core/src/rateLimit.test.ts
+++ b/packages/core/src/rateLimit.test.ts
@@ -31,6 +31,17 @@ describe('createSlidingWindowBudget', () => {
 		expect(budget.consume('user')).toBe(true);
 	});
 
+	it('accepts an explicit observation time', () => {
+		const budget = createSlidingWindowBudget<string>({
+			limit: 1,
+			windowMs: 1_000,
+			now: () => 10_000,
+		});
+		expect(budget.consume('user', 0)).toBe(true);
+		expect(budget.consume('user', 999)).toBe(false);
+		expect(budget.consume('user', 1_000)).toBe(true);
+	});
+
 	it('forgets inactive keys during an amortized sweep', () => {
 		let now = 0;
 		const budget = createSlidingWindowBudget<string>({

--- a/packages/core/src/rateLimit.test.ts
+++ b/packages/core/src/rateLimit.test.ts
@@ -42,6 +42,22 @@ describe('createSlidingWindowBudget', () => {
 		expect(budget.consume('user', 1_000)).toBe(true);
 	});
 
+	it('does not treat an older timestamp for another key as a clock rollback', () => {
+		const budget = createSlidingWindowBudget<string>({ limit: 1, windowMs: 10_000 });
+		expect(budget.consume('alice', 1_000)).toBe(true);
+		expect(budget.consume('bob', 2_000)).toBe(true);
+		expect(budget.consume('alice', 1_500)).toBe(false);
+		expect(budget.consume('bob', 2_500)).toBe(false);
+	});
+
+	it('resets only the affected key when its clock moves backwards', () => {
+		const budget = createSlidingWindowBudget<string>({ limit: 1, windowMs: 1_000 });
+		expect(budget.consume('alice', 1_000)).toBe(true);
+		expect(budget.consume('bob', 1_000)).toBe(true);
+		expect(budget.consume('alice', 0)).toBe(true);
+		expect(budget.consume('bob', 1_500)).toBe(false);
+	});
+
 	it('forgets inactive keys during an amortized sweep', () => {
 		let now = 0;
 		const budget = createSlidingWindowBudget<string>({

--- a/packages/core/src/rateLimit.ts
+++ b/packages/core/src/rateLimit.ts
@@ -21,26 +21,27 @@ export function createSlidingWindowBudget<Key>(
 	}
 	const now = options.now ?? (() => Date.now());
 	const recentByKey = new Map<Key, number[]>();
+	const lastObservedByKey = new Map<Key, number>();
 	let lastSweptAt: number | undefined;
-	let lastObservedAt: number | undefined;
 
 	return {
 		consume(key, timestamp): boolean {
 			const currentTime = timestamp ?? now();
+			const lastObservedAt = lastObservedByKey.get(key);
 			const clockRolledBack = lastObservedAt !== undefined && currentTime < lastObservedAt;
-			lastObservedAt = currentTime;
 			if (clockRolledBack) {
-				recentByKey.clear();
-				lastSweptAt = currentTime;
+				recentByKey.delete(key);
 			}
 			if (lastSweptAt === undefined || currentTime - lastSweptAt >= options.windowMs) {
 				lastSweptAt = currentTime;
 				for (const [trackedKey, timestamps] of recentByKey) {
 					if (timestamps.every((timestamp) => currentTime - timestamp >= options.windowMs)) {
 						recentByKey.delete(trackedKey);
+						lastObservedByKey.delete(trackedKey);
 					}
 				}
 			}
+			lastObservedByKey.set(key, currentTime);
 			const recent = (recentByKey.get(key) ?? []).filter(
 				(timestamp) => currentTime - timestamp < options.windowMs,
 			);

--- a/packages/core/src/rateLimit.ts
+++ b/packages/core/src/rateLimit.ts
@@ -5,7 +5,8 @@ export interface SlidingWindowBudgetOptions {
 }
 
 export interface SlidingWindowBudget<Key> {
-	consume(key: Key): boolean;
+	/** Consume capacity at `timestamp`, or at the configured clock's current time when omitted. */
+	consume(key: Key, timestamp?: number): boolean;
 	tracked(): number;
 }
 
@@ -24,8 +25,8 @@ export function createSlidingWindowBudget<Key>(
 	let lastObservedAt: number | undefined;
 
 	return {
-		consume(key): boolean {
-			const currentTime = now();
+		consume(key, timestamp): boolean {
+			const currentTime = timestamp ?? now();
 			const clockRolledBack = lastObservedAt !== undefined && currentTime < lastObservedAt;
 			lastObservedAt = currentTime;
 			if (clockRolledBack) {

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -80,6 +80,7 @@ describe('SandboxProvisioner', () => {
 			expect(result.usedFallback).toBe(false);
 			expect(result.url).toBe(EXPOSED_URL);
 			expect(result.sandbox).toBe(instance);
+			expect(result.timings.total).toEqual(expect.any(Number));
 
 			expect(calls.exec).toContain('true');
 			// Bucket was mounted (no fallback file copy).

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -148,7 +148,7 @@ export interface ProvisionResult {
 	url: string;
 	/** Whether files were loaded via manual copy (true) or bucket mount (false) */
 	usedFallback: boolean;
-	/** Per-phase ms: handle, reachable, files, inject, start, waitport, expose. */
+	/** Wall-clock total and per-phase ms: handle, reachable, files, inject, start, waitport, expose. */
 	timings: Timings;
 	/**
 	 * Non-duration measurements for the same wide event — workspace objects/bytes
@@ -280,6 +280,7 @@ export class SandboxProvisioner {
 	) {}
 
 	async provision(options: ProvisionOptions): Promise<ProvisionResult> {
+		const provisionStart = Date.now();
 		// A restored sandbox boots from the snapshot image; the workspace load below
 		// still refreshes the code from the bucket cache.
 		const createStart = Date.now();
@@ -297,6 +298,7 @@ export class SandboxProvisioner {
 			// Constructing the (usually lazy) handle, NOT the backend's create — that
 			// lands in `reachable_create` once the adapter resolves it.
 			result.timings.handle = createMs;
+			result.timings.total = Date.now() - provisionStart;
 			return result;
 		} catch (err) {
 			// Provisioning failed partway — destroy any partial sandbox before

--- a/packages/core/src/services/runtime/sandboxFiles.test.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.test.ts
@@ -72,6 +72,34 @@ describe('restoreWorkspace', () => {
 		]);
 	});
 
+	it('fetches up to 32 workspace objects concurrently', async () => {
+		const { nb } = nbCtx();
+		class ConcurrentGetBucket extends MemoryBucket {
+			activeGets = 0;
+			maxActiveGets = 0;
+
+			override async get(key: string) {
+				this.activeGets++;
+				this.maxActiveGets = Math.max(this.maxActiveGets, this.activeGets);
+				await Promise.resolve();
+				try {
+					return await super.get(key);
+				} finally {
+					this.activeGets--;
+				}
+			}
+		}
+		const bucket = new ConcurrentGetBucket();
+		for (let i = 0; i < 33; i++) {
+			await bucket.put(nb.workspaceFile(`file-${i}.txt`), 'x');
+		}
+		const { instance } = makeFsSandbox();
+
+		await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT);
+
+		expect(bucket.maxActiveGets).toBe(32);
+	});
+
 	it('round-trips binary files byte-identically', async () => {
 		const { nb } = nbCtx();
 		const bucket = new MemoryBucket();

--- a/packages/core/src/services/runtime/sandboxFiles.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.ts
@@ -10,11 +10,12 @@ import { listAllKeys, listAllObjects } from '../catalog/storage';
 import type { CommitSessionInput } from '../content/NotebookService';
 
 /**
- * Max concurrent per-file transfers: the bucket reads a restore batch issues, and
- * the per-file `exec` reads a capture makes. Bounded so neither floods the object
- * store nor the sandbox's command channel.
+ * Restore GETs touch only the object store and byte-bounded API memory, so they
+ * can fan out further than capture reads, which contend on the sandbox command
+ * channel.
  */
-const SANDBOX_FILE_CONCURRENCY = 8;
+const RESTORE_FETCH_CONCURRENCY = 32;
+const CAPTURE_FILE_CONCURRENCY = 8;
 
 /**
  * Attempts for an idempotent sandbox write. A backend stream can reset mid-call
@@ -163,7 +164,7 @@ export async function restoreWorkspace(
 	let objectCount = 0;
 	let bytes = 0;
 	for (const batch of batchByBytes(wanted, RESTORE_BATCH_BYTES)) {
-		const fetched = await mapWithConcurrency(batch, SANDBOX_FILE_CONCURRENCY, async (f) => {
+		const fetched = await mapWithConcurrency(batch, RESTORE_FETCH_CONCURRENCY, async (f) => {
 			const body = await bucket.get(f.key);
 			if (!body) return;
 			return { path: f.dest, content: await body.bytes() };
@@ -255,7 +256,7 @@ export async function captureWorkspace(
 
 		// A read failure skips just that file (logged); successful ones join the
 		// `present` mirror set that drives the delete pass below.
-		const captured = await mapWithConcurrency(selected, SANDBOX_FILE_CONCURRENCY, async (rel) => {
+		const captured = await mapWithConcurrency(selected, CAPTURE_FILE_CONCURRENCY, async (rel) => {
 			const result = await sandbox.exec(`base64 -w0 ${shellQuote(`${workingDir}/${rel}`)}`);
 			if (!result.success) {
 				console.warn(`captureWorkspace: could not read ${rel}; skipping`);

--- a/packages/core/src/services/runtime/sessionLifecycle.appMode.test.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.appMode.test.ts
@@ -132,6 +132,27 @@ describe('SessionLifecycleService (app sessions)', () => {
 		expect((await getStored(s)).connections_checked_at).toBe(iso(-60_000));
 	});
 
+	it('refreshes informational connection counts at most every five minutes', async () => {
+		await putSession();
+		const service = makeService();
+
+		await service.sweep(now);
+		await service.sweep(now + 60_000);
+		await service.sweep(now + 5 * 60_000);
+
+		expect(probe).toHaveBeenCalledTimes(2);
+	});
+
+	it('probes immediately when a reap decision becomes due', async () => {
+		await putSession({ expires_at: iso(30_000) });
+		const service = makeService();
+
+		await service.sweep(now);
+		await service.sweep(now + 60_000);
+
+		expect(probe).toHaveBeenCalledTimes(2);
+	});
+
 	it('probes under the kernel base path recovered from the client URL', async () => {
 		await putSession({ sandbox_url: 'https://hub.example/proxy/tok-abc/' });
 		await putSession({

--- a/packages/core/src/services/runtime/sessionLifecycle.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.ts
@@ -2,8 +2,9 @@ import type { Bucket } from '../../ports/bucket';
 import { MARIMO_PORT } from '../../constants';
 import { mapWithConcurrency } from '../../concurrency';
 import { Millis } from '../../duration';
-import type { NotebookId } from '../../ids';
+import type { NotebookId, SessionId } from '../../ids';
 import type { SandboxInstance, SandboxProvider } from '../../ports/sandbox';
+import { createSlidingWindowBudget } from '../../rateLimit';
 import type { Session } from '../../schema';
 import type { NotebookService } from '../content/NotebookService';
 import { SandboxProvisioner } from './SandboxProvisioner';
@@ -12,6 +13,8 @@ import { isTerminal, sessionModePolicy, sessionPersistsEdits } from './sessionSt
 import type { SessionService } from './SessionService';
 
 const SESSION_SWEEP_CONCURRENCY = 8;
+/** Cadence for informational connection counts; reap decisions always probe immediately. */
+const CONNECTION_COUNT_REFRESH_MS = Millis.minutes(5);
 
 /**
  * How long after `started_at` an `expired` record's sandbox is left alone.
@@ -119,6 +122,10 @@ export interface SweepResult {
 export class SessionLifecycleService {
 	private readonly provisioner: SandboxProvisioner;
 	private readonly retirer: SessionRetirer;
+	private readonly connectionProbeBudget = createSlidingWindowBudget<SessionId>({
+		limit: 1,
+		windowMs: CONNECTION_COUNT_REFRESH_MS,
+	});
 
 	constructor(
 		private sessions: SessionService,
@@ -187,8 +194,8 @@ export class SessionLifecycleService {
 			// Only probe when a reap decision hinges on it (cost control: one exec per
 			// near-deadline/stale session per sweep, nothing for healthy ones). Only an
 			// `expired` record can still have a live kernel among the terminal ones.
-			// Exception: every running app session is probed each sweep — its
-			// connection count feeds the "~N connected" stop-confirm hint.
+			// Informational counts for apps/shared editors feed the "~N connected"
+			// stop-confirm hint, but refresh on the slower cadence below.
 			let active: number | null = null;
 			const reapCandidate =
 				s.status === 'expired' ||
@@ -197,7 +204,11 @@ export class SessionLifecycleService {
 				s.status === 'running' &&
 				(sessionModePolicy(s).singleton ||
 					(sessionPersistsEdits(s) && (s.editor_sandbox_sharing ?? 'shared') === 'shared'));
-			if (this.cfg.connectionAware && (reapCandidate || connectionCountCheck)) {
+			const connectionCountDue =
+				this.cfg.connectionAware &&
+				connectionCountCheck &&
+				this.connectionProbeBudget.consume(s.session_id, now);
+			if (this.cfg.connectionAware && (reapCandidate || connectionCountDue)) {
 				active = await this.probe(sandbox, kernelBasePath(s));
 				// A null probe is "unknown" — leave the last stamp rather than write a
 				// lie. An unchanged count is skipped too: no CAS/ETag churn against


### PR DESCRIPTION
Raises workspace restore fetch concurrency from 8 to 32 (restore GETs only touch the object store and byte-bounded API memory, so they fan out further than capture reads, which still contend on the sandbox command channel at 8). Throttles informational connection-count probes to at most once every 5 minutes per session, while reap-decision probes still run immediately. Records a wall-clock `total` in provision timings.