### PR TITLE
fix(compute): listFiles distinguishes NOT_A_DIRECTORY from empty success

### DIFF
--- a/packages/api/src/__snapshots__/createApi.test.ts.snap
+++ b/packages/api/src/__snapshots__/createApi.test.ts.snap
@@ -72,7 +72,7 @@ exports[`createApi onError mapping > maps domain errors to response envelopes 1`
     "body": {
       "error": {
         "code": "INTERNAL_ERROR",
-        "message": "Internal server error",
+        "message": "Internal error",
       },
       "success": false,
     },

--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -70,7 +70,7 @@ describe('createApi onError mapping', () => {
 		expect(res.status).toBe(503);
 		expect(await res.json()).toEqual({
 			success: false,
-			error: { code: 'INTERNAL_ERROR', message: 'Internal server error' },
+			error: { code: 'INTERNAL_ERROR', message: 'Internal error' },
 		});
 		expect(log).toHaveBeenCalledOnce();
 		expect(log.mock.calls[0]?.[0]).toContain('request_error');

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -32,6 +32,10 @@ import { sandboxProxyMiddleware } from './sandboxProxy';
 import { createApp, fail } from './shared';
 import type { ErrorCode } from './shared';
 
+function internalErrorMessage(requestId: string | undefined): string {
+	return requestId ? `Internal error — ref ${requestId}` : 'Internal error';
+}
+
 const OPENAPI_DOC = {
 	openapi: '3.1.0' as const,
 	info: {
@@ -153,7 +157,7 @@ export function createApi(rawDeps: ApiDeps) {
 					status: res.status,
 					error: errorMetadata(err),
 				});
-				return fail(c, code, 'Internal server error', res.status);
+				return fail(c, code, internalErrorMessage(c.get('requestId')), res.status);
 			}
 			return fail(c, code, err.message || res.statusText || 'Request failed', res.status);
 		}
@@ -182,7 +186,7 @@ export function createApi(rawDeps: ApiDeps) {
 			status: 500,
 			error: describeError(err),
 		});
-		return fail(c, 'INTERNAL_ERROR', 'Internal server error', 500);
+		return fail(c, 'INTERNAL_ERROR', internalErrorMessage(c.get('requestId')), 500);
 	});
 
 	// Correlation id: reuse an inbound `X-Request-Id` or mint one, echo it on the

--- a/packages/api/src/routes/changeRequests.test.ts
+++ b/packages/api/src/routes/changeRequests.test.ts
@@ -154,6 +154,30 @@ describe('change request routes', () => {
 		expect(openChangeRequest).toHaveBeenCalledOnce();
 	});
 
+	it('reports entry-notebook inspection invariants with the request reference', async () => {
+		const { instance } = makeFsSandbox({ files: { 'other.py': 'print("other")' } });
+		const broken = createTestApi({
+			bucket: setup.bucket,
+			compute: fakeComputeFrom(instance),
+			deps: { sourceControlPublishers: setup.deps.sourceControlPublishers },
+		});
+		const error = await expectError(
+			await broken.request(
+				'POST',
+				route(),
+				{},
+				{ 'Idempotency-Key': 'missing-entry', 'X-Request-Id': 'capture-ref' },
+			),
+			500,
+			'INTERNAL_ERROR',
+		);
+
+		expect(error).toMatchObject({
+			message: 'Internal error — ref capture-ref',
+			request_id: 'capture-ref',
+		});
+	});
+
 	it('replays a recorded response after the publisher is disabled', async () => {
 		const headers = { 'Idempotency-Key': 'disabled-after-publish' };
 		const first = await expectOk(await setup.request('POST', route(), {}, headers), 201);

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
+import { NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
-import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import {
+	computeContract,
+	CONTRACT_NON_DIRECTORY_PATH,
+} from '@marimo-hub/core/testing/compute-contract';
 
 /**
  * Tests for the Cloudflare Containers compute adapter.
@@ -307,12 +311,14 @@ describe('CloudflareSandboxProvider', () => {
 
 	describe('instance.listFiles()', () => {
 		it('translates a vendor failure into the typed failure envelope', async () => {
+			fakeSandbox.exec.mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
 			fakeSandbox.listFiles.mockResolvedValueOnce({ success: false, files: [] });
 			const res = await makeProvider().create(SANDBOX_ID).listFiles('/w');
 			expect(res).toEqual(listFilesFailure());
 		});
 
 		it('projects each FileInfo field and forwards the options', async () => {
+			fakeSandbox.exec.mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
 			fakeSandbox.listFiles.mockResolvedValueOnce({
 				success: true,
 				files: [
@@ -432,14 +438,21 @@ describe('CloudflareSandboxProvider', () => {
 
 function primeContractFakes() {
 	fakeSandbox.exec.mockImplementation(async (cmd: string) =>
-		cmd.includes('mh-contract-fail')
+		cmd.includes(CONTRACT_NON_DIRECTORY_PATH)
 			? {
 					success: false,
 					stdout: '',
-					stderr: 'scripted failure',
+					stderr: NOT_A_DIRECTORY_MARKER,
 					error: { code: 'COMMAND_FAILED' },
 				}
-			: { success: true, stdout: '', stderr: '' },
+			: cmd.includes('mh-contract-fail')
+				? {
+						success: false,
+						stdout: '',
+						stderr: 'scripted failure',
+						error: { code: 'COMMAND_FAILED' },
+					}
+				: { success: true, stdout: '', stderr: '' },
 	);
 	fakeSandbox.execStream.mockImplementation(async () => new ReadableStream());
 	fakeSandbox.readFile.mockImplementation(async () => ({ success: false }));

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -310,36 +310,32 @@ describe('CloudflareSandboxProvider', () => {
 	});
 
 	describe('instance.listFiles()', () => {
-		it('translates a vendor failure into the typed failure envelope', async () => {
-			fakeSandbox.exec.mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
-			fakeSandbox.listFiles.mockResolvedValueOnce({ success: false, files: [] });
+		it('translates a find failure into the typed failure envelope', async () => {
+			fakeSandbox.listFiles.mockClear();
+			fakeSandbox.exec.mockResolvedValueOnce({
+				success: false,
+				stdout: '',
+				stderr: 'find failed',
+				error: { code: 'COMMAND_FAILED' },
+			});
 			const res = await makeProvider().create(SANDBOX_ID).listFiles('/w');
 			expect(res).toEqual(listFilesFailure());
+			expect(fakeSandbox.listFiles).not.toHaveBeenCalled();
 		});
 
-		it('projects each FileInfo field and forwards the options', async () => {
-			fakeSandbox.exec.mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
-			fakeSandbox.listFiles.mockResolvedValueOnce({
+		it('lists and parses files in one exec call', async () => {
+			fakeSandbox.listFiles.mockClear();
+			fakeSandbox.exec.mockResolvedValueOnce({
 				success: true,
-				files: [
-					{
-						name: 'a.py',
-						absolutePath: '/w/a.py',
-						relativePath: 'a.py',
-						type: 'file',
-						size: 12,
-						// an extra SDK field that must NOT leak through the projection
-						mode: 0o644,
-					},
-				],
+				stdout: 'f\t12\t/w/a.py\n',
+				stderr: '',
 			});
 			const res = await makeProvider()
 				.create(SANDBOX_ID)
 				.listFiles('/w', { recursive: true, includeHidden: true });
-			expect(fakeSandbox.listFiles).toHaveBeenCalledWith('/w', {
-				recursive: true,
-				includeHidden: true,
-			});
+			expect(fakeSandbox.exec).toHaveBeenLastCalledWith(expect.stringContaining("find '/w'"));
+			expect(fakeSandbox.exec.mock.calls.at(-1)?.[0]).not.toContain('-maxdepth');
+			expect(fakeSandbox.listFiles).not.toHaveBeenCalled();
 			expect(res).toEqual({
 				success: true,
 				files: [

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -323,11 +323,11 @@ describe('CloudflareSandboxProvider', () => {
 			expect(fakeSandbox.listFiles).not.toHaveBeenCalled();
 		});
 
-		it('lists and parses files in one exec call', async () => {
+		it('lists and parses newline-containing filenames in one exec call', async () => {
 			fakeSandbox.listFiles.mockClear();
 			fakeSandbox.exec.mockResolvedValueOnce({
 				success: true,
-				stdout: 'f\t12\t/w/a.py\n',
+				stdout: 'f\t12\t/w/a\nnotebook.py\0',
 				stderr: '',
 			});
 			const res = await makeProvider()
@@ -339,7 +339,13 @@ describe('CloudflareSandboxProvider', () => {
 			expect(res).toEqual({
 				success: true,
 				files: [
-					{ name: 'a.py', absolutePath: '/w/a.py', relativePath: 'a.py', type: 'file', size: 12 },
+					{
+						name: 'a\nnotebook.py',
+						absolutePath: '/w/a\nnotebook.py',
+						relativePath: 'a\nnotebook.py',
+						type: 'file',
+						size: 12,
+					},
 				],
 			});
 		});

--- a/packages/compute-cloudflare/src/index.ts
+++ b/packages/compute-cloudflare/src/index.ts
@@ -2,10 +2,11 @@ import { getSandbox, proxyToSandbox } from '@cloudflare/sandbox';
 import type { Sandbox } from '@cloudflare/sandbox';
 import {
 	base64Encode,
-	buildDirectoryProbeCommand,
+	buildFindFilesCommand,
 	buildGitCloneCommand,
 	classifyListFilesFailure,
 	mapWithConcurrency,
+	parseFindFilesOutput,
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
@@ -93,22 +94,11 @@ class CloudflareSandboxInstance implements SandboxInstance {
 	}
 
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {
-		const probe = await this.exec(buildDirectoryProbeCommand(path));
-		if (!probe.success) {
-			return listFilesFailure(classifyListFilesFailure(probe));
+		const result = await this.exec(buildFindFilesCommand(path, options));
+		if (!result.success) {
+			return listFilesFailure(classifyListFilesFailure(result));
 		}
-		const res = await this.sandbox.listFiles(path, options);
-		if (!res.success) return listFilesFailure();
-		return {
-			success: true,
-			files: res.files.map((f) => ({
-				name: f.name,
-				absolutePath: f.absolutePath,
-				relativePath: f.relativePath,
-				type: f.type,
-				size: f.size,
-			})),
-		};
+		return { success: true, files: parseFindFilesOutput(result.stdout, path, options) };
 	}
 
 	async writeFiles(files: readonly SandboxFileWrite[]): Promise<void> {

--- a/packages/compute-cloudflare/src/index.ts
+++ b/packages/compute-cloudflare/src/index.ts
@@ -2,7 +2,9 @@ import { getSandbox, proxyToSandbox } from '@cloudflare/sandbox';
 import type { Sandbox } from '@cloudflare/sandbox';
 import {
 	base64Encode,
+	buildDirectoryProbeCommand,
 	buildGitCloneCommand,
+	classifyListFilesFailure,
 	mapWithConcurrency,
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
@@ -91,6 +93,10 @@ class CloudflareSandboxInstance implements SandboxInstance {
 	}
 
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {
+		const probe = await this.exec(buildDirectoryProbeCommand(path));
+		if (!probe.success) {
+			return listFilesFailure(classifyListFilesFailure(probe));
+		}
 		const res = await this.sandbox.listFiles(path, options);
 		if (!res.success) return listFilesFailure();
 		return {

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -6,8 +6,10 @@ import {
 	base64Encode,
 	buildFindFilesCommand,
 	buildGitCloneCommand,
+	classifyListFilesFailure,
 	iterableToStream,
 	mapWithConcurrency,
+	NOT_A_DIRECTORY_MARKER,
 	parseFindFilesOutput,
 	pollUntilReady,
 	portWaitCommand,
@@ -93,19 +95,38 @@ describe('removeUndefined', () => {
 
 describe('buildFindFilesCommand', () => {
 	it('builds a non-recursive find command by default', () => {
-		expect(buildFindFilesCommand('/workspace')).toBe(
+		expect(buildFindFilesCommand('/workspace')).toContain(
 			"find '/workspace' -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%p\\n'",
 		);
 	});
 
 	it('omits maxdepth for recursive listings', () => {
-		expect(buildFindFilesCommand('/workspace', { recursive: true })).toBe(
-			"find '/workspace' -mindepth 1 -printf '%y\\t%s\\t%p\\n'",
-		);
+		const command = buildFindFilesCommand('/workspace', { recursive: true });
+		expect(command).toContain("find '/workspace' -mindepth 1 -printf '%y\\t%s\\t%p\\n'");
+		expect(command).not.toContain('-maxdepth');
+	});
+
+	it('marks an existing non-directory before find can return an empty success', () => {
+		expect(buildFindFilesCommand('/workspace/file.py')).toContain(NOT_A_DIRECTORY_MARKER);
 	});
 
 	it('quotes the root path', () => {
 		expect(buildFindFilesCommand("/work'space")).toContain("'/work'\\''space'");
+	});
+});
+
+describe('classifyListFilesFailure', () => {
+	it('recognizes the non-directory marker on either output stream', () => {
+		expect(classifyListFilesFailure({ stdout: NOT_A_DIRECTORY_MARKER, stderr: '' })).toBe(
+			'NOT_A_DIRECTORY',
+		);
+		expect(classifyListFilesFailure({ stdout: '', stderr: NOT_A_DIRECTORY_MARKER })).toBe(
+			'NOT_A_DIRECTORY',
+		);
+	});
+
+	it('otherwise returns the generic list failure', () => {
+		expect(classifyListFilesFailure({ stdout: '', stderr: 'not found' })).toBe('LIST_FAILED');
 	});
 });
 

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -1,14 +1,19 @@
 import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { AddressInfo } from 'node:net';
 import { describe, it, expect } from 'vitest';
 import {
 	base64Encode,
+	buildDirectoryProbeCommand,
 	buildFindFilesCommand,
 	buildGitCloneCommand,
 	classifyListFilesFailure,
 	iterableToStream,
 	mapWithConcurrency,
+	NOT_A_DIRECTORY_EXIT_CODE,
 	NOT_A_DIRECTORY_MARKER,
 	parseFindFilesOutput,
 	pollUntilReady,
@@ -106,12 +111,39 @@ describe('buildFindFilesCommand', () => {
 		expect(command).not.toContain('-maxdepth');
 	});
 
-	it('marks an existing non-directory before find can return an empty success', () => {
-		expect(buildFindFilesCommand('/workspace/file.py')).toContain(NOT_A_DIRECTORY_MARKER);
-	});
-
 	it('quotes the root path', () => {
 		expect(buildFindFilesCommand("/work'space")).toContain("'/work'\\''space'");
+	});
+});
+
+describe('buildDirectoryProbeCommand', () => {
+	it('distinguishes directories, files, and missing paths', () => {
+		const directory = mkdtempSync(join(tmpdir(), 'marimohub-list-files-'));
+		const file = join(directory, 'notebook.py');
+		const missing = join(directory, 'missing.py');
+		writeFileSync(file, 'print(1)');
+
+		try {
+			const directoryResult = spawnSync('sh', ['-c', buildDirectoryProbeCommand(directory)], {
+				encoding: 'utf8',
+			});
+			expect(directoryResult.status).toBe(0);
+			expect(directoryResult.stderr).toBe('');
+
+			const fileResult = spawnSync('sh', ['-c', buildDirectoryProbeCommand(file)], {
+				encoding: 'utf8',
+			});
+			expect(fileResult.status).toBe(NOT_A_DIRECTORY_EXIT_CODE);
+			expect(fileResult.stderr).toBe(`${NOT_A_DIRECTORY_MARKER}\n`);
+
+			const missingResult = spawnSync('sh', ['-c', buildDirectoryProbeCommand(missing)], {
+				encoding: 'utf8',
+			});
+			expect(missingResult.status).toBe(1);
+			expect(missingResult.stderr).toBe('');
+		} finally {
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 });
 
@@ -127,6 +159,12 @@ describe('classifyListFilesFailure', () => {
 
 	it('otherwise returns the generic list failure', () => {
 		expect(classifyListFilesFailure({ stdout: '', stderr: 'not found' })).toBe('LIST_FAILED');
+		expect(
+			classifyListFilesFailure({
+				stdout: '',
+				stderr: `find: '/tmp/${NOT_A_DIRECTORY_MARKER}': Permission denied`,
+			}),
+		).toBe('LIST_FAILED');
 	});
 });
 

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -101,13 +101,13 @@ describe('removeUndefined', () => {
 describe('buildFindFilesCommand', () => {
 	it('builds a non-recursive find command by default', () => {
 		expect(buildFindFilesCommand('/workspace')).toContain(
-			"find '/workspace' -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%p\\n'",
+			"find '/workspace' -mindepth 1 -maxdepth 1 -printf '%y\\t%s\\t%p\\0'",
 		);
 	});
 
 	it('omits maxdepth for recursive listings', () => {
 		const command = buildFindFilesCommand('/workspace', { recursive: true });
-		expect(command).toContain("find '/workspace' -mindepth 1 -printf '%y\\t%s\\t%p\\n'");
+		expect(command).toContain("find '/workspace' -mindepth 1 -printf '%y\\t%s\\t%p\\0'");
 		expect(command).not.toContain('-maxdepth');
 	});
 
@@ -176,10 +176,10 @@ describe('parseFindFilesOutput', () => {
 		's\t7\t/workspace/socket',
 		'f\t5\t/workspace/.hidden',
 		'not-enough-columns',
-	].join('\n');
+	].join('\0');
 
 	it('maps find rows into file info and filters hidden files by default', () => {
-		expect(parseFindFilesOutput(`${output}\n`, '/workspace')).toEqual([
+		expect(parseFindFilesOutput(`${output}\0`, '/workspace')).toEqual([
 			{
 				name: 'a.py',
 				absolutePath: '/workspace/a.py',
@@ -213,7 +213,7 @@ describe('parseFindFilesOutput', () => {
 
 	it('includes hidden files when requested', () => {
 		expect(
-			parseFindFilesOutput('f\t5\t/workspace/.hidden\n', '/workspace', { includeHidden: true }),
+			parseFindFilesOutput('f\t5\t/workspace/.hidden\0', '/workspace', { includeHidden: true }),
 		).toEqual([
 			{
 				name: '.hidden',
@@ -226,7 +226,7 @@ describe('parseFindFilesOutput', () => {
 	});
 
 	it('handles root paths and non-numeric sizes', () => {
-		expect(parseFindFilesOutput('f\tNaN\t/tmp/a.py\n', '/')).toEqual([
+		expect(parseFindFilesOutput('f\tNaN\t/tmp/a.py\0', '/')).toEqual([
 			{
 				name: 'a.py',
 				absolutePath: '/tmp/a.py',
@@ -237,17 +237,18 @@ describe('parseFindFilesOutput', () => {
 		]);
 	});
 
-	it('preserves tabs that appear inside file paths', () => {
-		expect(parseFindFilesOutput('f\t1\t/workspace/has\ttab.py\n', '/workspace')[0]).toMatchObject({
-			name: 'has\ttab.py',
-			absolutePath: '/workspace/has\ttab.py',
+	it('preserves tabs and newlines inside file paths', () => {
+		const path = '/workspace/has\ttab\nand-newline.py';
+		expect(parseFindFilesOutput(`f\t1\t${path}\0`, '/workspace')[0]).toMatchObject({
+			name: 'has\ttab\nand-newline.py',
+			absolutePath: path,
 		});
 	});
 
 	it('passes an absolute path outside rootPath through unchanged as relativePath', () => {
 		// A row whose path is NOT under rootPath keeps its absolute path as the
 		// relativePath (no accidental prefix-stripping of an unrelated dir).
-		expect(parseFindFilesOutput('f\t3\t/etc/passwd\n', '/workspace')).toEqual([
+		expect(parseFindFilesOutput('f\t3\t/etc/passwd\0', '/workspace')).toEqual([
 			{
 				name: 'passwd',
 				absolutePath: '/etc/passwd',

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -114,8 +114,8 @@ export function classifyListFilesFailure(output: {
 	stdout: string;
 	stderr: string;
 }): 'NOT_A_DIRECTORY' | 'LIST_FAILED' {
-	return output.stdout.includes(NOT_A_DIRECTORY_MARKER) ||
-		output.stderr.includes(NOT_A_DIRECTORY_MARKER)
+	const hasMarkerLine = (value: string) => value.split(/\r?\n/).includes(NOT_A_DIRECTORY_MARKER);
+	return hasMarkerLine(output.stdout) || hasMarkerLine(output.stderr)
 		? 'NOT_A_DIRECTORY'
 		: 'LIST_FAILED';
 }

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -129,7 +129,7 @@ export function buildFindFilesCommand(
 		shellQuote(path),
 		'-mindepth 1',
 		...(options?.recursive ? [] : ['-maxdepth 1']),
-		"-printf '%y\\t%s\\t%p\\n'",
+		"-printf '%y\\t%s\\t%p\\0'",
 	];
 	return `${buildDirectoryProbeCommand(path)}; ${parts.join(' ')}`;
 }
@@ -140,9 +140,9 @@ export function parseFindFilesOutput(
 	options?: Pick<FindFilesOptions, 'includeHidden'>,
 ): ParsedFileInfo[] {
 	const files: ParsedFileInfo[] = [];
-	for (const line of stdout.split('\n')) {
-		if (!line) continue;
-		const [typeChar, sizeStr, ...pathParts] = line.split('\t');
+	for (const record of stdout.split('\0')) {
+		if (!record) continue;
+		const [typeChar, sizeStr, ...pathParts] = record.split('\t');
 		const absolutePath = pathParts.join('\t');
 		if (!absolutePath) continue;
 		const name = absolutePath.slice(absolutePath.lastIndexOf('/') + 1);

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -102,6 +102,24 @@ export interface ParsedFileInfo {
 	size: number;
 }
 
+export const NOT_A_DIRECTORY_MARKER = 'MARIMOHUB_NOT_A_DIRECTORY';
+export const NOT_A_DIRECTORY_EXIT_CODE = 20;
+
+export function buildDirectoryProbeCommand(path: string): string {
+	const quotedPath = shellQuote(path);
+	return `if [ -d ${quotedPath} ]; then :; elif [ -e ${quotedPath} ] || [ -L ${quotedPath} ]; then printf '${NOT_A_DIRECTORY_MARKER}\\n' >&2; exit ${NOT_A_DIRECTORY_EXIT_CODE}; else exit 1; fi`;
+}
+
+export function classifyListFilesFailure(output: {
+	stdout: string;
+	stderr: string;
+}): 'NOT_A_DIRECTORY' | 'LIST_FAILED' {
+	return output.stdout.includes(NOT_A_DIRECTORY_MARKER) ||
+		output.stderr.includes(NOT_A_DIRECTORY_MARKER)
+		? 'NOT_A_DIRECTORY'
+		: 'LIST_FAILED';
+}
+
 export function buildFindFilesCommand(
 	path: string,
 	options?: Pick<FindFilesOptions, 'recursive'>,
@@ -113,7 +131,7 @@ export function buildFindFilesCommand(
 		...(options?.recursive ? [] : ['-maxdepth 1']),
 		"-printf '%y\\t%s\\t%p\\n'",
 	];
-	return parts.join(' ');
+	return `${buildDirectoryProbeCommand(path)}; ${parts.join(' ')}`;
 }
 
 export function parseFindFilesOutput(

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -400,7 +400,7 @@ describe('DockerCompute', () => {
 	});
 
 	describe('listFiles()', () => {
-		const findOutput = (lines: string[]) => `${lines.join('\n')}\n`;
+		const findOutput = (lines: string[]) => `${lines.join('\0')}\0`;
 		const onlyFind =
 			(stdout: string, exitCode = 0) =>
 			(args: string[]) => {

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest';
+import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectListFilesResult } from '@marimo-hub/core/testing';
-import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import {
+	computeContract,
+	isContractNonDirectoryFindCommand,
+} from '@marimo-hub/core/testing/compute-contract';
 import { DockerCompute, spawnDockerRunner } from './docker';
 import {
 	containerCliContract,
@@ -497,11 +501,17 @@ computeContract(
 	() =>
 		new DockerCompute(
 			{},
-			fakeRunner((args) =>
-				args.at(-1) === 'false'
-					? { stdout: '', stderr: 'failed', exitCode: 1 }
-					: defaultHandler(args),
-			).runner,
+			fakeRunner((args) => {
+				if (args.at(-1) === 'false') return { stdout: '', stderr: 'failed', exitCode: 1 };
+				if (isContractNonDirectoryFindCommand(args.at(-1))) {
+					return {
+						stdout: '',
+						stderr: NOT_A_DIRECTORY_MARKER,
+						exitCode: NOT_A_DIRECTORY_EXIT_CODE,
+					};
+				}
+				return defaultHandler(args);
+			}).runner,
 		),
 	{
 		mountFallsBack: true,

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -7,6 +7,7 @@ import { spawn } from 'node:child_process';
 import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
+	classifyListFilesFailure,
 	mapWithConcurrency,
 	parseFindFilesOutput,
 	pollUntilReady,
@@ -190,7 +191,9 @@ class ContainerSandboxInstance implements SandboxInstance {
 
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {
 		const res = await this.dexec(buildFindFilesCommand(path, options));
-		if (res.exitCode !== 0) return listFilesFailure();
+		if (res.exitCode !== 0) {
+			return listFilesFailure(classifyListFilesFailure(res));
+		}
 		return { success: true, files: parseFindFilesOutput(res.stdout, path, options) };
 	}
 

--- a/packages/compute-container/src/podman.test.ts
+++ b/packages/compute-container/src/podman.test.ts
@@ -1,4 +1,8 @@
-import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
+import {
+	computeContract,
+	isContractNonDirectoryFindCommand,
+} from '@marimo-hub/core/testing/compute-contract';
 import { PodmanCompute, spawnPodmanRunner } from './podman';
 import { containerCliContract } from './testing';
 import type { PodmanRunResult, PodmanRunner } from './podman';
@@ -11,6 +15,13 @@ function fakeRunner(): PodmanRunner {
 				return { stdout: '127.0.0.1:49153\n', stderr: '', exitCode: 0 };
 			}
 			if (args.at(-1) === 'false') return { stdout: '', stderr: 'failed', exitCode: 1 };
+			if (isContractNonDirectoryFindCommand(args.at(-1))) {
+				return {
+					stdout: '',
+					stderr: NOT_A_DIRECTORY_MARKER,
+					exitCode: NOT_A_DIRECTORY_EXIT_CODE,
+				};
+			}
 			return { stdout: '', stderr: '', exitCode: 0 };
 		},
 	};

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -636,7 +636,7 @@ describe('CoreWeaveCompute', () => {
 	});
 
 	describe('listFiles()', () => {
-		const findOutput = (lines: string[]) => `${lines.join('\n')}\n`;
+		const findOutput = (lines: string[]) => `${lines.join('\0')}\0`;
 		const onlyFind = (stdout: string, exitCode = 0) => ({
 			runImpl: async (cmd: readonly string[]) =>
 				cmd.join(' ').includes('find') ? procResult({ stdout, exitCode }) : procResult(),

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { CWSandboxNotFoundError } from '@coreweave/cwsandbox';
 import type { SandboxInfo } from '@coreweave/cwsandbox';
+import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
 import type { SandboxId, SandboxProvider } from '@marimo-hub/core';
-import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import {
+	computeContract,
+	isContractNonDirectoryFindCommand,
+} from '@marimo-hub/core/testing/compute-contract';
 import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
 import { coreWeaveProfileResources, CoreWeaveCompute } from './index';
@@ -887,10 +891,20 @@ computeContract(
 	() =>
 		makeCompute(
 			makeWorld({
-				runImpl: async (command) =>
-					command.at(-1)?.includes('mh-contract-fail')
-						? procResult({ exitCode: 1, failed: true, ok: false, stderr: 'failed' })
-						: procResult(),
+				runImpl: async (command) => {
+					if (command.at(-1)?.includes('mh-contract-fail')) {
+						return procResult({ exitCode: 1, failed: true, ok: false, stderr: 'failed' });
+					}
+					if (isContractNonDirectoryFindCommand(command.at(-1))) {
+						return procResult({
+							exitCode: NOT_A_DIRECTORY_EXIT_CODE,
+							failed: true,
+							ok: false,
+							stderr: NOT_A_DIRECTORY_MARKER,
+						});
+					}
+					return procResult();
+				},
 			}),
 		),
 	{ mountFallsBack: true, semantics: { failingCommand: 'mh-contract-fail' } },

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -51,6 +51,7 @@ import { createSandboxClient, DEFAULT_CONTAINER_IMAGE } from '@coreweave/cwsandb
 import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
+	classifyListFilesFailure,
 	iterableToStream,
 	parseFindFilesOutput,
 	portWaitCommand,
@@ -511,7 +512,9 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		// PERSIST_WORKSPACE=workspace.
 		try {
 			const res = await this.exec(buildFindFilesCommand(path, options));
-			if (!res.success) return listFilesFailure();
+			if (!res.success) {
+				return listFilesFailure(classifyListFilesFailure(res));
+			}
 			return { success: true, files: parseFindFilesOutput(res.stdout, path, options) };
 		} catch {
 			return listFilesFailure('BACKEND_ERROR');

--- a/packages/compute-coreweave/src/wandb.test.ts
+++ b/packages/compute-coreweave/src/wandb.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
+import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
 import { Seconds } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
-import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import {
+	computeContract,
+	isContractNonDirectoryFindCommand,
+} from '@marimo-hub/core/testing/compute-contract';
 import { expectExecResult } from '@marimo-hub/core/testing';
 import { CoreWeaveCompute } from './index';
 import { buildWandbMetadata, createWandbCompute, serviceAddressResolver } from './wandb';
@@ -111,10 +115,20 @@ computeContract(
 		createWandbCompute(
 			baseConfig,
 			makeWorld({
-				runImpl: async (command) =>
-					command.at(-1) === 'false'
-						? procResult({ exitCode: 1, failed: true, ok: false, stderr: 'failed' })
-						: procResult(),
+				runImpl: async (command) => {
+					if (command.at(-1) === 'false') {
+						return procResult({ exitCode: 1, failed: true, ok: false, stderr: 'failed' });
+					}
+					if (isContractNonDirectoryFindCommand(command.at(-1))) {
+						return procResult({
+							exitCode: NOT_A_DIRECTORY_EXIT_CODE,
+							failed: true,
+							ok: false,
+							stderr: NOT_A_DIRECTORY_MARKER,
+						});
+					}
+					return procResult();
+				},
 			}).client,
 		),
 	{ mountFallsBack: true, semantics: { failingCommand: 'false' } },

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
+import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
 import { Seconds } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectListFilesResult } from '@marimo-hub/core/testing';
-import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import {
+	computeContract,
+	isContractNonDirectoryFindCommand,
+} from '@marimo-hub/core/testing/compute-contract';
 import { createE2bClient, E2bCompute } from './index';
 import type {
 	E2bClient,
@@ -739,7 +743,20 @@ describe('createE2bClient', () => {
 computeContract(
 	'E2bCompute',
 	() =>
-		new E2bCompute(baseConfig, new FakeE2b({ failOn: (cmd) => cmd.includes('mh-contract-fail') })),
+		new E2bCompute(
+			baseConfig,
+			new FakeE2b({
+				failOn: (cmd) => cmd.includes('mh-contract-fail'),
+				runResult: (cmd) =>
+					isContractNonDirectoryFindCommand(cmd)
+						? {
+								stdout: '',
+								stderr: NOT_A_DIRECTORY_MARKER,
+								exitCode: NOT_A_DIRECTORY_EXIT_CODE,
+							}
+						: undefined,
+			}),
+		),
 	{
 		mountFallsBack: true,
 		semantics: {

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -494,7 +494,7 @@ describe('E2bCompute', () => {
 	});
 
 	describe('listFiles()', () => {
-		const findOutput = (lines: string[]) => `${lines.join('\n')}\n`;
+		const findOutput = (lines: string[]) => `${lines.join('\0')}\0`;
 
 		it('parses find output and filters hidden files', async () => {
 			const fake = new FakeE2b({

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -20,6 +20,7 @@
 import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
+	classifyListFilesFailure,
 	parseFindFilesOutput,
 	pollUntilReady,
 	withEnvPrefix,
@@ -225,7 +226,9 @@ class E2bSandboxInstance implements SandboxInstance {
 		// The SDK filesystem API has no recursive list shape we rely on; shell out
 		// via `find` (not on the provision/teardown hot path).
 		const res = await this.exec(buildFindFilesCommand(path, options));
-		if (!res.success) return listFilesFailure();
+		if (!res.success) {
+			return listFilesFailure(classifyListFilesFailure(res));
+		}
 		return { success: true, files: parseFindFilesOutput(res.stdout, path, options) };
 	}
 

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
 import { Millis } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
-import { computeContract } from '@marimo-hub/core/testing/compute-contract';
+import {
+	computeContract,
+	isContractNonDirectoryFindCommand,
+} from '@marimo-hub/core/testing/compute-contract';
 import {
 	expectExecResult,
 	expectFileResult,
@@ -815,8 +819,19 @@ computeContract(
 	() =>
 		makeCompute(
 			makeWorld({
-				execImpl: (command) =>
-					command.at(-1) === 'false' ? { stdout: '', stderr: 'failed', exitCode: 1 } : undefined,
+				execImpl: (command) => {
+					if (command.at(-1) === 'false') {
+						return { stdout: '', stderr: 'failed', exitCode: 1 };
+					}
+					if (isContractNonDirectoryFindCommand(command.at(-1))) {
+						return {
+							stdout: '',
+							stderr: NOT_A_DIRECTORY_MARKER,
+							exitCode: NOT_A_DIRECTORY_EXIT_CODE,
+						};
+					}
+					return;
+				},
 			}),
 		),
 	{ mountFallsBack: true, semantics: { failingCommand: 'false' } },

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -364,7 +364,7 @@ describe('KubernetesCompute', () => {
 	});
 
 	describe('listFiles()', () => {
-		const findOutput = (lines: string[]) => `${lines.join('\n')}\n`;
+		const findOutput = (lines: string[]) => `${lines.join('\0')}\0`;
 
 		it('parses find output and filters hidden files', async () => {
 			const world = makeWorld({

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -42,6 +42,7 @@
 import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
+	classifyListFilesFailure,
 	mapWithConcurrency,
 	parseFindFilesOutput,
 	pollUntilReady,
@@ -413,7 +414,9 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		// on teardown to enumerate the working dir under PERSIST_WORKSPACE=workspace.
 		try {
 			const res = await this.exec(buildFindFilesCommand(path, options));
-			if (!res.success) return listFilesFailure();
+			if (!res.success) {
+				return listFilesFailure(classifyListFilesFailure(res));
+			}
 			return { success: true, files: parseFindFilesOutput(res.stdout, path, options) };
 		} catch {
 			return listFilesFailure('BACKEND_ERROR');

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -371,8 +371,10 @@ class LocalSandboxInstance implements SandboxInstance {
 				});
 			}
 			return { success: true, files };
-		} catch {
-			return listFilesFailure();
+		} catch (error) {
+			return listFilesFailure(
+				(error as NodeJS.ErrnoException).code === 'ENOTDIR' ? 'NOT_A_DIRECTORY' : 'LIST_FAILED',
+			);
 		}
 	}
 

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { NotFoundError } from 'modal';
-import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
+import { NotFoundError, SandboxFilesystemNotADirectoryError } from 'modal';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
 import {
 	computeContract,
 	CONTRACT_HIDDEN_FILE,
-	CONTRACT_NON_DIRECTORY_PATH,
 	CONTRACT_VISIBLE_FILE,
 } from '@marimo-hub/core/testing/compute-contract';
 import { modalProfileResources, ModalCompute } from './index';
@@ -95,7 +93,12 @@ class FakeSandbox implements ModalSandboxLike {
 		writeBytes: async (content: Uint8Array, path: string) => {
 			this.writeFile(path, content);
 		},
-		listFiles: async (path: string) => this.directories.get(path) ?? [],
+		listFiles: async (path: string) => {
+			if (this.files.has(path)) {
+				throw new SandboxFilesystemNotADirectoryError(`${path} is not a directory`);
+			}
+			return this.directories.get(path) ?? [];
+		},
 	};
 
 	async exec(
@@ -348,6 +351,19 @@ describe('ModalCompute', () => {
 			.listFiles('/workspace', { recursive: true });
 
 		expect(result.files.map((file) => file.relativePath)).toEqual(['a.py', 'sub', 'sub/b.py']);
+		expect(sandbox.execCalls).toEqual([]);
+	});
+
+	it('returns NOT_A_DIRECTORY when the SDK rejects a file path', async () => {
+		const world = makeWorld();
+		const sandbox = new FakeSandbox();
+		sandbox.files.set('/workspace/notebook.py', 'print(1)');
+		world.existing.set(SANDBOX_ID, sandbox);
+
+		await expect(
+			makeCompute(world).create(SANDBOX_ID).listFiles('/workspace/notebook.py'),
+		).resolves.toEqual(listFilesFailure('NOT_A_DIRECTORY'));
+		expect(sandbox.execCalls).toEqual([]);
 	});
 
 	it('returns BACKEND_ERROR when the SDK listing throws', async () => {
@@ -473,9 +489,6 @@ function contractWorld() {
 	world.client.sandboxes.create = async (app, image, options) => {
 		const sandbox = (await create(app, image, options)) as FakeSandbox;
 		sandbox.execImpl = (command) => {
-			if (command[2]?.includes(CONTRACT_NON_DIRECTORY_PATH)) {
-				return processResult(NOT_A_DIRECTORY_EXIT_CODE, '', NOT_A_DIRECTORY_MARKER);
-			}
 			return command[2]?.includes('mh-contract-fail')
 				? processResult(1, '', 'scripted failure')
 				: processResult();

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { NotFoundError } from 'modal';
+import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
 import {
 	computeContract,
 	CONTRACT_HIDDEN_FILE,
+	CONTRACT_NON_DIRECTORY_PATH,
 	CONTRACT_VISIBLE_FILE,
 } from '@marimo-hub/core/testing/compute-contract';
 import { modalProfileResources, ModalCompute } from './index';
@@ -470,10 +472,14 @@ function contractWorld() {
 	const create = world.client.sandboxes.create.bind(world.client.sandboxes);
 	world.client.sandboxes.create = async (app, image, options) => {
 		const sandbox = (await create(app, image, options)) as FakeSandbox;
-		sandbox.execImpl = (command) =>
-			command[2]?.includes('mh-contract-fail')
+		sandbox.execImpl = (command) => {
+			if (command[2]?.includes(CONTRACT_NON_DIRECTORY_PATH)) {
+				return processResult(NOT_A_DIRECTORY_EXIT_CODE, '', NOT_A_DIRECTORY_MARKER);
+			}
+			return command[2]?.includes('mh-contract-fail')
 				? processResult(1, '', 'scripted failure')
 				: processResult();
+		};
 		return sandbox;
 	};
 	return world;

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import { posix } from 'node:path';
-import { ModalClient, NotFoundError as ModalNotFoundError } from 'modal';
 import {
-	buildDirectoryProbeCommand,
+	ModalClient,
+	NotFoundError as ModalNotFoundError,
+	SandboxFilesystemNotADirectoryError,
+} from 'modal';
+import {
 	buildGitCloneCommand,
-	classifyListFilesFailure,
 	mapWithConcurrency,
 	shellQuote,
 	withEnvPrefix,
@@ -137,6 +139,13 @@ function isNotFound(error: unknown): boolean {
 	return (
 		error instanceof ModalNotFoundError ||
 		(error instanceof Error && error.name === 'NotFoundError')
+	);
+}
+
+function isNotADirectory(error: unknown): boolean {
+	return (
+		error instanceof SandboxFilesystemNotADirectoryError ||
+		(error instanceof Error && error.name === 'SandboxFilesystemNotADirectoryError')
 	);
 }
 
@@ -300,10 +309,6 @@ class ModalSandboxInstance implements SandboxInstance {
 
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {
 		try {
-			const probe = await this.exec(buildDirectoryProbeCommand(path));
-			if (!probe.success) {
-				return listFilesFailure(classifyListFilesFailure(probe));
-			}
 			const filesystem = (await this.getSandbox()).filesystem;
 			const files: FileInfo[] = [];
 			const visit = async (directory: string): Promise<void> => {
@@ -321,8 +326,8 @@ class ModalSandboxInstance implements SandboxInstance {
 			};
 			await visit(path);
 			return { success: true, files };
-		} catch {
-			return listFilesFailure('BACKEND_ERROR');
+		} catch (error) {
+			return listFilesFailure(isNotADirectory(error) ? 'NOT_A_DIRECTORY' : 'BACKEND_ERROR');
 		}
 	}
 

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -2,7 +2,9 @@ import { randomUUID } from 'node:crypto';
 import { posix } from 'node:path';
 import { ModalClient, NotFoundError as ModalNotFoundError } from 'modal';
 import {
+	buildDirectoryProbeCommand,
 	buildGitCloneCommand,
+	classifyListFilesFailure,
 	mapWithConcurrency,
 	shellQuote,
 	withEnvPrefix,
@@ -298,6 +300,10 @@ class ModalSandboxInstance implements SandboxInstance {
 
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {
 		try {
+			const probe = await this.exec(buildDirectoryProbeCommand(path));
+			if (!probe.success) {
+				return listFilesFailure(classifyListFilesFailure(probe));
+			}
 			const filesystem = (await this.getSandbox()).filesystem;
 			const files: FileInfo[] = [];
 			const visit = async (directory: string): Promise<void> => {

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -90,10 +90,14 @@ export interface FileInfo {
 
 export type ListFilesResult =
 	| { success: true; files: FileInfo[] }
-	| { success: false; files: []; error: { code: 'LIST_FAILED' | 'BACKEND_ERROR' } };
+	| {
+			success: false;
+			files: [];
+			error: { code: 'NOT_A_DIRECTORY' | 'LIST_FAILED' | 'BACKEND_ERROR' };
+	  };
 
 export function listFilesFailure(
-	code: 'LIST_FAILED' | 'BACKEND_ERROR' = 'LIST_FAILED',
+	code: 'NOT_A_DIRECTORY' | 'LIST_FAILED' | 'BACKEND_ERROR' = 'LIST_FAILED',
 ): ListFilesResult {
 	return { success: false, files: [], error: { code } };
 }
@@ -141,6 +145,10 @@ export interface SandboxInstance {
 	exec(cmd: string): Promise<ExecResult>;
 	execStream(cmd: string, options?: ExecStreamOptions): Promise<ReadableStream>;
 	readFile(path: string): Promise<ReadFileResult>;
+	/**
+	 * List entries below a directory. An existing non-directory path returns
+	 * `NOT_A_DIRECTORY`; it must never succeed with an empty file list.
+	 */
 	listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult>;
 	/**
 	 * Write a set of files, creating parent directories. Always a set, so the

--- a/packages/core/src/services/content/NotebookProposalService.test.ts
+++ b/packages/core/src/services/content/NotebookProposalService.test.ts
@@ -1504,15 +1504,15 @@ describe('NotebookProposalService', () => {
 		expect(calls.readFile).toHaveLength(0);
 	});
 
-	it('maps a sandbox listing failure to a safe conflict', async () => {
+	it('maps a sandbox listing failure to an internal error', async () => {
 		const { instance } = makeFsSandbox({ files: { 'dashboard.py': 'changed' } });
 		const sandbox = { ...instance, listFiles: async () => listFilesFailure('BACKEND_ERROR') };
-		await expect(capture(sandbox)).rejects.toThrow('Could not inspect');
+		await expect(capture(sandbox)).rejects.toThrow('Entry notebook inspection invariant failed');
 	});
 
-	it('rejects a missing entry notebook', async () => {
+	it('maps a missing entry notebook to an internal error', async () => {
 		const { instance } = makeFsSandbox({ files: { 'other.py': 'changed' } });
-		await expect(capture(instance)).rejects.toThrow('missing from the session');
+		await expect(capture(instance)).rejects.toThrow('Entry notebook inspection invariant failed');
 	});
 
 	it.each([-1, Number.NaN, Number.POSITIVE_INFINITY, 1.5])(
@@ -1522,7 +1522,7 @@ describe('NotebookProposalService', () => {
 				files: { 'dashboard.py': 'changed' },
 				sizes: { 'dashboard.py': size },
 			});
-			await expect(capture(instance)).rejects.toThrow('invalid file metadata');
+			await expect(capture(instance)).rejects.toThrow('Entry notebook inspection invariant failed');
 			expect(calls.readFile).toHaveLength(0);
 		},
 	);
@@ -1536,10 +1536,10 @@ describe('NotebookProposalService', () => {
 		expect(calls.readFile).toHaveLength(0);
 	});
 
-	it('maps a sandbox read failure to a safe conflict', async () => {
+	it('maps a sandbox read failure to an internal error', async () => {
 		const { instance } = makeFsSandbox({ files: { 'dashboard.py': 'changed' } });
 		const sandbox = { ...instance, readFile: async () => readFileFailure('BACKEND_ERROR') };
-		await expect(capture(sandbox)).rejects.toThrow('Could not read');
+		await expect(capture(sandbox)).rejects.toThrow('Entry notebook inspection invariant failed');
 	});
 
 	it.each([
@@ -1552,7 +1552,7 @@ describe('NotebookProposalService', () => {
 			readFile: async () =>
 				({ success: true, ...readResult }) as Awaited<ReturnType<SandboxInstance['readFile']>>,
 		};
-		await expect(capture(sandbox)).rejects.toThrow(/invalid (encoding|base64 content)/);
+		await expect(capture(sandbox)).rejects.toThrow('Entry notebook inspection invariant failed');
 	});
 
 	it('returns an existing proposal without touching the sandbox', async () => {

--- a/packages/core/src/services/content/proposalCapture.ts
+++ b/packages/core/src/services/content/proposalCapture.ts
@@ -293,7 +293,13 @@ async function captureEntryNotebook(
 	base: VersionPaths,
 	source: NotebookProposal['source'],
 ): Promise<CapturedProposalChanges> {
-	const content = await readChangedFile(sandbox, workdir, source.entry_notebook);
+	let content: Uint8Array;
+	try {
+		content = await readChangedFile(sandbox, workdir, source.entry_notebook);
+	} catch (error) {
+		if (!(error instanceof ConflictError)) throw error;
+		throw new Error('Entry notebook inspection invariant failed', { cause: error });
+	}
 	const baseObject = await bucket.get(base.workspaceFile(source.entry_notebook));
 	if (!baseObject) throw new NotFoundError('The synced entry notebook is missing');
 	if (proposalBytesEqual(content, await baseObject.bytes())) {

--- a/packages/core/src/testing/assertions.ts
+++ b/packages/core/src/testing/assertions.ts
@@ -88,7 +88,7 @@ export function expectListFilesResult(
 	expect(typeof received.success).toBe('boolean');
 	expect(Array.isArray(received.files)).toBe(true);
 	if (!received.success) {
-		expect(['LIST_FAILED', 'BACKEND_ERROR']).toContain(received.error.code);
+		expect(['NOT_A_DIRECTORY', 'LIST_FAILED', 'BACKEND_ERROR']).toContain(received.error.code);
 	}
 	for (const file of received.files) {
 		expect(typeof file.name).toBe('string');

--- a/packages/core/src/testing/computeContract.ts
+++ b/packages/core/src/testing/computeContract.ts
@@ -20,6 +20,11 @@ import { expectExecResult, expectFileResult, expectListFilesResult } from './ass
 export const CONTRACT_SANDBOX_ID = 'sb-aaaaaaaaaaaaaaaa' as SandboxId;
 export const CONTRACT_VISIBLE_FILE = 'contract-visible.txt';
 export const CONTRACT_HIDDEN_FILE = '.contract-hidden';
+export const CONTRACT_NON_DIRECTORY_PATH = '/workspace/contract-file.txt';
+
+export function isContractNonDirectoryFindCommand(command: string | undefined): boolean {
+	return Boolean(command?.includes('find ') && command.includes(CONTRACT_NON_DIRECTORY_PATH));
+}
 
 const CONTRACT_ID = CONTRACT_SANDBOX_ID;
 
@@ -153,6 +158,16 @@ export function computeContract(
 		it('listFiles returns a well-formed ListFilesResult', async () => {
 			const res = await provider.create(CONTRACT_ID).listFiles('/workspace');
 			expectListFilesResult(res);
+		});
+
+		it('listFiles of a file returns NOT_A_DIRECTORY, never an empty success', async () => {
+			const inst = provider.create(CONTRACT_ID);
+			await inst.writeFiles([{ path: CONTRACT_NON_DIRECTORY_PATH, content: 'contract' }]);
+			expect(await inst.listFiles(CONTRACT_NON_DIRECTORY_PATH)).toEqual({
+				success: false,
+				files: [],
+				error: { code: 'NOT_A_DIRECTORY' },
+			});
 		});
 
 		it('unmountBucket resolves', async () => {

--- a/packages/core/src/testing/computeContract.ts
+++ b/packages/core/src/testing/computeContract.ts
@@ -163,7 +163,8 @@ export function computeContract(
 		it('listFiles of a file returns NOT_A_DIRECTORY, never an empty success', async () => {
 			const inst = provider.create(CONTRACT_ID);
 			await inst.writeFiles([{ path: CONTRACT_NON_DIRECTORY_PATH, content: 'contract' }]);
-			expect(await inst.listFiles(CONTRACT_NON_DIRECTORY_PATH)).toEqual({
+			const result = await inst.listFiles(CONTRACT_NON_DIRECTORY_PATH);
+			expectListFilesResult(result, {
 				success: false,
 				files: [],
 				error: { code: 'NOT_A_DIRECTORY' },

--- a/packages/core/src/testing/fakes.test.ts
+++ b/packages/core/src/testing/fakes.test.ts
@@ -10,4 +10,14 @@ describe('makeFsSandbox', () => {
 			listFilesFailure('NOT_A_DIRECTORY'),
 		);
 	});
+
+	it('lists relative and absolute directory paths consistently', async () => {
+		const { instance } = makeFsSandbox({ files: { 'dir/notebook.py': 'print(1)' } });
+
+		const relative = await instance.listFiles('dir');
+		const absolute = await instance.listFiles('/workspace/dir');
+
+		expect(relative).toEqual(absolute);
+		expect(relative.files).toHaveLength(1);
+	});
 });

--- a/packages/core/src/testing/fakes.test.ts
+++ b/packages/core/src/testing/fakes.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { listFilesFailure } from '../ports/sandbox';
+import { makeFsSandbox } from './fakes';
+
+describe('makeFsSandbox', () => {
+	it('returns NOT_A_DIRECTORY when listFiles receives a file path', async () => {
+		const { instance } = makeFsSandbox({ files: { 'notebook.py': 'print(1)' } });
+
+		await expect(instance.listFiles('/workspace/notebook.py')).resolves.toEqual(
+			listFilesFailure('NOT_A_DIRECTORY'),
+		);
+	});
+});

--- a/packages/core/src/testing/fakes.ts
+++ b/packages/core/src/testing/fakes.ts
@@ -219,7 +219,7 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 
 	/** Map an absolute (or already-relative) path to its `fs` key. */
 	const toRel = (path: string) =>
-		path.startsWith(`${root}/`) ? path.slice(root.length + 1) : path;
+		path === root ? '' : path.startsWith(`${root}/`) ? path.slice(root.length + 1) : path;
 
 	const instance = {
 		async exec(cmd: string): Promise<ExecResult> {
@@ -245,12 +245,11 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 			return { success: true, content: new TextDecoder().decode(bytes), encoding: 'utf-8' };
 		},
 		async listFiles(path: string): Promise<ListFilesResult> {
-			if (fs.has(toRel(path))) return listFilesFailure('NOT_A_DIRECTORY');
+			const relativePath = toRel(path);
+			if (fs.has(relativePath)) return listFilesFailure('NOT_A_DIRECTORY');
+			const prefix = relativePath ? `${relativePath}/` : '';
 			const files: FileInfo[] = [...fs.entries()]
-				.filter(([rel]) => {
-					const abs = `${root}/${rel}`;
-					return abs.startsWith(`${path}/`);
-				})
+				.filter(([rel]) => rel.startsWith(prefix))
 				.map(([rel, bytes]) => ({
 					name: rel.split('/').pop() ?? rel,
 					absolutePath: `${root}/${rel}`,

--- a/packages/core/src/testing/fakes.ts
+++ b/packages/core/src/testing/fakes.ts
@@ -66,6 +66,7 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 	instance: SandboxInstance;
 	calls: SandboxCalls;
 } {
+	const writtenFiles = new Set<string>();
 	const calls: SandboxCalls = {
 		exec: [],
 		mountBucket: [],
@@ -111,11 +112,15 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 			}
 			return { success: true, content };
 		},
-		listFiles: async () => ({ success: true, files: [] }),
+		listFiles: async (path) =>
+			opts.files?.[path] !== undefined || writtenFiles.has(path)
+				? listFilesFailure('NOT_A_DIRECTORY')
+				: { success: true, files: [] },
 		writeFiles: async (files: readonly SandboxFileWrite[]) => {
 			calls.writeFiles.push([...files]);
 			calls.writeFile.push(...files);
 			calls.sequence.push('writeFiles');
+			for (const file of files) writtenFiles.add(file.path);
 		},
 		gitCheckout: async () => {},
 		setEnvVars: async (vars: Record<string, string>, options?: SetEnvVarsOptions) => {
@@ -240,10 +245,11 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 			return { success: true, content: new TextDecoder().decode(bytes), encoding: 'utf-8' };
 		},
 		async listFiles(path: string): Promise<ListFilesResult> {
+			if (fs.has(toRel(path))) return listFilesFailure('NOT_A_DIRECTORY');
 			const files: FileInfo[] = [...fs.entries()]
 				.filter(([rel]) => {
 					const abs = `${root}/${rel}`;
-					return abs === path || abs.startsWith(`${path}/`);
+					return abs.startsWith(`${path}/`);
 				})
 				.map(([rel, bytes]) => ({
 					name: rel.split('/').pop() ?? rel,


### PR DESCRIPTION
A non-directory path must never resolve to a successful empty file list. Adds a `NOT_A_DIRECTORY` result code to the `listFiles` port, probes the target with a shared directory-check command in `compute-commons`, and surfaces the new code across every compute adapter, the fakes, and the compute contract.