### PR TITLE
feat(web): SQL-readiness checklist and query surface gating

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -209,7 +209,10 @@ The brokered runtime supports a narrow Iceberg REST configuration. It requires a
 - one or more guarded S3 read locations
 - system TLS and default runtime options
 
-Set `storage.broker_read_locations` to the bucket prefixes that DuckDB can read.
+Switch **Storage** from the default `catalog` scheme to `s3` before configuring the brokered
+profile. The `storage.broker_read_locations` field only appears on that `s3` branch; set it to
+the bucket prefixes that DuckDB can read. Set **Access delegation** to `none` because the default
+`vended_credentials` mode is not supported by Run SQL.
 The worker receives no real catalog or S3 credentials.
 The parent broker authorizes each request, injects credentials, checks DNS results, and pins the target socket.
 

--- a/docs/partials/integrations/iceberg_rest.md
+++ b/docs/partials/integrations/iceberg_rest.md
@@ -16,7 +16,7 @@ Fields marked 🔒 use an encrypted value or an external reference. API response
 | `auth.method` | `none`, `bearer_token`, `basic`, `oauth2_client_credentials`, `sigv4`, `google`, `entra` | Yes |  |  |
 | `storage` |  |  |  |  |
 | `runtime` |  |  |  |  |
-| `access_delegation` | `none`, `vended_credentials`, `remote_signing`, `both` |  | `vended_credentials` |  |
+| `access_delegation` | `none`, `vended_credentials`, `remote_signing`, `both` |  | `vended_credentials` | Catalog delegation mode. Run SQL requires none. |
 | `tls.ca_bundle` | string |  |  |  |
 | `tls.client_certificate` | string |  |  |  |
 | `tls.client_key` 🔒 | string |  |  |  |

--- a/internal/schemas/integrations.yml
+++ b/internal/schemas/integrations.yml
@@ -3029,6 +3029,7 @@ components:
           $ref: '#/components/schemas/IcebergRuntime'
         access_delegation:
           default: vended_credentials
+          description: Catalog delegation mode. Run SQL requires none.
           type: string
           enum:
             - none
@@ -3267,6 +3268,7 @@ components:
           $ref: '#/components/schemas/IcebergRuntimeStored'
         access_delegation:
           default: vended_credentials
+          description: Catalog delegation mode. Run SQL requires none.
           type: string
           enum:
             - none

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -1819,6 +1819,37 @@ components:
             - source
             - id
           additionalProperties: false
+    IntegrationQueryReadinessCheck:
+      type: object
+      properties:
+        label:
+          type: string
+          minLength: 1
+        ready:
+          type: boolean
+        field:
+          type: string
+        reason:
+          type: string
+          minLength: 1
+      required:
+        - label
+        - ready
+        - field
+        - reason
+    IntegrationQueryReadinessRequest:
+      type: object
+      properties:
+        kind:
+          type: string
+          minLength: 1
+        config:
+          type: object
+          additionalProperties: {}
+      required:
+        - kind
+        - config
+      additionalProperties: false
     IntegrationBrowseCapability:
       type: object
       properties:
@@ -7984,6 +8015,94 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/projects/{pid}/integrations/query-readiness:
+    post:
+      tags:
+        - Integrations
+      summary: Evaluate SQL readiness for an unsaved integration config (manager only)
+      parameters:
+        - schema:
+            type: string
+            pattern: ^proj-[0-9a-z]{16}$
+            example: proj-7h2k9qm4xz7rp3w8
+          required: true
+          name: pid
+          in: path
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationQueryReadinessRequest'
+      responses:
+        '200':
+          description: All SQL readiness checks
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/IntegrationQueryReadinessCheck'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/projects/{pid}/integrations/{iid}/browse:
     get:
       tags:
@@ -10652,6 +10771,86 @@ paths:
                 example: '5'
               required: true
               description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/org/integrations/query-readiness:
+    post:
+      tags:
+        - Integrations
+      summary: Evaluate SQL readiness for an unsaved org config (super admin only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IntegrationQueryReadinessRequest'
+      responses:
+        '200':
+          description: All SQL readiness checks
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/IntegrationQueryReadinessCheck'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
           content:
             application/json:
               schema:

--- a/packages/api/src/routes/integrations.test.ts
+++ b/packages/api/src/routes/integrations.test.ts
@@ -624,6 +624,28 @@ describe('Integrations routes', () => {
 		expect(JSON.stringify(checks)).not.toContain(secret);
 	});
 
+	it('rejects invalid raw config before evaluating SQL readiness', async () => {
+		const pid = await createProject();
+		await expectError(
+			await request('POST', `/projects/${pid}/integrations/query-readiness`, {
+				kind: 'iceberg_rest',
+				config: {
+					uri: 'https://catalog.example.com/api',
+					auth: { method: 'none' },
+					access_delegation: 'none',
+					storage: {
+						scheme: 's3',
+						endpoint: 'https://objects.example.com',
+						anonymous: true,
+						broker_read_locations: [{ bucket: 'warehouse', prefix: 'tables' }],
+					},
+					rest: { unsupported_option: true },
+				},
+			}),
+			422,
+		);
+	});
+
 	it('accepts a stored integration id when testing an edited draft', async () => {
 		const pid = await createProject();
 		const created = await createPg(pid);

--- a/packages/api/src/routes/integrations.test.ts
+++ b/packages/api/src/routes/integrations.test.ts
@@ -422,6 +422,13 @@ describe('Integrations routes', () => {
 			}),
 			403,
 		);
+		await expectError(
+			await editorReq('POST', `/projects/${pid}/integrations/query-readiness`, {
+				kind: 'iceberg_rest',
+				config: {},
+			}),
+			403,
+		);
 
 		const managed = await expectOk<{ id: string }>(
 			await managerReq('POST', `/projects/${pid}/integrations`, {
@@ -586,6 +593,35 @@ describe('Integrations routes', () => {
 			}),
 			422,
 		);
+	});
+
+	it('returns every SQL readiness blocker without echoing draft secrets', async () => {
+		const pid = await createProject();
+		const secret = 'preflight-secret-must-not-return';
+		const response = await request('POST', `/projects/${pid}/integrations/query-readiness`, {
+			kind: 'iceberg_rest',
+			config: {
+				uri: 'https://catalog.example.com/api',
+				auth: { method: 'bearer_token', token: secret },
+				headers: { 'X-Custom': 'value' },
+				extra_properties: { 'rest.custom-option': 'true' },
+				storage: { scheme: 'catalog' },
+			},
+		});
+		const checks =
+			await expectOk<{ label: string; ready: boolean; field: string; reason: string }[]>(response);
+
+		expect(checks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ label: 'Remove custom headers', field: 'headers', ready: false }),
+				expect.objectContaining({
+					label: 'Remove extra properties',
+					field: 'extra_properties',
+					ready: false,
+				}),
+			]),
+		);
+		expect(JSON.stringify(checks)).not.toContain(secret);
 	});
 
 	it('accepts a stored integration id when testing an edited draft', async () => {
@@ -767,6 +803,13 @@ describe('Org integrations routes', () => {
 				source: 'draft',
 				kind: 'postgres',
 				config: PG_CONFIG,
+			}),
+			403,
+		);
+		await expectError(
+			await asUser('POST', '/org/integrations/query-readiness', {
+				kind: 'iceberg_rest',
+				config: {},
 			}),
 			403,
 		);

--- a/packages/api/src/routes/integrations.ts
+++ b/packages/api/src/routes/integrations.ts
@@ -14,6 +14,7 @@ import type {
 	ObjectBrowseContext,
 	ProjectIntegrationsService,
 	OrgIntegrationsService,
+	QueryReadinessRequest,
 	SlidingWindowBudget,
 	TestIntegrationRequest,
 } from '@marimo-hub/core';
@@ -198,6 +199,20 @@ const TestIntegrationBody = z
 	])
 	.openapi('IntegrationTestRequest');
 
+const QueryReadinessBody = z
+	.object({ kind: z.string().min(1), config: ConfigSchema })
+	.strict()
+	.openapi('IntegrationQueryReadinessRequest');
+
+const QueryReadinessCheckSchema = z
+	.object({
+		label: z.string().min(1),
+		ready: z.boolean(),
+		field: z.string(),
+		reason: z.string().min(1),
+	})
+	.openapi('IntegrationQueryReadinessCheck');
+
 const CopyIntegrationBody = z
 	.object({
 		source_project_id: z
@@ -367,6 +382,22 @@ const testIntegration = createRoute({
 	},
 });
 
+const queryReadiness = createRoute({
+	method: 'post',
+	path: '/projects/{pid}/integrations/query-readiness',
+	tags: ['Integrations'],
+	summary: 'Evaluate SQL readiness for an unsaved integration config (manager only)',
+	request: { params: ProjectIdParam, body: jsonBody(QueryReadinessBody) },
+	responses: {
+		200: jsonContent(
+			z.object({ success: z.literal(true), data: z.array(QueryReadinessCheckSchema) }),
+			'All SQL readiness checks',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404),
+	},
+});
+
 // Org-scoped (deployment-wide) instances, inherited by every project. All
 // management is super-admin only — org integrations render into every
 // project's sessions, so no project role can be sufficient.
@@ -488,6 +519,22 @@ const testOrgIntegration = createRoute({
 		),
 		...commonErrors(),
 		...errorResponses(403, 404, 429),
+	},
+});
+
+const queryOrgReadiness = createRoute({
+	method: 'post',
+	path: '/org/integrations/query-readiness',
+	tags: ['Integrations'],
+	summary: 'Evaluate SQL readiness for an unsaved org config (super admin only)',
+	request: { body: jsonBody(QueryReadinessBody) },
+	responses: {
+		200: jsonContent(
+			z.object({ success: z.literal(true), data: z.array(QueryReadinessCheckSchema) }),
+			'All SQL readiness checks',
+		),
+		...commonErrors(),
+		...errorResponses(403, 404),
 	},
 });
 
@@ -747,6 +794,16 @@ app.openapi(testIntegration, async (c) => {
 	return c.json({ success: true, data: await integrations.test(pid, body, objectContext) }, 200);
 });
 
+app.openapi(queryReadiness, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	const { pid } = c.req.valid('param');
+	const integrations = requireIntegrations(deps);
+	await assertProjectRole(deps.services.projects, pid, user, 'manager', deps.policy);
+	const body = c.req.valid('json') as QueryReadinessRequest;
+	return c.json({ success: true, data: integrations.queryReadiness(body) }, 200);
+});
+
 app.route('/', integrationBrowseApp);
 
 app.openapi(listOrgIntegrations, async (c) => {
@@ -881,6 +938,14 @@ app.openapi(testOrgIntegration, async (c) => {
 			}),
 	);
 	return c.json({ success: true, data: await integrations.test(body, objectContext) }, 200);
+});
+
+app.openapi(queryOrgReadiness, (c) => {
+	const deps = c.get('deps');
+	const integrations = requireOrgIntegrations(deps);
+	assertSuperAdmin(c.get('user'), deps.policy);
+	const body = c.req.valid('json') as QueryReadinessRequest;
+	return c.json({ success: true, data: integrations.queryReadiness(body) }, 200);
 });
 
 async function objectTestContext(

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -6140,6 +6140,117 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/projects/{pid}/integrations/query-readiness': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/** Evaluate SQL readiness for an unsaved integration config (manager only) */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path: {
+					pid: string;
+				};
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					'application/json': components['schemas']['IntegrationQueryReadinessRequest'];
+				};
+			};
+			responses: {
+				/** @description All SQL readiness checks */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['IntegrationQueryReadinessCheck'][];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Access forbidden */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/projects/{pid}/integrations/{iid}/browse': {
 		parameters: {
 			query?: never;
@@ -8858,6 +8969,115 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/org/integrations/query-readiness': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/** Evaluate SQL readiness for an unsaved org config (super admin only) */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					'application/json': components['schemas']['IntegrationQueryReadinessRequest'];
+				};
+			};
+			responses: {
+				/** @description All SQL readiness checks */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': {
+							/** @enum {boolean} */
+							success: true;
+							data: components['schemas']['IntegrationQueryReadinessCheck'][];
+						};
+					};
+				};
+				/** @description Authentication required */
+				401: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Access forbidden */
+				403: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Not found */
+				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Request body too large */
+				413: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Validation error */
+				422: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Internal server error */
+				500: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Service unavailable */
+				503: {
+					headers: {
+						/** @description Seconds to wait before retrying. */
+						'Retry-After': string;
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/users/search': {
 		parameters: {
 			query?: never;
@@ -10089,6 +10309,18 @@ export interface components {
 					source: 'stored';
 					id: string;
 			  };
+		IntegrationQueryReadinessCheck: {
+			label: string;
+			ready: boolean;
+			field: string;
+			reason: string;
+		};
+		IntegrationQueryReadinessRequest: {
+			kind: string;
+			config: {
+				[key: string]: unknown;
+			};
+		};
 		IntegrationBrowseCapability: {
 			surfaces: {
 				tables?: {

--- a/packages/core/src/ports/integrations.ts
+++ b/packages/core/src/ports/integrations.ts
@@ -277,6 +277,18 @@ export type TestIntegrationRequest =
 	| { source: 'draft'; kind: string; config: Record<string, unknown>; id?: IntegrationId }
 	| { source: 'stored'; id: IntegrationId };
 
+export interface QueryReadinessRequest {
+	kind: string;
+	config: Record<string, unknown>;
+}
+
+export interface QueryReadinessCheck {
+	label: string;
+	ready: boolean;
+	field: string;
+	reason: string;
+}
+
 export interface CopyIntegrationOptions {
 	/** Name for the copy; defaults to the source instance's name. */
 	name?: string;

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -102,6 +102,7 @@ import {
 	findStraySecretBoxes,
 	configForCopy,
 	openConfig,
+	parseAuthoringWithPlaceholders,
 	parseStoredWithPlaceholders,
 	redactConfig,
 	sealConfig,
@@ -824,13 +825,20 @@ class ScopedIntegrationsStore {
 	}
 
 	queryReadiness(request: QueryReadinessRequest): QueryReadinessCheck[] {
-		const readiness = this.registry.get(request.kind).query?.readiness;
+		const def = this.registry.get(request.kind);
+		const readiness = def.query?.readiness;
 		if (!readiness) {
 			throw new ValidationError(
 				`Integration kind "${request.kind}" does not expose SQL readiness checks.`,
 			);
 		}
-		return readiness(request.config);
+		const parsed = parseAuthoringWithPlaceholders({
+			schema: def.configSchema,
+			paths: this.registry.secretPathsOf(def.kind),
+			authoring: request.config,
+			check: def.validate?.bind(def),
+		});
+		return readiness(parsed);
 	}
 
 	/**

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -41,6 +41,8 @@ import type {
 	IntegrationVersionPageRequest,
 	IntegrationSecretSources,
 	KindDescriptor,
+	QueryReadinessCheck,
+	QueryReadinessRequest,
 	SessionRender,
 	SessionRenderContext,
 	TableSchema,
@@ -819,6 +821,16 @@ class ScopedIntegrationsStore {
 				details: objectTestFailure(error, metadata.root_kind),
 			};
 		}
+	}
+
+	queryReadiness(request: QueryReadinessRequest): QueryReadinessCheck[] {
+		const readiness = this.registry.get(request.kind).query?.readiness;
+		if (!readiness) {
+			throw new ValidationError(
+				`Integration kind "${request.kind}" does not expose SQL readiness checks.`,
+			);
+		}
+		return readiness(request.config);
 	}
 
 	/**
@@ -1720,6 +1732,10 @@ export class ProjectIntegrationsStore implements ProjectIntegrationsService {
 		return this.store.test(projectScope(projectId), request, objectContext);
 	}
 
+	queryReadiness(request: QueryReadinessRequest): QueryReadinessCheck[] {
+		return this.store.queryReadiness(request);
+	}
+
 	copy(
 		sourceProjectId: ProjectId,
 		id: IntegrationId,
@@ -1996,6 +2012,10 @@ export class OrgIntegrationsStore implements OrgIntegrationsService {
 
 	test(request: TestIntegrationRequest, objectContext?: ObjectBrowseContext): Promise<TestResult> {
 		return this.store.test(ORG_SCOPE, request, objectContext);
+	}
+
+	queryReadiness(request: QueryReadinessRequest): QueryReadinessCheck[] {
+		return this.store.queryReadiness(request);
 	}
 }
 

--- a/packages/core/src/services/integrations/contracts.ts
+++ b/packages/core/src/services/integrations/contracts.ts
@@ -12,6 +12,8 @@ import type {
 	IntegrationVersionPageRequest,
 	IntegrationSecretSources,
 	KindDescriptor,
+	QueryReadinessCheck,
+	QueryReadinessRequest,
 	SessionRender,
 	SessionRenderContext,
 	TableSchema,
@@ -72,6 +74,7 @@ export interface ProjectIntegrationsService {
 		request: TestIntegrationRequest,
 		objectContext?: ObjectBrowseContext,
 	): Promise<TestResult>;
+	queryReadiness(request: QueryReadinessRequest): QueryReadinessCheck[];
 	/**
 	 * Read-only catalog browsing. Unlike `get`/`test`, the id resolves
 	 * project-first, then the inherited org tier (shadowed org instances read
@@ -193,4 +196,5 @@ export interface OrgIntegrationsService {
 		page?: IntegrationVersionPageRequest,
 	): Promise<IntegrationVersionPage>;
 	test(request: TestIntegrationRequest, objectContext?: ObjectBrowseContext): Promise<TestResult>;
+	queryReadiness(request: QueryReadinessRequest): QueryReadinessCheck[];
 }

--- a/packages/core/src/services/integrations/kinds/icebergRest.ts
+++ b/packages/core/src/services/integrations/kinds/icebergRest.ts
@@ -4,6 +4,7 @@ import { asRecord } from '../../../internal/validation';
 import type {
 	BrowsePageRequest,
 	IntegrationProbe,
+	QueryReadinessCheck,
 	TableColumn,
 	TableSchema,
 } from '../../../ports/integrations';
@@ -310,6 +311,7 @@ export const icebergRest = defineIntegration({
 	},
 
 	query: {
+		readiness: duckdbPreviewReadiness,
 		available(config) {
 			const reason = duckdbPreviewBlocker(config);
 			return reason ? { ok: false as const, reason } : { ok: true as const };
@@ -549,71 +551,192 @@ rows = [[json_safe(record.get(column)) for column in columns] for record in arro
 print(json.dumps({"columns": columns, "rows": rows}, allow_nan=False, default=str, separators=(",", ":")))
 `;
 
+const advancedS3Fields = [
+	'role_arn',
+	'role_session_name',
+	'signer',
+	'signer_uri',
+	'signer_endpoint',
+	'resolve_region',
+	'proxy_uri',
+	'connect_timeout',
+	'request_timeout',
+] as const;
+
+function readinessCheck(
+	label: string,
+	ready: boolean,
+	field: string,
+	reason: string,
+): QueryReadinessCheck {
+	return { label, ready, field, reason };
+}
+
+function parsedUrl(value: unknown): URL | undefined {
+	if (typeof value !== 'string') return undefined;
+	try {
+		return new URL(value);
+	} catch {
+		return undefined;
+	}
+}
+
+function duckdbPreviewReadiness(value: unknown): QueryReadinessCheck[] {
+	const config = asRecord(value) ?? {};
+	const auth = asRecord(config.auth) ?? {};
+	const tls = asRecord(config.tls) ?? {};
+	const headers = asRecord(config.headers) ?? {};
+	const extraProperties = asRecord(config.extra_properties) ?? {};
+	const storage = asRecord(config.storage) ?? {};
+	const credentials = asRecord(storage.credentials) ?? {};
+	const runtime = asRecord(config.runtime) ?? {};
+	const rest: Record<string, unknown> = asRecord(config.rest) ?? ICEBERG_REST_DEFAULTS;
+	const catalogUrl = parsedUrl(config.uri);
+	const endpoint = parsedUrl(storage.endpoint);
+	const hasEndpoint = typeof storage.endpoint === 'string' && storage.endpoint.length > 0;
+	const storageIsS3 = storage.scheme === 's3';
+	const endpointOriginOnly = endpoint
+		? endpoint.pathname === '/' && endpoint.search === '' && endpoint.hash === ''
+		: false;
+	const authMethod = auth.method;
+	const credentialsMethod = credentials.method;
+	const advancedField = advancedS3Fields.find((field) => {
+		const fieldValue = storage[field];
+		return field === 'connect_timeout' || field === 'request_timeout'
+			? fieldValue !== undefined
+			: Boolean(fieldValue);
+	});
+	const supportedCredentials =
+		storageIsS3 &&
+		(storage.anonymous === true || (storage.anonymous !== true && credentialsMethod === 'static'));
+	const credentialsReason =
+		credentialsMethod === 'ambient'
+			? 'ambient S3 credentials are not supported by DuckDB-Wasm preview'
+			: credentialsMethod === 'profile'
+				? 'profile S3 credentials are not supported by DuckDB-Wasm preview'
+				: 'DuckDB-Wasm preview requires static or anonymous S3 credentials';
+	const defaultRestOptions =
+		(rest.snapshot_loading_mode ?? ICEBERG_REST_DEFAULTS.snapshot_loading_mode) ===
+			ICEBERG_REST_DEFAULTS.snapshot_loading_mode &&
+		(rest.metrics_reporting_enabled ?? ICEBERG_REST_DEFAULTS.metrics_reporting_enabled) ===
+			ICEBERG_REST_DEFAULTS.metrics_reporting_enabled &&
+		rest.page_size === undefined &&
+		(rest.view_endpoints_supported ?? ICEBERG_REST_DEFAULTS.view_endpoints_supported) ===
+			ICEBERG_REST_DEFAULTS.view_endpoints_supported &&
+		(rest.scan_planning_mode ?? ICEBERG_REST_DEFAULTS.scan_planning_mode) ===
+			ICEBERG_REST_DEFAULTS.scan_planning_mode &&
+		(rest.namespace_separator ?? ICEBERG_REST_DEFAULTS.namespace_separator) ===
+			ICEBERG_REST_DEFAULTS.namespace_separator &&
+		(rest.table_cache_expire_after_write_ms ??
+			ICEBERG_REST_DEFAULTS.table_cache_expire_after_write_ms) ===
+			ICEBERG_REST_DEFAULTS.table_cache_expire_after_write_ms &&
+		(rest.table_cache_max_entries ?? ICEBERG_REST_DEFAULTS.table_cache_max_entries) ===
+			ICEBERG_REST_DEFAULTS.table_cache_max_entries;
+
+	return [
+		readinessCheck(
+			'Use no catalog authentication or a bearer token',
+			authMethod === 'none' || authMethod === 'bearer_token',
+			'auth',
+			`${String(authMethod)} authentication is not supported by DuckDB-Wasm preview`,
+		),
+		readinessCheck(
+			'Use system TLS without custom certificates',
+			!tls.ca_bundle && !tls.client_certificate,
+			'tls',
+			'custom TLS material is not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Remove custom headers',
+			Object.keys(headers).length === 0,
+			'headers',
+			'custom headers are not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Remove extra properties',
+			Object.keys(extraProperties).length === 0,
+			'extra_properties',
+			'extra properties are not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Use a catalog URL without query parameters',
+			catalogUrl?.search === '',
+			'uri',
+			'catalog URLs with query parameters are not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Use a catalog URL without encoded path separators',
+			catalogUrl !== undefined && !/%2f|%5c/i.test(catalogUrl.pathname),
+			'uri',
+			'catalog URLs with encoded path separators are not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Set access delegation to none',
+			config.access_delegation === 'none',
+			'access_delegation',
+			'catalog access delegation is not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Switch Storage to the s3 scheme',
+			storageIsS3,
+			'storage',
+			'DuckDB-Wasm preview requires explicit S3 storage configuration',
+		),
+		readinessCheck(
+			'Set an explicit S3 endpoint',
+			storageIsS3 && hasEndpoint,
+			storageIsS3 ? 'storage.endpoint' : 'storage',
+			'DuckDB-Wasm preview requires an explicit S3 endpoint',
+		),
+		readinessCheck(
+			'Use an origin-only S3 endpoint',
+			storageIsS3 && endpointOriginOnly,
+			storageIsS3 ? 'storage.endpoint' : 'storage',
+			'DuckDB-Wasm preview requires an origin-only S3 endpoint',
+		),
+		readinessCheck(
+			'Use path-style S3 addressing',
+			storageIsS3 && storage.force_virtual_addressing !== true,
+			storageIsS3 ? 'storage.force_virtual_addressing' : 'storage',
+			'virtual-hosted S3 addressing is not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Remove advanced S3 client options',
+			storageIsS3 && advancedField === undefined,
+			storageIsS3 && advancedField ? `storage.${advancedField}` : 'storage',
+			'advanced S3 client options are not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Use static S3 credentials or anonymous access',
+			supportedCredentials,
+			storageIsS3 ? 'storage.credentials' : 'storage',
+			credentialsReason,
+		),
+		readinessCheck(
+			'Add at least one guarded S3 read location',
+			storageIsS3 &&
+				Array.isArray(storage.broker_read_locations) &&
+				storage.broker_read_locations.length > 0,
+			storageIsS3 ? 'storage.broker_read_locations' : 'storage',
+			'DuckDB-Wasm preview requires at least one guarded S3 read location',
+		),
+		readinessCheck(
+			'Keep PyIceberg runtime options at their defaults',
+			Object.keys(runtime).length === Object.keys(ICEBERG_RUNTIME_DEFAULTS).length,
+			'runtime',
+			'PyIceberg runtime options are not supported by DuckDB-Wasm preview',
+		),
+		readinessCheck(
+			'Keep REST client options at their defaults',
+			defaultRestOptions,
+			'rest',
+			'custom REST client options are not supported by DuckDB-Wasm preview',
+		),
+	];
+}
+
 function duckdbPreviewBlocker(config: IcebergRestConfig): string | undefined {
-	if (config.auth.method !== 'none' && config.auth.method !== 'bearer_token') {
-		return `${config.auth.method} authentication is not supported by DuckDB-Wasm preview`;
-	}
-	if (config.tls.ca_bundle || config.tls.client_certificate) {
-		return 'custom TLS material is not supported by DuckDB-Wasm preview';
-	}
-	if (Object.keys(config.headers).length > 0 || Object.keys(config.extra_properties).length > 0) {
-		return 'custom headers and properties are not supported by DuckDB-Wasm preview';
-	}
-	const catalogUrl = new URL(config.uri);
-	if (catalogUrl.search) {
-		return 'catalog URLs with query parameters are not supported by DuckDB-Wasm preview';
-	}
-	if (/%2f|%5c/i.test(catalogUrl.pathname)) {
-		return 'catalog URLs with encoded path separators are not supported by DuckDB-Wasm preview';
-	}
-	if (config.access_delegation !== 'none') {
-		return 'catalog access delegation is not supported by DuckDB-Wasm preview';
-	}
-	if (config.storage.scheme !== 's3') {
-		return 'DuckDB-Wasm preview requires explicit S3 storage configuration';
-	}
-	if (!config.storage.endpoint) {
-		return 'DuckDB-Wasm preview requires an explicit S3 endpoint';
-	}
-	const endpoint = new URL(config.storage.endpoint);
-	if (endpoint.pathname !== '/' || endpoint.search || endpoint.hash) {
-		return 'DuckDB-Wasm preview requires an origin-only S3 endpoint';
-	}
-	if (config.storage.force_virtual_addressing) {
-		return 'virtual-hosted S3 addressing is not supported by DuckDB-Wasm preview';
-	}
-	if (
-		config.storage.role_arn ||
-		config.storage.role_session_name ||
-		config.storage.signer ||
-		config.storage.signer_uri ||
-		config.storage.signer_endpoint ||
-		config.storage.resolve_region ||
-		config.storage.proxy_uri ||
-		config.storage.connect_timeout !== undefined ||
-		config.storage.request_timeout !== undefined
-	) {
-		return 'advanced S3 client options are not supported by DuckDB-Wasm preview';
-	}
-	if (!config.storage.anonymous && config.storage.credentials.method === 'ambient') {
-		return 'ambient S3 credentials are not supported by DuckDB-Wasm preview';
-	}
-	if (!config.storage.anonymous && config.storage.credentials.method === 'profile') {
-		return 'profile S3 credentials are not supported by DuckDB-Wasm preview';
-	}
-	if (!config.storage.anonymous && config.storage.credentials.method !== 'static') {
-		return 'DuckDB-Wasm preview requires static or anonymous S3 credentials';
-	}
-	if (config.storage.broker_read_locations.length === 0) {
-		return 'DuckDB-Wasm preview requires at least one guarded S3 read location';
-	}
-	if (JSON.stringify(config.runtime) !== JSON.stringify(ICEBERG_RUNTIME_DEFAULTS)) {
-		return 'PyIceberg runtime options are not supported by DuckDB-Wasm preview';
-	}
-	if (JSON.stringify(config.rest) !== JSON.stringify(ICEBERG_REST_DEFAULTS)) {
-		return 'custom REST client options are not supported by DuckDB-Wasm preview';
-	}
-	return undefined;
+	return duckdbPreviewReadiness(config).find((check) => !check.ready)?.reason;
 }
 
 function duckdbAuthOptions(

--- a/packages/core/src/services/integrations/kinds/icebergRest.ts
+++ b/packages/core/src/services/integrations/kinds/icebergRest.ts
@@ -581,7 +581,7 @@ function parsedUrl(value: unknown): URL | undefined {
 	}
 }
 
-function duckdbPreviewReadiness(value: unknown): QueryReadinessCheck[] {
+function duckdbPreviewReadiness(value: IcebergRestConfig): QueryReadinessCheck[] {
 	const config = asRecord(value) ?? {};
 	const auth = asRecord(config.auth) ?? {};
 	const tls = asRecord(config.tls) ?? {};

--- a/packages/core/src/services/integrations/kinds/icebergRest.ts
+++ b/packages/core/src/services/integrations/kinds/icebergRest.ts
@@ -88,7 +88,8 @@ const icebergRestConfig = z.strictObject({
 	runtime: icebergRuntimeSchema,
 	access_delegation: z
 		.enum(['none', 'vended_credentials', 'remote_signing', 'both'])
-		.default('vended_credentials'),
+		.default('vended_credentials')
+		.describe('Catalog delegation mode. Run SQL requires none.'),
 	tls: z
 		.strictObject({
 			ca_bundle: z.string().min(1).optional(),

--- a/packages/core/src/services/integrations/kinds/kinds.test.ts
+++ b/packages/core/src/services/integrations/kinds/kinds.test.ts
@@ -777,6 +777,45 @@ describe('kind renders (golden)', () => {
 		});
 	});
 
+	it('iceberg_rest derives query availability from its complete readiness result', () => {
+		const config = icebergRest.configSchema.parse({
+			uri: 'https://catalog.example.com/api',
+			auth: { method: 'none' },
+			access_delegation: 'none',
+			storage: {
+				scheme: 's3',
+				endpoint: 'https://objects.example.com',
+				anonymous: true,
+				broker_read_locations: [{ bucket: 'warehouse', prefix: 'tables' }],
+			},
+		});
+		const readyChecks = icebergRest.query?.readiness?.(config) ?? [];
+		expect(readyChecks.length).toBeGreaterThan(0);
+		expect(readyChecks.every((check) => check.ready)).toBe(true);
+		expect(icebergRest.query?.available(config)).toEqual({ ok: true });
+
+		const blocked = {
+			...config,
+			headers: { 'X-Custom': 'value' },
+			extra_properties: { 'rest.custom-option': 'true' },
+		};
+		const blockedChecks = icebergRest.query?.readiness?.(blocked) ?? [];
+		expect(blockedChecks).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ label: 'Remove custom headers', field: 'headers', ready: false }),
+				expect.objectContaining({
+					label: 'Remove extra properties',
+					field: 'extra_properties',
+					ready: false,
+				}),
+			]),
+		);
+		expect(icebergRest.query?.available(blocked)).toEqual({
+			ok: false,
+			reason: blockedChecks.find((check) => !check.ready)?.reason,
+		});
+	});
+
 	it('iceberg_rest keeps every remote value bound when optional warehouse is absent', () => {
 		const uri = "https://catalog.example.com/a'b";
 		const programs = icebergPreviewPrograms(

--- a/packages/core/src/services/integrations/sdk.test.ts
+++ b/packages/core/src/services/integrations/sdk.test.ts
@@ -389,7 +389,7 @@ describe('defineIntegration available-reason guard', () => {
 					{
 						label: `Remove ${String((config as { token?: unknown }).token)}`,
 						ready: false,
-						field: 'token',
+						field: String((config as { token?: unknown }).token),
 						reason: `query denied for ${String((config as { token?: unknown }).token)}`,
 					},
 				],
@@ -408,7 +408,7 @@ describe('defineIntegration available-reason guard', () => {
 			{
 				label: 'Meet the SQL configuration requirements',
 				ready: false,
-				field: 'token',
+				field: '',
 				reason: 'this configuration cannot run SQL from the hub',
 			},
 		]);

--- a/packages/core/src/services/integrations/sdk.test.ts
+++ b/packages/core/src/services/integrations/sdk.test.ts
@@ -385,6 +385,14 @@ describe('defineIntegration available-reason guard', () => {
 			configSchema: z.object({ token: zSecret() }),
 			render: () => ({}),
 			query: {
+				readiness: (config) => [
+					{
+						label: `Remove ${String((config as { token?: unknown }).token)}`,
+						ready: false,
+						field: 'token',
+						reason: `query denied for ${String((config as { token?: unknown }).token)}`,
+					},
+				],
 				available: (config) => ({ ok: false, reason: `query denied for ${config.token}` }),
 				plan: ({ config }) => {
 					throw new ValidationError(`bad plan for ${encodeURIComponent(config.token)}`);
@@ -396,6 +404,14 @@ describe('defineIntegration available-reason guard', () => {
 			ok: false,
 			reason: 'this instance cannot run SQL from the hub',
 		});
+		expect(queryLeaky.query!.readiness?.({ token: 'query secret/value' })).toEqual([
+			{
+				label: 'Meet the SQL configuration requirements',
+				ready: false,
+				field: 'token',
+				reason: 'this configuration cannot run SQL from the hub',
+			},
+		]);
 		expect(() =>
 			queryLeaky.query!.plan({
 				config: { token: 'query secret/value' },

--- a/packages/core/src/services/integrations/sdk.ts
+++ b/packages/core/src/services/integrations/sdk.ts
@@ -201,7 +201,7 @@ export interface IntegrationDefinition<S extends z.ZodType = z.ZodType> {
 		programs(input: PreviewProgramInput<z.infer<S>>): PreviewPrograms;
 	};
 	query?: {
-		readiness?(config: unknown): QueryReadinessCheck[];
+		readiness?(config: z.infer<S>): QueryReadinessCheck[];
 		available(config: z.infer<S>): { ok: true } | { ok: false; reason: string };
 		plan(input: { config: z.infer<S>; integration: IntegrationVersionPin }): DataQueryPlan;
 	};
@@ -274,20 +274,24 @@ function guardedQuery<C>(
 	return {
 		...(readiness
 			? {
-					readiness(config: unknown) {
+					readiness(config: C) {
 						try {
 							return readiness(config).map((check) => {
-								if (
+								const contentEchoesSecret =
 									echoesSecret(check.label, config, pathsOf()) ||
-									echoesSecret(check.reason, config, pathsOf())
-								) {
-									return {
-										...check,
-										label: 'Meet the SQL configuration requirements',
-										reason: 'this configuration cannot run SQL from the hub',
-									};
-								}
-								return check;
+									echoesSecret(check.reason, config, pathsOf());
+								const fieldEchoesSecret = echoesSecret(check.field, config, pathsOf());
+								if (!contentEchoesSecret && !fieldEchoesSecret) return check;
+								return {
+									...check,
+									...(contentEchoesSecret
+										? {
+												label: 'Meet the SQL configuration requirements',
+												reason: 'this configuration cannot run SQL from the hub',
+											}
+										: {}),
+									...(fieldEchoesSecret ? { field: '' } : {}),
+								};
 							});
 						} catch {
 							return [

--- a/packages/core/src/services/integrations/sdk.ts
+++ b/packages/core/src/services/integrations/sdk.ts
@@ -7,6 +7,7 @@ import type {
 	IntegrationCategory,
 	IntegrationProbe,
 	IntegrationVersionPin,
+	QueryReadinessCheck,
 	KindBrand,
 	ProbeRequestInit,
 	TableSchema,
@@ -200,6 +201,7 @@ export interface IntegrationDefinition<S extends z.ZodType = z.ZodType> {
 		programs(input: PreviewProgramInput<z.infer<S>>): PreviewPrograms;
 	};
 	query?: {
+		readiness?(config: unknown): QueryReadinessCheck[];
 		available(config: z.infer<S>): { ok: true } | { ok: false; reason: string };
 		plan(input: { config: z.infer<S>; integration: IntegrationVersionPin }): DataQueryPlan;
 	};
@@ -268,7 +270,38 @@ function guardedQuery<C>(
 	pathsOf: () => SecretPath[],
 ): NonNullable<IntegrationDefinition<z.ZodType<C>>['query']> {
 	const available = query.available.bind(query);
+	const readiness = query.readiness?.bind(query);
 	return {
+		...(readiness
+			? {
+					readiness(config: unknown) {
+						try {
+							return readiness(config).map((check) => {
+								if (
+									echoesSecret(check.label, config, pathsOf()) ||
+									echoesSecret(check.reason, config, pathsOf())
+								) {
+									return {
+										...check,
+										label: 'Meet the SQL configuration requirements',
+										reason: 'this configuration cannot run SQL from the hub',
+									};
+								}
+								return check;
+							});
+						} catch {
+							return [
+								{
+									label: 'Use a supported SQL configuration',
+									ready: false,
+									field: '',
+									reason: 'this configuration cannot run SQL from the hub',
+								},
+							];
+						}
+					},
+				}
+			: {}),
 		available(config) {
 			let verdict: ReturnType<typeof available>;
 			try {

--- a/packages/core/src/services/integrations/secretFields.ts
+++ b/packages/core/src/services/integrations/secretFields.ts
@@ -180,31 +180,11 @@ export async function sealConfig(options: {
 	check?: (parsed: unknown) => void;
 }): Promise<Record<string, unknown>> {
 	const { schema, paths, authoring, previous, seal, check } = options;
+	const parsed = parseAuthoringWithPlaceholders({ schema, paths, authoring, check });
 
-	// 1. Structural validation on a placeholder-substituted copy.
-	const sanitized = structuredClone(authoring);
-	for (const path of paths) {
-		for (const concrete of expandPath(sanitized, path)) {
-			const value = getAt(sanitized, concrete);
-			if (typeof value === 'string' || isKeepMarker(value) || isReferenceSecret(value)) {
-				setAt(sanitized, concrete, PLACEHOLDER);
-			} else if (value !== undefined) {
-				// Anything else (e.g. a forged stored envelope) is rejected outright.
-				throw new ValidationError(
-					`Secret field "${dotted(concrete)}" must be an encrypted value, an external reference, or a keep marker.`,
-				);
-			}
-		}
-	}
-	const parsed = schema.safeParse(sanitized);
-	if (!parsed.success) {
-		throw new ValidationError(`Invalid config: ${z.prettifyError(parsed.error)}`);
-	}
-	check?.(parsed.data);
-
-	// 2. Swap sealed values into the parsed output (which has defaults applied
-	//    and unknown keys stripped).
-	const stored = parsed.data as Record<string, unknown>;
+	// Swap sealed values into the parsed output (which has defaults applied
+	// and unknown keys stripped).
+	const stored = parsed as Record<string, unknown>;
 	for (const path of paths) {
 		for (const concrete of expandPath(stored, path)) {
 			if (getAt(stored, concrete) !== PLACEHOLDER) continue;
@@ -232,6 +212,36 @@ export async function sealConfig(options: {
 		}
 	}
 	return stored;
+}
+
+/** Parses authoring config without resolving or retaining its secret values. */
+export function parseAuthoringWithPlaceholders(options: {
+	schema: z.ZodType;
+	paths: SecretPath[];
+	authoring: Record<string, unknown>;
+	check?: (parsed: unknown) => void;
+}): unknown {
+	const { schema, paths, authoring, check } = options;
+	const sanitized = structuredClone(authoring);
+	for (const path of paths) {
+		for (const concrete of expandPath(sanitized, path)) {
+			const value = getAt(sanitized, concrete);
+			if (typeof value === 'string' || isKeepMarker(value) || isReferenceSecret(value)) {
+				setAt(sanitized, concrete, PLACEHOLDER);
+			} else if (value !== undefined) {
+				// Anything else (e.g. a forged stored envelope) is rejected outright.
+				throw new ValidationError(
+					`Secret field "${dotted(concrete)}" must be an encrypted value, an external reference, or a keep marker.`,
+				);
+			}
+		}
+	}
+	const parsed = schema.safeParse(sanitized);
+	if (!parsed.success) {
+		throw new ValidationError(`Invalid config: ${z.prettifyError(parsed.error)}`);
+	}
+	check?.(parsed.data);
+	return parsed.data;
 }
 
 /**

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -700,6 +700,27 @@ export function useTestIntegration(scope: IntegrationsScope) {
 	});
 }
 
+export function useQueryReadinessQuery(
+	scope: IntegrationsScope,
+	request: { kind: string; config: Record<string, unknown> },
+	enabled = true,
+) {
+	return useQuery({
+		queryKey: ['integration-query-readiness', integrationsListKey(scope), request],
+		enabled,
+		retry: false,
+		queryFn: () =>
+			apiData(
+				scope === 'org'
+					? apiClient.POST('/api/v1/org/integrations/query-readiness', { body: request })
+					: apiClient.POST('/api/v1/projects/{pid}/integrations/query-readiness', {
+							params: { path: { pid: scope.pid } },
+							body: request,
+						}),
+			),
+	});
+}
+
 // Data browser (read-only catalog metadata over an integration)
 
 /**

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -82,6 +82,7 @@ function makeFetch({
 	tables = ['orders'],
 	capability = { metadata: true, preview: false },
 	querySurface,
+	queryEnabled = querySurface !== undefined,
 	role = 'editor',
 	namespacesDown = false,
 	kind = icebergKind,
@@ -120,6 +121,7 @@ function makeFetch({
 	tables?: string[];
 	capability?: { metadata: boolean; preview: boolean; reason?: string };
 	querySurface?: { available: boolean; reason?: string };
+	queryEnabled?: boolean;
 	role?: 'editor' | 'manager';
 	namespacesDown?: boolean;
 	kind?: IntegrationKind;
@@ -163,7 +165,7 @@ function makeFetch({
 		const target = new URL(url, 'http://test');
 		if (url.includes('/api/v1/capabilities')) {
 			return ok({
-				data_browser: { available, preview: false, query: querySurface !== undefined },
+				data_browser: { available, preview: false, query: queryEnabled },
 			});
 		}
 		if (url.includes('/api/v1/integrations/kinds')) {
@@ -354,17 +356,33 @@ afterEach(() => {
 });
 
 describe('DataBrowserPage', () => {
-	it('hides Query when the server reports it unavailable', async () => {
+	it('shows a disabled Query control with the server blocker reason', async () => {
 		setup(`/projects/${PID}/data/${IID}`, {
 			role: 'manager',
 			querySurface: { available: false, reason: 'Broker unavailable.' },
 		});
 
 		await screen.findByTestId('browse-namespace', undefined, { timeout: 5000 });
-		expect(screen.queryByRole('button', { name: 'Tables' })).not.toBeInTheDocument();
-		expect(screen.queryByRole('button', { name: 'Query' })).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Tables' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Query' })).toBeDisabled();
 		expect(screen.queryByRole('button', { name: 'Objects' })).not.toBeInTheDocument();
-		expect(screen.queryByText(/Run SQL unavailable/)).not.toBeInTheDocument();
+		expect(screen.getByText('Run SQL unavailable.')).toBeInTheDocument();
+		expect(screen.getByText('Broker unavailable.')).toBeInTheDocument();
+	});
+
+	it('shows the deployment blocker when the global Run SQL capability is off', async () => {
+		setup(`/projects/${PID}/data/${IID}`, {
+			role: 'manager',
+			queryEnabled: false,
+			querySurface: {
+				available: false,
+				reason: 'Run SQL is not enabled on this deployment.',
+			},
+		});
+
+		await screen.findByTestId('browse-namespace', undefined, { timeout: 5000 });
+		expect(screen.getByRole('button', { name: 'Query' })).toBeDisabled();
+		expect(screen.getByText('Run SQL is not enabled on this deployment.')).toBeInTheDocument();
 	});
 
 	it('restores a deep link: tree expanded to the namespace, table selected, schema shown', async () => {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -200,10 +200,12 @@ export default function DataBrowserPage() {
 	const requestedSurface = searchParams.get('surface');
 	const selectedCapability = useBrowseCapabilityQuery(pid!, iid ?? '', selected !== undefined);
 	const querySurface = selectedCapability.data?.surfaces.query;
-	const canManageQueries =
+	const canManageQueries = project.your_role === 'manager' || project.your_role === 'admin';
+	const querySurfaceAvailable =
+		canManageQueries &&
 		(capabilities?.data_browser?.query ?? false) &&
-		(project.your_role === 'manager' || project.your_role === 'admin');
-	const querySurfaceAvailable = canManageQueries && (querySurface?.available ?? false);
+		(querySurface?.available ?? false);
+	const showQuerySurface = canManageQueries && querySurface !== undefined;
 	const selectedSurface =
 		requestedSurface === 'query' && querySurfaceAvailable
 			? 'query'
@@ -258,7 +260,7 @@ export default function DataBrowserPage() {
 				[
 					supportsTableBrowse(selectedKind),
 					supportsObjectBrowse(selectedKind),
-					querySurfaceAvailable,
+					showQuerySurface,
 				].filter(Boolean).length > 1 && (
 					<div
 						className="flex w-fit rounded-md border border-input p-1"
@@ -282,17 +284,36 @@ export default function DataBrowserPage() {
 								Objects
 							</Button>
 						) : null}
-						{querySurfaceAvailable ? (
+						{showQuerySurface ? (
 							<Button
 								size="sm"
 								variant={selectedSurface === 'query' ? 'primary' : 'ghost'}
 								onPress={() => selectSurface('query')}
+								isDisabled={!querySurfaceAvailable}
+								aria-describedby={querySurfaceAvailable ? undefined : 'query-surface-unavailable'}
 							>
 								Query
 							</Button>
 						) : null}
 					</div>
 				)}
+			{showQuerySurface && !querySurfaceAvailable && (
+				<output
+					id="query-surface-unavailable"
+					className="block rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-sm"
+				>
+					<p>
+						<span className="font-medium">Run SQL unavailable.</span>{' '}
+						<span className="text-muted-foreground">
+							{querySurface.reason ?? 'This integration is not SQL-ready.'}
+						</span>
+					</p>
+					<p className="mt-1 text-xs text-muted-foreground">
+						Edit this integration under Project environment → Integrations to see its SQL-ready
+						checklist.
+					</p>
+				</output>
+			)}
 			{!available ? (
 				<EmptyState
 					icon={<Database />}

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable jsx-a11y/prefer-tag-over-role -- output cannot contain this status's paragraphs */
 import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
@@ -298,7 +299,8 @@ export default function DataBrowserPage() {
 					</div>
 				)}
 			{showQuerySurface && !querySurfaceAvailable && (
-				<output
+				<div
+					role="status"
 					id="query-surface-unavailable"
 					className="block rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-sm"
 				>
@@ -312,7 +314,7 @@ export default function DataBrowserPage() {
 						Edit this integration under Project environment → Integrations to see its SQL-ready
 						checklist.
 					</p>
-				</output>
+				</div>
 			)}
 			{!available ? (
 				<EmptyState

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -189,6 +189,16 @@ function makeFetch({
 			return kinds === null ? notFound() : ok(kinds);
 		}
 		if (url.includes('/api/v1/org/integrations')) {
+			if (method === 'POST' && url.includes('/query-readiness')) {
+				return ok([
+					{
+						label: 'Set access delegation to none',
+						ready: false,
+						field: 'access_delegation',
+						reason: 'delegation is unsupported',
+					},
+				]);
+			}
 			if (method === 'GET') return ok({ items: orgEntries, next_cursor: null });
 			if (method === 'POST' && !url.includes('/test')) {
 				return ok(
@@ -210,6 +220,28 @@ function makeFetch({
 		}
 		if (url.includes(`/projects/${PID}/integrations/test`) && method === 'POST') {
 			return ok({ ok: true, latency_ms: 5 });
+		}
+		if (url.includes(`/projects/${PID}/integrations/query-readiness`) && method === 'POST') {
+			return ok([
+				{
+					label: 'Set access delegation to none',
+					ready: false,
+					field: 'access_delegation',
+					reason: 'delegation is unsupported',
+				},
+				{
+					label: 'Switch Storage to the s3 scheme',
+					ready: false,
+					field: 'storage',
+					reason: 's3 storage is required',
+				},
+				{
+					label: 'Add at least one guarded S3 read location',
+					ready: false,
+					field: 'storage',
+					reason: 'a read location is required',
+				},
+			]);
 		}
 		if (
 			(url.endsWith('/api/v1/projects') || url.includes('/api/v1/projects?')) &&
@@ -466,7 +498,7 @@ describe('ProjectIntegrationsPanel — create flow', () => {
 		await user.click(screen.getByText('Iceberg REST Catalog'));
 
 		expect(screen.getByRole('heading', { name: 'Run SQL readiness' })).toBeInTheDocument();
-		expect(screen.getByText('Set access delegation to none')).toBeInTheDocument();
+		expect(await screen.findByText('Set access delegation to none')).toBeInTheDocument();
 		expect(screen.getByText('Switch Storage to the s3 scheme')).toBeInTheDocument();
 		expect(screen.getByText('Add at least one guarded S3 read location')).toBeInTheDocument();
 	});

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -100,6 +100,13 @@ const clickhouseKind: IntegrationKind = {
 	},
 };
 
+const icebergRestKind: IntegrationKind = {
+	...postgresKind,
+	kind: 'iceberg_rest',
+	title: 'Iceberg REST Catalog',
+	category: 'catalog',
+};
+
 const entry = (over: Partial<IntegrationEntry> = {}): IntegrationEntry => ({
 	id: 'i_1',
 	kind: 'postgres',
@@ -451,6 +458,19 @@ describe('ProjectIntegrationsPanel — list view', () => {
 });
 
 describe('ProjectIntegrationsPanel — create flow', () => {
+	it('shows the SQL-ready preflight for Iceberg REST', async () => {
+		const user = userEvent.setup();
+		setup({}, { kinds: [icebergRestKind], entries: [] });
+
+		await user.click(await screen.findByRole('button', { name: /add integration/i }));
+		await user.click(screen.getByText('Iceberg REST Catalog'));
+
+		expect(screen.getByRole('heading', { name: 'Run SQL readiness' })).toBeInTheDocument();
+		expect(screen.getByText('Set access delegation to none')).toBeInTheDocument();
+		expect(screen.getByText('Switch Storage to the s3 scheme')).toBeInTheDocument();
+		expect(screen.getByText('Add at least one guarded S3 read location')).toBeInTheDocument();
+	});
+
 	it('picks a kind from the catalog, fills the form, and POSTs the pruned config', async () => {
 		const user = userEvent.setup();
 		const { calls } = setup({}, { kinds: [postgresKind, customEnvKind], entries: [] });

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.test.tsx
@@ -105,6 +105,21 @@ const icebergRestKind: IntegrationKind = {
 	kind: 'iceberg_rest',
 	title: 'Iceberg REST Catalog',
 	category: 'catalog',
+	json_schema: {
+		type: 'object',
+		properties: {
+			headers: {
+				type: 'object',
+				additionalProperties: { type: 'string' },
+				default: {},
+			},
+			extra_properties: {
+				type: 'object',
+				additionalProperties: { type: 'string' },
+				default: {},
+			},
+		},
+	},
 };
 
 const entry = (over: Partial<IntegrationEntry> = {}): IntegrationEntry => ({
@@ -626,6 +641,40 @@ describe('ProjectIntegrationsPanel — edit flow', () => {
 				},
 			});
 		});
+	});
+
+	it('redacts arbitrary record values from automatic readiness requests', async () => {
+		const user = userEvent.setup();
+		const icebergEntry = entry({ id: 'i_iceberg', kind: 'iceberg_rest', name: 'lake' });
+		const { calls } = setup(
+			{},
+			{
+				kinds: [icebergRestKind],
+				entries: [icebergEntry],
+				details: {
+					i_iceberg: {
+						...icebergEntry,
+						config: {
+							headers: { 'X-Custom': 'header-credential' },
+							extra_properties: { option: 'property-credential' },
+						},
+					},
+				},
+			},
+		);
+
+		await user.click(await screen.findByRole('button', { name: 'Edit lake' }));
+		await waitFor(() => {
+			const readiness = calls.find((call) => call.url.includes('/query-readiness'));
+			expect(readiness?.body).toEqual({
+				kind: 'iceberg_rest',
+				config: {
+					headers: { 'X-Custom': '' },
+					extra_properties: { option: '' },
+				},
+			});
+		});
+		expect(JSON.stringify(calls)).not.toMatch(/header-credential|property-credential/);
 	});
 
 	it('does not PATCH after Replace is selected but the required secret is left blank', async () => {

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/api/hooks';
 import type { IntegrationsScope } from '@/api/hooks';
 import { BRAND_ICONS } from './brandIcons';
+import { SqlReadinessChecklist } from './SqlReadinessChecklist';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { canManageProject } from '@/lib/roles';
 import { filterBySearch } from '@/lib/search';
@@ -900,6 +901,7 @@ function EditorForm({
 				onChange={setName}
 				error={errors.__name}
 			/>
+			{kind.kind === 'iceberg_rest' && <SqlReadinessChecklist config={config} />}
 			<SchemaForm
 				schema={schema}
 				hints={hints}

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
@@ -840,7 +840,10 @@ function EditorForm({
 	const testIntegration = useTestIntegration(scope);
 	const readinessConfig = useMemo(
 		() =>
-			redactSecretsForRequest(schema, pruneForSubmit(schema, config)) as Record<string, unknown>,
+			redactSecretsForRequest(schema, pruneForSubmit(schema, config), config) as Record<
+				string,
+				unknown
+			>,
 		[schema, config],
 	);
 	const debouncedReadinessConfig = useDebouncedValue(readinessConfig);

--- a/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
+++ b/packages/web/src/components/Project/ProjectIntegrationsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import {
 	ArrowLeft,
@@ -30,6 +30,7 @@ import {
 	SchemaForm,
 	buildDefaults,
 	pruneForSubmit,
+	redactSecretsForRequest,
 	validateValue,
 } from '@/components/form/schema-form';
 import type { JsonSchemaNode, UiHints } from '@/components/form/schema-form';
@@ -42,6 +43,7 @@ import {
 	useIntegrationsQuery,
 	useProjectPickerQuery,
 	useProjectRoleQuery,
+	useQueryReadinessQuery,
 	useTestIntegration,
 	useUpdateIntegration,
 } from '@/api/hooks';
@@ -49,6 +51,7 @@ import type { IntegrationsScope } from '@/api/hooks';
 import { BRAND_ICONS } from './brandIcons';
 import { SqlReadinessChecklist } from './SqlReadinessChecklist';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
 import { canManageProject } from '@/lib/roles';
 import { filterBySearch } from '@/lib/search';
 import type { IntegrationEntry, IntegrationKind, ProjectDetail } from '@/types';
@@ -835,6 +838,17 @@ function EditorForm({
 	const createIntegration = useCreateIntegration(scope);
 	const updateIntegration = useUpdateIntegration(scope);
 	const testIntegration = useTestIntegration(scope);
+	const readinessConfig = useMemo(
+		() =>
+			redactSecretsForRequest(schema, pruneForSubmit(schema, config)) as Record<string, unknown>,
+		[schema, config],
+	);
+	const debouncedReadinessConfig = useDebouncedValue(readinessConfig);
+	const readinessQuery = useQueryReadinessQuery(
+		scope,
+		{ kind: kind.kind, config: debouncedReadinessConfig },
+		kind.kind === 'iceberg_rest',
+	);
 	const isPending = createIntegration.isPending || updateIntegration.isPending;
 
 	const submit = async () => {
@@ -901,7 +915,13 @@ function EditorForm({
 				onChange={setName}
 				error={errors.__name}
 			/>
-			{kind.kind === 'iceberg_rest' && <SqlReadinessChecklist config={config} />}
+			{kind.kind === 'iceberg_rest' && (
+				<SqlReadinessChecklist
+					checks={readinessQuery.data}
+					isPending={readinessQuery.isPending || readinessConfig !== debouncedReadinessConfig}
+					isError={readinessQuery.isError}
+				/>
+			)}
 			<SchemaForm
 				schema={schema}
 				hints={hints}

--- a/packages/web/src/components/Project/SqlReadinessChecklist.test.ts
+++ b/packages/web/src/components/Project/SqlReadinessChecklist.test.ts
@@ -1,58 +1,58 @@
+import { createElement } from 'react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { icebergRestSqlReadiness } from './SqlReadinessChecklist';
+import { SqlReadinessChecklist } from './SqlReadinessChecklist';
 
-const sqlReadyConfig = {
-	uri: 'https://catalog.example.com/api',
-	auth: { method: 'bearer_token', token: 'redacted' },
-	access_delegation: 'none',
-	storage: {
-		scheme: 's3',
-		endpoint: 'https://objects.example.com',
-		credentials: { method: 'static', access_key_id: 'key', secret_access_key: 'secret' },
-		force_virtual_addressing: false,
-		anonymous: false,
-		broker_read_locations: [{ bucket: 'warehouse', prefix: 'tables' }],
-	},
-	tls: {},
-	headers: {},
-	extra_properties: {},
-	runtime: {},
-	rest: {
-		snapshot_loading_mode: 'all',
-		metrics_reporting_enabled: true,
-		view_endpoints_supported: false,
-		scan_planning_mode: 'client',
-		namespace_separator: '%1F',
-		table_cache_expire_after_write_ms: 300_000,
-		table_cache_max_entries: 100,
-	},
-};
+const check = (label: string, field: string, ready = false) => ({
+	label,
+	field,
+	ready,
+	reason: `${label} is required`,
+});
 
-describe('icebergRestSqlReadiness', () => {
-	it('accepts the brokered SQL profile', () => {
-		expect(icebergRestSqlReadiness(sqlReadyConfig).every((check) => check.ready)).toBe(true);
+describe('SqlReadinessChecklist', () => {
+	it('renders the server-provided readiness result', () => {
+		render(
+			createElement(SqlReadinessChecklist, {
+				checks: [
+					check('Set access delegation to none', 'access_delegation'),
+					check('Ready', 'uri', true),
+				],
+				isPending: false,
+				isError: false,
+			}),
+		);
+
+		expect(
+			screen.getByText(
+				'1 of 2 configuration checks pass. Select a failing check to edit its field.',
+			),
+		).toBeTruthy();
+		expect(screen.getByRole('link', { name: /Set access delegation to none/ })).toHaveAttribute(
+			'href',
+			'#integration-field-access_delegation',
+		);
 	});
 
-	it('returns every blocker instead of stopping after access delegation', () => {
-		const checks = icebergRestSqlReadiness({
-			...sqlReadyConfig,
-			uri: 'https://catalog.example.com/api?tenant=demo',
-			auth: { method: 'oauth2_client_credentials' },
-			access_delegation: 'vended_credentials',
-			storage: { scheme: 'catalog' },
-			headers: { 'X-Custom': 'value' },
-			runtime: { max_workers: 2 },
-		});
-		const blockers = checks.filter((check) => !check.ready).map((check) => check.label);
-
-		expect(blockers).toContain('Use no catalog authentication or a bearer token');
-		expect(blockers).toContain('Remove custom headers and extra properties');
-		expect(blockers).toContain(
-			'Use a catalog URL without query parameters or encoded path separators',
+	it('links header and extra-property blockers to separate fields', () => {
+		render(
+			createElement(SqlReadinessChecklist, {
+				checks: [
+					check('Remove custom headers', 'headers'),
+					check('Remove extra properties', 'extra_properties'),
+				],
+				isPending: false,
+				isError: false,
+			}),
 		);
-		expect(blockers).toContain('Set access delegation to none');
-		expect(blockers).toContain('Switch Storage to the s3 scheme');
-		expect(blockers).toContain('Add at least one guarded S3 read location');
-		expect(blockers).toContain('Keep PyIceberg runtime options at their defaults');
+
+		expect(screen.getByRole('link', { name: /Remove custom headers/ })).toHaveAttribute(
+			'href',
+			'#integration-field-headers',
+		);
+		expect(screen.getByRole('link', { name: /Remove extra properties/ })).toHaveAttribute(
+			'href',
+			'#integration-field-extra_properties',
+		);
 	});
 });

--- a/packages/web/src/components/Project/SqlReadinessChecklist.test.ts
+++ b/packages/web/src/components/Project/SqlReadinessChecklist.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { icebergRestSqlReadiness } from './SqlReadinessChecklist';
+
+const sqlReadyConfig = {
+	uri: 'https://catalog.example.com/api',
+	auth: { method: 'bearer_token', token: 'redacted' },
+	access_delegation: 'none',
+	storage: {
+		scheme: 's3',
+		endpoint: 'https://objects.example.com',
+		credentials: { method: 'static', access_key_id: 'key', secret_access_key: 'secret' },
+		force_virtual_addressing: false,
+		anonymous: false,
+		broker_read_locations: [{ bucket: 'warehouse', prefix: 'tables' }],
+	},
+	tls: {},
+	headers: {},
+	extra_properties: {},
+	runtime: {},
+	rest: {
+		snapshot_loading_mode: 'all',
+		metrics_reporting_enabled: true,
+		view_endpoints_supported: false,
+		scan_planning_mode: 'client',
+		namespace_separator: '%1F',
+		table_cache_expire_after_write_ms: 300_000,
+		table_cache_max_entries: 100,
+	},
+};
+
+describe('icebergRestSqlReadiness', () => {
+	it('accepts the brokered SQL profile', () => {
+		expect(icebergRestSqlReadiness(sqlReadyConfig).every((check) => check.ready)).toBe(true);
+	});
+
+	it('returns every blocker instead of stopping after access delegation', () => {
+		const checks = icebergRestSqlReadiness({
+			...sqlReadyConfig,
+			uri: 'https://catalog.example.com/api?tenant=demo',
+			auth: { method: 'oauth2_client_credentials' },
+			access_delegation: 'vended_credentials',
+			storage: { scheme: 'catalog' },
+			headers: { 'X-Custom': 'value' },
+			runtime: { max_workers: 2 },
+		});
+		const blockers = checks.filter((check) => !check.ready).map((check) => check.label);
+
+		expect(blockers).toContain('Use no catalog authentication or a bearer token');
+		expect(blockers).toContain('Remove custom headers and extra properties');
+		expect(blockers).toContain(
+			'Use a catalog URL without query parameters or encoded path separators',
+		);
+		expect(blockers).toContain('Set access delegation to none');
+		expect(blockers).toContain('Switch Storage to the s3 scheme');
+		expect(blockers).toContain('Add at least one guarded S3 read location');
+		expect(blockers).toContain('Keep PyIceberg runtime options at their defaults');
+	});
+});

--- a/packages/web/src/components/Project/SqlReadinessChecklist.tsx
+++ b/packages/web/src/components/Project/SqlReadinessChecklist.tsx
@@ -1,0 +1,207 @@
+import { Check, CircleAlert } from 'lucide-react';
+import { schemaFieldId } from '@/components/form/schema-form';
+
+export interface SqlReadinessCheck {
+	label: string;
+	ready: boolean;
+	field: string;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+	typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+
+function catalogUrlReady(value: unknown): boolean {
+	if (typeof value !== 'string') return false;
+	try {
+		const url = new URL(value);
+		return url.search === '' && !/%2f|%5c/i.test(url.pathname);
+	} catch {
+		return false;
+	}
+}
+
+function storageEndpointReady(value: unknown): boolean {
+	if (typeof value !== 'string' || value === '') return false;
+	try {
+		const url = new URL(value);
+		return url.pathname === '/' && url.search === '' && url.hash === '';
+	} catch {
+		return false;
+	}
+}
+
+const advancedStorageKeys = [
+	'role_arn',
+	'role_session_name',
+	'signer',
+	'signer_uri',
+	'signer_endpoint',
+	'resolve_region',
+	'proxy_uri',
+	'connect_timeout',
+	'request_timeout',
+] as const;
+
+export function icebergRestSqlReadiness(config: Record<string, unknown>): SqlReadinessCheck[] {
+	const auth = asRecord(config.auth);
+	const tls = asRecord(config.tls);
+	const headers = asRecord(config.headers);
+	const extraProperties = asRecord(config.extra_properties);
+	const storage = asRecord(config.storage);
+	const credentials = asRecord(storage.credentials);
+	const runtime = asRecord(config.runtime);
+	const rest = asRecord(config.rest);
+	const storageIsS3 = storage.scheme === 's3';
+	const advancedStorageBlocker = advancedStorageKeys.find((key) => Boolean(storage[key]));
+	const usesSupportedCredentials =
+		storageIsS3 && (storage.anonymous === true || credentials.method === 'static');
+	const usesDefaultRestOptions =
+		(rest.snapshot_loading_mode ?? 'all') === 'all' &&
+		(rest.metrics_reporting_enabled ?? true) === true &&
+		rest.page_size === undefined &&
+		(rest.view_endpoints_supported ?? false) === false &&
+		(rest.scan_planning_mode ?? 'client') === 'client' &&
+		(rest.namespace_separator ?? '%1F') === '%1F' &&
+		(rest.table_cache_expire_after_write_ms ?? 300_000) === 300_000 &&
+		(rest.table_cache_max_entries ?? 100) === 100;
+
+	return [
+		{
+			label: 'Use no catalog authentication or a bearer token',
+			ready: auth.method === 'none' || auth.method === 'bearer_token',
+			field: 'auth',
+		},
+		{
+			label: 'Use system TLS without custom certificates',
+			ready: !tls.ca_bundle && !tls.client_certificate,
+			field: 'tls',
+		},
+		{
+			label: 'Remove custom headers and extra properties',
+			ready: Object.keys(headers).length === 0 && Object.keys(extraProperties).length === 0,
+			field: Object.keys(headers).length > 0 ? 'headers' : 'extra_properties',
+		},
+		{
+			label: 'Use a catalog URL without query parameters or encoded path separators',
+			ready: catalogUrlReady(config.uri),
+			field: 'uri',
+		},
+		{
+			label: 'Set access delegation to none',
+			ready: config.access_delegation === 'none',
+			field: 'access_delegation',
+		},
+		{
+			label: 'Switch Storage to the s3 scheme',
+			ready: storageIsS3,
+			field: 'storage',
+		},
+		{
+			label: 'Set an origin-only S3 endpoint',
+			ready: storageIsS3 && storageEndpointReady(storage.endpoint),
+			field: storageIsS3 ? 'storage.endpoint' : 'storage',
+		},
+		{
+			label: 'Use path-style S3 addressing and no advanced client options',
+			ready:
+				storageIsS3 &&
+				storage.force_virtual_addressing !== true &&
+				advancedStorageKeys.every((key) => !storage[key]),
+			field: storageIsS3
+				? storage.force_virtual_addressing === true
+					? 'storage.force_virtual_addressing'
+					: advancedStorageBlocker
+						? `storage.${advancedStorageBlocker}`
+						: 'storage.force_virtual_addressing'
+				: 'storage',
+		},
+		{
+			label: 'Use static S3 credentials or anonymous access',
+			ready: usesSupportedCredentials,
+			field: storageIsS3 ? 'storage.credentials' : 'storage',
+		},
+		{
+			label: 'Add at least one guarded S3 read location',
+			ready:
+				storageIsS3 &&
+				Array.isArray(storage.broker_read_locations) &&
+				storage.broker_read_locations.length > 0,
+			field: storageIsS3 ? 'storage.broker_read_locations' : 'storage',
+		},
+		{
+			label: 'Keep PyIceberg runtime options at their defaults',
+			ready: Object.keys(runtime).length === 0,
+			field: 'runtime',
+		},
+		{
+			label: 'Keep REST client options at their defaults',
+			ready: usesDefaultRestOptions,
+			field: 'rest',
+		},
+	];
+}
+
+function revealField(path: string) {
+	const target = document.getElementById(schemaFieldId(path));
+	if (!target) return;
+	let disclosure = target.closest('details');
+	while (disclosure) {
+		disclosure.open = true;
+		disclosure = disclosure.parentElement?.closest('details') ?? null;
+	}
+	requestAnimationFrame(() => {
+		target.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
+		target.querySelector<HTMLElement>('input, textarea, button, select, summary')?.focus();
+	});
+}
+
+export function SqlReadinessChecklist({ config }: { config: Record<string, unknown> }) {
+	const checks = icebergRestSqlReadiness(config);
+	const readyCount = checks.filter((check) => check.ready).length;
+	const ready = readyCount === checks.length;
+
+	return (
+		<section className="rounded-lg border bg-muted/20 p-3" aria-labelledby="sql-readiness-title">
+			<div className="flex items-start gap-2">
+				{ready ? (
+					<Check className="mt-0.5 size-4 shrink-0 text-emerald-600" aria-hidden />
+				) : (
+					<CircleAlert className="mt-0.5 size-4 shrink-0 text-amber-600" aria-hidden />
+				)}
+				<div>
+					<h4 id="sql-readiness-title" className="text-xs font-semibold">
+						Run SQL readiness
+					</h4>
+					<p className="mt-0.5 text-xs text-muted-foreground">
+						{ready
+							? 'This configuration is SQL-ready. Deployment-level Run SQL settings still apply.'
+							: `${readyCount} of ${checks.length} configuration checks pass. Select a failing check to edit its field.`}
+					</p>
+				</div>
+			</div>
+			<ul className="mt-3 grid gap-1.5 sm:grid-cols-2">
+				{checks.map((check) => (
+					<li key={check.label}>
+						<a
+							href={`#${schemaFieldId(check.field)}`}
+							onClick={(event) => {
+								event.preventDefault();
+								revealField(check.field);
+							}}
+							className="flex items-start gap-1.5 rounded px-1.5 py-1 text-xs hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						>
+							{check.ready ? (
+								<Check className="mt-0.5 size-3.5 shrink-0 text-emerald-600" aria-hidden />
+							) : (
+								<CircleAlert className="mt-0.5 size-3.5 shrink-0 text-amber-600" aria-hidden />
+							)}
+							<span className={check.ready ? 'text-muted-foreground' : 'text-foreground'}>
+								{check.label}
+							</span>
+						</a>
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+}

--- a/packages/web/src/components/Project/SqlReadinessChecklist.tsx
+++ b/packages/web/src/components/Project/SqlReadinessChecklist.tsx
@@ -1,145 +1,6 @@
 import { Check, CircleAlert } from 'lucide-react';
 import { schemaFieldId } from '@/components/form/schema-form';
-
-export interface SqlReadinessCheck {
-	label: string;
-	ready: boolean;
-	field: string;
-}
-
-const asRecord = (value: unknown): Record<string, unknown> =>
-	typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
-
-function catalogUrlReady(value: unknown): boolean {
-	if (typeof value !== 'string') return false;
-	try {
-		const url = new URL(value);
-		return url.search === '' && !/%2f|%5c/i.test(url.pathname);
-	} catch {
-		return false;
-	}
-}
-
-function storageEndpointReady(value: unknown): boolean {
-	if (typeof value !== 'string' || value === '') return false;
-	try {
-		const url = new URL(value);
-		return url.pathname === '/' && url.search === '' && url.hash === '';
-	} catch {
-		return false;
-	}
-}
-
-const advancedStorageKeys = [
-	'role_arn',
-	'role_session_name',
-	'signer',
-	'signer_uri',
-	'signer_endpoint',
-	'resolve_region',
-	'proxy_uri',
-	'connect_timeout',
-	'request_timeout',
-] as const;
-
-export function icebergRestSqlReadiness(config: Record<string, unknown>): SqlReadinessCheck[] {
-	const auth = asRecord(config.auth);
-	const tls = asRecord(config.tls);
-	const headers = asRecord(config.headers);
-	const extraProperties = asRecord(config.extra_properties);
-	const storage = asRecord(config.storage);
-	const credentials = asRecord(storage.credentials);
-	const runtime = asRecord(config.runtime);
-	const rest = asRecord(config.rest);
-	const storageIsS3 = storage.scheme === 's3';
-	const advancedStorageBlocker = advancedStorageKeys.find((key) => Boolean(storage[key]));
-	const usesSupportedCredentials =
-		storageIsS3 && (storage.anonymous === true || credentials.method === 'static');
-	const usesDefaultRestOptions =
-		(rest.snapshot_loading_mode ?? 'all') === 'all' &&
-		(rest.metrics_reporting_enabled ?? true) === true &&
-		rest.page_size === undefined &&
-		(rest.view_endpoints_supported ?? false) === false &&
-		(rest.scan_planning_mode ?? 'client') === 'client' &&
-		(rest.namespace_separator ?? '%1F') === '%1F' &&
-		(rest.table_cache_expire_after_write_ms ?? 300_000) === 300_000 &&
-		(rest.table_cache_max_entries ?? 100) === 100;
-
-	return [
-		{
-			label: 'Use no catalog authentication or a bearer token',
-			ready: auth.method === 'none' || auth.method === 'bearer_token',
-			field: 'auth',
-		},
-		{
-			label: 'Use system TLS without custom certificates',
-			ready: !tls.ca_bundle && !tls.client_certificate,
-			field: 'tls',
-		},
-		{
-			label: 'Remove custom headers and extra properties',
-			ready: Object.keys(headers).length === 0 && Object.keys(extraProperties).length === 0,
-			field: Object.keys(headers).length > 0 ? 'headers' : 'extra_properties',
-		},
-		{
-			label: 'Use a catalog URL without query parameters or encoded path separators',
-			ready: catalogUrlReady(config.uri),
-			field: 'uri',
-		},
-		{
-			label: 'Set access delegation to none',
-			ready: config.access_delegation === 'none',
-			field: 'access_delegation',
-		},
-		{
-			label: 'Switch Storage to the s3 scheme',
-			ready: storageIsS3,
-			field: 'storage',
-		},
-		{
-			label: 'Set an origin-only S3 endpoint',
-			ready: storageIsS3 && storageEndpointReady(storage.endpoint),
-			field: storageIsS3 ? 'storage.endpoint' : 'storage',
-		},
-		{
-			label: 'Use path-style S3 addressing and no advanced client options',
-			ready:
-				storageIsS3 &&
-				storage.force_virtual_addressing !== true &&
-				advancedStorageKeys.every((key) => !storage[key]),
-			field: storageIsS3
-				? storage.force_virtual_addressing === true
-					? 'storage.force_virtual_addressing'
-					: advancedStorageBlocker
-						? `storage.${advancedStorageBlocker}`
-						: 'storage.force_virtual_addressing'
-				: 'storage',
-		},
-		{
-			label: 'Use static S3 credentials or anonymous access',
-			ready: usesSupportedCredentials,
-			field: storageIsS3 ? 'storage.credentials' : 'storage',
-		},
-		{
-			label: 'Add at least one guarded S3 read location',
-			ready:
-				storageIsS3 &&
-				Array.isArray(storage.broker_read_locations) &&
-				storage.broker_read_locations.length > 0,
-			field: storageIsS3 ? 'storage.broker_read_locations' : 'storage',
-		},
-		{
-			label: 'Keep PyIceberg runtime options at their defaults',
-			ready: Object.keys(runtime).length === 0,
-			field: 'runtime',
-		},
-		{
-			label: 'Keep REST client options at their defaults',
-			ready: usesDefaultRestOptions,
-			field: 'rest',
-		},
-	];
-}
+import type { QueryReadinessCheck } from '@/types';
 
 function revealField(path: string) {
 	const target = document.getElementById(schemaFieldId(path));
@@ -155,8 +16,27 @@ function revealField(path: string) {
 	});
 }
 
-export function SqlReadinessChecklist({ config }: { config: Record<string, unknown> }) {
-	const checks = icebergRestSqlReadiness(config);
+export function SqlReadinessChecklist({
+	checks,
+	isPending,
+	isError,
+}: {
+	checks: QueryReadinessCheck[] | undefined;
+	isPending: boolean;
+	isError: boolean;
+}) {
+	if (isPending || isError || checks === undefined) {
+		return (
+			<section className="rounded-lg border bg-muted/20 p-3" aria-labelledby="sql-readiness-title">
+				<h4 id="sql-readiness-title" className="text-xs font-semibold">
+					Run SQL readiness
+				</h4>
+				<p className="mt-0.5 text-xs text-muted-foreground">
+					{isError ? 'Could not check SQL readiness.' : 'Checking this configuration…'}
+				</p>
+			</section>
+		);
+	}
 	const readyCount = checks.filter((check) => check.ready).length;
 	const ready = readyCount === checks.length;
 

--- a/packages/web/src/components/form/schema-form/SchemaForm.test.tsx
+++ b/packages/web/src/components/form/schema-form/SchemaForm.test.tsx
@@ -305,6 +305,46 @@ describe('textarea widget', () => {
 	});
 });
 
+describe('advanced union fields', () => {
+	const storageSchema: JsonSchemaNode = {
+		type: 'object',
+		properties: {
+			storage: {
+				oneOf: [
+					{
+						type: 'object',
+						properties: {
+							scheme: { type: 'string', const: 's3' },
+							endpoint: { type: 'string' },
+							broker_read_locations: { type: 'array', items: { type: 'object' } },
+						},
+					},
+				],
+			},
+		},
+	};
+
+	it('renders advanced hints in a nested disclosure', async () => {
+		const user = userEvent.setup();
+		const value = buildDefaults(storageSchema) as Record<string, unknown>;
+		render(
+			<SchemaForm
+				schema={storageSchema}
+				hints={{ 'storage.broker_read_locations': { advanced: true } }}
+				value={value}
+				onChange={() => {}}
+			/>,
+		);
+
+		expect(screen.getByLabelText('Endpoint')).toBeVisible();
+		expect(screen.getByText('Advanced').closest('details')).not.toHaveAttribute('open');
+		expect(screen.getByText('Broker read locations')).not.toBeVisible();
+
+		await user.click(screen.getByText('Advanced'));
+		expect(screen.getByText('Broker read locations')).toBeVisible();
+	});
+});
+
 describe('kv-pairs editor', () => {
 	// A record widget: rows convert via Object.fromEntries, which silently keeps
 	// only the LAST value per key — duplicates/blank names must be called out.

--- a/packages/web/src/components/form/schema-form/SchemaForm.tsx
+++ b/packages/web/src/components/form/schema-form/SchemaForm.tsx
@@ -16,6 +16,7 @@ import {
 	KEEP_SECRET,
 	needsSecretSource,
 	referenceSecret,
+	schemaFieldId,
 	unionBranches,
 } from './model';
 import type { FieldHint, JsonSchemaNode, SecretSources, UiHints } from './model';
@@ -93,7 +94,6 @@ function GroupSection({
 	advanced: boolean;
 	children: ReactNode;
 }) {
-	const [open, setOpen] = useState(!advanced);
 	if (!advanced) {
 		return (
 			<section className="flex flex-col gap-3">
@@ -103,17 +103,13 @@ function GroupSection({
 		);
 	}
 	return (
-		<section className="flex flex-col gap-2 border-t pt-3">
-			<button
-				type="button"
-				className="flex items-center gap-1 text-left text-xs font-semibold text-muted-foreground hover:text-foreground"
-				onClick={() => setOpen((o) => !o)}
-			>
-				<ChevronRight className={cn('size-3.5 transition-transform', open && 'rotate-90')} />
+		<details className="group border-t pt-3">
+			<summary className="flex cursor-pointer list-none items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground">
+				<ChevronRight className="size-3.5 transition-transform group-open:rotate-90" />
 				{title || 'Advanced'}
-			</button>
-			{open && <div className="flex flex-col gap-3">{children}</div>}
-		</section>
+			</summary>
+			<div className="mt-3 flex flex-col gap-3">{children}</div>
+		</details>
 	);
 }
 
@@ -129,6 +125,14 @@ interface SchemaFieldProps {
 }
 
 function SchemaField(props: SchemaFieldProps) {
+	return (
+		<div id={schemaFieldId(props.path)} data-schema-field={props.path}>
+			<SchemaFieldControl {...props} />
+		</div>
+	);
+}
+
+function SchemaFieldControl(props: SchemaFieldProps) {
 	const { path, node, hints, value, onChange, errors } = props;
 	const hint = hintFor(hints, path);
 	const error = errors?.[path];
@@ -274,23 +278,18 @@ function UnionField(props: SchemaFieldProps & { label: string }) {
 					if (branch) onChange(buildDefaults(branch));
 				}}
 			/>
-			<div className="flex flex-col gap-3 border-l-2 border-input pl-3 empty:hidden">
-				{Object.entries(active.properties ?? {})
-					.filter(([key]) => key !== discriminator?.key)
-					.map(([key, child]) => (
-						<SchemaField
-							key={key}
-							path={`${path}.${key}`}
-							node={child}
-							hints={hints}
-							value={record[key]}
-							onChange={(next) => onChange({ ...record, [key]: next })}
-							errors={errors}
-							editing={editing}
-							secretSources={secretSources}
-						/>
-					))}
-			</div>
+			<NestedFields
+				path={path}
+				properties={Object.fromEntries(
+					Object.entries(active.properties ?? {}).filter(([key]) => key !== discriminator?.key),
+				)}
+				hints={hints}
+				record={record}
+				onChange={onChange}
+				errors={errors}
+				editing={editing}
+				secretSources={secretSources}
+			/>
 		</div>
 	);
 }
@@ -301,21 +300,69 @@ function NestedObjectField(props: SchemaFieldProps & { label: string }) {
 	return (
 		<div className="flex flex-col gap-2">
 			<span className="text-xs font-medium text-muted-foreground">{label}</span>
-			<div className="flex flex-col gap-3 border-l-2 border-input pl-3">
-				{Object.entries(node.properties ?? {}).map(([key, child]) => (
-					<SchemaField
-						key={key}
-						path={`${path}.${key}`}
-						node={child}
-						hints={hints}
-						value={record[key]}
-						onChange={(next) => onChange({ ...record, [key]: next })}
-						errors={errors}
-						editing={editing}
-						secretSources={secretSources}
-					/>
-				))}
-			</div>
+			<NestedFields
+				path={path}
+				properties={node.properties ?? {}}
+				hints={hints}
+				record={record}
+				onChange={onChange}
+				errors={errors}
+				editing={editing}
+				secretSources={secretSources}
+			/>
+		</div>
+	);
+}
+
+function NestedFields({
+	path,
+	properties,
+	hints,
+	record,
+	onChange,
+	errors,
+	editing,
+	secretSources,
+}: {
+	path: string;
+	properties: Record<string, JsonSchemaNode>;
+	hints: UiHints;
+	record: Record<string, unknown>;
+	onChange: (next: unknown) => void;
+	errors?: Record<string, string>;
+	editing?: boolean;
+	secretSources: SecretSources;
+}) {
+	const entries = Object.entries(properties);
+	const advanced = entries.filter(([key]) => hintFor(hints, `${path}.${key}`)?.advanced);
+	const regular = entries.filter(([key]) => !hintFor(hints, `${path}.${key}`)?.advanced);
+	const fields = (items: [string, JsonSchemaNode][]) =>
+		items.map(([key, child]) => (
+			<SchemaField
+				key={key}
+				path={`${path}.${key}`}
+				node={child}
+				hints={hints}
+				value={record[key]}
+				onChange={(next) => onChange({ ...record, [key]: next })}
+				errors={errors}
+				editing={editing}
+				secretSources={secretSources}
+			/>
+		));
+
+	return (
+		<div className="flex flex-col gap-3 border-l-2 border-input pl-3 empty:hidden">
+			{fields(regular)}
+			{advanced.length > 0 && (
+				<details className="group border-t pt-2">
+					<summary className="flex cursor-pointer list-none items-center gap-1 text-xs font-semibold text-muted-foreground hover:text-foreground">
+						<ChevronRight className="size-3.5 transition-transform group-open:rotate-90" />
+						Advanced
+					</summary>
+					<div className="mt-3 flex flex-col gap-3">{fields(advanced)}</div>
+				</details>
+			)}
 		</div>
 	);
 }

--- a/packages/web/src/components/form/schema-form/index.ts
+++ b/packages/web/src/components/form/schema-form/index.ts
@@ -5,6 +5,7 @@ export {
 	isKeepMarker,
 	KEEP_SECRET,
 	pruneForSubmit,
+	redactSecretsForRequest,
 	schemaFieldId,
 	SECRET_MARK,
 	validateValue,

--- a/packages/web/src/components/form/schema-form/index.ts
+++ b/packages/web/src/components/form/schema-form/index.ts
@@ -5,6 +5,7 @@ export {
 	isKeepMarker,
 	KEEP_SECRET,
 	pruneForSubmit,
+	schemaFieldId,
 	SECRET_MARK,
 	validateValue,
 } from './model';

--- a/packages/web/src/components/form/schema-form/model.test.ts
+++ b/packages/web/src/components/form/schema-form/model.test.ts
@@ -246,7 +246,7 @@ describe('redactSecretsForRequest', () => {
 			username: 'admin',
 			password: 'must-not-leave-the-form',
 			auth: { method: 'basic', user: 'reader', unexpected: 'nested-secret' },
-			props: { region: 'record-secret' },
+			props: { '': 'discarded-record-secret', region: 'record-secret' },
 			unexpected: 'root-secret',
 		};
 		const redacted = redactSecretsForRequest(schema, pruneForSubmit(schema, raw), raw);
@@ -261,8 +261,21 @@ describe('redactSecretsForRequest', () => {
 			unexpected: null,
 		});
 		expect(JSON.stringify(redacted)).not.toMatch(
-			/must-not|nested-secret|record-secret|root-secret/,
+			/must-not|nested-secret|record-secret|discarded-record-secret|root-secret/,
 		);
+	});
+
+	it('does not restore an empty optional array removed during pruning', () => {
+		const optionalArraySchema: JsonSchemaNode = {
+			type: 'object',
+			properties: {
+				values: { type: 'array', items: { type: 'string' } },
+			},
+		};
+		const raw = { values: [] };
+		expect(
+			redactSecretsForRequest(optionalArraySchema, pruneForSubmit(optionalArraySchema, raw), raw),
+		).toEqual({});
 	});
 
 	it('preserves an invalid record shape without retaining its value', () => {

--- a/packages/web/src/components/form/schema-form/model.test.ts
+++ b/packages/web/src/components/form/schema-form/model.test.ts
@@ -278,6 +278,18 @@ describe('redactSecretsForRequest', () => {
 		).toEqual({});
 	});
 
+	it('retains evidence of an invalid array shape when the pruned value is absent', () => {
+		const optionalArraySchema: JsonSchemaNode = {
+			type: 'object',
+			properties: {
+				values: { type: 'array', items: { type: 'string' } },
+			},
+		};
+		expect(redactSecretsForRequest(optionalArraySchema, {}, { values: 'invalid' })).toEqual({
+			values: null,
+		});
+	});
+
 	it('preserves an invalid record shape without retaining its value', () => {
 		const props = schema.properties!.props;
 		expect(redactSecretsForRequest(props, {}, 'credential')).toBeNull();

--- a/packages/web/src/components/form/schema-form/model.test.ts
+++ b/packages/web/src/components/form/schema-form/model.test.ts
@@ -9,6 +9,7 @@ import {
 	KEEP_SECRET,
 	needsSecretSource,
 	pruneForSubmit,
+	redactSecretsForRequest,
 	validateValue,
 } from './model';
 import type { JsonSchemaNode, UiHints } from './model';
@@ -234,6 +235,28 @@ describe('pruneForSubmit', () => {
 			},
 		};
 		expect(pruneForSubmit(optionalSecretSchema, { password: '' })).toEqual({});
+	});
+});
+
+describe('redactSecretsForRequest', () => {
+	it('replaces secret values while retaining non-secret draft fields', () => {
+		expect(
+			redactSecretsForRequest(schema, {
+				host: 'db.internal',
+				database: 'app',
+				username: 'admin',
+				password: 'must-not-leave-the-form',
+				auth: { method: 'basic', user: 'reader' },
+				props: { region: 'us-east-1' },
+			}),
+		).toEqual({
+			host: 'db.internal',
+			database: 'app',
+			username: 'admin',
+			password: KEEP_SECRET,
+			auth: { method: 'basic', user: 'reader' },
+			props: { region: 'us-east-1' },
+		});
 	});
 });
 

--- a/packages/web/src/components/form/schema-form/model.test.ts
+++ b/packages/web/src/components/form/schema-form/model.test.ts
@@ -239,24 +239,35 @@ describe('pruneForSubmit', () => {
 });
 
 describe('redactSecretsForRequest', () => {
-	it('replaces secret values while retaining non-secret draft fields', () => {
-		expect(
-			redactSecretsForRequest(schema, {
-				host: 'db.internal',
-				database: 'app',
-				username: 'admin',
-				password: 'must-not-leave-the-form',
-				auth: { method: 'basic', user: 'reader' },
-				props: { region: 'us-east-1' },
-			}),
-		).toEqual({
+	it('redacts secret-capable values and retains evidence of unknown fields', () => {
+		const raw = {
+			host: 'db.internal',
+			database: 'app',
+			username: 'admin',
+			password: 'must-not-leave-the-form',
+			auth: { method: 'basic', user: 'reader', unexpected: 'nested-secret' },
+			props: { region: 'record-secret' },
+			unexpected: 'root-secret',
+		};
+		const redacted = redactSecretsForRequest(schema, pruneForSubmit(schema, raw), raw);
+
+		expect(redacted).toEqual({
 			host: 'db.internal',
 			database: 'app',
 			username: 'admin',
 			password: KEEP_SECRET,
-			auth: { method: 'basic', user: 'reader' },
-			props: { region: 'us-east-1' },
+			auth: { method: 'basic', user: 'reader', unexpected: null },
+			props: { region: '' },
+			unexpected: null,
 		});
+		expect(JSON.stringify(redacted)).not.toMatch(
+			/must-not|nested-secret|record-secret|root-secret/,
+		);
+	});
+
+	it('preserves an invalid record shape without retaining its value', () => {
+		const props = schema.properties!.props;
+		expect(redactSecretsForRequest(props, {}, 'credential')).toBeNull();
 	});
 });
 

--- a/packages/web/src/components/form/schema-form/model.ts
+++ b/packages/web/src/components/form/schema-form/model.ts
@@ -184,24 +184,43 @@ export function pruneForSubmit(node: JsonSchemaNode, value: unknown): unknown {
 	return value;
 }
 
-/** Replaces schema-marked values before a draft is sent to non-secret preflight APIs. */
-export function redactSecretsForRequest(node: JsonSchemaNode, value: unknown): unknown {
-	const branch = branchForValue(node, value);
-	if (branch) return redactSecretsForRequest(branch, value);
+/** Removes secret-capable values without hiding invalid fields from server validation. */
+export function redactSecretsForRequest(
+	node: JsonSchemaNode,
+	value: unknown,
+	rawValue: unknown = value,
+): unknown {
+	const branch = branchForValue(node, rawValue);
+	if (branch) return redactSecretsForRequest(branch, value, rawValue);
 	if (isSecretNode(node)) return value === undefined ? undefined : KEEP_SECRET;
 	if (node.type === 'object') {
-		if (isRecordNode(node)) return value;
-		const record = (value as Record<string, unknown>) ?? {};
-		const out: Record<string, unknown> = {};
-		for (const [key, child] of Object.entries(node.properties ?? {})) {
-			const redacted = redactSecretsForRequest(child, record[key]);
-			if (redacted !== undefined) out[key] = redacted;
+		if (
+			rawValue !== undefined &&
+			(typeof rawValue !== 'object' || rawValue === null || Array.isArray(rawValue))
+		) {
+			return null;
 		}
-		return out;
+		const rawRecord = (rawValue as Record<string, unknown>) ?? {};
+		if (isRecordNode(node)) {
+			return Object.fromEntries(Object.keys(rawRecord).map((key) => [key, '']));
+		}
+		const record = (value as Record<string, unknown>) ?? {};
+		const properties = node.properties ?? {};
+		const entries: [string, unknown][] = [];
+		for (const [key, child] of Object.entries(properties)) {
+			const redacted = redactSecretsForRequest(child, record[key], rawRecord[key]);
+			if (redacted !== undefined) entries.push([key, redacted]);
+		}
+		for (const key of Object.keys(rawRecord)) {
+			if (!(key in properties)) entries.push([key, null]);
+		}
+		return Object.fromEntries(entries);
 	}
 	if (node.type === 'array') {
-		return ((value as unknown[]) ?? []).map((item) =>
-			redactSecretsForRequest(node.items ?? {}, item),
+		if (rawValue !== undefined && !Array.isArray(rawValue)) return null;
+		const rawItems = (rawValue as unknown[]) ?? [];
+		return ((value as unknown[]) ?? []).map((item, index) =>
+			redactSecretsForRequest(node.items ?? {}, item, rawItems[index]),
 		);
 	}
 	return value;

--- a/packages/web/src/components/form/schema-form/model.ts
+++ b/packages/web/src/components/form/schema-form/model.ts
@@ -217,8 +217,8 @@ export function redactSecretsForRequest(
 		return Object.fromEntries(entries);
 	}
 	if (node.type === 'array') {
-		if (value === undefined) return undefined;
 		if (rawValue !== undefined && !Array.isArray(rawValue)) return null;
+		if (value === undefined) return undefined;
 		const rawItems = (rawValue as unknown[]) ?? [];
 		return ((value as unknown[]) ?? []).map((item, index) =>
 			redactSecretsForRequest(node.items ?? {}, item, rawItems[index]),

--- a/packages/web/src/components/form/schema-form/model.ts
+++ b/packages/web/src/components/form/schema-form/model.ts
@@ -201,10 +201,10 @@ export function redactSecretsForRequest(
 			return null;
 		}
 		const rawRecord = (rawValue as Record<string, unknown>) ?? {};
-		if (isRecordNode(node)) {
-			return Object.fromEntries(Object.keys(rawRecord).map((key) => [key, '']));
-		}
 		const record = (value as Record<string, unknown>) ?? {};
+		if (isRecordNode(node)) {
+			return Object.fromEntries(Object.keys(record).map((key) => [key, '']));
+		}
 		const properties = node.properties ?? {};
 		const entries: [string, unknown][] = [];
 		for (const [key, child] of Object.entries(properties)) {
@@ -217,6 +217,7 @@ export function redactSecretsForRequest(
 		return Object.fromEntries(entries);
 	}
 	if (node.type === 'array') {
+		if (value === undefined) return undefined;
 		if (rawValue !== undefined && !Array.isArray(rawValue)) return null;
 		const rawItems = (rawValue as unknown[]) ?? [];
 		return ((value as unknown[]) ?? []).map((item, index) =>

--- a/packages/web/src/components/form/schema-form/model.ts
+++ b/packages/web/src/components/form/schema-form/model.ts
@@ -184,6 +184,29 @@ export function pruneForSubmit(node: JsonSchemaNode, value: unknown): unknown {
 	return value;
 }
 
+/** Replaces schema-marked values before a draft is sent to non-secret preflight APIs. */
+export function redactSecretsForRequest(node: JsonSchemaNode, value: unknown): unknown {
+	const branch = branchForValue(node, value);
+	if (branch) return redactSecretsForRequest(branch, value);
+	if (isSecretNode(node)) return value === undefined ? undefined : KEEP_SECRET;
+	if (node.type === 'object') {
+		if (isRecordNode(node)) return value;
+		const record = (value as Record<string, unknown>) ?? {};
+		const out: Record<string, unknown> = {};
+		for (const [key, child] of Object.entries(node.properties ?? {})) {
+			const redacted = redactSecretsForRequest(child, record[key]);
+			if (redacted !== undefined) out[key] = redacted;
+		}
+		return out;
+	}
+	if (node.type === 'array') {
+		return ((value as unknown[]) ?? []).map((item) =>
+			redactSecretsForRequest(node.items ?? {}, item),
+		);
+	}
+	return value;
+}
+
 /** Performs lightweight form validation; the server schema remains authoritative. */
 export function validateValue(
 	node: JsonSchemaNode,

--- a/packages/web/src/components/form/schema-form/model.ts
+++ b/packages/web/src/components/form/schema-form/model.ts
@@ -36,6 +36,9 @@ export type UiHints = Record<string, FieldHint | undefined>;
 
 export type SecretSources = IntegrationKind['secret_sources'];
 
+export const schemaFieldId = (path: string): string =>
+	`integration-field-${encodeURIComponent(path)}`;
+
 /** Submitted for an untouched secret to retain its stored value. */
 export const KEEP_SECRET = { $secret: { kind: 'managed', set: true } } as const;
 

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -83,6 +83,7 @@ export type IntegrationEntry = ClientIntegrationEntry;
 export type IntegrationDetail = ClientIntegrationDetail;
 /** Outcome of the integration "Test" probe. */
 export type IntegrationTestResult = ClientIntegrationTestResult;
+export type QueryReadinessCheck = components['schemas']['IntegrationQueryReadinessCheck'];
 /** Whether one integration instance can be browsed (and why not). */
 export type IntegrationBrowseCapability = ClientIntegrationBrowseCapability;
 export type IntegrationBrowseNamespacePage = ClientIntegrationBrowseNamespacePage;


### PR DESCRIPTION
Surfaces a SQL-ready checklist when editing an integration and gates the data browser's Query surface behind it. When an integration isn't SQL-ready, the Query tab is shown but disabled with an inline explanation and reason, instead of being hidden. Managers/admins see the checklist under Project environment → Integrations.