### PR TITLE
feat(source-control): observe change request publish outcomes

### DIFF
--- a/packages/api/src/routes/changeRequestPublishing.ts
+++ b/packages/api/src/routes/changeRequestPublishing.ts
@@ -26,6 +26,12 @@ export interface PreparedProposal {
 	proposal: NotebookProposal;
 	publisher?: SourceControlPublisher;
 	notebookTitle?: string;
+	state: 'new' | 'pending' | 'published';
+}
+
+interface ReusableProposalLookup {
+	record?: NotebookProposalRecord;
+	exists: boolean;
 }
 
 function publisherFor(deps: PrepareProposalInput['deps'], provider: string) {
@@ -48,36 +54,36 @@ function assertReusableProposal(record: NotebookProposalRecord, input: PreparePr
 	}
 }
 
-async function reusableProposal(
-	input: PrepareProposalInput,
-): Promise<NotebookProposalRecord | undefined> {
+async function reusableProposal(input: PrepareProposalInput): Promise<ReusableProposalLookup> {
 	try {
-		return await input.deps.services.proposals.getReusableProposal(
+		const record = await input.deps.services.proposals.getReusableProposal(
 			input.projectId,
 			input.notebookId,
 			input.proposalId,
 		);
+		return { record, exists: true };
 	} catch (error) {
-		if (error instanceof NotFoundError) return undefined;
+		if (error instanceof NotFoundError) return { exists: false };
 		throw error;
 	}
 }
 
 export async function prepareProposal(input: PrepareProposalInput): Promise<PreparedProposal> {
 	const reusable = await reusableProposal(input);
-	if (reusable) {
-		assertReusableProposal(reusable, input);
-		if (reusable.publication.state === 'published') {
-			return { proposal: reusable.proposal };
+	if (reusable.record) {
+		assertReusableProposal(reusable.record, input);
+		if (reusable.record.publication.state === 'published') {
+			return { proposal: reusable.record.proposal, state: 'published' };
 		}
 		const notebook = await input.deps.services.notebooks.getNotebook(
 			input.projectId,
 			input.notebookId,
 		);
 		return {
-			proposal: reusable.proposal,
-			publisher: publisherFor(input.deps, reusable.proposal.source.provider),
+			proposal: reusable.record.proposal,
+			publisher: publisherFor(input.deps, reusable.record.proposal.source.provider),
 			notebookTitle: notebook.meta.title,
+			state: 'pending',
 		};
 	}
 
@@ -125,5 +131,10 @@ export async function prepareProposal(input: PrepareProposalInput): Promise<Prep
 		targetProposalId: input.targetProposalId,
 		resolvedSourceRevision: sourceRevision,
 	});
-	return { proposal, publisher, notebookTitle: notebook.meta.title };
+	return {
+		proposal,
+		publisher,
+		notebookTitle: notebook.meta.title,
+		state: reusable.exists ? 'pending' : 'new',
+	};
 }

--- a/packages/api/src/routes/changeRequestPublishing.ts
+++ b/packages/api/src/routes/changeRequestPublishing.ts
@@ -29,11 +29,6 @@ export interface PreparedProposal {
 	state: 'new' | 'pending' | 'published';
 }
 
-interface ReusableProposalLookup {
-	record?: NotebookProposalRecord;
-	exists: boolean;
-}
-
 function publisherFor(deps: PrepareProposalInput['deps'], provider: string) {
 	const publisher = deps.sourceControl?.getPublisher(provider);
 	if (!publisher) {
@@ -54,34 +49,35 @@ function assertReusableProposal(record: NotebookProposalRecord, input: PreparePr
 	}
 }
 
-async function reusableProposal(input: PrepareProposalInput): Promise<ReusableProposalLookup> {
+async function reusableProposal(
+	input: PrepareProposalInput,
+): Promise<NotebookProposalRecord | undefined> {
 	try {
-		const record = await input.deps.services.proposals.getReusableProposal(
+		return await input.deps.services.proposals.getReusableProposal(
 			input.projectId,
 			input.notebookId,
 			input.proposalId,
 		);
-		return { record, exists: true };
 	} catch (error) {
-		if (error instanceof NotFoundError) return { exists: false };
+		if (error instanceof NotFoundError) return undefined;
 		throw error;
 	}
 }
 
 export async function prepareProposal(input: PrepareProposalInput): Promise<PreparedProposal> {
 	const reusable = await reusableProposal(input);
-	if (reusable.record) {
-		assertReusableProposal(reusable.record, input);
-		if (reusable.record.publication.state === 'published') {
-			return { proposal: reusable.record.proposal, state: 'published' };
+	if (reusable) {
+		assertReusableProposal(reusable, input);
+		if (reusable.publication.state === 'published') {
+			return { proposal: reusable.proposal, state: 'published' };
 		}
 		const notebook = await input.deps.services.notebooks.getNotebook(
 			input.projectId,
 			input.notebookId,
 		);
 		return {
-			proposal: reusable.record.proposal,
-			publisher: publisherFor(input.deps, reusable.record.proposal.source.provider),
+			proposal: reusable.proposal,
+			publisher: publisherFor(input.deps, reusable.proposal.source.provider),
 			notebookTitle: notebook.meta.title,
 			state: 'pending',
 		};
@@ -120,7 +116,7 @@ export async function prepareProposal(input: PrepareProposalInput): Promise<Prep
 		legacySourceRevision,
 	);
 	const publisher = publisherFor(input.deps, sourceRevision.provider);
-	const proposal = await input.deps.services.proposals.captureProposal({
+	const { proposal, created } = await input.deps.services.proposals.captureProposalWithOutcome({
 		projectId: input.projectId,
 		notebookId: input.notebookId,
 		proposalId: input.proposalId,
@@ -135,6 +131,6 @@ export async function prepareProposal(input: PrepareProposalInput): Promise<Prep
 		proposal,
 		publisher,
 		notebookTitle: notebook.meta.title,
-		state: reusable.exists ? 'pending' : 'new',
+		state: created ? 'new' : 'pending',
 	};
 }

--- a/packages/api/src/routes/changeRequestPublishing.ts
+++ b/packages/api/src/routes/changeRequestPublishing.ts
@@ -116,21 +116,22 @@ export async function prepareProposal(input: PrepareProposalInput): Promise<Prep
 		legacySourceRevision,
 	);
 	const publisher = publisherFor(input.deps, sourceRevision.provider);
-	const { proposal, created } = await input.deps.services.proposals.captureProposalWithOutcome({
-		projectId: input.projectId,
-		notebookId: input.notebookId,
-		proposalId: input.proposalId,
-		session,
-		sandbox: input.deps.compute.create(session.sandbox_id),
-		workdir: input.deps.sandbox.workdir,
-		author: input.author,
-		targetProposalId: input.targetProposalId,
-		resolvedSourceRevision: sourceRevision,
-	});
+	const { proposal, created, publicationState } =
+		await input.deps.services.proposals.captureProposalWithOutcome({
+			projectId: input.projectId,
+			notebookId: input.notebookId,
+			proposalId: input.proposalId,
+			session,
+			sandbox: input.deps.compute.create(session.sandbox_id),
+			workdir: input.deps.sandbox.workdir,
+			author: input.author,
+			targetProposalId: input.targetProposalId,
+			resolvedSourceRevision: sourceRevision,
+		});
 	return {
 		proposal,
 		publisher,
 		notebookTitle: notebook.meta.title,
-		state: created ? 'new' : 'pending',
+		state: created ? 'new' : publicationState,
 	};
 }

--- a/packages/api/src/routes/changeRequests.test.ts
+++ b/packages/api/src/routes/changeRequests.test.ts
@@ -166,7 +166,7 @@ describe('change request routes', () => {
 		const broken = createTestApi({
 			bucket: setup.bucket,
 			compute: fakeComputeFrom(instance),
-			deps: { sourceControlPublishers: setup.deps.sourceControlPublishers },
+			deps: { sourceControl: setup.deps.sourceControl },
 		});
 		const error = await expectError(
 			await broken.request(
@@ -539,6 +539,32 @@ describe('change request routes', () => {
 		const eventNames = events.map(({ event }) => event);
 		expect(eventNames).not.toContain('change_request.captured');
 		expect(eventNames).toContain('change_request.published');
+	});
+
+	it('reports reuse when another request publishes after the reusable lookup misses', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const headers = { 'Idempotency-Key': 'published-lookup-race' };
+		vi.spyOn(setup.deps.services.idempotency, 'record').mockRejectedValueOnce(
+			new Error('response record unavailable'),
+		);
+
+		await expectError(await setup.request('POST', route(), {}, headers), 500, 'INTERNAL_ERROR');
+		expect(openChangeRequest).toHaveBeenCalledOnce();
+		log.mockClear();
+
+		vi.spyOn(setup.deps.services.proposals, 'getReusableProposal').mockRejectedValueOnce(
+			new NotFoundError('Proposal lookup missed a concurrent publication'),
+		);
+		const capture = vi.spyOn(setup.deps.services.proposals, 'captureProposalWithOutcome');
+
+		await expectOk(await setup.request('POST', route(), {}, headers), 201);
+
+		expect(capture).toHaveBeenCalledOnce();
+		expect(openChangeRequest).toHaveBeenCalledOnce();
+		const outcomes = log.mock.calls
+			.map(([line]) => JSON.parse(line as string) as { event?: string })
+			.filter(({ event }) => event?.startsWith('change_request.'));
+		expect(outcomes.map(({ event }) => event)).toEqual(['change_request.reused']);
 	});
 
 	it('requires a configured publisher when resuming a pending proposal', async () => {

--- a/packages/api/src/routes/changeRequests.test.ts
+++ b/packages/api/src/routes/changeRequests.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createProposalId,
 	createSandboxId,
+	markSourceControlPublishFailure,
 	MAX_VERSIONS,
 	paths,
 	UnavailableError,
@@ -383,6 +384,7 @@ describe('change request routes', () => {
 	});
 
 	it('recovers a published proposal when response recording failed and its publisher is disabled', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 		const headers = { 'Idempotency-Key': 'disabled-before-response-recorded' };
 		vi.spyOn(setup.deps.services.idempotency, 'record').mockRejectedValueOnce(
 			new Error('response record unavailable'),
@@ -410,6 +412,15 @@ describe('change request routes', () => {
 		});
 		expect(getPublisher).not.toHaveBeenCalled();
 		expect(openChangeRequest).toHaveBeenCalledOnce();
+		const outcomes = log.mock.calls
+			.map(([line]) => JSON.parse(line as string) as { event?: string })
+			.filter(({ event }) => event?.startsWith('change_request.'));
+		expect(outcomes.map(({ event }) => event)).toEqual([
+			'change_request.captured',
+			'change_request.published',
+			'change_request.reused',
+		]);
+		log.mockRestore();
 	});
 
 	it('replays a recorded response after its source version is pruned', async () => {
@@ -445,17 +456,59 @@ describe('change request routes', () => {
 	});
 
 	it('resumes the same proposal after a publication failure', async () => {
-		openChangeRequest.mockRejectedValueOnce(new UnavailableError('GitHub is unavailable'));
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		openChangeRequest.mockRejectedValueOnce(
+			markSourceControlPublishFailure(
+				new UnavailableError('GitHub request failed with status 403'),
+				{ provider: 'github', stage: 'installation', status: 403 },
+			),
+		);
 		const path = `/projects/${projectId}/notebooks/${notebookId}/sessions/${sessionId}/change-requests`;
 		const headers = { 'Idempotency-Key': 'retry-dashboard-pr' };
 
-		await expectError(await setup.request('POST', path, {}, headers), 503, 'SERVICE_UNAVAILABLE');
+		const failure = await expectError(
+			await setup.request('POST', path, {}, headers),
+			503,
+			'SERVICE_UNAVAILABLE',
+		);
 		await expectOk(await setup.request('POST', path, {}, headers), 201);
 
+		expect(failure.message).toBe('GitHub request failed with status 403');
+		const events = log.mock.calls.map(
+			([line]) => JSON.parse(line as string) as Record<string, unknown>,
+		);
+		expect(events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					level: 'info',
+					event: 'change_request.captured',
+					project_id: projectId,
+					notebook_id: notebookId,
+					size_bytes: expect.any(Number),
+				}),
+				expect.objectContaining({
+					level: 'warn',
+					event: 'change_request.publish_failed',
+					provider: 'github',
+					stage: 'installation',
+					status: 403,
+				}),
+				expect.objectContaining({
+					level: 'info',
+					event: 'change_request.published',
+					provider: 'github',
+					pr_number: 17,
+				}),
+			]),
+		);
+		expect(
+			events.find((event) => event.event === 'change_request.publish_failed'),
+		).not.toHaveProperty('message');
 		expect(openChangeRequest).toHaveBeenCalledTimes(2);
 		expect(openChangeRequest.mock.calls[0]?.[0].headBranch).toBe(
 			openChangeRequest.mock.calls[1]?.[0].headBranch,
 		);
+		log.mockRestore();
 	});
 
 	it('requires a configured publisher when resuming a pending proposal', async () => {

--- a/packages/api/src/routes/changeRequests.test.ts
+++ b/packages/api/src/routes/changeRequests.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createProposalId,
 	createSandboxId,
 	markSourceControlPublishFailure,
 	MAX_VERSIONS,
+	NotFoundError,
 	paths,
 	UnavailableError,
 } from '@marimo-hub/core';
@@ -106,6 +107,10 @@ describe('change request routes', () => {
 		});
 		sessionId = session.session_id;
 		await setup.deps.services.sessions.setRunning(projectId, sessionId, 'https://sandbox.example');
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
 	it('opens a draft change request from the exact session revision', async () => {
@@ -359,7 +364,7 @@ describe('change request routes', () => {
 
 	it('rejects an update target that has not been published', async () => {
 		openChangeRequest.mockRejectedValueOnce(new UnavailableError('GitHub is unavailable'));
-		const capture = vi.spyOn(setup.deps.services.proposals, 'captureProposal');
+		const capture = vi.spyOn(setup.deps.services.proposals, 'captureProposalWithOutcome');
 		await expectError(
 			await setup.request('POST', route(), {}, { 'Idempotency-Key': 'pending-update-target' }),
 			503,
@@ -367,7 +372,7 @@ describe('change request routes', () => {
 		);
 		const captureResult = capture.mock.results[0];
 		if (captureResult?.type !== 'return') throw new Error('Expected proposal capture');
-		const target = await captureResult.value;
+		const { proposal: target } = await captureResult.value;
 
 		await expectError(
 			await setup.request(
@@ -420,7 +425,6 @@ describe('change request routes', () => {
 			'change_request.published',
 			'change_request.reused',
 		]);
-		log.mockRestore();
 	});
 
 	it('replays a recorded response after its source version is pruned', async () => {
@@ -491,6 +495,7 @@ describe('change request routes', () => {
 					event: 'change_request.publish_failed',
 					provider: 'github',
 					stage: 'installation',
+					condition: null,
 					status: 403,
 				}),
 				expect.objectContaining({
@@ -508,7 +513,32 @@ describe('change request routes', () => {
 		expect(openChangeRequest.mock.calls[0]?.[0].headBranch).toBe(
 			openChangeRequest.mock.calls[1]?.[0].headBranch,
 		);
-		log.mockRestore();
+	});
+
+	it('does not report a second capture when another capture wins a lookup race', async () => {
+		openChangeRequest.mockRejectedValueOnce(new UnavailableError('GitHub is unavailable'));
+		const headers = { 'Idempotency-Key': 'capture-lookup-race' };
+		await expectError(
+			await setup.request('POST', route(), {}, headers),
+			503,
+			'SERVICE_UNAVAILABLE',
+		);
+
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		vi.spyOn(setup.deps.services.proposals, 'getReusableProposal').mockRejectedValueOnce(
+			new NotFoundError('Proposal lookup missed a concurrent capture'),
+		);
+		const capture = vi.spyOn(setup.deps.services.proposals, 'captureProposalWithOutcome');
+
+		await expectOk(await setup.request('POST', route(), {}, headers), 201);
+
+		expect(capture).toHaveBeenCalledOnce();
+		const events = log.mock.calls.map(
+			([line]) => JSON.parse(line as string) as Record<string, unknown>,
+		);
+		const eventNames = events.map(({ event }) => event);
+		expect(eventNames).not.toContain('change_request.captured');
+		expect(eventNames).toContain('change_request.published');
 	});
 
 	it('requires a configured publisher when resuming a pending proposal', async () => {
@@ -526,7 +556,10 @@ describe('change request routes', () => {
 			compute: setup.deps.compute,
 			deps: { sourceControl: { ...stubSourceControl(), getPublisher } },
 		});
-		const capture = vi.spyOn(withoutPublisher.deps.services.proposals, 'captureProposal');
+		const capture = vi.spyOn(
+			withoutPublisher.deps.services.proposals,
+			'captureProposalWithOutcome',
+		);
 
 		await expectError(
 			await withoutPublisher.request('POST', route(), {}, headers),
@@ -541,7 +574,7 @@ describe('change request routes', () => {
 
 	it('finishes an incomplete proposal capture before retrying publication', async () => {
 		openChangeRequest.mockRejectedValueOnce(new UnavailableError('GitHub is unavailable'));
-		const capture = vi.spyOn(setup.deps.services.proposals, 'captureProposal');
+		const capture = vi.spyOn(setup.deps.services.proposals, 'captureProposalWithOutcome');
 		const headers = { 'Idempotency-Key': 'retry-incomplete-capture' };
 
 		await expectError(
@@ -551,7 +584,7 @@ describe('change request routes', () => {
 		);
 		const firstCapture = capture.mock.results[0];
 		if (firstCapture?.type !== 'return') throw new Error('Expected proposal capture');
-		const proposal = await firstCapture.value;
+		const { proposal } = await firstCapture.value;
 		const changePath = paths
 			.project(projectId)
 			.notebook(notebookId)
@@ -567,7 +600,7 @@ describe('change request routes', () => {
 
 	it('resumes a captured proposal after its session and source version are removed', async () => {
 		openChangeRequest.mockRejectedValueOnce(new UnavailableError('GitHub is unavailable'));
-		const capture = vi.spyOn(setup.deps.services.proposals, 'captureProposal');
+		const capture = vi.spyOn(setup.deps.services.proposals, 'captureProposalWithOutcome');
 		const headers = { 'Idempotency-Key': 'retry-after-session-removal' };
 
 		await expectError(
@@ -655,7 +688,10 @@ describe('change request routes', () => {
 			bucket: setup.bucket,
 			compute: setup.deps.compute,
 		});
-		const capture = vi.spyOn(withoutPublisher.deps.services.proposals, 'captureProposal');
+		const capture = vi.spyOn(
+			withoutPublisher.deps.services.proposals,
+			'captureProposalWithOutcome',
+		);
 		await expectError(
 			await withoutPublisher.request(
 				'POST',

--- a/packages/api/src/routes/changeRequests.ts
+++ b/packages/api/src/routes/changeRequests.ts
@@ -1,8 +1,12 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { deriveProposalId, ProposalId } from '@marimo-hub/core';
-import type { AuthUser, SourceControlCommitIdentity } from '@marimo-hub/core';
+import { deriveProposalId, ProposalId, sourceControlPublishFailure } from '@marimo-hub/core';
+import type {
+	AuthUser,
+	OpenChangeRequestResult,
+	SourceControlCommitIdentity,
+} from '@marimo-hub/core';
 import { idempotentCreate } from '../idempotency';
-import { appendAudit } from '../log';
+import { appendAudit, logEvent } from '../log';
 import { prepareProposal } from './changeRequestPublishing';
 import {
 	assertProjectRole,
@@ -101,7 +105,7 @@ changeRequestRoutes.openapi(openChangeRequest, async (c) => {
 	const routeId = `POST /projects/${pid}/notebooks/${nid}/sessions/${sid}/change-requests`;
 	const data = await idempotentCreate(c, routeId, async () => {
 		const proposalId = await deriveProposalId(`${user.id}\n${routeId}\n${idempotencyKey}`);
-		const { proposal, publisher, notebookTitle } = await prepareProposal({
+		const { proposal, publisher, notebookTitle, state } = await prepareProposal({
 			deps,
 			projectId: pid,
 			notebookId: nid,
@@ -110,17 +114,74 @@ changeRequestRoutes.openapi(openChangeRequest, async (c) => {
 			author: user.id,
 			targetProposalId: request.target_proposal_id,
 		});
-		const changeRequest = await deps.services.proposals.publishChangeRequest({
-			projectId: pid,
-			notebookId: nid,
-			proposalId: proposal.proposal_id,
-			publisher,
-			title: request.title ?? `Update ${notebookTitle ?? 'notebook'}`,
-			body:
-				request.body ??
-				`Changes proposed from marimohub session ${sid}.\n\nBase commit: ${proposal.source.commit}`,
-			coAuthor: commitCoAuthor(user),
-		});
+		const eventContext = {
+			request_id: c.get('requestId') ?? null,
+			user_id: user.id,
+			project_id: pid,
+			notebook_id: nid,
+			proposal_id: proposal.proposal_id,
+		};
+		if (state === 'new') {
+			logEvent({
+				level: 'info',
+				event: 'change_request.captured',
+				...eventContext,
+				size_bytes: proposal.changes.reduce(
+					(total, change) => total + (change.operation === 'delete' ? 0 : change.size_bytes),
+					0,
+				),
+			});
+		}
+		const publishStartedAt = Date.now();
+		let changeRequest: OpenChangeRequestResult;
+		try {
+			changeRequest = await deps.services.proposals.publishChangeRequest({
+				projectId: pid,
+				notebookId: nid,
+				proposalId: proposal.proposal_id,
+				publisher,
+				title: request.title ?? `Update ${notebookTitle ?? 'notebook'}`,
+				body:
+					request.body ??
+					`Changes proposed from marimohub session ${sid}.\n\nBase commit: ${proposal.source.commit}`,
+				coAuthor: commitCoAuthor(user),
+			});
+		} catch (error) {
+			const failure = sourceControlPublishFailure(error);
+			if (failure) {
+				logEvent({
+					level: 'warn',
+					event: 'change_request.publish_failed',
+					...eventContext,
+					provider: failure.provider,
+					repo: proposal.source.repo,
+					stage: failure.stage,
+					status: failure.status ?? null,
+					latency_ms: Date.now() - publishStartedAt,
+				});
+			}
+			throw error;
+		}
+		if (state === 'published') {
+			logEvent({
+				level: 'info',
+				event: 'change_request.reused',
+				...eventContext,
+				provider: proposal.source.provider,
+				repo: proposal.source.repo,
+				pr_number: changeRequest.number,
+			});
+		} else {
+			logEvent({
+				level: 'info',
+				event: 'change_request.published',
+				...eventContext,
+				provider: proposal.source.provider,
+				repo: proposal.source.repo,
+				pr_number: changeRequest.number,
+				latency_ms: Date.now() - publishStartedAt,
+			});
+		}
 		const auditEvent = proposal.target_proposal_id
 			? 'notebook.change_request.update'
 			: 'notebook.change_request.open';

--- a/packages/api/src/routes/changeRequests.ts
+++ b/packages/api/src/routes/changeRequests.ts
@@ -156,6 +156,7 @@ changeRequestRoutes.openapi(openChangeRequest, async (c) => {
 					provider: failure.provider,
 					repo: proposal.source.repo,
 					stage: failure.stage,
+					condition: failure.condition ?? null,
 					status: failure.status ?? null,
 					latency_ms: Date.now() - publishStartedAt,
 				});

--- a/packages/core/src/ports/sourceControl.test.ts
+++ b/packages/core/src/ports/sourceControl.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { markSourceControlPublishFailure, sourceControlPublishFailure } from './sourceControl';
+
+describe('source-control publish failures', () => {
+	it('preserves a non-Error thrown value as the annotated error cause', () => {
+		const thrown = 'connection reset';
+		const error = markSourceControlPublishFailure(thrown, {
+			provider: 'github',
+			stage: 'push',
+		});
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error.cause).toBe(thrown);
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'push',
+		});
+	});
+
+	it('preserves the provider metadata closest to the failure', () => {
+		const error = markSourceControlPublishFailure(new Error('rejected'), {
+			provider: 'github',
+			stage: 'branch',
+			condition: 'branch_changed',
+		});
+
+		markSourceControlPublishFailure(error, {
+			provider: 'github',
+			stage: 'pr',
+		});
+
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'branch',
+			condition: 'branch_changed',
+		});
+	});
+});

--- a/packages/core/src/ports/sourceControl.ts
+++ b/packages/core/src/ports/sourceControl.ts
@@ -58,6 +58,44 @@ export interface UpdateChangeRequestInput {
 	changes: readonly SourceControlChange[];
 }
 
+export const SOURCE_CONTROL_PUBLISH_STAGES = [
+	'auth',
+	'installation',
+	'branch',
+	'push',
+	'pr',
+] as const;
+
+export type SourceControlPublishStage = (typeof SOURCE_CONTROL_PUBLISH_STAGES)[number];
+
+export interface SourceControlPublishFailure {
+	provider: string;
+	stage: SourceControlPublishStage;
+	status?: string | number;
+}
+
+const sourceControlPublishFailures = new WeakMap<Error, SourceControlPublishFailure>();
+
+export function markSourceControlPublishFailure(
+	error: unknown,
+	failure: SourceControlPublishFailure,
+): Error {
+	const annotated = error instanceof Error ? error : new Error('Source control failed');
+	const current = sourceControlPublishFailures.get(annotated);
+	const merged = { ...failure, ...current };
+	if (current?.status === undefined && failure.status !== undefined) {
+		merged.status = failure.status;
+	}
+	sourceControlPublishFailures.set(annotated, merged);
+	return annotated;
+}
+
+export function sourceControlPublishFailure(
+	error: unknown,
+): SourceControlPublishFailure | undefined {
+	return error instanceof Error ? sourceControlPublishFailures.get(error) : undefined;
+}
+
 export interface SourceControlPublisher {
 	/** Stable id stored on source revisions, such as `github` or `gitlab`. */
 	readonly provider: string;

--- a/packages/core/src/ports/sourceControl.ts
+++ b/packages/core/src/ports/sourceControl.ts
@@ -68,9 +68,15 @@ export const SOURCE_CONTROL_PUBLISH_STAGES = [
 
 export type SourceControlPublishStage = (typeof SOURCE_CONTROL_PUBLISH_STAGES)[number];
 
+export const SOURCE_CONTROL_PUBLISH_CONDITIONS = ['branch_deleted', 'branch_changed'] as const;
+
+export type SourceControlPublishCondition = (typeof SOURCE_CONTROL_PUBLISH_CONDITIONS)[number];
+
 export interface SourceControlPublishFailure {
 	provider: string;
 	stage: SourceControlPublishStage;
+	condition?: SourceControlPublishCondition;
+	/** HTTP status returned by the source-control provider. */
 	status?: string | number;
 }
 
@@ -80,12 +86,18 @@ export function markSourceControlPublishFailure(
 	error: unknown,
 	failure: SourceControlPublishFailure,
 ): Error {
-	const annotated = error instanceof Error ? error : new Error('Source control failed');
+	const annotated =
+		error instanceof Error ? error : new Error('Source control failed', { cause: error });
 	const current = sourceControlPublishFailures.get(annotated);
 	const merged = { ...failure, ...current };
+	if (current?.condition === undefined && failure.condition !== undefined) {
+		merged.condition = failure.condition;
+	}
 	if (current?.status === undefined && failure.status !== undefined) {
 		merged.status = failure.status;
 	}
+	if (merged.condition === undefined) delete merged.condition;
+	if (merged.status === undefined) delete merged.status;
 	sourceControlPublishFailures.set(annotated, merged);
 	return annotated;
 }

--- a/packages/core/src/services/content/NotebookProposalService.test.ts
+++ b/packages/core/src/services/content/NotebookProposalService.test.ts
@@ -4,11 +4,14 @@ import { mkdtempSync, mkdirSync, renameSync, rmSync, symlinkSync, writeFileSync 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { MAX_REQUEST_BYTES } from '../../constants';
+import { UnavailableError } from '../../errors';
 import { createNotebookId, createProjectId, createProposalId, createVersionId } from '../../ids';
 import type { NotebookId, ProjectId, ProposalId, UserId, VersionId } from '../../ids';
 import { paths } from '../../paths';
 import type { Bucket, BucketPutOptions } from '../../ports/bucket';
+import type { Metrics } from '../../ports/metrics';
 import { execResult, listFilesFailure, readFileFailure } from '../../ports/sandbox';
+import { markSourceControlPublishFailure } from '../../ports/sourceControl';
 import type { OpenChangeRequestResult, SourceControlPublisher } from '../../ports/sourceControl';
 import type { SandboxInstance } from '../../ports/sandbox';
 import type { Session } from '../../schema';
@@ -712,6 +715,74 @@ describe('NotebookProposalService', () => {
 				draft: true,
 				changes: [expect.objectContaining({ path: 'apps/dashboard.py', operation: 'modify' })],
 			}),
+		);
+	});
+
+	it('records capture, publish, failure, latency, and reuse metrics', async () => {
+		const histogram = vi.fn<NonNullable<Metrics['histogram']>>();
+		const metrics: Metrics = {
+			increment: vi.fn(),
+			gauge: vi.fn(),
+			histogram,
+		};
+		const service = new NotebookProposalService(env.bucket, metrics);
+		const proposal = await captureWith(
+			service,
+			makeFsSandbox({ files: { 'dashboard.py': 'print("after")' } }).instance,
+			createProposalId(),
+		);
+		const openChangeRequest = vi
+			.fn<SourceControlPublisher['openChangeRequest']>()
+			.mockRejectedValueOnce(
+				markSourceControlPublishFailure(new UnavailableError('GitHub rejected the push'), {
+					provider: 'github',
+					stage: 'push',
+					status: 403,
+				}),
+			)
+			.mockImplementation(async (input) => ({
+				number: 17,
+				url: 'https://github.com/owner/repo/pull/17',
+				headBranch: input.headBranch,
+				headCommit: 'published-head',
+			}));
+		const publishInput = {
+			projectId,
+			notebookId,
+			proposalId: proposal.proposal_id,
+			publisher: { provider: 'github', openChangeRequest } satisfies SourceControlPublisher,
+			title: 'Update dashboard',
+			body: '',
+		};
+
+		await expect(service.publishChangeRequest(publishInput)).rejects.toThrow(
+			'GitHub rejected the push',
+		);
+		await expect(service.publishChangeRequest(publishInput)).resolves.toMatchObject({ number: 17 });
+		await service.getReusableProposal(projectId, notebookId, proposal.proposal_id);
+
+		expect(vi.mocked(metrics.increment).mock.calls).toEqual(
+			expect.arrayContaining([
+				['change_requests.captured'],
+				['change_requests.failed', 1, { provider: 'github', stage: 'push' }],
+				['change_requests.published', 1, { provider: 'github' }],
+				['change_requests.reused', 1, { state: 'published' }],
+			]),
+		);
+		expect(histogram.mock.calls).toEqual(
+			expect.arrayContaining([
+				['change_requests.capture_size_bytes', expect.any(Number)],
+				[
+					'change_requests.publish_latency_ms',
+					expect.any(Number),
+					{ provider: 'github', stage: 'push', outcome: 'failure' },
+				],
+				[
+					'change_requests.publish_latency_ms',
+					expect.any(Number),
+					{ provider: 'github', outcome: 'success' },
+				],
+			]),
 		);
 	});
 

--- a/packages/core/src/services/content/NotebookProposalService.test.ts
+++ b/packages/core/src/services/content/NotebookProposalService.test.ts
@@ -11,7 +11,10 @@ import { paths } from '../../paths';
 import type { Bucket, BucketPutOptions } from '../../ports/bucket';
 import type { Metrics } from '../../ports/metrics';
 import { execResult, listFilesFailure, readFileFailure } from '../../ports/sandbox';
-import { markSourceControlPublishFailure } from '../../ports/sourceControl';
+import {
+	markSourceControlPublishFailure,
+	sourceControlPublishFailure,
+} from '../../ports/sourceControl';
 import type { OpenChangeRequestResult, SourceControlPublisher } from '../../ports/sourceControl';
 import type { SandboxInstance } from '../../ports/sandbox';
 import type { Session } from '../../schema';
@@ -196,6 +199,22 @@ describe('NotebookProposalService', () => {
 		proposalId: ProposalId,
 	) {
 		return service.captureProposal({
+			projectId,
+			notebookId,
+			proposalId,
+			session,
+			sandbox,
+			workdir: '/workspace',
+			author: ACTOR,
+		});
+	}
+
+	function captureWithOutcome(
+		service: NotebookProposalService,
+		sandbox: SandboxInstance,
+		proposalId: ProposalId,
+	) {
+		return service.captureProposalWithOutcome({
 			projectId,
 			notebookId,
 			proposalId,
@@ -763,15 +782,15 @@ describe('NotebookProposalService', () => {
 
 		expect(vi.mocked(metrics.increment).mock.calls).toEqual(
 			expect.arrayContaining([
-				['change_requests.captured'],
+				['change_requests.captured', 1, { provider: 'github' }],
 				['change_requests.failed', 1, { provider: 'github', stage: 'push' }],
 				['change_requests.published', 1, { provider: 'github' }],
-				['change_requests.reused', 1, { state: 'published' }],
+				['change_requests.reused', 1, { provider: 'github', state: 'published' }],
 			]),
 		);
 		expect(histogram.mock.calls).toEqual(
 			expect.arrayContaining([
-				['change_requests.capture_size_bytes', expect.any(Number)],
+				['change_requests.capture_size_bytes', expect.any(Number), { provider: 'github' }],
 				[
 					'change_requests.publish_latency_ms',
 					expect.any(Number),
@@ -783,6 +802,40 @@ describe('NotebookProposalService', () => {
 					{ provider: 'github', outcome: 'success' },
 				],
 			]),
+		);
+	});
+
+	it('does not record a capture when persistence fails after proposal metadata is written', async () => {
+		const histogram = vi.fn<NonNullable<Metrics['histogram']>>();
+		const metrics: Metrics = {
+			increment: vi.fn(),
+			gauge: vi.fn(),
+			histogram,
+		};
+		const proposalId = createProposalId();
+		const publicationPath = paths
+			.project(projectId)
+			.notebook(notebookId)
+			.proposal(proposalId).publication;
+		const bucket = proxyBucket(async (key, value, options) => {
+			if (key === publicationPath) throw new Error('publication write failed');
+			return env.bucket.put(key, value, options);
+		});
+		const service = new NotebookProposalService(bucket, metrics);
+
+		await expect(
+			captureWith(
+				service,
+				makeFsSandbox({ files: { 'dashboard.py': 'print("after")' } }).instance,
+				proposalId,
+			),
+		).rejects.toThrow('publication write failed');
+
+		expect(vi.mocked(metrics.increment).mock.calls.map(([name]) => name)).not.toContain(
+			'change_requests.captured',
+		);
+		expect(histogram.mock.calls.map(([name]) => name)).not.toContain(
+			'change_requests.capture_size_bytes',
 		);
 	});
 
@@ -1643,20 +1696,42 @@ describe('NotebookProposalService', () => {
 		const proposalId = createProposalId();
 		const puts: { key: string; options?: BucketPutOptions }[] = [];
 		const deleteObject = vi.fn<Bucket['delete']>((key) => env.bucket.delete(key));
+		const histogram = vi.fn<NonNullable<Metrics['histogram']>>();
+		const metrics: Metrics = {
+			increment: vi.fn(),
+			gauge: vi.fn(),
+			histogram,
+		};
 		const bucket = proxyBucket(async (key, value, options) => {
 			puts.push({ key, options });
 			return env.bucket.put(key, value, options);
 		}, deleteObject);
-		const service = new NotebookProposalService(bucket);
+		const service = new NotebookProposalService(bucket, metrics);
 		const first = makeFsSandbox({ files: { 'dashboard.py': 'concurrent change' } }).instance;
 		const second = makeFsSandbox({ files: { 'dashboard.py': 'concurrent change' } }).instance;
 
 		const [left, right] = await Promise.all([
-			captureWith(service, first, proposalId),
-			captureWith(service, second, proposalId),
+			captureWithOutcome(service, first, proposalId),
+			captureWithOutcome(service, second, proposalId),
 		]);
 
-		expect(right).toEqual(left);
+		expect(right.proposal).toEqual(left.proposal);
+		expect([left.created, right.created]).toEqual(expect.arrayContaining([false, true]));
+		const changeRequestMetrics = vi
+			.mocked(metrics.increment)
+			.mock.calls.filter(([name]) => name.startsWith('change_requests.'));
+		expect(changeRequestMetrics).toEqual(
+			expect.arrayContaining([
+				['change_requests.captured', 1, { provider: 'github' }],
+				['change_requests.reused', 1, { provider: 'github', state: 'pending' }],
+			]),
+		);
+		expect(changeRequestMetrics).toHaveLength(2);
+		expect(histogram).toHaveBeenCalledExactlyOnceWith(
+			'change_requests.capture_size_bytes',
+			expect.any(Number),
+			{ provider: 'github' },
+		);
 		expect(puts.filter(({ key }) => key.includes(`/proposals/${proposalId}/`))).not.toHaveLength(0);
 		expect(
 			puts
@@ -2051,6 +2126,54 @@ describe('NotebookProposalService', () => {
 		expect(
 			(await env.proposals.getProposal(projectId, notebookId, proposal.proposal_id)).publication,
 		).toMatchObject({ state: 'pending' });
+	});
+
+	it('records an invalid provider result as a pull-request failure', async () => {
+		const histogram = vi.fn<NonNullable<Metrics['histogram']>>();
+		const metrics: Metrics = {
+			increment: vi.fn(),
+			gauge: vi.fn(),
+			histogram,
+		};
+		const service = new NotebookProposalService(env.bucket, metrics);
+		const proposal = await captureWith(
+			service,
+			makeFsSandbox({ files: { 'dashboard.py': 'changed' } }).instance,
+			createProposalId(),
+		);
+		const failure = await service
+			.publishChangeRequest({
+				projectId,
+				notebookId,
+				proposalId: proposal.proposal_id,
+				publisher: {
+					provider: 'github',
+					openChangeRequest: async (input) => ({
+						number: 0,
+						url: 'https://github.com/owner/repo/pull/1',
+						headBranch: input.headBranch,
+						headCommit: 'head-sha',
+					}),
+				},
+				title: 'Update',
+				body: '',
+			})
+			.catch((error: unknown) => error);
+
+		expect(failure).toBeInstanceOf(UnavailableError);
+		expect(sourceControlPublishFailure(failure)).toEqual({
+			provider: 'github',
+			stage: 'pr',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('change_requests.failed', 1, {
+			provider: 'github',
+			stage: 'pr',
+		});
+		expect(histogram).toHaveBeenCalledWith(
+			'change_requests.publish_latency_ms',
+			expect.any(Number),
+			{ provider: 'github', stage: 'pr', outcome: 'failure' },
+		);
 	});
 
 	it('leaves the proposal pending when the provider is unavailable', async () => {

--- a/packages/core/src/services/content/NotebookProposalService.test.ts
+++ b/packages/core/src/services/content/NotebookProposalService.test.ts
@@ -1783,8 +1783,8 @@ describe('NotebookProposalService', () => {
 		);
 
 		await expect(
-			captureWith(new NotebookProposalService(bucket), sandbox, proposalId),
-		).resolves.toEqual(proposal);
+			captureWithOutcome(new NotebookProposalService(bucket), sandbox, proposalId),
+		).resolves.toEqual({ proposal, created: false, publicationState: 'published' });
 		expect(
 			(await env.proposals.getProposal(projectId, notebookId, proposalId)).publication,
 		).toMatchObject({ state: 'published', change_request: { head_commit: 'published-head' } });
@@ -1918,6 +1918,42 @@ describe('NotebookProposalService', () => {
 		await expect(
 			env.proposals.getReusableProposal(projectId, notebookId, proposalId),
 		).resolves.toBeUndefined();
+	});
+
+	it('records one reuse when an incomplete proposal payload is repaired', async () => {
+		const metrics: Metrics = {
+			increment: vi.fn(),
+			gauge: vi.fn(),
+			histogram: vi.fn(),
+		};
+		const service = new NotebookProposalService(env.bucket, metrics);
+		const proposalId = createProposalId();
+		const sandbox = makeFsSandbox({ files: { 'dashboard.py': 'changed' } }).instance;
+		const first = await captureWithOutcome(service, sandbox, proposalId);
+		const changePath = paths.project(projectId).notebook(notebookId).proposal(proposalId).change(0);
+		vi.mocked(metrics.increment).mockClear();
+		await env.bucket.delete(changePath);
+
+		await expect(
+			service.getReusableProposal(projectId, notebookId, proposalId),
+		).resolves.toBeUndefined();
+		expect(metrics.increment).not.toHaveBeenCalledWith(
+			'change_requests.reused',
+			expect.anything(),
+			expect.anything(),
+		);
+		await expect(captureWithOutcome(service, sandbox, proposalId)).resolves.toMatchObject({
+			proposal: { proposal_id: first.proposal.proposal_id },
+			created: false,
+			publicationState: 'pending',
+		});
+
+		const reuseMetrics = vi
+			.mocked(metrics.increment)
+			.mock.calls.filter(([name]) => name === 'change_requests.reused');
+		expect(reuseMetrics).toEqual([
+			['change_requests.reused', 1, { provider: 'github', state: 'pending' }],
+		]);
 	});
 
 	it('resolves repository coordinates for a version written before git_source was stored', async () => {

--- a/packages/core/src/services/content/NotebookProposalService.ts
+++ b/packages/core/src/services/content/NotebookProposalService.ts
@@ -69,6 +69,11 @@ export interface CaptureProposalInput {
 	legacySourceRevision?: GitSourceRevision;
 }
 
+export interface CaptureProposalResult {
+	proposal: NotebookProposal;
+	created: boolean;
+}
+
 export interface PublishProposalChangeRequestInput {
 	projectId: ProjectId;
 	notebookId: NotebookId;
@@ -129,6 +134,10 @@ export class NotebookProposalService {
 	}
 
 	async captureProposal(input: CaptureProposalInput): Promise<NotebookProposal> {
+		return (await this.captureProposalWithOutcome(input)).proposal;
+	}
+
+	async captureProposalWithOutcome(input: CaptureProposalInput): Promise<CaptureProposalResult> {
 		const { session } = input;
 		if (input.proposalId) {
 			try {
@@ -138,10 +147,14 @@ export class NotebookProposalService {
 					input.proposalId,
 				);
 				this.assertProposalRetry(proposal, input);
-				if (publication.state === 'published') return proposal;
+				if (publication.state === 'published') {
+					this.recordCaptureReuse(proposal, publication.state);
+					return { proposal, created: false };
+				}
 				this.assertPayloadNotExpired(proposal);
 				if (await this.hasCompletePayload(input.projectId, input.notebookId, proposal)) {
-					return proposal;
+					this.recordCaptureReuse(proposal, publication.state);
+					return { proposal, created: false };
 				}
 			} catch (error) {
 				if (!(error instanceof NotFoundError)) throw error;
@@ -200,23 +213,16 @@ export class NotebookProposalService {
 		};
 		const proposalPaths = notebook.proposal(proposalId);
 		let captured = proposal;
+		let created = true;
 		await saga(metricsObserver(this.metrics, 'saga.notebook_proposal_capture'))
 			.step('write_proposal', async () => {
 				try {
 					await this.bucket.put(proposalPaths.meta, JSON.stringify(proposal), {
 						onlyIfNotExists: true,
 					});
-					this.metrics.increment('change_requests.captured');
-					this.metrics.histogram?.(
-						'change_requests.capture_size_bytes',
-						proposal.changes.reduce(
-							(total, change) => total + (change.operation === 'delete' ? 0 : change.size_bytes),
-							0,
-						),
-					);
 				} catch (error) {
 					if (!(error instanceof PreconditionFailedError)) throw error;
-					this.metrics.increment('change_requests.reused', 1, { state: 'pending' });
+					created = false;
 					const existing = await this.bucket.get(proposalPaths.meta);
 					if (!existing) throw new ConflictError('Proposal capture raced with another request');
 					captured = await readStored(NotebookProposalSchema, existing, proposalPaths.meta);
@@ -317,7 +323,31 @@ export class NotebookProposalService {
 				}
 			})
 			.run();
-		return captured;
+		if (created) {
+			const provider = captured.source.provider;
+			this.metrics.increment('change_requests.captured', 1, { provider });
+			this.metrics.histogram?.(
+				'change_requests.capture_size_bytes',
+				captured.changes.reduce(
+					(total, change) => total + (change.operation === 'delete' ? 0 : change.size_bytes),
+					0,
+				),
+				{ provider },
+			);
+		} else {
+			this.recordCaptureReuse(captured, 'pending');
+		}
+		return { proposal: captured, created };
+	}
+
+	private recordCaptureReuse(
+		proposal: NotebookProposal,
+		state: ProposalPublication['state'],
+	): void {
+		this.metrics.increment('change_requests.reused', 1, {
+			provider: proposal.source.provider,
+			state,
+		});
 	}
 
 	private assertProposalRetry(proposal: NotebookProposal, input: CaptureProposalInput): void {
@@ -405,9 +435,7 @@ export class NotebookProposalService {
 		proposalId: ProposalId,
 	): Promise<NotebookProposalRecord | undefined> {
 		const record = await this.getProposal(projectId, notebookId, proposalId);
-		this.metrics.increment('change_requests.reused', 1, {
-			state: record.publication.state,
-		});
+		this.recordCaptureReuse(record.proposal, record.publication.state);
 		if (record.publication.state === 'published') return record;
 		const { proposal } = record;
 		this.assertPayloadNotExpired(proposal);
@@ -588,7 +616,11 @@ export class NotebookProposalService {
 				(result.number !== expectedChangeRequest.number ||
 					result.url !== expectedChangeRequest.url))
 		) {
-			throw new UnavailableError('Source-control provider returned an invalid change request');
+			throw this.recordPublishFailure(
+				new UnavailableError('Source-control provider returned an invalid change request'),
+				publisher.provider,
+				publishStartedAt,
+			);
 		}
 		const published = await mutateObject(
 			this.bucket,
@@ -648,14 +680,9 @@ export class NotebookProposalService {
 	}
 
 	private recordPublishFailure(error: unknown, provider: string, startedAt: number): Error {
-		const status =
-			typeof (error as { status?: unknown })?.status === 'number'
-				? (error as { status: number }).status
-				: undefined;
 		const marked = markSourceControlPublishFailure(error, {
 			provider,
 			stage: 'pr',
-			status,
 		});
 		const failure = sourceControlPublishFailure(marked);
 		this.metrics.increment('change_requests.failed', 1, {

--- a/packages/core/src/services/content/NotebookProposalService.ts
+++ b/packages/core/src/services/content/NotebookProposalService.ts
@@ -72,6 +72,7 @@ export interface CaptureProposalInput {
 export interface CaptureProposalResult {
 	proposal: NotebookProposal;
 	created: boolean;
+	publicationState: ProposalPublication['state'];
 }
 
 export interface PublishProposalChangeRequestInput {
@@ -149,12 +150,12 @@ export class NotebookProposalService {
 				this.assertProposalRetry(proposal, input);
 				if (publication.state === 'published') {
 					this.recordCaptureReuse(proposal, publication.state);
-					return { proposal, created: false };
+					return { proposal, created: false, publicationState: publication.state };
 				}
 				this.assertPayloadNotExpired(proposal);
 				if (await this.hasCompletePayload(input.projectId, input.notebookId, proposal)) {
 					this.recordCaptureReuse(proposal, publication.state);
-					return { proposal, created: false };
+					return { proposal, created: false, publicationState: publication.state };
 				}
 			} catch (error) {
 				if (!(error instanceof NotFoundError)) throw error;
@@ -214,6 +215,7 @@ export class NotebookProposalService {
 		const proposalPaths = notebook.proposal(proposalId);
 		let captured = proposal;
 		let created = true;
+		let publicationState: ProposalPublication['state'] = 'pending';
 		await saga(metricsObserver(this.metrics, 'saga.notebook_proposal_capture'))
 			.step('write_proposal', async () => {
 				try {
@@ -319,7 +321,9 @@ export class NotebookProposalService {
 					if (!(error instanceof PreconditionFailedError)) throw error;
 					const existing = await this.bucket.get(proposalPaths.publication);
 					if (!existing) throw new ConflictError('Proposal state raced with another request');
-					await readStored(ProposalPublicationSchema, existing, proposalPaths.publication);
+					publicationState = (
+						await readStored(ProposalPublicationSchema, existing, proposalPaths.publication)
+					).state;
 				}
 			})
 			.run();
@@ -335,9 +339,9 @@ export class NotebookProposalService {
 				{ provider },
 			);
 		} else {
-			this.recordCaptureReuse(captured, 'pending');
+			this.recordCaptureReuse(captured, publicationState);
 		}
-		return { proposal: captured, created };
+		return { proposal: captured, created, publicationState };
 	}
 
 	private recordCaptureReuse(
@@ -435,11 +439,15 @@ export class NotebookProposalService {
 		proposalId: ProposalId,
 	): Promise<NotebookProposalRecord | undefined> {
 		const record = await this.getProposal(projectId, notebookId, proposalId);
-		this.recordCaptureReuse(record.proposal, record.publication.state);
-		if (record.publication.state === 'published') return record;
+		if (record.publication.state === 'published') {
+			this.recordCaptureReuse(record.proposal, record.publication.state);
+			return record;
+		}
 		const { proposal } = record;
 		this.assertPayloadNotExpired(proposal);
-		return (await this.hasCompletePayload(projectId, notebookId, proposal)) ? record : undefined;
+		if (!(await this.hasCompletePayload(projectId, notebookId, proposal))) return undefined;
+		this.recordCaptureReuse(proposal, record.publication.state);
+		return record;
 	}
 
 	private async hasCompletePayload(

--- a/packages/core/src/services/content/NotebookProposalService.ts
+++ b/packages/core/src/services/content/NotebookProposalService.ts
@@ -20,6 +20,10 @@ import type {
 	SourceControlCommitIdentity,
 	SourceControlPublisher,
 } from '../../ports/sourceControl';
+import {
+	markSourceControlPublishFailure,
+	sourceControlPublishFailure,
+} from '../../ports/sourceControl';
 import type { SandboxInstance } from '../../ports/sandbox';
 import {
 	NotebookProposalSchema,
@@ -202,8 +206,17 @@ export class NotebookProposalService {
 					await this.bucket.put(proposalPaths.meta, JSON.stringify(proposal), {
 						onlyIfNotExists: true,
 					});
+					this.metrics.increment('change_requests.captured');
+					this.metrics.histogram?.(
+						'change_requests.capture_size_bytes',
+						proposal.changes.reduce(
+							(total, change) => total + (change.operation === 'delete' ? 0 : change.size_bytes),
+							0,
+						),
+					);
 				} catch (error) {
 					if (!(error instanceof PreconditionFailedError)) throw error;
+					this.metrics.increment('change_requests.reused', 1, { state: 'pending' });
 					const existing = await this.bucket.get(proposalPaths.meta);
 					if (!existing) throw new ConflictError('Proposal capture raced with another request');
 					captured = await readStored(NotebookProposalSchema, existing, proposalPaths.meta);
@@ -392,6 +405,9 @@ export class NotebookProposalService {
 		proposalId: ProposalId,
 	): Promise<NotebookProposalRecord | undefined> {
 		const record = await this.getProposal(projectId, notebookId, proposalId);
+		this.metrics.increment('change_requests.reused', 1, {
+			state: record.publication.state,
+		});
 		if (record.publication.state === 'published') return record;
 		const { proposal } = record;
 		this.assertPayloadNotExpired(proposal);
@@ -507,6 +523,7 @@ export class NotebookProposalService {
 		let expectedChangeRequest: OpenChangeRequestResult | undefined;
 		let rootProposalId: ProposalId | undefined;
 		let observedHeadCommits: ReadonlySet<string> | undefined;
+		let publishStartedAt: number;
 		if (proposal.target_proposal_id) {
 			const target = await this.resolvePublishedChangeRequestTarget(
 				input.projectId,
@@ -523,29 +540,39 @@ export class NotebookProposalService {
 			expectedChangeRequest = target.changeRequest;
 			observedHeadCommits = target.observedHeadCommits;
 			headBranch = expectedChangeRequest.headBranch;
-			result = await publisher.updateChangeRequest({
-				repository: proposal.source.repo,
-				baseBranch: proposal.source.branch,
-				baseCommit: proposal.source.commit,
-				changeRequest: expectedChangeRequest,
-				title: input.title,
-				body: input.body,
-				coAuthor: input.coAuthor,
-				changes,
-			});
+			publishStartedAt = Date.now();
+			try {
+				result = await publisher.updateChangeRequest({
+					repository: proposal.source.repo,
+					baseBranch: proposal.source.branch,
+					baseCommit: proposal.source.commit,
+					changeRequest: expectedChangeRequest,
+					title: input.title,
+					body: input.body,
+					coAuthor: input.coAuthor,
+					changes,
+				});
+			} catch (error) {
+				throw this.recordPublishFailure(error, publisher.provider, publishStartedAt);
+			}
 		} else {
 			headBranch = `marimohub/${proposal.notebook_id}/${proposal.proposal_id}`;
-			result = await publisher.openChangeRequest({
-				repository: proposal.source.repo,
-				baseBranch: proposal.source.branch,
-				baseCommit: proposal.source.commit,
-				headBranch,
-				title: input.title,
-				body: input.body,
-				draft: true,
-				coAuthor: input.coAuthor,
-				changes,
-			});
+			publishStartedAt = Date.now();
+			try {
+				result = await publisher.openChangeRequest({
+					repository: proposal.source.repo,
+					baseBranch: proposal.source.branch,
+					baseCommit: proposal.source.commit,
+					headBranch,
+					title: input.title,
+					body: input.body,
+					draft: true,
+					coAuthor: input.coAuthor,
+					changes,
+				});
+			} catch (error) {
+				throw this.recordPublishFailure(error, publisher.provider, publishStartedAt);
+			}
 		}
 		const parsedResult = ChangeRequestPublicationSchema.safeParse({
 			provider: publisher.provider,
@@ -600,6 +627,11 @@ export class NotebookProposalService {
 		) {
 			throw new UnavailableError('Stored publication contains an invalid change request');
 		}
+		this.metrics.increment('change_requests.published', 1, { provider: publisher.provider });
+		this.metrics.histogram?.('change_requests.publish_latency_ms', Date.now() - publishStartedAt, {
+			provider: publisher.provider,
+			outcome: 'success',
+		});
 		if (rootProposalId && expectedChangeRequest && observedHeadCommits) {
 			await this.advanceChangeRequestHead(
 				input.projectId,
@@ -613,6 +645,29 @@ export class NotebookProposalService {
 			);
 		}
 		return publishedResult;
+	}
+
+	private recordPublishFailure(error: unknown, provider: string, startedAt: number): Error {
+		const status =
+			typeof (error as { status?: unknown })?.status === 'number'
+				? (error as { status: number }).status
+				: undefined;
+		const marked = markSourceControlPublishFailure(error, {
+			provider,
+			stage: 'pr',
+			status,
+		});
+		const failure = sourceControlPublishFailure(marked);
+		this.metrics.increment('change_requests.failed', 1, {
+			provider: failure?.provider ?? provider,
+			stage: failure?.stage ?? 'pr',
+		});
+		this.metrics.histogram?.('change_requests.publish_latency_ms', Date.now() - startedAt, {
+			provider: failure?.provider ?? provider,
+			stage: failure?.stage ?? 'pr',
+			outcome: 'failure',
+		});
+		return marked;
 	}
 
 	private async resolvePublishedChangeRequestTarget(

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -32,6 +32,7 @@ export {
 } from './content/NotebookProposalService';
 export type {
 	CaptureProposalInput,
+	CaptureProposalResult,
 	NotebookProposalRecord,
 	PruneExpiredProposalPayloadsOptions,
 	PublishProposalChangeRequestInput,
@@ -380,6 +381,7 @@ export function createServices(
 	);
 	const proposals = wrap('NotebookProposalService', new NotebookProposalService(bucket, metrics), {
 		captureProposal: (input) => notebook(input.projectId, input.notebookId),
+		captureProposalWithOutcome: (input) => notebook(input.projectId, input.notebookId),
 		getProposal: proposal,
 		getReusableProposal: proposal,
 		publishChangeRequest: (input) => proposal(input.projectId, input.notebookId, input.proposalId),

--- a/packages/source-control-github/src/githubClient.ts
+++ b/packages/source-control-github/src/githubClient.ts
@@ -1,5 +1,5 @@
 import { createPrivateKey, createSign } from 'node:crypto';
-import { UnavailableError } from '@marimo-hub/core';
+import { markSourceControlPublishFailure, UnavailableError } from '@marimo-hub/core';
 import { numberField, responseJson, stringField } from './githubResponses';
 
 export type GitHubFetch = (input: string, init?: RequestInit) => Promise<Response>;
@@ -19,6 +19,22 @@ export interface GitHubAppPublisherRuntime {
 }
 
 const GITHUB_API_BASE_URL = 'https://api.github.com';
+class GitHubRequestError extends UnavailableError {
+	readonly providerStatus: number;
+
+	constructor(status: number, message: string) {
+		super(message);
+		this.name = 'GitHubRequestError';
+		this.providerStatus = status;
+	}
+}
+
+function githubRequestError(response: Response): GitHubRequestError {
+	return new GitHubRequestError(
+		response.status,
+		`GitHub request failed with status ${response.status}`,
+	);
+}
 
 function encodeBase64Url(value: string): string {
 	return Buffer.from(value).toString('base64url');
@@ -84,33 +100,60 @@ export class GitHubClient {
 			throw new UnavailableError('GitHub is unavailable', { cause: error });
 		}
 		if (!response.ok && !allowedStatuses.includes(response.status)) {
-			throw new UnavailableError(`GitHub request failed with status ${response.status}`);
+			throw githubRequestError(response);
 		}
 		return response;
 	}
 
 	async installationToken(owner: string, repo: string): Promise<string> {
-		const installationResponse = await this.request(
-			`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/installation`,
-			this.appJwt(),
-			{},
-			[404],
-		);
+		let jwt: string;
+		try {
+			jwt = this.appJwt();
+		} catch (error) {
+			throw markSourceControlPublishFailure(error, { provider: 'github', stage: 'auth' });
+		}
+		let installationResponse: Response;
+		try {
+			installationResponse = await this.request(
+				`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/installation`,
+				jwt,
+				{},
+				[404],
+			);
+		} catch (error) {
+			throw markSourceControlPublishFailure(error, {
+				provider: 'github',
+				stage: 'installation',
+				status: error instanceof GitHubRequestError ? error.providerStatus : undefined,
+			});
+		}
 		if (installationResponse.status === 404) {
-			throw new UnavailableError(`The GitHub App is not installed for ${owner}/${repo}`);
+			throw markSourceControlPublishFailure(
+				new UnavailableError(`The GitHub App is not installed for ${owner}/${repo}`),
+				{ provider: 'github', stage: 'installation', status: 404 },
+			);
 		}
 		const installationId = numberField(await responseJson(installationResponse), 'id');
-		const tokenResponse = await this.request(
-			`/app/installations/${installationId}/access_tokens`,
-			this.appJwt(),
-			{
-				method: 'POST',
-				body: JSON.stringify({
-					repositories: [repo],
-					permissions: { contents: 'write', pull_requests: 'write' },
-				}),
-			},
-		);
+		let tokenResponse: Response;
+		try {
+			tokenResponse = await this.request(
+				`/app/installations/${installationId}/access_tokens`,
+				jwt,
+				{
+					method: 'POST',
+					body: JSON.stringify({
+						repositories: [repo],
+						permissions: { contents: 'write', pull_requests: 'write' },
+					}),
+				},
+			);
+		} catch (error) {
+			throw markSourceControlPublishFailure(error, {
+				provider: 'github',
+				stage: 'auth',
+				status: error instanceof GitHubRequestError ? error.providerStatus : undefined,
+			});
+		}
 		return stringField(await responseJson(tokenResponse), 'token');
 	}
 }

--- a/packages/source-control-github/src/githubPullRequests.test.ts
+++ b/packages/source-control-github/src/githubPullRequests.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { sourceControlPublishFailure } from '@marimo-hub/core';
 import type { GitHubClient } from './githubClient';
 import { GitHubPullRequests } from './githubPullRequests';
 import type { GitHubRepositoryWriter } from './githubRepository';
@@ -79,5 +80,22 @@ describe('GitHubPullRequests.updateMetadata', () => {
 		await expect(githubPullRequests.updateMetadata(updateInput, 'updated-head')).rejects.toThrow(
 			'unexpected updated pull request metadata',
 		);
+	});
+
+	it('marks a mismatched response head as a local branch change', async () => {
+		const { pullRequests: githubPullRequests } = pullRequests(
+			updatedPull({ head: { sha: 'different-head' } }),
+		);
+
+		const error = await githubPullRequests
+			.updateMetadata(updateInput, 'updated-head')
+			.catch((failure) => failure);
+
+		expect(error).toBeInstanceOf(Error);
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'pr',
+			condition: 'branch_changed',
+		});
 	});
 });

--- a/packages/source-control-github/src/githubPullRequests.ts
+++ b/packages/source-control-github/src/githubPullRequests.ts
@@ -171,7 +171,10 @@ export class GitHubPullRequests {
 			throw new UnavailableError('GitHub returned unexpected updated pull request metadata');
 		}
 		if (nestedString(pull, 'head', 'sha') !== headCommit) {
-			throw new ConflictError('The GitHub pull request branch changed while updating');
+			throw markSourceControlPublishFailure(
+				new ConflictError('The GitHub pull request branch changed while updating'),
+				{ provider: 'github', stage: 'pr', condition: 'branch_changed' },
+			);
 		}
 		return { ...input.changeRequest, headCommit };
 	}

--- a/packages/source-control-github/src/githubPullRequests.ts
+++ b/packages/source-control-github/src/githubPullRequests.ts
@@ -1,4 +1,9 @@
-import { ConflictError, ProposalRetryRequiredError, UnavailableError } from '@marimo-hub/core';
+import {
+	ConflictError,
+	markSourceControlPublishFailure,
+	ProposalRetryRequiredError,
+	UnavailableError,
+} from '@marimo-hub/core';
 import type {
 	OpenChangeRequestInput,
 	OpenChangeRequestResult,
@@ -125,7 +130,10 @@ export class GitHubPullRequests {
 					headCommit: existing.headCommit,
 				};
 			}
-			throw new UnavailableError('GitHub rejected the pull request');
+			throw markSourceControlPublishFailure(
+				new UnavailableError('GitHub rejected the pull request'),
+				{ provider: 'github', stage: 'pr', status: 422 },
+			);
 		}
 		const pull = await responseJson(response);
 		const number = numberField(pull, 'number');

--- a/packages/source-control-github/src/index.test.ts
+++ b/packages/source-control-github/src/index.test.ts
@@ -406,9 +406,16 @@ describe('GitHubAppPublisher', () => {
 			throw new Error(`unexpected request: ${method} ${parsed.pathname}`);
 		});
 
-		await expect(publisher(fetcher).updateChangeRequest(updateInput)).rejects.toThrow(
-			'branch changed while updating',
-		);
+		const error = await publisher(fetcher)
+			.updateChangeRequest(updateInput)
+			.catch((failure) => failure);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain('branch changed while updating');
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'branch',
+			condition: 'branch_changed',
+		});
 	});
 
 	it('recovers an appended update after its publication record failed', async () => {
@@ -690,9 +697,16 @@ describe('GitHubAppPublisher', () => {
 			throw new Error(`unexpected request: ${method} ${parsed.pathname}`);
 		});
 
-		await expect(publisher(fetcher).updateChangeRequest(updateInput)).rejects.toThrow(
-			'changed outside marimohub',
-		);
+		const error = await publisher(fetcher)
+			.updateChangeRequest(updateInput)
+			.catch((failure) => failure);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain('changed outside marimohub');
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'branch',
+			condition: 'branch_changed',
+		});
 		expect(fetcher.mock.calls.some(([url]) => String(url).endsWith('/graphql'))).toBe(false);
 	});
 
@@ -743,9 +757,18 @@ describe('GitHubAppPublisher', () => {
 			throw new Error(`unexpected request: ${init?.method ?? 'GET'} ${parsed.pathname}`);
 		});
 
-		await expect(publisher(fetcher).updateChangeRequest(updateInput)).rejects.toThrow(
+		const error = await publisher(fetcher)
+			.updateChangeRequest(updateInput)
+			.catch((failure) => failure);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain(
 			'pull request branch was deleted; create a new pull request',
 		);
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'branch',
+			condition: 'branch_deleted',
+		});
 		expect(fetcher.mock.calls.some(([url]) => String(url).includes('/git/commits/'))).toBe(false);
 	});
 
@@ -1556,9 +1579,15 @@ describe('GitHubAppPublisher', () => {
 		const fetcher = vi.fn(async () => {
 			throw new Error('socket included a credential');
 		});
-		await expect(publisher(fetcher).openChangeRequest(input)).rejects.toThrow(
-			'GitHub is unavailable',
-		);
+		const error = await publisher(fetcher)
+			.openChangeRequest(input)
+			.catch((failure) => failure);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toBe('GitHub is unavailable');
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'installation',
+		});
 	});
 
 	it('rejects invalid JSON from GitHub', async () => {

--- a/packages/source-control-github/src/index.test.ts
+++ b/packages/source-control-github/src/index.test.ts
@@ -1,5 +1,6 @@
 import { generateKeyPairSync } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
+import { sourceControlPublishFailure } from '@marimo-hub/core';
 import { GitHubAppPublisher } from './index';
 
 const PRIVATE_KEY = generateKeyPairSync('rsa', { modulusLength: 2048 })
@@ -1518,14 +1519,23 @@ describe('GitHubAppPublisher', () => {
 
 	it('reports an app installation miss without trying to mint a token', async () => {
 		const fetcher = vi.fn(async () => response({ message: 'secret details' }, 404));
-		await expect(publisher(fetcher).openChangeRequest(input)).rejects.toThrow(
-			'The GitHub App is not installed for owner/repo',
-		);
+		const error = await publisher(fetcher)
+			.openChangeRequest(input)
+			.catch((failure) => failure);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toBe('The GitHub App is not installed for owner/repo');
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'installation',
+			status: 404,
+		});
 		expect(fetcher).toHaveBeenCalledOnce();
 	});
 
-	it('does not expose a GitHub error response body', async () => {
-		const fetcher = vi.fn(async () => response({ message: 'sensitive upstream detail' }, 500));
+	it('does not expose the GitHub error response body', async () => {
+		const fetcher = vi.fn(async () =>
+			response({ message: 'Resource not accessible by integration' }, 403),
+		);
 		let thrown: unknown;
 		try {
 			await publisher(fetcher).openChangeRequest(input);
@@ -1533,8 +1543,13 @@ describe('GitHubAppPublisher', () => {
 			thrown = error;
 		}
 		expect(thrown).toBeInstanceOf(Error);
-		expect((thrown as Error).message).toBe('GitHub request failed with status 500');
-		expect((thrown as Error).message).not.toContain('sensitive');
+		expect((thrown as Error).message).toBe('GitHub request failed with status 403');
+		expect((thrown as Error).message).not.toContain('Resource not accessible by integration');
+		expect(sourceControlPublishFailure(thrown)).toEqual({
+			provider: 'github',
+			stage: 'installation',
+			status: 403,
+		});
 	});
 
 	it('maps a network exception to a provider availability error', async () => {
@@ -1824,6 +1839,37 @@ describe('GitHubAppPublisher', () => {
 			headCommit: 'existing-head',
 		});
 		expect(fetcher).toHaveBeenCalledTimes(11);
+	});
+
+	it('does not expose a pull request rejection body when no matching request exists', async () => {
+		const fetcher = vi.fn(async (url: string, init?: RequestInit) => {
+			const parsed = new URL(url);
+			const method = init?.method ?? 'GET';
+			if (parsed.pathname.endsWith('/installation')) return response({ id: 42 });
+			if (parsed.pathname.endsWith('/access_tokens')) return response({ token: 'token' });
+			if (parsed.pathname.includes('/git/ref/heads/')) {
+				return response({ object: { sha: 'existing-head' } });
+			}
+			if (parsed.pathname.endsWith('/pulls') && method === 'GET') return response([]);
+			if (parsed.pathname.endsWith('/pulls') && method === 'POST') {
+				return response({ message: 'App lacks pull request permission' }, 422);
+			}
+			const proposalResponse = proposalTreeResponse(parsed, ['existing-head']);
+			if (proposalResponse) return proposalResponse;
+			throw new Error(`unexpected request: ${method} ${parsed.pathname}`);
+		});
+
+		const error = await publisher(fetcher)
+			.openChangeRequest(input)
+			.catch((failure) => failure);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toBe('GitHub rejected the pull request');
+		expect((error as Error).message).not.toContain('App lacks pull request permission');
+		expect(sourceControlPublishFailure(error)).toEqual({
+			provider: 'github',
+			stage: 'pr',
+			status: 422,
+		});
 	});
 
 	it('renders delete changes as null tree entries without creating blobs', async () => {

--- a/packages/source-control-github/src/index.ts
+++ b/packages/source-control-github/src/index.ts
@@ -1,9 +1,15 @@
-import { ConflictError, UnavailableError, ValidationError } from '@marimo-hub/core';
+import {
+	ConflictError,
+	markSourceControlPublishFailure,
+	UnavailableError,
+	ValidationError,
+} from '@marimo-hub/core';
 import type {
 	OpenChangeRequestInput,
 	OpenChangeRequestResult,
 	SourceBranchHead,
 	SourceControlPublisher,
+	SourceControlPublishStage,
 	SourceControlReader,
 	SourceWorkspaceFile,
 	UpdateChangeRequestInput,
@@ -36,6 +42,18 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 
 	constructor(options: GitHubAppPublisherOptions, runtime: GitHubAppPublisherRuntime = {}) {
 		this.client = new GitHubClient(options, runtime);
+	}
+
+	private async atStage<T>(stage: SourceControlPublishStage, action: () => Promise<T>): Promise<T> {
+		try {
+			return await action();
+		} catch (error) {
+			const status =
+				typeof (error as { providerStatus?: unknown })?.providerStatus === 'number'
+					? (error as { providerStatus: number }).providerStatus
+					: undefined;
+			throw markSourceControlPublishFailure(error, { provider: 'github', stage, status });
+		}
 	}
 
 	private async publicationContext(owner: string, repo: string): Promise<GitHubPublicationContext> {
@@ -97,51 +115,77 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 
 	async openChangeRequest(input: OpenChangeRequestInput): Promise<OpenChangeRequestResult> {
 		const { owner, repo } = validateOpenInput(input);
-		const { repository, pullRequests } = await this.publicationContext(owner, repo);
-		const existingRef = await repository.getRef(input.headBranch);
-		const candidates = await pullRequests.listForBranch(input.headBranch, input.baseBranch);
-		const treeSha = await repository.createProposalTree(input, input.baseCommit);
-		const existing = await pullRequests.matchingProposal(candidates, input.baseCommit, treeSha);
+		const { repository, pullRequests } = await this.atStage('installation', () =>
+			this.publicationContext(owner, repo),
+		);
+		const existingRef = await this.atStage('branch', () => repository.getRef(input.headBranch));
+		const candidates = await this.atStage('pr', () =>
+			pullRequests.listForBranch(input.headBranch, input.baseBranch),
+		);
+		const treeSha = await this.atStage('push', () =>
+			repository.createProposalTree(input, input.baseCommit),
+		);
+		const existing = await this.atStage('pr', () =>
+			pullRequests.matchingProposal(candidates, input.baseCommit, treeSha),
+		);
 		if (existing) return existing;
 
 		if (existingRef) {
-			await repository.assertProposalCommit(existingRef, input.baseCommit, treeSha);
-			return pullRequests.create(input, existingRef);
+			await this.atStage('branch', () =>
+				repository.assertProposalCommit(existingRef, input.baseCommit, treeSha),
+			);
+			return this.atStage('pr', () => pullRequests.create(input, existingRef));
 		}
 
-		const proposedCommit = await repository.createProposalCommit(
-			input.baseCommit,
-			treeSha,
-			input.title,
-			input.body,
-			input.coAuthor,
+		const proposedCommit = await this.atStage('push', () =>
+			repository.createProposalCommit(
+				input.baseCommit,
+				treeSha,
+				input.title,
+				input.body,
+				input.coAuthor,
+			),
 		);
-		const createdRef = await repository.createRef(input.headBranch, proposedCommit);
+		const createdRef = await this.atStage('branch', () =>
+			repository.createRef(input.headBranch, proposedCommit),
+		);
 		if (createdRef.existed) {
-			await repository.assertProposalCommit(createdRef.headCommit, input.baseCommit, treeSha);
+			await this.atStage('branch', () =>
+				repository.assertProposalCommit(createdRef.headCommit, input.baseCommit, treeSha),
+			);
 		}
-		return pullRequests.create(input, createdRef.headCommit);
+		return this.atStage('pr', () => pullRequests.create(input, createdRef.headCommit));
 	}
 
 	async updateChangeRequest(input: UpdateChangeRequestInput): Promise<OpenChangeRequestResult> {
 		const { owner, repo } = validateUpdateInput(input);
-		const { repository, pullRequests } = await this.publicationContext(owner, repo);
-		const candidates = await pullRequests.listForBranch(
-			input.changeRequest.headBranch,
-			input.baseBranch,
+		const { repository, pullRequests } = await this.atStage('installation', () =>
+			this.publicationContext(owner, repo),
 		);
-		this.assertTargetPullRequest(candidates, input);
+		const candidates = await this.atStage('pr', () =>
+			pullRequests.listForBranch(input.changeRequest.headBranch, input.baseBranch),
+		);
+		try {
+			this.assertTargetPullRequest(candidates, input);
+		} catch (error) {
+			throw markSourceControlPublishFailure(error, { provider: 'github', stage: 'pr' });
+		}
 		const expectedHead = input.changeRequest.headCommit;
-		let currentHead = await repository.getRef(input.changeRequest.headBranch);
+		let currentHead = await this.atStage('branch', () =>
+			repository.getRef(input.changeRequest.headBranch),
+		);
 		if (!currentHead) {
-			throw new ConflictError(
-				'The GitHub pull request branch was deleted; create a new pull request',
+			throw markSourceControlPublishFailure(
+				new ConflictError('The GitHub pull request branch was deleted; create a new pull request'),
+				{ provider: 'github', stage: 'branch', status: 404 },
 			);
 		}
 
 		let appendTree: string | undefined;
 		try {
-			appendTree = await repository.createProposalTree(input, expectedHead);
+			appendTree = await this.atStage('push', () =>
+				repository.createProposalTree(input, expectedHead),
+			);
 		} catch (error) {
 			if (!(error instanceof ConflictError)) throw error;
 		}
@@ -152,31 +196,42 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 				currentHead,
 				appendTree,
 			);
-			return pullRequests.updateMetadata(input, recovered.headCommit);
+			return this.atStage('pr', () => pullRequests.updateMetadata(input, recovered.headCommit));
 		}
 
 		if (appendTree) {
-			const appendCommit = await repository.createProposalCommit(
-				expectedHead,
-				appendTree,
-				input.title,
-				input.body,
-				input.coAuthor,
+			const appendCommit = await this.atStage('push', () =>
+				repository.createProposalCommit(
+					expectedHead,
+					appendTree,
+					input.title,
+					input.body,
+					input.coAuthor,
+				),
 			);
-			if (await repository.updateRef(input.changeRequest.headBranch, appendCommit, false)) {
-				return pullRequests.updateMetadata(input, appendCommit);
+			if (
+				await this.atStage('branch', () =>
+					repository.updateRef(input.changeRequest.headBranch, appendCommit, false),
+				)
+			) {
+				return this.atStage('pr', () => pullRequests.updateMetadata(input, appendCommit));
 			}
-			currentHead = await repository.getRef(input.changeRequest.headBranch);
+			currentHead = await this.atStage('branch', () =>
+				repository.getRef(input.changeRequest.headBranch),
+			);
 			if (currentHead === appendCommit) {
-				return pullRequests.updateMetadata(input, appendCommit);
+				return this.atStage('pr', () => pullRequests.updateMetadata(input, appendCommit));
 			}
 			if (currentHead !== expectedHead) {
-				throw new ConflictError('The GitHub pull request branch changed while updating');
+				throw markSourceControlPublishFailure(
+					new ConflictError('The GitHub pull request branch changed while updating'),
+					{ provider: 'github', stage: 'branch', status: 409 },
+				);
 			}
 		}
 
 		const replaced = await this.replacePullRequestHead(input, repository, expectedHead);
-		return pullRequests.updateMetadata(input, replaced.headCommit);
+		return this.atStage('pr', () => pullRequests.updateMetadata(input, replaced.headCommit));
 	}
 
 	private assertTargetPullRequest(
@@ -201,15 +256,26 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 		const expectedHead = input.changeRequest.headCommit;
 		if (
 			appendTree &&
-			(await repository.proposalCommitMatches(currentHead, expectedHead, appendTree))
+			(await this.atStage('branch', () =>
+				repository.proposalCommitMatches(currentHead, expectedHead, appendTree),
+			))
 		) {
 			return { ...input.changeRequest, headCommit: currentHead };
 		}
-		const replacementTree = await repository.createProposalTree(input, input.baseCommit);
-		if (await repository.proposalCommitMatches(currentHead, input.baseCommit, replacementTree)) {
+		const replacementTree = await this.atStage('push', () =>
+			repository.createProposalTree(input, input.baseCommit),
+		);
+		if (
+			await this.atStage('branch', () =>
+				repository.proposalCommitMatches(currentHead, input.baseCommit, replacementTree),
+			)
+		) {
 			return { ...input.changeRequest, headCommit: currentHead };
 		}
-		throw new ConflictError('The GitHub pull request branch changed outside marimohub');
+		throw markSourceControlPublishFailure(
+			new ConflictError('The GitHub pull request branch changed outside marimohub'),
+			{ provider: 'github', stage: 'branch', status: 409 },
+		);
 	}
 
 	private async replacePullRequestHead(
@@ -217,21 +283,29 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 		repository: GitHubRepositoryWriter,
 		expectedHead: string,
 	): Promise<OpenChangeRequestResult> {
-		const replacementTree = await repository.createProposalTree(input, input.baseCommit);
-		const replacementCommit = await repository.createProposalCommit(
-			input.baseCommit,
-			replacementTree,
-			input.title,
-			input.body,
-			input.coAuthor,
+		const replacementTree = await this.atStage('push', () =>
+			repository.createProposalTree(input, input.baseCommit),
 		);
-		await repository.forceUpdateRef(
-			input.changeRequest.headBranch,
-			expectedHead,
-			replacementCommit,
+		const replacementCommit = await this.atStage('push', () =>
+			repository.createProposalCommit(
+				input.baseCommit,
+				replacementTree,
+				input.title,
+				input.body,
+				input.coAuthor,
+			),
 		);
-		if ((await repository.getRef(input.changeRequest.headBranch)) !== replacementCommit) {
-			throw new UnavailableError('GitHub did not update the pull request branch');
+		await this.atStage('branch', () =>
+			repository.forceUpdateRef(input.changeRequest.headBranch, expectedHead, replacementCommit),
+		);
+		if (
+			(await this.atStage('branch', () => repository.getRef(input.changeRequest.headBranch))) !==
+			replacementCommit
+		) {
+			throw markSourceControlPublishFailure(
+				new UnavailableError('GitHub did not update the pull request branch'),
+				{ provider: 'github', stage: 'branch' },
+			);
 		}
 		return { ...input.changeRequest, headCommit: replacementCommit };
 	}

--- a/packages/source-control-github/src/index.ts
+++ b/packages/source-control-github/src/index.ts
@@ -177,7 +177,7 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 		if (!currentHead) {
 			throw markSourceControlPublishFailure(
 				new ConflictError('The GitHub pull request branch was deleted; create a new pull request'),
-				{ provider: 'github', stage: 'branch', status: 404 },
+				{ provider: 'github', stage: 'branch', condition: 'branch_deleted' },
 			);
 		}
 
@@ -225,7 +225,7 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 			if (currentHead !== expectedHead) {
 				throw markSourceControlPublishFailure(
 					new ConflictError('The GitHub pull request branch changed while updating'),
-					{ provider: 'github', stage: 'branch', status: 409 },
+					{ provider: 'github', stage: 'branch', condition: 'branch_changed' },
 				);
 			}
 		}
@@ -274,7 +274,7 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 		}
 		throw markSourceControlPublishFailure(
 			new ConflictError('The GitHub pull request branch changed outside marimohub'),
-			{ provider: 'github', stage: 'branch', status: 409 },
+			{ provider: 'github', stage: 'branch', condition: 'branch_changed' },
 		);
 	}
 
@@ -295,9 +295,18 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 				input.coAuthor,
 			),
 		);
-		await this.atStage('branch', () =>
-			repository.forceUpdateRef(input.changeRequest.headBranch, expectedHead, replacementCommit),
-		);
+		try {
+			await this.atStage('branch', () =>
+				repository.forceUpdateRef(input.changeRequest.headBranch, expectedHead, replacementCommit),
+			);
+		} catch (error) {
+			if (!(error instanceof ConflictError)) throw error;
+			throw markSourceControlPublishFailure(error, {
+				provider: 'github',
+				stage: 'branch',
+				condition: 'branch_changed',
+			});
+		}
 		if (
 			(await this.atStage('branch', () => repository.getRef(input.changeRequest.headBranch))) !==
 			replacementCommit


### PR DESCRIPTION
Adds observability to notebook change request publishing.

- Annotate source control publish failures with the failing stage (auth, installation, branch, push, pr) and provider status via a `markSourceControlPublishFailure` seam in `core`.
- Emit metrics from `NotebookProposalService` for captured, reused, published, and failed change requests, plus publish latency and capture-size histograms, tagged by provider/stage/outcome.
- Emit structured log events from the API route (`change_request.captured`/`reused`/`published`/`publish_failed`) with request context.
- GitHub adapter wraps each publish step in the corresponding stage so failures carry accurate stage/status.