### PR TITLE
feat(source-control): pull-mode git sources with materialized .git directory

### DIFF
--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -166,7 +166,7 @@ mirror of the sandbox working directory. It contains `notebook.py` and
 - **Runtime files are opt-in.** Under the default `MARIMOHUB_PERSIST_WORKSPACE=source`, `workspace/` contains only `notebook.py` + `pyproject.toml`. Under `workspace`, the sandbox's non-source files are captured here on teardown and restored on the next session (§8).
 - **The mount is rooted at `workspace/`.** When a sandbox mounts the bucket, the working dir maps to `workspace/`. Because `meta.json` / `README.md` / `source.json` / `versions/` sit **outside** `workspace/`, control metadata is never exposed to user code in the sandbox.
 
-For a `git` source, each push writes a complete tree under
+For a `git` source, each sync writes a complete tree under
 `versions/{vid}/workspace/`. The source pointer selects one immutable version.
 The notebook has no mutable workspace mirror. A session receives a copy of the
 selected version and cannot write changes back.

--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -131,8 +131,8 @@ s3-bucket/
             └── {notebook-id}/
                 ├── meta.json               ← notebook metadata (title, author, tags…)
                 ├── README.md               ← human description
-                ├── source.json             ← `local` or push-synced `git` source metadata
-                ├── integration_sync_token.json ← Git-sync token hash (Git sources only)
+                ├── source.json             ← `local` or `git` source metadata
+                ├── integration_sync_token.json ← push-sync token hash (push-mode Git sources only)
                 ├── fs_snapshot.json        ← optional provider filesystem-snapshot pointer
                 ├── workspace/              ← local sources only: latest sandbox workspace
                 │   ├── notebook.py          ← latest local code
@@ -149,7 +149,8 @@ s3-bucket/
                         ├── version.json
                         ├── notebook.py         ← local source snapshot
                         ├── pyproject.toml      ← local dependency snapshot
-                        ├── workspace/          ← Git sources only: complete pushed tree
+                        ├── workspace/          ← Git sources only: complete synced tree
+                        ├── git/                ← pull-mode Git sources only: credential-free `.git` payload
                         ├── notebook.html       ← optional snapshot (see below)
                         └── session.json        ← optional snapshot (see below)
 ```

--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -198,8 +198,8 @@ selected version and cannot write changes back.
 | `_system/integrations/_names/{name}.json`                                 | JSON     | Organization-wide name claim. Claims are unique within this tier, so a project integration can use the same name.                                                                                                                                                                                                                                                                                                                                                                                      |
 | `projects/{pid}/notebooks/{nid}/meta.json`                                | JSON     | Notebook metadata: title, description, status, author, tags, last_run_at. Never contains code or paths.                                                                                                                                                                                                                                                                                                                                                                                                |
 | `projects/{pid}/notebooks/{nid}/README.md`                                | Markdown | Human-readable description and usage notes.                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `projects/{pid}/notebooks/{nid}/source.json`                              | JSON     | Typed source record. `local` stores the current version pointer. `git` stores Git coordinates, sync state, and the current pushed version.                                                                                                                                                                                                                                                                                                                                                             |
-| `projects/{pid}/notebooks/{nid}/integration_sync_token.json`              | JSON     | Git-sync credential for one notebook. The record stores a token hash, not the plaintext token. Present only for Git-synced notebooks.                                                                                                                                                                                                                                                                                                                                                                  |
+| `projects/{pid}/notebooks/{nid}/source.json`                              | JSON     | Typed source record. `local` stores the current version pointer. `git` stores Git coordinates, mode, sync state, and the current synced version.                                                                                                                                                                                                                                                                                                                                                       |
+| `projects/{pid}/notebooks/{nid}/integration_sync_token.json`              | JSON     | Push-sync credential for one notebook. The record stores a token hash, not the plaintext token. Present only for push-mode Git notebooks.                                                                                                                                                                                                                                                                                                                                                              |
 | `projects/{pid}/notebooks/{nid}/fs_snapshot.json`                         | JSON     | **Optional.** Pointer to the notebook's current CoreWeave-native filesystem snapshot (`{ snapshot_id, captured_at, owner_user_id }`). Mutable, last-writer-wins, written only by the teardown snapshot path. Exclusive editors restore snapshots only for the same owner; shared editors may restore across starters. Present only under `MARIMOHUB_COMPUTE_COREWEAVE_FILESYSTEM_SNAPSHOT=true`. **Not recommended alongside `MARIMOHUB_PERSIST_WORKSPACE=workspace`** — the two double-persist state. |
 | `projects/{pid}/notebooks/{nid}/proposals/{proposal-id}/proposal.json`    | JSON     | Immutable proposal manifest containing capture strategy, author/session provenance, pinned Git source revision, and ordered change hashes. Created with create-if-absent.                                                                                                                                                                                                                                                                                                                              |
 | `projects/{pid}/notebooks/{nid}/proposals/{proposal-id}/changes/{index}`  | any      | Temporary bytes for a non-delete proposal change. The index corresponds to `proposal.json.changes`; delete changes have no object. These objects may be deleted after retention expires even though their manifest remains.                                                                                                                                                                                                                                                                            |
@@ -210,7 +210,8 @@ selected version and cannot write changes back.
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/notebook.py`               | Python   | Immutable version snapshot of the code.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/pyproject.toml`            | TOML     | Dependency snapshot at time of version.                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/version.json`              | JSON     | Version metadata: saved_at, author, message, parent_id, optional snapshot descriptors.                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `projects/{pid}/notebooks/{nid}/versions/{vid}/workspace/`                | any      | Complete immutable tree from one Git push. Present only for a `git` source version.                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `projects/{pid}/notebooks/{nid}/versions/{vid}/workspace/`                | any      | Complete immutable tree from one Git sync. Present only for a `git` source version.                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `projects/{pid}/notebooks/{nid}/versions/{vid}/git/`                      | any      | Immutable credential-free `.git` payload for a pull-mode source version. Restored into the sandbox workdir at provision and pruned with the enclosing version.                                                                                                                                                                                                                                                                                                                                         |
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/notebook.html`             | HTML     | **Optional.** Rendered HTML snapshot, copied from `__marimo__/notebook.html` on session teardown. Immutable once written.                                                                                                                                                                                                                                                                                                                                                                              |
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/session.json`              | JSON     | **Optional.** marimo session state (cell outputs), copied from `__marimo__/session/{notebook}.py.json` on teardown. Immutable.                                                                                                                                                                                                                                                                                                                                                                         |
 
@@ -334,20 +335,23 @@ workspace. A local source uses this shape:
 }
 ```
 
-A Git source stores `type: "git"`, `provider: "github"`, `sync_mode: "push"`,
+A Git source stores `type: "git"`, a provider, `sync_mode: "push" | "pull"`,
 Git coordinates, and sync timestamps. `current_version_id` is `null` before the
-first push.
+first successful sync.
 
 ### 4.6 Source types
 
 `source.json` is a discriminated union on `type`. The current schema supports
 `local` and `git` records. A `local` record points to the current version in the
-bucket. A `git` record stores Git coordinates and the state of the last push.
+bucket. A `git` record stores Git coordinates, its push or pull mode, and the
+state of the last sync.
 
-The hub does not fetch a `git` source from GitHub. An external workflow sends
-the workspace to `/api/sync/git/v1` with a notebook-scoped sync token. The hub
-stores the pushed files under `versions/{vid}/workspace/` and creates an
-immutable version.
+In push mode, an external workflow sends the workspace to `/api/sync/git/v1`
+with a notebook-scoped sync token. Pull mode has no token. The hub reads the
+GitHub branch and creates a credential-free shallow Git directory through the
+source-control adapter. Both modes store repository files under
+`versions/{vid}/workspace/`. Pull mode also stores `.git` content under the
+sibling `versions/{vid}/git/` prefix.
 See the [sync guide](../docs/syncing.md) for the API and token lifecycle.
 
 ### 4.7 `versions/{vid}/version.json`
@@ -367,7 +371,7 @@ See the [sync guide](../docs/syncing.md) for the API and token lifecycle.
 
 Versions are immutable once written. A local save writes a new version, updates
 `source.current_version_id`, and updates the notebook-level workspace. A Git
-push writes the complete workspace inside the new version, then advances the
+sync writes the complete workspace inside the new version. It then advances the
 source pointer with CAS.
 
 **Optional snapshot descriptors.** `html_snapshot` and `session_snapshot` record the _presence and metadata_ of a rendered HTML snapshot (`notebook.html`) and a marimo session state file (`session.json`) sitting alongside the code in the version folder. They carry `captured_at` and `size_bytes` — **never a storage path** (clients address notebooks by ID, §13). Each field is **absent** when that artifact wasn't captured; both are written only on session teardown (§8) and only if marimo actually produced the source file, so most versions have neither. Adding these optional fields is forward-tolerant — a reader that doesn't know them ignores them — so it requires no breaking migration of existing `version.json` objects.
@@ -754,8 +758,9 @@ PUT _system/catalog.json  If-Match: {current_etag}
 PUT _system/events/{today}/{event-id}.json
 ```
 
-A Git sync uses a different content write. It writes the uploaded tree under a
-new `versions/{vid}/workspace/` prefix. It then advances
+A Git sync uses a different content write. It stores the fetched or uploaded
+tree under a new `versions/{vid}/workspace/` prefix. Pull mode also stores Git
+metadata under `versions/{vid}/git/`. The sync then advances
 `source.current_version_id` with ETag CAS. See §4.6.
 
 > **Conflict Safety:** If two writers race on Step 5, one receives `412 Precondition Failed` and retries from Step 3. Steps 1–2 are idempotent — re-running them on retry is safe; the content files are already written before the conflict window opens. The loser also deletes the snapshot it wrote in Step 4 before retrying, so a failed attempt never leaves an orphan. Note that the content files in Step 1 are written _before and outside_ the conditional swap: two concurrent saves to the **same** notebook are last-writer-wins on the live `workspace/notebook.py`, while the immutable `versions/{vid}/` objects remain the authoritative per-version record.

--- a/development_docs/source_control_publishing.md
+++ b/development_docs/source_control_publishing.md
@@ -49,11 +49,18 @@ Capture selects one of two strategies automatically and records the choice in
   configured entry notebook with the immutable source version, preserving compatibility with
   copy-based sandbox backends.
 
+Pull-mode GitHub sources store a shallow Git directory for the exact synced
+commit. The control plane restores it when the session starts. Repository
+credentials never enter the sandbox. Pull sources therefore use
+`git-working-tree`. Push sources use this strategy only when the uploaded archive
+contains `.git`.
+
 The Git strategy uses Git only to discover paths and operations. The control plane reads the final
 file bytes through the sandbox port, hashes them, and stores normal provider-neutral proposal
 changes; it does not trust or persist an opaque patch. Tracked modifications and deletions must
-exist in the immutable source version. New regular files may be added. Symlinks and other special
-files are rejected, and mode-only changes are ignored because the proposal format is content-only.
+exist in the immutable source version. New regular files can be added. Source ingest omits
+symlinks and other special files. Capture ignores their missing index entries. It also ignores
+mode-only changes because the proposal format stores content only.
 
 Capture is limited to 1,000 changes and 10 MB of combined content. It excludes `.git`,
 `__marimo__`, `.venv`, `__pycache__`, `node_modules`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`,
@@ -75,7 +82,7 @@ GitHub source control. If only one variable is set, startup fails. The key can b
 single-line base64 encoding of the PEM. No GitHub App webhook is required.
 
 The GitHub App supports publishing and
-[server-initiated sync](../docs/syncing.md#server-initiated-sync-with-github). Project editors can
+[server sync](../docs/syncing.md#sync-now-with-github). Project editors can
 compare a synced notebook with its branch head and pull that commit on demand. Pulls use the same
 workspace parser and limits as pushed archives. The drift and sync endpoints always use the
 source coordinates stored on the notebook. They do not accept a repository from the caller.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -347,7 +347,9 @@ Server-wide settings; no backend selector.
 
 ## Source control publishing
 
-Connect git-synced notebooks to source control from the server. Editors can compare a notebook with its branch head and pull the current GitHub content with **Sync now**. Managers can publish session edits as draft pull requests. The server keeps the provider credentials and never sends them to a notebook sandbox. The first implementation supports GitHub.com through a GitHub App. See [Syncing from external sources](./syncing.md) for sync behavior and limits.
+Connect Git-synced notebooks to GitHub through the server. Editors can create pull sources without a CI workflow. They can also compare and sync either source mode with **Sync now**. Managers can publish session edits as draft pull requests.
+
+The server stores credential-free Git metadata for pull sources. Provider credentials never enter a notebook sandbox. GitHub.com is the only supported provider in this release. See [Syncing from external sources](./syncing.md) for source modes and limits.
 
 ### GitHub App
 

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -8,17 +8,19 @@ description: Sync read-only notebooks into marimohub from external Git repositor
 > request/response shapes documented here are not yet stable, and there is no
 > backwards-compatibility guarantee between releases.
 
-marimohub can serve a notebook whose source of truth lives in an external
-**Git repository**. You can update the notebook with either sync method:
+marimohub can serve a notebook whose source of truth is an external **Git
+repository**. Choose a source mode when you create the notebook:
 
-- **Push sync** sends an archive from a CI workflow. It uses a notebook-scoped
-  sync token and does not give marimohub repository credentials.
-- **Server-initiated sync** pulls a configured GitHub branch on demand. It uses
-  the server's GitHub App credentials and does not require a CI workflow.
+| Mode   | Primary sync path               | Credential | Supported path  | Git metadata                    |
+| ------ | ------------------------------- | ---------- | --------------- | ------------------------------- |
+| `push` | CI upload or **Sync now**       | Sync token | Root or subtree | Only when the upload has `.git` |
+| `pull` | Create request and **Sync now** | GitHub App | Root only       | Included in every version       |
 
-You can use both methods for the same notebook. Each successful sync creates an
-immutable version of the repository files under `root_path`. Running sessions
-get a fresh copy of the latest version. Optional
+The source mode cannot change after creation. For a push source, **Sync now**
+updates the files but does not add Git metadata to the version.
+
+Each successful sync creates an immutable version of the repository files under
+`root_path`. Each session starts with a fresh copy of the latest version. Optional
 [source-control publishing](configuration.md#source-control-publishing) can send
 session edits to the provider without changing these stored versions.
 
@@ -43,7 +45,7 @@ Each sync writes the repository files into a fresh
 notebook's source pointer. Concurrent syncs cannot combine files from different
 versions. The source pointer always references one complete version.
 
-## 1. Create a synced notebook
+## Create a synced notebook
 
 ```http
 POST /api/v1/projects/{pid}/notebooks/git
@@ -56,31 +58,31 @@ Content-Type: application/json
   "repo": "acme/analytics",
   "branch": "main",
   "root_path": "apps",
-  "entry_notebook": "dashboard.py"
+  "entry_notebook": "dashboard.py",
+  "sync_mode": "push"
 }
 ```
 
-| Field            | Required | Notes                                                                                      |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------ |
-| `provider`       | no       | `github` or `gitlab`. Usually derived from `repo`; see below.                              |
-| `repo`           | yes      | Repository URL or `owner/name`. Server sync pulls from it, and push headers must match it. |
-| `branch`         | yes      | Branch this notebook tracks.                                                               |
-| `root_path`      | no       | Repo subdirectory whose tree is mirrored. Defaults to the repo root (`""`).                |
-| `entry_notebook` | yes      | The notebook to open (`.py`, `.md`, `.markdown`, or `.qmd`), **relative to `root_path`**.  |
+| Field            | Required | Notes                                                                                     |
+| ---------------- | -------- | ----------------------------------------------------------------------------------------- |
+| `provider`       | no       | `github` or `gitlab`. Usually derived from `repo`.                                        |
+| `repo`           | yes      | Repository URL or `owner/name`. Pull mode currently supports GitHub.com only.             |
+| `branch`         | yes      | Branch this notebook tracks.                                                              |
+| `root_path`      | no       | Repo subdirectory whose tree is mirrored. Defaults to the repo root (`""`).               |
+| `entry_notebook` | yes      | The notebook to open (`.py`, `.md`, `.markdown`, or `.qmd`), **relative to `root_path`**. |
+| `sync_mode`      | no       | `push` (default) or `pull`. Pull mode is GitHub-only and requires `root_path: ""`.        |
 
-`repo` accepts `owner/repo` (GitHub shorthand; gitlab.com when `provider` is
-`gitlab`) or a repository URL such as
-`https://gitlab.example.com/group/subgroup/project` — nested GitLab groups
-included. Scheme-less `host.tld/group/project` and SSH remotes
-(`git@host:path.git`) are rewritten to https on write.
+`repo` accepts `owner/repo` or a repository URL. The shorthand refers to GitHub,
+unless `provider` is `gitlab`. GitLab URLs can contain nested groups, such as
+`https://gitlab.example.com/group/subgroup/project`. marimohub converts
+scheme-less and SSH remotes to HTTPS when it stores them.
 
-`provider` picks the UI's link layout (GitLab nests deep links under `/-/`).
-It is derived from the host name — hosts containing `github` or `gitlab` are
-recognized — so pass it only when the host doesn't give it away (e.g.
-`code.example.com`). With no recognized host and no `provider`, the UI shows
-the sync metadata without links.
+marimohub normally derives `provider` from the host name. Set it only when a
+custom host does not identify the provider. The value controls provider links
+in the web interface. If neither the host nor `provider` identifies a provider,
+the interface shows the sync metadata without links.
 
-The response returns the notebook plus its sync credentials:
+For push mode, the response returns the notebook plus its sync credentials:
 
 ```json
 {
@@ -96,11 +98,50 @@ The response returns the notebook plus its sync credentials:
 The `sync_token` is shown **once**. Store it as a CI secret. The server keeps
 only a SHA-256 of it.
 
+### Pull mode: connect a GitHub repository
+
+Use pull mode when marimohub must sync the repository. Set `sync_mode` to
+`pull` and use an empty `root_path`:
+
+```json
+{
+	"title": "Sales dashboard",
+	"description": "Connected to the analytics repo",
+	"repo": "acme/analytics",
+	"branch": "main",
+	"root_path": "",
+	"entry_notebook": "apps/dashboard.py",
+	"sync_mode": "pull"
+}
+```
+
+The deployment must list `"github"` in `source_control.pull_source_providers`
+from `GET /api/v1/capabilities`. The create request reads the branch head before
+it returns. On success, the response contains an active notebook without
+`sync_url` or `sync_token`.
+
+If the first pull fails, the response contains a draft notebook and
+`sync_error`. Correct the repository coordinates or GitHub App access. Then use
+**Sync now** to retry.
+
+Pull mode supports only the repository root in v1. Put the full
+repository-relative path in `entry_notebook`. For example, use
+`apps/dashboard.py` instead of `root_path: "apps"`.
+
+Each pull stores a shallow, credential-free Git directory for the exact commit.
+marimohub restores this directory into the session workspace. Session startup
+fails if the Git directory cannot be restored completely. The GitHub
+installation token stays on the server.
+
+Git data larger than 25 MB is rejected. Use push mode for a repository that
+exceeds this limit.
+
 ### View or edit sync settings
 
-In the project notebook menu, open **Sync settings** to view the repository,
-branch, repo folder, entry notebook, sync URL, and last successful sync. Project
-editors can change all four source coordinates:
+In the notebook menu, open **Sync settings** to view the repository, branch,
+repository folder, entry notebook, and last successful sync. Push sources also
+show the sync URL and token controls. Project editors can change the four source
+coordinates:
 
 ```http
 PATCH /api/v1/projects/{pid}/notebooks/{nid}/source
@@ -114,28 +155,36 @@ Content-Type: application/json
 }
 ```
 
-When editing, a bare `owner/repo` keeps naming a path on the host the source
-already lives on; github.com shorthand stays bare.
+For an existing custom-host source, a bare `owner/repo` continues to use that
+host. GitHub.com shorthand remains bare.
+
+The source mode cannot change. A pull source must continue to use the repository
+root and a supported GitHub.com repository. marimohub rejects unsupported source
+changes before it stores them.
 
 Before the first successful sync, changes take effect immediately. After that,
-changes remain pending until a push or server pull matches the new source
+changes remain pending until a CI upload or server sync matches the new source
 coordinates. The notebook continues to serve its last successful version in
 the meantime. Editing the source does not change the sync URL or rotate its
-token.
+token. Pull sources promote pending settings on the next **Sync now**. Push
+sources promote them on a matching CI upload or server sync.
 
-## Server-initiated sync with GitHub
+## Sync now with GitHub
 
-For GitHub notebooks, this method can replace push step 2. The deployment must
-have a configured [GitHub App](configuration.md#source-control-publishing). A
-project editor can compare a notebook with its branch head and pull that commit
-into marimohub. This method currently supports GitHub.com repositories only.
+**Sync now** reads a GitHub branch through the server. Pull sources use this
+action as their normal sync method. Push sources can use it as an alternative to
+a CI upload.
+
+The deployment must have a configured
+[GitHub App](configuration.md#source-control-publishing). This feature currently
+supports GitHub.com repositories only.
 
 The deployment advertises supported providers in
 `source_control.sync_providers` from `GET /api/v1/capabilities`. The list
 contains `"github"` when the GitHub App is configured. The notebook's
 `source.provider` must appear in this list.
 
-The API provides two endpoints:
+The API provides these endpoints:
 
 | Endpoint                                                  | Result                                                                        |
 | --------------------------------------------------------- | ----------------------------------------------------------------------------- |
@@ -151,28 +200,33 @@ The drift response includes `current_commit`, `remote_commit`, `in_sync`,
 time and does not change notebook state. Pending source settings always set
 `in_sync` to `false`.
 
-The sync endpoint downloads the repository tree under `root_path` at the
-resolved commit. It applies the same file-count and size limits as push sync to
-the files under `root_path`. Files outside `root_path` do not count against
-these limits, so a small subtree can sync from a large monorepo. The repository
-download itself is limited to 100 MB compressed and 2 GB uncompressed. If
-no source settings are pending and the notebook already points to that commit,
-it returns `synced: false` and does not create a version. A successful sync
-against pending source settings makes those settings active. The response also
-includes the resolved `commit` and the new `version_id`. The `version_id` is
-`null` for a no-op.
+The sync endpoint reads the repository tree at the resolved commit. It applies
+the push-sync file-count and size limits to files under `root_path`. For a push
+source, files outside `root_path` do not count against these limits. Pull sources
+always use the repository root.
 
-The web interface shows the drift status and a **Sync now** button in **Sync
-settings** and in the repository popover. The button is available only to
-editors when the source provider supports server-initiated sync.
+Server sync omits symlinks and other special entries from the workspace. For a
+pull source, proposal capture also ignores these omitted Git index entries.
 
-Push sync and server-initiated sync share commit-based idempotency. If either
-method already synced a commit, the other method does not create a duplicate
-version. GitHub archives do not include `.git`, so a server-pulled workspace
-supports entry-notebook publishing only. To capture changes across multiple
-files, use push sync and [include `.git`](#include-git-for-multi-file-publishing).
+The repository download is limited to 100 MB compressed and 2 GB uncompressed.
+If no settings are pending and the notebook already points to the commit, the
+endpoint returns `synced: false` and creates no version. A sync against pending
+source settings makes those settings active. The response includes the resolved
+`commit` and the new `version_id`. For a no-op, `version_id` is `null`.
 
-## 2. Push an archive
+The web interface shows drift status and **Sync now** in **Sync settings** and
+the repository popover. The action is available to editors when the provider
+supports server sync.
+
+CI uploads and **Sync now** share commit-based idempotency. If one method already
+synced a commit, the other method does not create a duplicate version.
+
+A pull-mode version always includes `.git`. Publishing can therefore capture
+added, modified, and deleted files across the working tree. A push-mode server
+sync stores repository files only. Include `.git` in CI archives when a push
+source needs multi-file capture.
+
+## Push an archive
 
 Use push sync for GitLab, self-hosted Git providers, or deployments without a
 GitHub App. You can also use it for GitHub notebooks that support **Sync now**.
@@ -257,7 +311,7 @@ Archive the complete checkout instead of using `git archive`:
   run: tar czf /tmp/sync.tgz .
 ```
 
-Upload `/tmp/sync.tgz` with the headers from [Push an archive](#_2-push-an-archive).
+Upload `/tmp/sync.tgz` with the headers from [Push an archive](#push-an-archive).
 Omit `X-Marimohub-Root-Path`, or set it to an empty string.
 
 This method has these requirements:
@@ -272,9 +326,9 @@ This method has these requirements:
   Files inside `.git` count toward these limits.
 
 marimohub stores `.git` with the immutable version and restores it into each
-session workspace. If `.git` or the `git` binary is unavailable, capture uses
-the entry-notebook fallback. If Git cannot resolve `X-Marimohub-Commit`,
-publishing fails without falling back.
+session workspace. If `.git` is absent or the `git` binary is unavailable,
+capture uses the entry-notebook fallback. If Git cannot resolve
+`X-Marimohub-Commit`, publishing fails without falling back.
 
 ### Idempotency
 

--- a/internal/schemas/README.md
+++ b/internal/schemas/README.md
@@ -4,11 +4,11 @@ OpenAPI 3.1 renderings of marimohub's persisted-data and API contracts,
 committed so every contract change shows up in review as a plain-text diff and
 CI can flag the breaking ones.
 
-| Spec                                                                 | Contract                                  | Generated from                                             |
-| -------------------------------------------------------------------- | ----------------------------------------- | ---------------------------------------------------------- |
-| [`bucket.yml`](./bucket.yml)                                         | Every JSON object persisted in the bucket | zod schemas in `packages/core/src/schema.ts` + `paths.ts`  |
-| [`integrations.yml`](./integrations.yml)                             | Every integration kind's config schema    | `defaultRegistry()` (`core/…/services/integrations/kinds`) |
-| [`../../packages/api/openapi.yaml`](../../packages/api/openapi.yaml) | The HTTP API                              | `@hono/zod-openapi` routes in `packages/api`               |
+| Spec                                                                 | Contract                                          | Generated from                                             |
+| -------------------------------------------------------------------- | ------------------------------------------------- | ---------------------------------------------------------- |
+| [`bucket.yml`](./bucket.yml)                                         | Persisted JSON objects and artifact path families | zod schemas in `packages/core/src/schema.ts` + `paths.ts`  |
+| [`integrations.yml`](./integrations.yml)                             | Configuration schema for each integration kind    | `defaultRegistry()` (`core/…/services/integrations/kinds`) |
+| [`../../packages/api/openapi.yaml`](../../packages/api/openapi.yaml) | The HTTP API                                      | `@hono/zod-openapi` routes in `packages/api`               |
 
 The API spec stays in `packages/api` (it is published at `/openapi.yaml` and
 feeds `@marimo-hub/client` codegen) but is covered by the same CI gate.

--- a/internal/schemas/allowed-breaking/api.md
+++ b/internal/schemas/allowed-breaking/api.md
@@ -30,3 +30,13 @@ POST /api/v1/projects/{pid}/integrations/{iid}/browse/objects/preview added `sub
 POST /api/v1/projects/{pid}/notebooks/git removed the enum value `github` of the request property `provider`
 POST /api/v1/projects/{pid}/notebooks/git removed the enum value `gitlab` of the request property `provider`
 POST /api/v1/projects/{pid}/notebooks/git the `provider` request property's minLength was increased from `0` to `1`
+
+`sync_mode` now accepts pull sources. Pull creation omits the push-only token
+and URL. Existing push responses still contain both fields.
+
+```text
+POST /api/v1/projects/{pid}/notebooks/git the response property `data/sync_token` became optional for the status `201`
+POST /api/v1/projects/{pid}/notebooks/git the response property `data/sync_url` became optional for the status `201`
+GET /api/v1/projects/{pid}/notebooks/{nid} added the new `pull` enum value to the `data/source/oneOf[subschema #2]/sync_mode` response property for the response status `200`
+PATCH /api/v1/projects/{pid}/notebooks/{nid}/source added the new `pull` enum value to the `data/source/sync_mode` response property for the response status `200`
+```

--- a/internal/schemas/allowed-breaking/bucket.md
+++ b/internal/schemas/allowed-breaking/bucket.md
@@ -35,3 +35,13 @@ PUT /projects/{pid}/notebooks/{nid}/source.json `removed the enum value `github`
 PUT /projects/{pid}/notebooks/{nid}/source.json `removed the enum value `gitlab` of the request property `oneOf[subschema #2]/provider/anyOf[subschema #1]/``
 PUT /projects/{pid}/notebooks/{nid}/source.json `the `oneOf[subschema #2]/provider/anyOf[subschema #1]/` request property's minLength was increased from `0` to `1``
 ```
+
+`sync_mode` changed from the stored literal `push` to the `push | pull` enum.
+Existing source records remain valid. New pull records use the second value.
+
+```text
+GET /projects/{pid}/notebooks/{nid}/source.json the `sync_mode` response property const value `push` was removed for the status `200`
+PUT /projects/{pid}/notebooks/{nid}/source.json request property `oneOf[subschema #2]/sync_mode` was restricted to a list of enum values
+GET /projects/{pid}/notebooks/{nid}/source.json added the new `pull` enum value to the `oneOf[subschema #2]/sync_mode` response property for the response status `200`
+GET /projects/{pid}/notebooks/{nid}/source.json added the new `push` enum value to the `oneOf[subschema #2]/sync_mode` response property for the response status `200`
+```

--- a/internal/schemas/bucket.yml
+++ b/internal/schemas/bucket.yml
@@ -4,7 +4,8 @@ info:
   version: 1.0.0
   description: |-
     Machine-checkable description of every JSON object marimohub persists in
-    its storage bucket, generated from the zod schemas in
+    its storage bucket plus artifact families with contractual storage
+    semantics, generated from the zod schemas in
     `packages/core/src/schema.ts` and the key templates in
     `packages/core/src/paths.ts`. This is not an HTTP API: paths are bucket
     key templates, GET models what readers must accept, PUT models what
@@ -12,10 +13,11 @@ info:
     invariants in AGENTS.md and development_docs/bucket_spec.md.
 
     Deliberately excluded (no zod schema; internal operational records or
-    non-JSON artifacts): idempotency records, integration name claims,
+    other non-JSON artifacts): idempotency records, integration name claims,
     reconcile orphan markers, advisory locks, and version/workspace file
     artifacts (notebook.py, pyproject.toml, notebook.html, session.json,
-    README.md, workspace files).
+    README.md, workspace files). Pull-source Git metadata is included because
+    its immutable version-scoped location is part of the sync contract.
 tags:
   - name: catalog
     description: Catalog pointer and snapshots (`_system/`)
@@ -952,6 +954,58 @@ paths:
       responses:
         '204':
           description: Stored.
+  /projects/{pid}/notebooks/{nid}/versions/{vid}/git/{relative_path}:
+    summary: Immutable pull-source Git metadata file, addressed relative to `.git`.
+    parameters:
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: nid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: vid
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: relative_path
+        in: path
+        required: true
+        schema:
+          type: string
+    x-mutability: immutable
+    get:
+      operationId: read_projects_notebooks_versions_git
+      summary: Read GitDirectoryFile
+      tags:
+        - notebook
+      responses:
+        '200':
+          description: The stored artifact.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+    put:
+      operationId: write_projects_notebooks_versions_git
+      summary: Write GitDirectoryFile
+      tags:
+        - notebook
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '204':
+          description: Stored.
 components:
   schemas:
     Catalog:
@@ -1498,7 +1552,9 @@ components:
                 - entry_notebook
             sync_mode:
               type: string
-              const: push
+              enum:
+                - push
+                - pull
             current_version_id:
               anyOf:
                 - type: string

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -168,9 +168,18 @@ components:
                 lookup and "Sync now").
               example:
                 - github
+            pull_source_providers:
+              type: array
+              items:
+                type: string
+              description: Provider ids configured to create pull-mode sources with
+                server-materialized Git metadata.
+              example:
+                - github
           required:
             - change_request_providers
             - sync_providers
+            - pull_source_providers
         project_alerts:
           type: object
           properties:
@@ -984,10 +993,20 @@ components:
           type: string
         sync_token:
           type: string
+        sync_error:
+          type: object
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+          required:
+            - code
+            - message
+          description: Initial pull failure. The draft notebook remains available and can
+            be retried with Sync now.
       required:
         - notebook
-        - sync_url
-        - sync_token
     SyncToken:
       type: object
       properties:
@@ -1129,6 +1148,7 @@ components:
               type: string
               enum:
                 - push
+                - pull
             current_version_id:
               type:
                 - string
@@ -4974,6 +4994,12 @@ paths:
                 compute_profile:
                   type: string
                   minLength: 1
+                sync_mode:
+                  type: string
+                  enum:
+                    - push
+                    - pull
+                  default: push
               required:
                 - title
                 - description
@@ -5017,6 +5043,12 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '404':
           description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: Conflict
           content:
             application/json:
               schema:
@@ -5188,6 +5220,11 @@ paths:
                   type: string
                   minLength: 1
                   example: my_app.py
+                sync_mode:
+                  type: string
+                  enum:
+                    - push
+                    - pull
               required:
                 - repo
                 - branch
@@ -5247,6 +5284,7 @@ paths:
                             type: string
                             enum:
                               - push
+                              - pull
                           current_version_id:
                             type:
                               - string

--- a/packages/api/src/capabilities.test.ts
+++ b/packages/api/src/capabilities.test.ts
@@ -72,7 +72,11 @@ describe('GET /api/v1/capabilities', () => {
 	it('reports configured source-control publisher and reader providers', async () => {
 		const none = makeTestDeps(new MemoryBucket(), { authenticator: authed });
 		expect(await expectOk(await createApi(none).request('/api/v1/capabilities'))).toMatchObject({
-			source_control: { change_request_providers: [], sync_providers: [] },
+			source_control: {
+				change_request_providers: [],
+				sync_providers: [],
+				pull_source_providers: [],
+			},
 		});
 
 		const configured = makeTestDeps(new MemoryBucket(), {
@@ -84,13 +88,18 @@ describe('GET /api/v1/capabilities', () => {
 					supportsRepository: () => true,
 					getBranchHead: vi.fn(),
 					fetchWorkspace: vi.fn(),
+					fetchGitDirectory: vi.fn(),
 				},
 			}),
 		});
 		expect(
 			await expectOk(await createApi(configured).request('/api/v1/capabilities')),
 		).toMatchObject({
-			source_control: { change_request_providers: ['github'], sync_providers: ['github'] },
+			source_control: {
+				change_request_providers: ['github'],
+				sync_providers: ['github'],
+				pull_source_providers: ['github'],
+			},
 		});
 	});
 

--- a/packages/api/src/routes/notebooks.ts
+++ b/packages/api/src/routes/notebooks.ts
@@ -626,7 +626,10 @@ app.openapi(createGitNotebook, async (c) => {
 	}
 	const createdMeta =
 		prospectiveSource.sync_mode === 'pull'
-			? (await notebooks.getNotebook(pid, meta.id)).meta
+			? await notebooks
+					.getNotebook(pid, meta.id)
+					.then(({ meta: refreshedMeta }) => refreshedMeta)
+					.catch(() => meta)
 			: meta;
 	return c.json(
 		{

--- a/packages/api/src/routes/notebooks.ts
+++ b/packages/api/src/routes/notebooks.ts
@@ -2,7 +2,11 @@ import { createRoute, z } from '@hono/zod-openapi';
 import type { Context } from 'hono';
 import { zipSync } from 'fflate';
 import {
+	applyGitSourceUpdate,
+	assertSyncedSource,
 	BadRequestError,
+	createGitSource,
+	DomainError,
 	ForbiddenError,
 	NotebookId,
 	NotFoundError,
@@ -41,7 +45,7 @@ import {
 } from '../shared';
 import { idempotentCreate } from '../idempotency';
 import { appendAudit } from '../log';
-import { pullSourceToHead, resolveSyncTarget } from './sourcePullSync';
+import { assertPullSourceSupported, pullSourceToHead, resolveSyncTarget } from './sourcePullSync';
 import type { HonoEnv, SandboxConfig } from '../context';
 import { pageSchema, paginate, PaginationQuery } from '../pagination';
 import { scheduleProjectAlert } from '../notifications';
@@ -89,6 +93,7 @@ const CreateGitNotebookBody = z.object({
 	runtime: RuntimeResponseSchema.optional(),
 	base_image: z.string().min(1).optional(),
 	compute_profile: z.string().min(1).optional(),
+	sync_mode: z.enum(['push', 'pull']).optional().default('push'),
 });
 
 const SyncTokenResponseSchema = z
@@ -101,8 +106,12 @@ const SyncTokenResponseSchema = z
 const GitNotebookCreateResponseSchema = z
 	.object({
 		notebook: NotebookMetaResponseSchema,
-		sync_url: z.string(),
-		sync_token: z.string(),
+		sync_url: z.string().optional(),
+		sync_token: z.string().optional(),
+		sync_error: z.object({ code: z.string(), message: z.string() }).optional().openapi({
+			description:
+				'Initial pull failure. The draft notebook remains available and can be retried with Sync now.',
+		}),
 	})
 	.openapi('GitNotebookCreateResult');
 
@@ -111,6 +120,7 @@ const UpdateGitSourceBody = z.object({
 	branch: z.string().min(1).openapi({ example: 'main' }),
 	root_path: z.string().openapi({ example: 'apps' }),
 	entry_notebook: z.string().min(1).openapi({ example: 'my_app.py' }),
+	sync_mode: z.enum(['push', 'pull']).optional(),
 });
 
 const UpdateNotebookBody = z.object({
@@ -239,7 +249,7 @@ const createGitNotebook = createRoute({
 			'Git-synced notebook created',
 		),
 		...commonErrors(),
-		...errorResponses(400, 403, 404),
+		...errorResponses(400, 403, 404, 409),
 	},
 });
 
@@ -577,18 +587,54 @@ app.openapi(createGitNotebook, async (c) => {
 	const body = c.req.valid('json');
 	const base_image = checkBaseImage(deps.sandbox.images, body.base_image) ?? undefined;
 	const compute_profile = checkComputeProfile(deps.sandbox, body.compute_profile) ?? undefined;
-	const { meta, sync_token } = await notebooks.synced.create(
-		pid,
-		{ ...body, base_image, compute_profile },
-		user.id,
-	);
+	const input = { ...body, base_image, compute_profile };
+	const prospectiveSource = createGitSource(input);
+	if (prospectiveSource.sync_mode === 'pull') {
+		assertPullSourceSupported(deps, prospectiveSource);
+	}
+	const { meta, sync_token } = await notebooks.synced.create(pid, input, user.id);
+	let syncError: { code: string; message: string } | undefined;
+	if (prospectiveSource.sync_mode === 'pull') {
+		try {
+			const outcome = await pullSourceToHead(deps, pid, meta.id, user.id);
+			if (outcome.synced) {
+				await appendAudit(
+					{
+						requestId: c.get('requestId'),
+						method: c.req.method,
+						path: c.req.path,
+						userId: user.id,
+					},
+					'notebook.source.sync',
+					() =>
+						deps.services.events.append({
+							event: 'notebook.source.sync',
+							actor: user.id,
+							project_id: pid,
+							notebook_id: meta.id,
+							commit: outcome.commit,
+							trigger: 'create',
+						}),
+				);
+			}
+		} catch (error) {
+			syncError =
+				error instanceof DomainError
+					? { code: error.code, message: error.message }
+					: { code: 'SYNC_FAILED', message: 'The initial repository sync failed' };
+		}
+	}
+	const createdMeta =
+		prospectiveSource.sync_mode === 'pull'
+			? (await notebooks.getNotebook(pid, meta.id)).meta
+			: meta;
 	return c.json(
 		{
 			success: true,
 			data: {
-				notebook: toPublicNotebookMeta(meta),
-				sync_url: syncUrl(c, pid, meta.id),
-				sync_token,
+				notebook: toPublicNotebookMeta(createdMeta),
+				...(sync_token ? { sync_url: syncUrl(c, pid, meta.id), sync_token } : {}),
+				...(syncError ? { sync_error: syncError } : {}),
 			},
 		},
 		201,
@@ -611,7 +657,11 @@ app.openapi(updateGitSource, async (c) => {
 	const user = c.get('user');
 	const { pid, nid } = c.req.valid('param');
 	await assertProjectRole(projects, pid, user, 'editor', deps.policy);
-	const source = await notebooks.synced.updateSource(pid, nid, c.req.valid('json'), user.id);
+	const input = c.req.valid('json');
+	const current = assertSyncedSource((await notebooks.getNotebook(pid, nid)).source);
+	const prospective = applyGitSourceUpdate(current, input) ?? current;
+	if (current.sync_mode === 'pull') assertPullSourceSupported(deps, prospective);
+	const source = await notebooks.synced.updateSource(pid, nid, input, user.id);
 	const { schema_version: _schemaVersion, ...publicSource } = source;
 	return c.json({ success: true, data: { source: publicSource } }, 200);
 });

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -897,9 +897,14 @@ app.openapi(createSession, async (c) => {
 	if (!workspacePolicy.persistSessionEdits && !syncedVersionId) {
 		throw new ConflictError('Synced notebook has not been synced yet');
 	}
-	const workspacePrefix = syncedVersionId
-		? paths.project(pid).notebook(nid).version(syncedVersionId).workspacePrefix
+	const syncedVersionPaths = syncedVersionId
+		? paths.project(pid).notebook(nid).version(syncedVersionId)
 		: undefined;
+	const workspacePrefix = syncedVersionPaths?.workspacePrefix;
+	const gitPrefix =
+		notebook.source.type === 'git' && notebook.source.sync_mode === 'pull'
+			? syncedVersionPaths?.gitPrefix
+			: undefined;
 	// Staleness provenance: a session that serves a frozen snapshot — a
 	// non-persisting mode (`app`), or any mode on a synced source (a read-only
 	// mirror, even under `edit`) — is stamped with the head committed version it
@@ -1293,6 +1298,7 @@ app.openapi(createSession, async (c) => {
 								? 'copy-only'
 								: workspacePolicy.loadMode,
 						workspacePrefix,
+						gitPrefix,
 					});
 					({ url, usedFallback } = provisionResult);
 					// Per-phase durations onto the session_provision event.

--- a/packages/api/src/routes/sourcePullSync.ts
+++ b/packages/api/src/routes/sourcePullSync.ts
@@ -1,4 +1,5 @@
 import {
+	assertGitDirectoryLimits,
 	effectiveGitSourceConfig,
 	isAtBranchHead,
 	NotFoundError,
@@ -91,6 +92,7 @@ export async function pullSourceToHead(
 			? reader.fetchGitDirectory!(config.repo, head.commit, config.branch)
 			: undefined,
 	]);
+	if (gitFiles) assertGitDirectoryLimits(gitFiles);
 	const { versionId } = await notebooks.synced.sync(
 		projectId,
 		notebookId,

--- a/packages/api/src/routes/sourcePullSync.ts
+++ b/packages/api/src/routes/sourcePullSync.ts
@@ -42,7 +42,17 @@ function requireSyncReader(
 	const provider = providerForRepo(source, config.repo);
 	const reader = provider ? deps.sourceControl?.getReader(provider) : undefined;
 	if (!reader?.supportsRepository(config.repo)) throw new SyncNotConfiguredError();
+	if (source.sync_mode === 'pull' && !reader.fetchGitDirectory) {
+		throw new SyncNotConfiguredError();
+	}
 	return { git: source, reader, config };
+}
+
+export function assertPullSourceSupported(deps: PullSyncDeps, source: Source): void {
+	if (source.type !== 'git' || source.sync_mode !== 'pull') {
+		throw new SyncNotConfiguredError();
+	}
+	requireSyncReader(deps, source);
 }
 
 /** Resolve the reader and live branch head for a notebook's effective sync coordinates. */
@@ -75,7 +85,12 @@ export async function pullSourceToHead(
 	if (isAtBranchHead(git, head.commit)) {
 		return { synced: false, commit: head.commit, version_id: null };
 	}
-	const files = await reader.fetchWorkspace(config.repo, head.commit, config.root_path);
+	const [files, gitFiles] = await Promise.all([
+		reader.fetchWorkspace(config.repo, head.commit, config.root_path),
+		git.sync_mode === 'pull'
+			? reader.fetchGitDirectory!(config.repo, head.commit, config.branch)
+			: undefined,
+	]);
 	const { versionId } = await notebooks.synced.sync(
 		projectId,
 		notebookId,
@@ -85,6 +100,7 @@ export async function pullSourceToHead(
 			root_path: config.root_path,
 			commit: head.commit,
 			files,
+			...(gitFiles ? { git_files: gitFiles } : {}),
 			// The head was resolved against this source state; if another sync
 			// advances it during the download, conflict instead of regressing.
 			expected_source_version: git.current_version_id,

--- a/packages/api/src/routes/sourcePullSync.ts
+++ b/packages/api/src/routes/sourcePullSync.ts
@@ -1,5 +1,4 @@
 import {
-	assertGitDirectoryLimits,
 	effectiveGitSourceConfig,
 	isAtBranchHead,
 	NotFoundError,
@@ -92,7 +91,6 @@ export async function pullSourceToHead(
 			? reader.fetchGitDirectory!(config.repo, head.commit, config.branch)
 			: undefined,
 	]);
-	if (gitFiles) assertGitDirectoryLimits(gitFiles);
 	const { versionId } = await notebooks.synced.sync(
 		projectId,
 		notebookId,

--- a/packages/api/src/routes/sourceSync.test.ts
+++ b/packages/api/src/routes/sourceSync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { zipSync } from 'fflate';
 import {
 	BadRequestError,
@@ -202,7 +202,7 @@ describe('Source drift and sync-now routes', () => {
 		).toMatchObject({ sync_mode: 'pull', current_version_id: null });
 	});
 
-	it('rejects oversized Git metadata before calling the sync service', async () => {
+	it('rejects oversized Git metadata before persisting a version', async () => {
 		const reader = stubReader({
 			fetchGitDirectory: async () =>
 				Array.from({ length: MAX_GIT_DIRECTORY_FILES + 1 }, (_, index) => ({
@@ -211,7 +211,6 @@ describe('Source drift and sync-now routes', () => {
 				})),
 		});
 		const { request, deps } = api(reader);
-		const sync = vi.spyOn(deps.services.notebooks.synced, 'sync');
 		const created = await expectOk<{
 			notebook: { id: string; status: string };
 			sync_error: { code: string; message: string };
@@ -230,7 +229,9 @@ describe('Source drift and sync-now routes', () => {
 		expect(created.notebook.status).toBe('draft');
 		expect(created.sync_error).toMatchObject({ code: 'BAD_REQUEST' });
 		expect(created.sync_error.message).toMatch(`${MAX_GIT_DIRECTORY_FILES}-file limit`);
-		expect(sync).not.toHaveBeenCalled();
+		expect(
+			await deps.services.notebooks.listVersions(projectId, created.notebook.id as NotebookId),
+		).toHaveLength(0);
 	});
 
 	it('rejects mode switching for a pull source', async () => {

--- a/packages/api/src/routes/sourceSync.test.ts
+++ b/packages/api/src/routes/sourceSync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { zipSync } from 'fflate';
 import {
 	BadRequestError,
@@ -138,6 +138,41 @@ describe('Source drift and sync-now routes', () => {
 				paths.project(projectId).notebook(created.notebook.id as NotebookId).integrationSyncToken,
 			),
 		).toBeNull();
+	});
+
+	it('returns the created notebook when the post-sync refetch fails', async () => {
+		const reader = stubReader({
+			fetchGitDirectory: async () => [{ path: 'HEAD', bytes: encode('HEAD') }],
+		});
+		const { request, deps } = api(reader);
+		const getNotebook = deps.services.notebooks.getNotebook.bind(deps.services.notebooks);
+		const notebookLookup = vi
+			.spyOn(deps.services.notebooks, 'getNotebook')
+			.mockImplementationOnce(getNotebook)
+			.mockImplementationOnce(getNotebook)
+			.mockRejectedValueOnce(new UnavailableError('Notebook refetch failed'));
+
+		const created = await expectOk<{
+			notebook: { id: string; status: string };
+			sync_error?: unknown;
+		}>(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Connected app',
+				description: 'Pulled by the server',
+				repo: 'org/repo',
+				branch: 'main',
+				entry_notebook: 'app.py',
+				sync_mode: 'pull',
+			}),
+			201,
+		);
+
+		expect(created.notebook.status).toBe('draft');
+		expect(created.sync_error).toBeUndefined();
+		expect(notebookLookup).toHaveBeenCalledTimes(3);
+		expect(
+			await deps.services.notebooks.listVersions(projectId, created.notebook.id as NotebookId),
+		).toHaveLength(1);
 	});
 
 	it('rejects pull creation without Git materialization support or with a subtree', async () => {

--- a/packages/api/src/routes/sourceSync.test.ts
+++ b/packages/api/src/routes/sourceSync.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { zipSync } from 'fflate';
 import {
 	BadRequestError,
 	createNotebookId,
 	createServices,
+	MAX_GIT_DIRECTORY_FILES,
 	paths,
 	UnavailableError,
 } from '@marimo-hub/core';
@@ -199,6 +200,37 @@ describe('Source drift and sync-now routes', () => {
 				)
 			).source,
 		).toMatchObject({ sync_mode: 'pull', current_version_id: null });
+	});
+
+	it('rejects oversized Git metadata before calling the sync service', async () => {
+		const reader = stubReader({
+			fetchGitDirectory: async () =>
+				Array.from({ length: MAX_GIT_DIRECTORY_FILES + 1 }, (_, index) => ({
+					path: `objects/${index}`,
+					bytes: new Uint8Array(),
+				})),
+		});
+		const { request, deps } = api(reader);
+		const sync = vi.spyOn(deps.services.notebooks.synced, 'sync');
+		const created = await expectOk<{
+			notebook: { id: string; status: string };
+			sync_error: { code: string; message: string };
+		}>(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Connected app',
+				description: 'Pulled by the server',
+				repo: 'org/repo',
+				branch: 'main',
+				entry_notebook: 'app.py',
+				sync_mode: 'pull',
+			}),
+			201,
+		);
+
+		expect(created.notebook.status).toBe('draft');
+		expect(created.sync_error).toMatchObject({ code: 'BAD_REQUEST' });
+		expect(created.sync_error.message).toMatch(`${MAX_GIT_DIRECTORY_FILES}-file limit`);
+		expect(sync).not.toHaveBeenCalled();
 	});
 
 	it('rejects mode switching for a pull source', async () => {

--- a/packages/api/src/routes/sourceSync.test.ts
+++ b/packages/api/src/routes/sourceSync.test.ts
@@ -74,6 +74,276 @@ describe('Source drift and sync-now routes', () => {
 		return data.notebook.id;
 	}
 
+	async function createPullNotebook(request: ReturnType<typeof createTestApi>['request']) {
+		const data = await expectOk<{ notebook: { id: string } }>(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Connected app',
+				description: 'Pulled by the server',
+				repo: 'org/repo',
+				branch: 'main',
+				entry_notebook: 'app.py',
+				sync_mode: 'pull',
+			}),
+			201,
+		);
+		return data.notebook.id;
+	}
+
+	it('creates a pull source with an inline first sync and no push credentials', async () => {
+		const reader = stubReader({
+			fetchGitDirectory: async () => [
+				{ path: 'HEAD', bytes: encode('ref: refs/heads/main\n') },
+				{ path: 'index', bytes: encode('index') },
+			],
+		});
+		const { request, deps } = api(reader);
+		const created = await expectOk<{
+			notebook: { id: string; status: string };
+			sync_url?: string;
+			sync_token?: string;
+		}>(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Connected app',
+				description: 'Pulled by the server',
+				repo: 'org/repo',
+				branch: 'main',
+				root_path: '',
+				entry_notebook: 'app.py',
+				sync_mode: 'pull',
+			}),
+			201,
+		);
+		expect(created.notebook.status).toBe('active');
+		expect(created.sync_url).toBeUndefined();
+		expect(created.sync_token).toBeUndefined();
+
+		const detail = await deps.services.notebooks.getNotebook(
+			projectId,
+			created.notebook.id as NotebookId,
+		);
+		expect(detail.source).toMatchObject({ sync_mode: 'pull', commit: HEAD });
+		if (detail.source.type !== 'git' || !detail.source.current_version_id) {
+			throw new Error('expected pull source version');
+		}
+		const version = paths
+			.project(projectId)
+			.notebook(created.notebook.id as NotebookId)
+			.version(detail.source.current_version_id);
+		expect(await (await bucket.get(version.gitFile('HEAD')))!.text()).toBe(
+			'ref: refs/heads/main\n',
+		);
+		expect(
+			await bucket.get(
+				paths.project(projectId).notebook(created.notebook.id as NotebookId).integrationSyncToken,
+			),
+		).toBeNull();
+	});
+
+	it('rejects pull creation without Git materialization support or with a subtree', async () => {
+		const { request } = api(stubReader());
+		const body = {
+			title: 'Connected app',
+			description: 'Pulled by the server',
+			repo: 'org/repo',
+			branch: 'main',
+			root_path: '',
+			entry_notebook: 'app.py',
+			sync_mode: 'pull',
+		};
+		await expectError(
+			await request('POST', `/projects/${projectId}/notebooks/git`, body),
+			409,
+			'SYNC_NOT_CONFIGURED',
+		);
+		const capable = api(stubReader({ fetchGitDirectory: async () => [] }));
+		await expectError(
+			await capable.request('POST', `/projects/${projectId}/notebooks/git`, {
+				...body,
+				root_path: 'apps',
+			}),
+			400,
+		);
+	});
+
+	it('keeps a draft pull source and surfaces an inline sync failure', async () => {
+		const reader = stubReader({
+			fetchWorkspace: async () => {
+				throw new UnavailableError('GitHub tarball is unavailable');
+			},
+			fetchGitDirectory: async () => [{ path: 'HEAD', bytes: encode('HEAD') }],
+		});
+		const { request } = api(reader);
+		const created = await expectOk<{
+			notebook: { id: string; status: string };
+			sync_error: { code: string; message: string };
+		}>(
+			await request('POST', `/projects/${projectId}/notebooks/git`, {
+				title: 'Connected app',
+				description: 'Pulled by the server',
+				repo: 'org/repo',
+				branch: 'main',
+				entry_notebook: 'app.py',
+				sync_mode: 'pull',
+			}),
+			201,
+		);
+		expect(created.notebook.status).toBe('draft');
+		expect(created.sync_error).toMatchObject({
+			code: 'SERVICE_UNAVAILABLE',
+			message: 'GitHub tarball is unavailable',
+		});
+		expect(
+			(
+				await expectOk<any>(
+					await request('GET', `/projects/${projectId}/notebooks/${created.notebook.id}`),
+				)
+			).source,
+		).toMatchObject({ sync_mode: 'pull', current_version_id: null });
+	});
+
+	it('rejects mode switching for a pull source', async () => {
+		const { request } = api(
+			stubReader({
+				supportsRepository: (repo) => !repo.includes('enterprise'),
+				fetchGitDirectory: async () => [{ path: 'HEAD', bytes: encode('HEAD') }],
+			}),
+		);
+		const notebookId = await createPullNotebook(request);
+		const path = `/projects/${projectId}/notebooks/${notebookId}/source`;
+		await expectError(
+			await request('PATCH', path, {
+				repo: 'org/repo',
+				branch: 'main',
+				root_path: '',
+				entry_notebook: 'app.py',
+				sync_mode: 'push',
+			}),
+			400,
+		);
+		const detail = await expectOk<{ source: { sync_mode: string } }>(
+			await request('GET', `/projects/${projectId}/notebooks/${notebookId}`),
+		);
+		expect(detail.source.sync_mode).toBe('pull');
+	});
+
+	it('rejects subtree settings for a pull source', async () => {
+		const { request } = api(
+			stubReader({ fetchGitDirectory: async () => [{ path: 'HEAD', bytes: encode('HEAD') }] }),
+		);
+		const notebookId = await createPullNotebook(request);
+		const path = `/projects/${projectId}/notebooks/${notebookId}/source`;
+
+		await expectError(
+			await request('PATCH', path, {
+				repo: 'org/repo',
+				branch: 'main',
+				root_path: 'apps',
+				entry_notebook: 'app.py',
+			}),
+			400,
+		);
+		const detail = await expectOk<{
+			source: { root_path: string; pending_config?: unknown };
+		}>(await request('GET', `/projects/${projectId}/notebooks/${notebookId}`));
+		expect(detail.source).toMatchObject({ root_path: '' });
+		expect(detail.source.pending_config).toBeUndefined();
+	});
+
+	it('rejects unsupported pull repositories without mutating the source', async () => {
+		const { request } = api(
+			stubReader({
+				supportsRepository: (repo) => !repo.includes('enterprise'),
+				fetchGitDirectory: async () => [{ path: 'HEAD', bytes: encode('HEAD') }],
+			}),
+		);
+		const notebookId = await createPullNotebook(request);
+		const path = `/projects/${projectId}/notebooks/${notebookId}/source`;
+
+		await expectError(
+			await request('PATCH', path, {
+				repo: 'https://gitlab.com/org/repo',
+				branch: 'main',
+				root_path: '',
+				entry_notebook: 'app.py',
+			}),
+			409,
+			'SYNC_NOT_CONFIGURED',
+		);
+		await expectError(
+			await request('PATCH', path, {
+				repo: 'https://github.enterprise.example/org/repo',
+				branch: 'main',
+				root_path: '',
+				entry_notebook: 'app.py',
+			}),
+			409,
+			'SYNC_NOT_CONFIGURED',
+		);
+		const detail = await expectOk<{
+			source: { repo: string; branch: string; pending_config?: unknown };
+		}>(await request('GET', `/projects/${projectId}/notebooks/${notebookId}`));
+		expect(detail.source).toMatchObject({ repo: 'org/repo', branch: 'main' });
+		expect(detail.source.pending_config).toBeUndefined();
+	});
+
+	it('keeps a supported pending update when a later pull-source update is rejected', async () => {
+		const { request } = api(
+			stubReader({ fetchGitDirectory: async () => [{ path: 'HEAD', bytes: encode('HEAD') }] }),
+		);
+		const notebookId = await createPullNotebook(request);
+		const path = `/projects/${projectId}/notebooks/${notebookId}/source`;
+		await expectOk(
+			await request('PATCH', path, {
+				repo: 'other/repo',
+				branch: 'release',
+				root_path: '',
+				entry_notebook: 'app.py',
+			}),
+		);
+		await expectError(
+			await request('PATCH', path, {
+				repo: 'https://gitlab.com/org/repo',
+				branch: 'main',
+				root_path: '',
+				entry_notebook: 'app.py',
+			}),
+			409,
+			'SYNC_NOT_CONFIGURED',
+		);
+
+		const detail = await expectOk<{
+			source: { pending_config?: { repo: string; branch: string } };
+		}>(await request('GET', `/projects/${projectId}/notebooks/${notebookId}`));
+		expect(detail.source.pending_config).toMatchObject({
+			repo: 'other/repo',
+			branch: 'release',
+		});
+	});
+
+	it('rejects pull-source updates when the configured reader is removed', async () => {
+		const capable = api(
+			stubReader({ fetchGitDirectory: async () => [{ path: 'HEAD', bytes: encode('HEAD') }] }),
+		);
+		const notebookId = await createPullNotebook(capable.request);
+		const disconnected = api();
+
+		await expectError(
+			await disconnected.request('PATCH', `/projects/${projectId}/notebooks/${notebookId}/source`, {
+				repo: 'other/repo',
+				branch: 'main',
+				root_path: '',
+				entry_notebook: 'app.py',
+			}),
+			409,
+			'SYNC_NOT_CONFIGURED',
+		);
+		const detail = await expectOk<{ source: { repo: string; pending_config?: unknown } }>(
+			await disconnected.request('GET', `/projects/${projectId}/notebooks/${notebookId}`),
+		);
+		expect(detail.source.repo).toBe('org/repo');
+		expect(detail.source.pending_config).toBeUndefined();
+	});
+
 	it('rejects drift and sync when no reader is configured (409 SYNC_NOT_CONFIGURED)', async () => {
 		const { request } = api();
 		const nid = await createSyncedNotebook(request);

--- a/packages/api/src/routes/system.ts
+++ b/packages/api/src/routes/system.ts
@@ -100,6 +100,7 @@ app.openapi(capabilitiesRoute, (c) => {
 		source_control: {
 			change_request_providers: [...(deps.sourceControl?.publisherProviders() ?? [])],
 			sync_providers: [...(deps.sourceControl?.readerProviders() ?? [])],
+			pull_source_providers: [...(deps.sourceControl?.pullSourceProviders() ?? [])],
 		},
 		project_alerts: {
 			available: Boolean(deps.projectAlerts),

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -717,7 +717,7 @@ export const GitSourceResponseSchema = z.object({
 	}),
 	...GitSourceConfigResponseSchema.shape,
 	pending_config: GitSourceConfigResponseSchema.optional(),
-	sync_mode: z.literal('push'),
+	sync_mode: z.enum(['push', 'pull']),
 	current_version_id: z.string().nullable(),
 	commit: z.string().nullable(),
 	last_synced_at: nullableDt(),
@@ -1007,6 +1007,11 @@ export const CapabilitiesResponseSchema = z
 			sync_providers: z.array(z.string()).openapi({
 				description:
 					'Provider ids configured for server-initiated pull sync (drift lookup and "Sync now").',
+				example: ['github'],
+			}),
+			pull_source_providers: z.array(z.string()).openapi({
+				description:
+					'Provider ids configured to create pull-mode sources with server-materialized Git metadata.',
 				example: ['github'],
 			}),
 		}),

--- a/packages/api/src/testing/index.ts
+++ b/packages/api/src/testing/index.ts
@@ -49,6 +49,7 @@ export function stubSourceControl(
 		getReader: (provider) => (provider === reader?.provider ? reader : undefined),
 		publisherProviders: () => (publisher ? [publisher.provider] : []),
 		readerProviders: () => (reader ? [reader.provider] : []),
+		pullSourceProviders: () => (reader?.fetchGitDirectory ? [reader.provider] : []),
 	};
 }
 

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -2770,6 +2770,11 @@ export interface paths {
 						};
 						base_image?: string;
 						compute_profile?: string;
+						/**
+						 * @default push
+						 * @enum {string}
+						 */
+						sync_mode?: 'push' | 'pull';
 					};
 				};
 			};
@@ -2816,6 +2821,15 @@ export interface paths {
 				};
 				/** @description Not found */
 				404: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content: {
+						'application/json': components['schemas']['ErrorResponse'];
+					};
+				};
+				/** @description Conflict */
+				409: {
 					headers: {
 						[name: string]: unknown;
 					};
@@ -3021,6 +3035,8 @@ export interface paths {
 						root_path: string;
 						/** @example my_app.py */
 						entry_notebook: string;
+						/** @enum {string} */
+						sync_mode?: 'push' | 'pull';
 					};
 				};
 			};
@@ -3065,7 +3081,7 @@ export interface paths {
 									entry_notebook: string;
 									pending_config?: components['schemas']['GitSourceConfig'];
 									/** @enum {string} */
-									sync_mode: 'push';
+									sync_mode: 'push' | 'pull';
 									current_version_id: string | null;
 									commit: string | null;
 									/**
@@ -9841,6 +9857,13 @@ export interface components {
 				 *     ]
 				 */
 				sync_providers: string[];
+				/**
+				 * @description Provider ids configured to create pull-mode sources with server-materialized Git metadata.
+				 * @example [
+				 *       "github"
+				 *     ]
+				 */
+				pull_source_providers: string[];
 			};
 			project_alerts: {
 				available: boolean;
@@ -10176,8 +10199,13 @@ export interface components {
 		};
 		GitNotebookCreateResult: {
 			notebook: components['schemas']['NotebookMeta'];
-			sync_url: string;
-			sync_token: string;
+			sync_url?: string;
+			sync_token?: string;
+			/** @description Initial pull failure. The draft notebook remains available and can be retried with Sync now. */
+			sync_error?: {
+				code: string;
+				message: string;
+			};
 		};
 		SyncToken: {
 			sync_url: string;
@@ -10263,7 +10291,7 @@ export interface components {
 					entry_notebook: string;
 					pending_config?: components['schemas']['GitSourceConfig'];
 					/** @enum {string} */
-					sync_mode: 'push';
+					sync_mode: 'push' | 'pull';
 					current_version_id: string | null;
 					commit: string | null;
 					/**

--- a/packages/config/src/sourceControl.ts
+++ b/packages/config/src/sourceControl.ts
@@ -33,6 +33,10 @@ function sourceControlRegistry(
 		getReader: (provider) => readersByProvider.get(provider),
 		publisherProviders: () => [...publishersByProvider.keys()],
 		readerProviders: () => [...readersByProvider.keys()],
+		pullSourceProviders: () =>
+			[...readersByProvider.values()]
+				.filter((reader) => reader.fetchGitDirectory)
+				.map((reader) => reader.provider),
 	};
 }
 

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -1078,7 +1078,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 	{
 		name: 'Source control publishing',
 		description:
-			'Connect git-synced notebooks to source control from the server. Editors can compare a notebook with its branch head and pull the current GitHub content with **Sync now**. Managers can publish session edits as draft pull requests. The server keeps the provider credentials and never sends them to a notebook sandbox. The first implementation supports GitHub.com through a GitHub App. See [Syncing from external sources](./syncing.md) for sync behavior and limits.',
+			'Connect Git-synced notebooks to GitHub through the server. Editors can create pull sources without a CI workflow. They can also compare and sync either source mode with **Sync now**. Managers can publish session edits as draft pull requests.\n\nThe server stores credential-free Git metadata for pull sources. Provider credentials never enter a notebook sandbox. GitHub.com is the only supported provider in this release. See [Syncing from external sources](./syncing.md) for source modes and limits.',
 		backends: [
 			{
 				name: 'GitHub App',

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -42,7 +42,7 @@ export type SessionMode = (typeof SESSION_MODES)[number];
 export const EDITOR_SANDBOX_SHARING_VALUES = ['shared', 'exclusive'] as const;
 export type EditorSandboxSharing = (typeof EDITOR_SANDBOX_SHARING_VALUES)[number];
 
-/** Where a notebook's source lives. `git` = a git repo push-synced from an external host. */
+/** Where a notebook's source lives. `git` = a repository synced from an external host. */
 export const SOURCE_TYPES = ['local', 'git'] as const;
 export type SourceType = (typeof SOURCE_TYPES)[number];
 

--- a/packages/core/src/integrations/remoteWorkspace.ts
+++ b/packages/core/src/integrations/remoteWorkspace.ts
@@ -13,7 +13,7 @@ export type WorkspaceLoadMode = 'mount-or-copy' | 'copy-only';
 /**
  * How a notebook's source behaves as a sandbox workspace. Local notebooks are
  * editable and round-trip session edits back to the store; synced (git) sources
- * are read-only mirrors restored fresh from their last push. Source-type-specific
+ * are read-only mirrors restored fresh from their last sync. Source-type-specific
  * behavior is funnelled through this one descriptor so the provisioner, session
  * route, and read paths stay source-agnostic — see `WORKSPACE_SOURCE_POLICIES`.
  */

--- a/packages/core/src/integrations/syncedSource.test.ts
+++ b/packages/core/src/integrations/syncedSource.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { ConflictError } from '../errors';
+import { BadRequestError, ConflictError } from '../errors';
 import type { VersionId } from '../ids';
 import type { GitSource } from '../schema';
 import {
+	applyGitSourceUpdate,
 	assertSyncSourcePrecondition,
 	createGitSource,
 	isAtBranchHead,
@@ -26,6 +27,80 @@ function syncedSource(overrides: Partial<GitSource> = {}): GitSource {
 }
 
 const PENDING = { repo: 'org/repo', branch: 'main', root_path: '', entry_notebook: 'other.py' };
+const ACTIVE = { repo: 'org/repo', branch: 'main', root_path: '', entry_notebook: 'app.py' };
+
+describe('createGitSource', () => {
+	it('rejects a pull source rooted below the repository root', () => {
+		expect(() =>
+			createGitSource({
+				title: 'Dash',
+				description: 'd',
+				repo: 'org/repo',
+				branch: 'main',
+				root_path: 'notebooks',
+				entry_notebook: 'app.py',
+				sync_mode: 'pull',
+			}),
+		).toThrow(BadRequestError);
+	});
+});
+
+describe('applyGitSourceUpdate', () => {
+	it('rejects mode changes in both directions', () => {
+		expect(() => applyGitSourceUpdate(syncedSource(), { ...ACTIVE, sync_mode: 'pull' })).toThrow(
+			'Changing sync_mode is not supported',
+		);
+		expect(() =>
+			applyGitSourceUpdate(syncedSource({ sync_mode: 'pull' }), {
+				...ACTIVE,
+				sync_mode: 'push',
+			}),
+		).toThrow('Changing sync_mode is not supported');
+	});
+
+	it('rejects subtree settings for a pull source when the mode is omitted', () => {
+		expect(() =>
+			applyGitSourceUpdate(syncedSource({ sync_mode: 'pull' }), {
+				...ACTIVE,
+				root_path: 'apps',
+			}),
+		).toThrow('Pull-mode sources require root_path to be empty');
+	});
+
+	it('returns no mutation for active and already-pending settings', () => {
+		expect(applyGitSourceUpdate(syncedSource(), ACTIVE)).toBeNull();
+		expect(applyGitSourceUpdate(syncedSource({ pending_config: PENDING }), PENDING)).toBeNull();
+	});
+
+	it('clears pending settings when the active settings are restored', () => {
+		const updated = applyGitSourceUpdate(syncedSource({ pending_config: PENDING }), ACTIVE);
+
+		expect(updated?.pending_config).toBeUndefined();
+		expect(updated).toMatchObject(ACTIVE);
+	});
+
+	it('applies a draft update immediately and derives its provider from the new host', () => {
+		const updated = applyGitSourceUpdate(syncedSource(), {
+			...ACTIVE,
+			repo: 'https://gitlab.com/group/project',
+		});
+
+		expect(updated).toMatchObject({
+			repo: 'https://gitlab.com/group/project',
+			provider: 'gitlab',
+		});
+		expect(updated?.pending_config).toBeUndefined();
+	});
+
+	it('stages an update after the first sync without changing the active source', () => {
+		const updated = applyGitSourceUpdate(
+			syncedSource({ current_version_id: 'ver_01ARZ3NDEKTSV4RRFFQ69G5FAV' as VersionId }),
+			PENDING,
+		);
+
+		expect(updated).toMatchObject({ ...ACTIVE, pending_config: PENDING });
+	});
+});
 
 describe('isAtBranchHead', () => {
 	it('is true only for the synced commit with nothing pending', () => {

--- a/packages/core/src/integrations/syncedSource.ts
+++ b/packages/core/src/integrations/syncedSource.ts
@@ -32,6 +32,7 @@ export interface CreateSyncedNotebookInput {
 	runtime?: { python_version?: string; marimo_version?: string };
 	base_image?: string;
 	compute_profile?: string;
+	sync_mode?: 'push' | 'pull';
 }
 
 export interface SyncNotebookInput {
@@ -40,6 +41,8 @@ export interface SyncNotebookInput {
 	root_path: string;
 	commit: string;
 	files: SyncedWorkspaceFile[];
+	/** Files relative to `.git`, present only for pull-mode sources. */
+	git_files?: SyncedWorkspaceFile[];
 	/**
 	 * Optimistic precondition for server-initiated pulls: the source
 	 * `current_version_id` observed when the branch head was resolved (null for
@@ -53,7 +56,9 @@ export interface SyncNotebookInput {
 	expected_source_version?: VersionId | null;
 }
 
-export type UpdateSyncedNotebookSourceInput = GitSourceConfig;
+export type UpdateSyncedNotebookSourceInput = GitSourceConfig & {
+	sync_mode?: 'push' | 'pull';
+};
 
 export const SyncTokenRecordSchema = z.object({
 	schema_version: z.literal(1),
@@ -173,12 +178,44 @@ export function resolveUpdatedConfig(
 	return rehomed;
 }
 
+export function applyGitSourceUpdate(
+	current: GitSource,
+	input: UpdateSyncedNotebookSourceInput,
+): GitSource | null {
+	const desired = normalizeGitSourceConfig(input);
+	if (input.sync_mode && input.sync_mode !== current.sync_mode) {
+		throw new BadRequestError('Changing sync_mode is not supported');
+	}
+	if (current.sync_mode === 'pull' && desired.root_path !== '') {
+		throw new BadRequestError('Pull-mode sources require root_path to be empty');
+	}
+	const resolved = resolveUpdatedConfig(current, desired);
+	const active = gitSourceConfig(current);
+	if (current.pending_config && gitSourceConfigsEqual(current.pending_config, resolved))
+		return null;
+	const { pending_config: _pendingConfig, ...withoutPending } = current;
+	if (gitSourceConfigsEqual(active, resolved)) {
+		return current.pending_config ? withoutPending : null;
+	}
+	if (current.current_version_id === null) {
+		return {
+			...withoutPending,
+			...resolved,
+			provider: providerForRepo(current, resolved.repo),
+		};
+	}
+	return { ...current, pending_config: resolved };
+}
+
 export function createGitSource(input: CreateSyncedNotebookInput): GitSource {
 	// Shorthand means github.com — unless the caller says GitLab, then gitlab.com.
 	const config = rehomeShorthand(
 		normalizeGitSourceConfig(input),
 		input.provider === 'gitlab' ? 'https://gitlab.com' : null,
 	);
+	if (input.sync_mode === 'pull' && config.root_path !== '') {
+		throw new BadRequestError('Pull-mode sources require root_path to be empty');
+	}
 	return {
 		schema_version: 1,
 		type: 'git',
@@ -186,7 +223,7 @@ export function createGitSource(input: CreateSyncedNotebookInput): GitSource {
 		// never contradict a recognized host; the claim covers unknown hosts.
 		provider: detectProvider(config.repo) ?? input.provider ?? null,
 		...config,
-		sync_mode: 'push',
+		sync_mode: input.sync_mode ?? 'push',
 		current_version_id: null,
 		commit: null,
 		last_synced_at: null,

--- a/packages/core/src/paths.test.ts
+++ b/packages/core/src/paths.test.ts
@@ -83,6 +83,8 @@ describe('paths', () => {
 			{
 			  "code": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/notebook.py",
 			  "deps": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/pyproject.toml",
+			  "gitFile": [Function],
+			  "gitPrefix": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/git/",
 			  "html": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/notebook.html",
 			  "meta": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/version.json",
 			  "session": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/session.json",

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -17,6 +17,9 @@ export interface VersionPaths {
 	meta: string;
 	workspacePrefix: string;
 	workspaceFile: (rel: string) => string;
+	/** Pull-source Git metadata, stored outside the workspace mirror. */
+	gitPrefix: string;
+	gitFile: (rel: string) => string;
 	/** Optional rendered HTML snapshot captured on teardown (`notebook.html`). */
 	html: string;
 	/** Optional marimo session-state snapshot captured on teardown (`session.json`). */
@@ -91,12 +94,15 @@ export interface ProjectPaths {
 function versionPaths(base: string, vid: VersionId): VersionPaths {
 	const prefix = `${base}/versions/${vid}`;
 	const workspace = `${prefix}/workspace`;
+	const git = `${prefix}/git`;
 	return {
 		code: `${prefix}/notebook.py`,
 		deps: `${prefix}/pyproject.toml`,
 		meta: `${prefix}/version.json`,
 		workspacePrefix: `${workspace}/`,
 		workspaceFile: (rel: string) => `${workspace}/${rel}`,
+		gitPrefix: `${git}/`,
+		gitFile: (rel: string) => `${git}/${rel}`,
 		html: `${prefix}/notebook.html`,
 		session: `${prefix}/session.json`,
 	};

--- a/packages/core/src/ports/sourceControl.test.ts
+++ b/packages/core/src/ports/sourceControl.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { markSourceControlPublishFailure, sourceControlPublishFailure } from './sourceControl';
+import { MAX_WORKSPACE_FILE_BYTES } from '../constants';
+import { BadRequestError } from '../errors';
+import {
+	GitDirectoryLimitTracker,
+	markSourceControlPublishFailure,
+	MAX_GIT_DIRECTORY_BYTES,
+	MAX_GIT_DIRECTORY_FILES,
+	sourceControlPublishFailure,
+} from './sourceControl';
 
 describe('source-control publish failures', () => {
 	it('preserves a non-Error thrown value as the annotated error cause', () => {
@@ -35,4 +43,44 @@ describe('source-control publish failures', () => {
 			condition: 'branch_changed',
 		});
 	});
+});
+describe('GitDirectoryLimitTracker', () => {
+	it('accepts the exact file-count and cumulative-byte boundaries', () => {
+		const limits = new GitDirectoryLimitTracker();
+		const entryBytes = Math.floor(MAX_GIT_DIRECTORY_BYTES / MAX_GIT_DIRECTORY_FILES);
+		for (let index = 0; index < MAX_GIT_DIRECTORY_FILES - 1; index++) {
+			limits.add(`objects/${index}`, entryBytes);
+		}
+		limits.add(
+			'objects/final',
+			MAX_GIT_DIRECTORY_BYTES - entryBytes * (MAX_GIT_DIRECTORY_FILES - 1),
+		);
+	});
+
+	it('rejects an entry beyond the file-count cap', () => {
+		const limits = new GitDirectoryLimitTracker();
+		for (let index = 0; index < MAX_GIT_DIRECTORY_FILES; index++) {
+			limits.add(`objects/${index}`, 0);
+		}
+		expect(() => limits.add('objects/overflow', 0)).toThrow(
+			`${MAX_GIT_DIRECTORY_FILES}-file limit`,
+		);
+	});
+
+	it('rejects cumulative materialized bytes beyond the cap', () => {
+		const limits = new GitDirectoryLimitTracker();
+		const part = Math.floor(MAX_GIT_DIRECTORY_BYTES / 5) + 1;
+		for (let index = 0; index < 4; index++) limits.add(`objects/${index}`, part);
+		expect(() => limits.add('objects/overflow', part)).toThrow(
+			`${MAX_GIT_DIRECTORY_BYTES}-byte limit`,
+		);
+	});
+
+	it.each([MAX_WORKSPACE_FILE_BYTES + 1, -1, Number.NaN])(
+		'rejects an invalid individual entry size: %s',
+		(size) => {
+			const limits = new GitDirectoryLimitTracker();
+			expect(() => limits.add('objects/invalid', size)).toThrow(BadRequestError);
+		},
+	);
 });

--- a/packages/core/src/ports/sourceControl.ts
+++ b/packages/core/src/ports/sourceControl.ts
@@ -151,6 +151,15 @@ export interface SourceControlReader {
 		commit: string,
 		rootPath: string,
 	): Promise<SourceWorkspaceFile[]>;
+	/**
+	 * Materialize a credential-free Git directory for the exact commit. Paths
+	 * are relative to `.git`; the returned object database must resolve commit.
+	 */
+	fetchGitDirectory?(
+		repository: string,
+		commit: string,
+		branch: string,
+	): Promise<SourceWorkspaceFile[]>;
 }
 
 /** Server-side source-control capabilities configured for this deployment. */
@@ -161,4 +170,6 @@ export interface SourceControlRegistry {
 	publisherProviders(): readonly string[];
 	/** Provider ids that can serve server-initiated pull sync. */
 	readerProviders(): readonly string[];
+	/** Provider ids that can create pull-mode sources with a real Git working tree. */
+	pullSourceProviders(): readonly string[];
 }

--- a/packages/core/src/ports/sourceControl.ts
+++ b/packages/core/src/ports/sourceControl.ts
@@ -1,3 +1,6 @@
+import { MAX_WORKSPACE_FILE_BYTES } from '../constants';
+import { BadRequestError } from '../errors';
+
 export interface SourceControlContentChange {
 	/** Repository-relative path; absolute paths and `..` segments are invalid. */
 	path: string;
@@ -127,6 +130,47 @@ export interface SourceWorkspaceFile {
 	bytes: Uint8Array;
 }
 
+/** Maximum number of materialized files accepted in a pull source's `.git` directory. */
+export const MAX_GIT_DIRECTORY_FILES = 1000;
+
+/** Maximum cumulative size of a pull source's materialized `.git` directory. */
+export const MAX_GIT_DIRECTORY_BYTES = 100 * 1024 * 1024;
+
+/** Maximum cumulative size of Git protocol responses for one fetch. */
+export const MAX_GIT_FETCH_BYTES = MAX_WORKSPACE_FILE_BYTES;
+
+/** Maximum file count after the fetched Git objects are expanded into a checkout. */
+export const MAX_GIT_EXPANDED_FILES = 1000;
+
+/** Maximum byte count after the fetched Git objects are expanded into a checkout. */
+export const MAX_GIT_EXPANDED_BYTES = 100 * 1024 * 1024;
+
+export class GitDirectoryLimitTracker {
+	private fileCount = 0;
+	private totalBytes = 0;
+
+	add(path: string, size: number): void {
+		if (!Number.isSafeInteger(size) || size < 0 || size > MAX_WORKSPACE_FILE_BYTES) {
+			throw new BadRequestError(
+				`Git directory file exceeds the ${MAX_WORKSPACE_FILE_BYTES}-byte limit: ${path}`,
+			);
+		}
+		if (this.fileCount + 1 > MAX_GIT_DIRECTORY_FILES) {
+			throw new BadRequestError(`Git directory exceeds the ${MAX_GIT_DIRECTORY_FILES}-file limit`);
+		}
+		if (this.totalBytes + size > MAX_GIT_DIRECTORY_BYTES) {
+			throw new BadRequestError(`Git directory exceeds the ${MAX_GIT_DIRECTORY_BYTES}-byte limit`);
+		}
+		this.fileCount += 1;
+		this.totalBytes += size;
+	}
+}
+
+export function assertGitDirectoryLimits(files: readonly SourceWorkspaceFile[]): void {
+	const limits = new GitDirectoryLimitTracker();
+	for (const file of files) limits.add(file.path, file.bytes.byteLength);
+}
+
 /** The read side of a provider: resolve branch heads and fetch workspace trees. */
 export interface SourceControlReader {
 	/** Same id namespace as `SourceControlPublisher` (`github`, `gitlab`, …). */
@@ -154,6 +198,11 @@ export interface SourceControlReader {
 	/**
 	 * Materialize a credential-free Git directory for the exact commit. Paths
 	 * are relative to `.git`; the returned object database must resolve commit.
+	 * Implementations MUST enforce `MAX_GIT_DIRECTORY_FILES`,
+	 * `MAX_WORKSPACE_FILE_BYTES` per entry, and `MAX_GIT_DIRECTORY_BYTES` on the
+	 * materialized output before buffering file bodies. Implementations MUST also
+	 * enforce `MAX_GIT_FETCH_BYTES` across all protocol responses and
+	 * `MAX_GIT_EXPANDED_FILES`/`MAX_GIT_EXPANDED_BYTES` after pack expansion.
 	 */
 	fetchGitDirectory?(
 		repository: string,

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -429,14 +429,10 @@ export const LocalSourceSchema = z.object({
 	current_version_id: VersionIdSchema,
 });
 
-// A git repository mirrored into the store by an external pusher (e.g. a CI
-// workflow). The platform never reaches out to the host — content arrives by
-// `push` only — so `provider` is informational (for display/links) and `repo`,
-// `branch`, `commit` are plain git coordinates, host-agnostic. `repo` is
-// either `owner/repo` (GitHub shorthand) or a repository URL. Host detection
-// takes precedence over an explicit provider claim; provider is null when
-// neither is available. Sync fields are null until the first push lands; see
-// `SyncedNotebookService`.
+// A Git repository mirrored into the store by CI push or a configured provider
+// reader. `repo`, `branch`, and `commit` remain provider-neutral coordinates.
+// Host detection takes precedence over an explicit provider claim; provider is
+// null when neither is available. Sync fields are null until the first sync.
 // Static repository coordinates supplied when a git-backed notebook is configured.
 export const GitSourceConfigSchema = z.object({
 	repo: z.string(),
@@ -463,7 +459,7 @@ export const GitSourceSchema = z.object({
 	provider: z.string().min(1).nullable(),
 	...GitSourceConfigSchema.shape,
 	pending_config: GitSourceConfigSchema.optional(),
-	sync_mode: z.literal('push'),
+	sync_mode: z.enum(['push', 'pull']),
 	current_version_id: VersionIdSchema.nullable(),
 	commit: z.string().nullable(),
 	last_synced_at: z.iso.datetime().nullable(),

--- a/packages/core/src/services/content/NotebookProposalService.test.ts
+++ b/packages/core/src/services/content/NotebookProposalService.test.ts
@@ -323,6 +323,35 @@ describe('NotebookProposalService', () => {
 		);
 	});
 
+	it('ignores deleted Git entries that were excluded from the synced workspace', async () => {
+		const { instance } = makeGitSandbox({
+			files: { 'dashboard.py': 'print("after")' },
+			diff: [
+				['M', 'dashboard.py'],
+				['D', 'link-to-data'],
+			],
+		});
+
+		const proposal = await capture(instance);
+
+		expect(proposal.changes).toEqual([
+			expect.objectContaining({ path: 'dashboard.py', operation: 'modify' }),
+		]);
+	});
+
+	it('treats a workspace with only excluded Git deletions as unchanged', async () => {
+		const { instance, exec } = makeGitSandbox({
+			files: { 'dashboard.py': 'print("before")' },
+			diff: [
+				['D', 'link-to-data'],
+				['D', 'device-node'],
+			],
+		});
+
+		await expect(capture(instance)).rejects.toThrow('no changes');
+		expect(exec.mock.calls.some(([command]) => command.includes('os.O_NOFOLLOW'))).toBe(false);
+	});
+
 	it('excludes runtime and cache files from Git capture', async () => {
 		const ignored = [
 			'__marimo__/state.json',

--- a/packages/core/src/services/content/SyncedNotebookService.test.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.test.ts
@@ -78,6 +78,21 @@ describe('SyncedNotebookService', () => {
 			expect(p?.notebook_count).toBe(1);
 		});
 
+		it('creates pull sources without a sync-token sidecar', async () => {
+			const created = await notebooks.synced.create(
+				projectId,
+				{ ...CREATE_INPUT, sync_mode: 'pull' },
+				ACTOR,
+			);
+			const nb = paths.project(projectId).notebook(created.meta.id);
+			expect(created.sync_token).toBeUndefined();
+			expect(await bucket.get(nb.integrationSyncToken)).toBeNull();
+			expect((await notebooks.getNotebook(projectId, created.meta.id)).source).toMatchObject({
+				type: 'git',
+				sync_mode: 'pull',
+			});
+		});
+
 		it('rejects a repo that is neither owner/repo nor a repository URL', async () => {
 			for (const repo of ['just-a-name', 'a/b/c', 'https://gitlab.com/only-group']) {
 				await expect(
@@ -150,6 +165,18 @@ describe('SyncedNotebookService', () => {
 			expect(rotated).not.toBe(sync_token);
 			expect(await notebooks.synced.verifyToken(projectId, meta.id, rotated)).toBe(true);
 			expect(await notebooks.synced.verifyToken(projectId, meta.id, sync_token)).toBe(false);
+		});
+
+		it('does not mint a token for a pull source', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{ ...CREATE_INPUT, sync_mode: 'pull' },
+				ACTOR,
+			);
+			expect(await notebooks.synced.verifyToken(projectId, meta.id, 'mhsync_any')).toBe(false);
+			await expect(notebooks.synced.rotateToken(projectId, meta.id)).rejects.toThrow(
+				'Pull-mode sources do not use sync tokens',
+			);
 		});
 	});
 
@@ -423,6 +450,54 @@ describe('SyncedNotebookService', () => {
 
 			const e = await entry(meta.id);
 			expect(e?.status).toBe('active');
+		});
+
+		it('stores pull-source Git metadata beside the immutable workspace', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{ ...CREATE_INPUT, sync_mode: 'pull' },
+				ACTOR,
+			);
+			const synced = await notebooks.synced.sync(projectId, meta.id, {
+				...syncInput('commit-aaaa'),
+				git_files: [
+					{ path: 'HEAD', bytes: enc('ref: refs/heads/main\n') },
+					{ path: 'objects/pack/pack-a.pack', bytes: enc('pack') },
+				],
+			});
+			const version = paths.project(projectId).notebook(meta.id).version(synced.versionId!);
+			expect(await (await bucket.get(version.gitFile('HEAD')))!.text()).toBe(
+				'ref: refs/heads/main\n',
+			);
+			expect(await (await bucket.get(version.gitFile('objects/pack/pack-a.pack')))!.text()).toBe(
+				'pack',
+			);
+		});
+
+		it('rejects a pull sync without Git metadata', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{ ...CREATE_INPUT, sync_mode: 'pull' },
+				ACTOR,
+			);
+			await expect(
+				notebooks.synced.sync(projectId, meta.id, syncInput('commit-aaaa')),
+			).rejects.toThrow('Pull sync did not include Git metadata');
+		});
+
+		it('rejects a pull sync with an empty Git metadata set', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{ ...CREATE_INPUT, sync_mode: 'pull' },
+				ACTOR,
+			);
+			await expect(
+				notebooks.synced.sync(projectId, meta.id, {
+					...syncInput('commit-aaaa'),
+					git_files: [],
+				}),
+			).rejects.toThrow('Sync archive did not contain any files');
+			expect(await notebooks.listVersions(projectId, meta.id)).toHaveLength(0);
 		});
 
 		it('records a null provider on versions synced from an unrecognized host', async () => {

--- a/packages/core/src/services/content/SyncedNotebookService.test.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { MAX_WORKSPACE_FILE_BYTES } from '../../constants';
 import { PreconditionFailedError } from '../../errors';
 import { ACTOR, restoreClock, setupTestEnv, useFakeClock } from '../../testing';
 import type { MemoryBucket } from '../../testing';
 import type { ProjectId } from '../../ids';
 import { paths } from '../../paths';
 import { noopMetrics } from '../../ports/metrics';
+import { MAX_GIT_DIRECTORY_BYTES, MAX_GIT_DIRECTORY_FILES } from '../../ports/sourceControl';
 import type { CatalogService } from '../catalog/CatalogService';
 import type { NotebookService } from './NotebookService';
 import type { ProjectService } from './ProjectService';
@@ -497,6 +499,61 @@ describe('SyncedNotebookService', () => {
 					git_files: [],
 				}),
 			).rejects.toThrow('Sync archive did not contain any files');
+			expect(await notebooks.listVersions(projectId, meta.id)).toHaveLength(0);
+		});
+
+		it('rejects pull Git metadata beyond the file-count cap before persistence', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{ ...CREATE_INPUT, sync_mode: 'pull' },
+				ACTOR,
+			);
+			const empty = new Uint8Array();
+			await expect(
+				notebooks.synced.sync(projectId, meta.id, {
+					...syncInput('commit-aaaa'),
+					git_files: Array.from({ length: MAX_GIT_DIRECTORY_FILES + 1 }, (_, index) => ({
+						path: `objects/${index}`,
+						bytes: empty,
+					})),
+				}),
+			).rejects.toThrow(`${MAX_GIT_DIRECTORY_FILES}-file limit`);
+			expect(await notebooks.listVersions(projectId, meta.id)).toHaveLength(0);
+		});
+
+		it('rejects an oversized pull Git metadata file before persistence', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{ ...CREATE_INPUT, sync_mode: 'pull' },
+				ACTOR,
+			);
+			await expect(
+				notebooks.synced.sync(projectId, meta.id, {
+					...syncInput('commit-aaaa'),
+					git_files: [
+						{ path: 'objects/large', bytes: new Uint8Array(MAX_WORKSPACE_FILE_BYTES + 1) },
+					],
+				}),
+			).rejects.toThrow(`${MAX_WORKSPACE_FILE_BYTES}-byte limit`);
+			expect(await notebooks.listVersions(projectId, meta.id)).toHaveLength(0);
+		});
+
+		it('rejects pull Git metadata beyond the cumulative-byte cap before persistence', async () => {
+			const { meta } = await notebooks.synced.create(
+				projectId,
+				{ ...CREATE_INPUT, sync_mode: 'pull' },
+				ACTOR,
+			);
+			const part = new Uint8Array(Math.floor(MAX_GIT_DIRECTORY_BYTES / 5) + 1);
+			await expect(
+				notebooks.synced.sync(projectId, meta.id, {
+					...syncInput('commit-aaaa'),
+					git_files: Array.from({ length: 5 }, (_, index) => ({
+						path: `objects/${index}`,
+						bytes: part,
+					})),
+				}),
+			).rejects.toThrow(`${MAX_GIT_DIRECTORY_BYTES}-byte limit`);
 			expect(await notebooks.listVersions(projectId, meta.id)).toHaveLength(0);
 		});
 

--- a/packages/core/src/services/content/SyncedNotebookService.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.ts
@@ -1,20 +1,17 @@
 import type { Bucket } from '../../ports/bucket';
-import { NotFoundError } from '../../errors';
+import { BadRequestError, ConflictError, NotFoundError } from '../../errors';
 import { createNotebookId, createVersionId, SYSTEM_ACTOR } from '../../ids';
 import type { NotebookId, ProjectId, UserId, VersionId } from '../../ids';
 import {
+	applyGitSourceUpdate,
 	assertSyncSourcePrecondition,
 	assertSyncedSource,
 	createGitSource,
 	createSyncToken,
 	createSyncTokenRecord,
-	gitSourceConfig,
-	gitSourceConfigsEqual,
 	isAtBranchHead,
-	normalizeGitSourceConfig,
 	prepareSync,
 	providerForRepo,
-	resolveUpdatedConfig,
 	SyncTokenRecordSchema,
 	verifySyncTokenRecord,
 } from '../../integrations/syncedSource';
@@ -35,6 +32,7 @@ import { buildNotebookEntry, buildNotebookMeta, buildVersion } from './notebookM
 import { listAllKeys } from '../catalog/storage';
 import type { GitSource, NotebookMeta, Source } from '../../schema';
 import { loadNotebookCatalogPatch } from './catalogProjection';
+import { toSyncedWorkspaceFileMap } from '../../integrations/remoteWorkspace';
 
 interface SyncedNotebookServiceHooks {
 	getNotebook: (
@@ -45,8 +43,8 @@ interface SyncedNotebookServiceHooks {
 }
 
 /**
- * Notebooks whose source is push-synced from an external git repo (see
- * `GitSource`). A version per push is the unit of truth: each sync writes a fresh,
+ * Notebooks whose source is synced from an external git repo (see `GitSource`).
+ * A version per sync is the unit of truth: each sync writes a fresh,
  * immutable `versions/{vid}/workspace/` mirror and then compare-and-swaps the
  * notebook's `source.json` pointer to it. There is no mutable workspace mirror to
  * corrupt, so concurrent pushes can only orphan a version, never interleave one.
@@ -63,11 +61,11 @@ export class SyncedNotebookService {
 		projectId: ProjectId,
 		input: CreateSyncedNotebookInput,
 		actor: UserId,
-	): Promise<{ meta: NotebookMeta; sync_token: string }> {
+	): Promise<{ meta: NotebookMeta; sync_token?: string }> {
 		const notebookId = createNotebookId();
 		const now = new Date().toISOString();
 		const source = createGitSource(input);
-		const syncToken = createSyncToken();
+		const syncToken = source.sync_mode === 'push' ? createSyncToken() : undefined;
 
 		const meta = buildNotebookMeta({
 			notebookId,
@@ -83,10 +81,11 @@ export class SyncedNotebookService {
 			computeProfile: input.compute_profile,
 		});
 
-		const tokenRecord = await createSyncTokenRecord(syncToken, now);
+		const tokenRecord = syncToken ? await createSyncTokenRecord(syncToken, now) : undefined;
 
 		const nb = paths.project(projectId).notebook(notebookId);
-		const contentKeys = [nb.meta, nb.readme, nb.source, nb.integrationSyncToken];
+		const contentKeys = [nb.meta, nb.readme, nb.source];
+		if (tokenRecord) contentKeys.push(nb.integrationSyncToken);
 
 		await saga(metricsObserver(this.metrics, 'saga.synced_notebook_create'))
 			.step(
@@ -100,7 +99,9 @@ export class SyncedNotebookService {
 								input.readme ?? `# ${input.title}\n\n${input.description}\n`,
 							),
 						() => this.bucket.put(nb.source, JSON.stringify(source)),
-						() => this.bucket.put(nb.integrationSyncToken, JSON.stringify(tokenRecord)),
+						...(tokenRecord
+							? [() => this.bucket.put(nb.integrationSyncToken, JSON.stringify(tokenRecord))]
+							: []),
 					],
 					() => this.bucket.delete(contentKeys),
 				),
@@ -115,17 +116,23 @@ export class SyncedNotebookService {
 			)
 			.run();
 
-		return { meta, sync_token: syncToken };
+		return { meta, ...(syncToken ? { sync_token: syncToken } : {}) };
 	}
 
 	private async deleteVersion(versionPaths: VersionPaths): Promise<void> {
-		const keys = await listAllKeys(this.bucket, versionPaths.workspacePrefix);
-		await this.bucket.delete([versionPaths.meta, ...keys]);
+		const [workspaceKeys, gitKeys] = await Promise.all([
+			listAllKeys(this.bucket, versionPaths.workspacePrefix),
+			listAllKeys(this.bucket, versionPaths.gitPrefix),
+		]);
+		await this.bucket.delete([versionPaths.meta, ...workspaceKeys, ...gitKeys]);
 	}
 
 	async rotateToken(projectId: ProjectId, notebookId: NotebookId): Promise<{ sync_token: string }> {
 		const { source } = await this.hooks.getNotebook(projectId, notebookId);
-		assertSyncedSource(source);
+		const git = assertSyncedSource(source);
+		if (git.sync_mode !== 'push') {
+			throw new ConflictError('Pull-mode sources do not use sync tokens');
+		}
 		const token = createSyncToken();
 		const record = await createSyncTokenRecord(token, new Date().toISOString());
 		await this.bucket.put(
@@ -141,31 +148,12 @@ export class SyncedNotebookService {
 		input: UpdateSyncedNotebookSourceInput,
 		actor: UserId,
 	): Promise<GitSource> {
-		const desired = normalizeGitSourceConfig(input);
 		const nb = paths.project(projectId).notebook(notebookId);
 		const source = await mutateObject(
 			this.bucket,
 			nb.source,
 			(raw) => assertSyncedSource(parseStored(SourceSchema, raw, nb.source)),
-			(current) => {
-				const resolved = resolveUpdatedConfig(current, desired);
-				const active = gitSourceConfig(current);
-				if (current.pending_config && gitSourceConfigsEqual(current.pending_config, resolved)) {
-					return null;
-				}
-				const { pending_config: _pendingConfig, ...withoutPending } = current;
-				if (gitSourceConfigsEqual(active, resolved)) {
-					return current.pending_config ? withoutPending : null;
-				}
-				if (current.current_version_id === null) {
-					return {
-						...withoutPending,
-						...resolved,
-						provider: providerForRepo(current, resolved.repo),
-					};
-				}
-				return { ...current, pending_config: resolved };
-			},
+			(current) => applyGitSourceUpdate(current, input),
 		);
 		const now = new Date().toISOString();
 		await mutateObject(
@@ -225,6 +213,10 @@ export class SyncedNotebookService {
 		}
 		const syncedSource = assertSyncedSource(source);
 		const prepared = prepareSync(syncedSource, input);
+		const gitFiles = input.git_files ? toSyncedWorkspaceFileMap(input.git_files) : undefined;
+		if (syncedSource.sync_mode === 'pull' && !gitFiles) {
+			throw new BadRequestError('Pull sync did not include Git metadata');
+		}
 
 		// Re-syncing the same commit (a retried CI run) is a genuine no-op, not a conflict.
 		if (isAtBranchHead(syncedSource, prepared.commit)) {
@@ -264,6 +256,11 @@ export class SyncedNotebookService {
 							([path, bytes]) =>
 								() =>
 									this.bucket.put(versionPaths.workspaceFile(path), bytes),
+						),
+						...[...(gitFiles?.entries() ?? [])].map(
+							([path, bytes]) =>
+								() =>
+									this.bucket.put(versionPaths.gitFile(path), bytes),
 						),
 					],
 					() => this.deleteVersion(versionPaths),

--- a/packages/core/src/services/content/SyncedNotebookService.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.ts
@@ -21,6 +21,7 @@ import type {
 	UpdateSyncedNotebookSourceInput,
 } from '../../integrations/syncedSource';
 import type { Metrics } from '../../ports/metrics';
+import { assertGitDirectoryLimits } from '../../ports/sourceControl';
 import { paths } from '../../paths';
 import { logOperationalError } from '../../operationalLog';
 import type { VersionPaths } from '../../paths';
@@ -213,6 +214,7 @@ export class SyncedNotebookService {
 		}
 		const syncedSource = assertSyncedSource(source);
 		const prepared = prepareSync(syncedSource, input);
+		if (input.git_files) assertGitDirectoryLimits(input.git_files);
 		const gitFiles = input.git_files ? toSyncedWorkspaceFileMap(input.git_files) : undefined;
 		if (syncedSource.sync_mode === 'pull' && !gitFiles) {
 			throw new BadRequestError('Pull sync did not include Git metadata');

--- a/packages/core/src/services/content/proposalCapture.ts
+++ b/packages/core/src/services/content/proposalCapture.ts
@@ -261,6 +261,9 @@ async function captureGitWorkingTree(
 	)) {
 		const baseObject = operation === 'add' ? null : await bucket.get(base.workspaceFile(path));
 		if (operation !== 'add' && !baseObject) {
+			// Provider workspace ingest omits symlinks and special files, although
+			// they remain tracked in the restored Git index as missing paths.
+			if (operation === 'delete') continue;
 			throw new ConflictError(`Changed file ${path} is missing from the synced source version`);
 		}
 		if (operation === 'delete') {

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -39,6 +39,9 @@ export type {
 } from './content/NotebookProposalService';
 export type { CreateNotebookInput, NotebookVersionProtector } from './content/NotebookService';
 export {
+	applyGitSourceUpdate,
+	assertSyncedSource,
+	createGitSource,
 	effectiveGitSourceConfig,
 	isAtBranchHead,
 	providerForRepo,

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -764,6 +764,34 @@ describe('SandboxProvisioner', () => {
 			expect(calls.destroy).toBe(1);
 		});
 
+		it('fails provisioning instead of skipping an unsafe Git metadata path', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceFile('app.py'), 'import marimo as mo');
+			await bucketHandle.put(version.gitFile('HEAD'), 'ref: refs/heads/main\n');
+			await bucketHandle.put(`${version.gitPrefix}../config`, 'unsafe');
+
+			await expect(
+				provisioner.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					bucketHandle,
+					entryNotebook: 'app.py',
+					workspaceLoadMode: 'copy-only',
+					workspacePrefix: version.workspacePrefix,
+					gitPrefix: version.gitPrefix,
+				}),
+			).rejects.toThrow('restoring Git metadata into the sandbox');
+			expect(calls.writeFiles.flat().some((file) => file.path.includes('/.git/'))).toBe(false);
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
+		});
+
 		it('fails provisioning when Git metadata has no bucket handle', async () => {
 			const { instance, calls } = makeFakeSandbox();
 			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Millis } from '../../duration';
-import { createNotebookId, createProjectId, createSandboxId } from '../../ids';
+import { createNotebookId, createProjectId, createSandboxId, createVersionId } from '../../ids';
 import { paths } from '../../paths';
 import {
 	ACTOR,
@@ -635,6 +635,155 @@ describe('SandboxProvisioner', () => {
 			expect(calls.mountBucket).toHaveLength(0);
 			expect(calls.writeFiles.flat().some((f) => f.path.endsWith('apps/my_app.py'))).toBe(true);
 			expect(calls.startProcess[0].cmd).toContain("marimo edit 'apps/my_app.py'");
+		});
+
+		it('restores pull-source Git metadata into the workspace .git directory', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceFile('app.py'), 'import marimo as mo');
+			await bucketHandle.put(version.gitFile('HEAD'), 'ref: refs/heads/main\n');
+			await bucketHandle.put(version.gitFile('objects/pack/pack-a.pack'), 'pack');
+
+			const result = await provisioner.provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				bucketHandle,
+				entryNotebook: 'app.py',
+				workspaceLoadMode: 'copy-only',
+				workspacePrefix: version.workspacePrefix,
+				gitPrefix: version.gitPrefix,
+			});
+
+			const restored = calls.writeFiles.flat().map((file) => file.path);
+			expect(restored).toContain(`${MOUNT_PATH}/app.py`);
+			expect(restored).toContain(`${MOUNT_PATH}/.git/HEAD`);
+			expect(restored).toContain(`${MOUNT_PATH}/.git/objects/pack/pack-a.pack`);
+			expect(result.counters).toMatchObject({ files_objects: 3 });
+		});
+
+		it('restores Git metadata after a successful workspace mount', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.gitFile('HEAD'), 'ref: refs/heads/main\n');
+
+			const result = await provisioner.provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				bucketHandle,
+				entryNotebook: 'app.py',
+				workspacePrefix: version.workspacePrefix,
+				gitPrefix: version.gitPrefix,
+			});
+
+			expect(result.usedFallback).toBe(false);
+			expect(calls.mountBucket).toHaveLength(1);
+			expect(calls.writeFiles.flat().map((file) => file.path)).toEqual([`${MOUNT_PATH}/.git/HEAD`]);
+			expect(result.counters).toMatchObject({ files_objects: 1 });
+		});
+
+		it('fails provisioning when a later Git metadata batch cannot be restored', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const writeFiles = instance.writeFiles.bind(instance);
+			let gitWriteAttempts = 0;
+			const failingInstance: SandboxInstance = {
+				...instance,
+				async writeFiles(files) {
+					await writeFiles(files);
+					if (files.some((file) => file.path.includes('/.git/')) && ++gitWriteAttempts > 1) {
+						throw new Error('Git pack write failed');
+					}
+				},
+			};
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(failingInstance));
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceFile('app.py'), 'import marimo as mo');
+			await bucketHandle.put(version.gitFile('HEAD'), 'ref: refs/heads/main\n');
+			await bucketHandle.put(
+				version.gitFile('objects/pack/pack-a.pack'),
+				new Uint8Array(8 * 1024 * 1024),
+			);
+
+			await expect(
+				provisioner.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					bucketHandle,
+					entryNotebook: 'app.py',
+					workspaceLoadMode: 'copy-only',
+					workspacePrefix: version.workspacePrefix,
+					gitPrefix: version.gitPrefix,
+				}),
+			).rejects.toThrow('restoring Git metadata into the sandbox');
+			expect(gitWriteAttempts).toBeGreaterThan(1);
+			expect(calls.writeFiles.flat().map((file) => file.path)).toEqual(
+				expect.arrayContaining([
+					`${MOUNT_PATH}/.git/HEAD`,
+					`${MOUNT_PATH}/.git/objects/pack/pack-a.pack`,
+				]),
+			);
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
+		});
+
+		it('fails provisioning when the stored Git directory is empty', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceFile('app.py'), 'import marimo as mo');
+
+			await expect(
+				provisioner.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					bucketHandle,
+					entryNotebook: 'app.py',
+					workspaceLoadMode: 'copy-only',
+					workspacePrefix: version.workspacePrefix,
+					gitPrefix: version.gitPrefix,
+				}),
+			).rejects.toThrow('restoring Git metadata into the sandbox');
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
+		});
+
+		it('fails provisioning when Git metadata has no bucket handle', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+
+			await expect(
+				provisioner.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					entryNotebook: 'app.py',
+					workspacePrefix: version.workspacePrefix,
+					gitPrefix: version.gitPrefix,
+				}),
+			).rejects.toThrow('restoring Git metadata into the sandbox');
+			expect(calls.mountBucket).toHaveLength(1);
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
 		});
 
 		it('uses the injected workspace loader selected by workspaceLoadMode', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -419,6 +419,7 @@ export class SandboxProvisioner {
 				options.bucketHandle,
 				options.gitPrefix,
 				`${mountPath}/.git`,
+				{ requireComplete: true },
 			);
 			if (gitStats.objectCount === 0) {
 				throw new Error('the stored Git directory is empty');

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -141,6 +141,8 @@ export interface ProvisionOptions {
 	 * `versions/{vid}/workspace/` prefix instead.
 	 */
 	workspacePrefix?: string;
+	/** Pull-source Git metadata restored into `<workdir>/.git`. */
+	gitPrefix?: string;
 }
 
 export interface ProvisionResult {
@@ -398,7 +400,7 @@ export class SandboxProvisioner {
 			options.workspaceLoadMode === 'copy-only'
 				? this.workspaceLoadStrategies.copyOnly
 				: this.workspaceLoadStrategies.mountOrCopy;
-		return await strategy.load({
+		const loaded = await strategy.load({
 			sandbox,
 			projectId: options.projectId,
 			notebookId: options.notebookId,
@@ -407,6 +409,41 @@ export class SandboxProvisioner {
 			mountPath,
 			workspacePrefix,
 		});
+		if (!options.gitPrefix) return loaded;
+		try {
+			if (!options.bucketHandle) {
+				throw new Error('bucket handle is required for Git metadata restoration');
+			}
+			const gitStats = await restoreWorkspace(
+				sandbox,
+				options.bucketHandle,
+				options.gitPrefix,
+				`${mountPath}/.git`,
+			);
+			if (gitStats.objectCount === 0) {
+				throw new Error('the stored Git directory is empty');
+			}
+			if (!loaded.stats) return { ...loaded, stats: gitStats };
+			return {
+				...loaded,
+				stats: {
+					objectCount: loaded.stats.objectCount + gitStats.objectCount,
+					bytes: loaded.stats.bytes + gitStats.bytes,
+				},
+			};
+		} catch (error) {
+			logOperationalError(
+				'git_workspace_restore_failed',
+				{
+					operation: 'session.git.restore',
+					object: options.gitPrefix,
+					project_id: options.projectId,
+					notebook_id: options.notebookId,
+				},
+				error,
+			);
+			throw provisionFailure('restoring Git metadata into the sandbox', error);
+		}
 	}
 
 	private async injectSessionEnv(

--- a/packages/core/src/services/runtime/sandboxFiles.test.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createNotebookId, createProjectId } from '../../ids';
+import { createNotebookId, createProjectId, createVersionId } from '../../ids';
 import { paths } from '../../paths';
 import { MAX_ARTIFACT_BYTES, MAX_WORKSPACE_FILE_BYTES } from '../../constants';
 import {
@@ -23,6 +23,17 @@ function nbCtx() {
 }
 
 const decode = (b: Uint8Array) => new TextDecoder().decode(b);
+
+class VanishingObjectBucket extends MemoryBucket {
+	constructor(private readonly missingKey: string) {
+		super();
+	}
+
+	override async get(key: string) {
+		if (key === this.missingKey) return null;
+		return super.get(key);
+	}
+}
 
 describe('restoreWorkspace', () => {
 	it('restores every workspace key without spending a mkdir exec', async () => {
@@ -171,6 +182,19 @@ describe('restoreWorkspace', () => {
 		expect(fs.size).toBe(0);
 	});
 
+	it('skips a listed object that disappears during a best-effort restore', async () => {
+		const { nb } = nbCtx();
+		const missingKey = nb.workspaceFile('missing.txt');
+		const bucket = new VanishingObjectBucket(missingKey);
+		await bucket.put(missingKey, 'content');
+		const { instance, calls } = makeFsSandbox();
+
+		const stats = await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT);
+
+		expect(stats).toEqual({ objectCount: 0, bytes: 0 });
+		expect(calls.writeFiles).toHaveLength(0);
+	});
+
 	describe('caps', () => {
 		let warn: ReturnType<typeof vi.spyOn>;
 		beforeEach(() => {
@@ -197,6 +221,22 @@ describe('restoreWorkspace', () => {
 			expect(rec.calls.get).toContain(nb.workspaceFile('small.txt'));
 			expect(rec.calls.get).not.toContain(bigKey);
 			expect(warn).toHaveBeenCalled();
+		});
+
+		it('rejects an oversized object when a complete restore is required', async () => {
+			const { nb } = nbCtx();
+			const rec = new RecordingBucket(new MemoryBucket());
+			const version = nb.version(createVersionId());
+			const bigKey = version.gitFile('objects/huge');
+			await rec.put(bigKey, bytesOfSize(MAX_WORKSPACE_FILE_BYTES + 1));
+			const { instance } = makeFsSandbox();
+
+			await expect(
+				restoreWorkspace(instance, rec, version.gitPrefix, `${MOUNT}/.git`, {
+					requireComplete: true,
+				}),
+			).rejects.toThrow('per-file cap');
+			expect(rec.calls.get).not.toContain(bigKey);
 		});
 	});
 });
@@ -525,6 +565,37 @@ describe('sandboxFiles security', () => {
 		for (const cmd of calls.exec) {
 			if (cmd.startsWith('mkdir -p ')) expect(cmd).not.toContain('/../');
 		}
+	});
+
+	it('rejects an unsafe path when a complete restore is required', async () => {
+		const { nb } = nbCtx();
+		const version = nb.version(createVersionId());
+		const bucket = new MemoryBucket();
+		await bucket.put(`${version.gitPrefix}../config`, 'unsafe');
+		const { instance, calls } = makeFsSandbox();
+
+		await expect(
+			restoreWorkspace(instance, bucket, version.gitPrefix, `${MOUNT}/.git`, {
+				requireComplete: true,
+			}),
+		).rejects.toThrow('unsafe workspace path');
+		expect(calls.writeFiles).toHaveLength(0);
+	});
+
+	it('rejects a listed object that disappears during a complete restore', async () => {
+		const { nb } = nbCtx();
+		const version = nb.version(createVersionId());
+		const missingKey = version.gitFile('objects/missing');
+		const bucket = new VanishingObjectBucket(missingKey);
+		await bucket.put(missingKey, 'object');
+		const { instance, calls } = makeFsSandbox();
+
+		await expect(
+			restoreWorkspace(instance, bucket, version.gitPrefix, `${MOUNT}/.git`, {
+				requireComplete: true,
+			}),
+		).rejects.toThrow('listed object is missing');
+		expect(calls.writeFiles).toHaveLength(0);
 	});
 
 	it('captureWorkspace shell-safely handles a filename with shell metacharacters', async () => {

--- a/packages/core/src/services/runtime/sandboxFiles.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.ts
@@ -109,6 +109,10 @@ export interface WorkspaceRestoreStats {
 	bytes: number;
 }
 
+export interface WorkspaceRestoreOptions {
+	requireComplete?: boolean;
+}
+
 /**
  * Restore a workspace mirror (every key under `sourcePrefix`) from the bucket into
  * the sandbox working directory. Unconditional and binary-safe: every object is
@@ -125,6 +129,7 @@ export async function restoreWorkspace(
 	bucket: Bucket,
 	sourcePrefix: string,
 	workingDir: string,
+	options: WorkspaceRestoreOptions = {},
 ): Promise<WorkspaceRestoreStats> {
 	// Select from the LISTING (sizes included) so an oversized object is skipped
 	// before `bucket.get()` buffers its body — the size check must never use the
@@ -136,12 +141,20 @@ export async function restoreWorkspace(
 		if (!rel) continue;
 		// A poisoned key (e.g. from a compromised/synced source) whose relative path
 		// carries `..`/absolute/backslash segments would escape workingDir once
-		// concatenated. Skip it — the sandbox working dir is a hard boundary.
+		// concatenated. Reject or skip it — the sandbox working dir is a hard boundary.
 		if (!isSafeWorkspacePath(rel)) {
+			if (options.requireComplete) {
+				throw new Error(`restoreWorkspace: unsafe workspace path: ${rel}`);
+			}
 			console.warn(`restoreWorkspace: unsafe workspace path; skipping ${rel}`);
 			continue;
 		}
 		if (obj.size > MAX_WORKSPACE_FILE_BYTES) {
+			if (options.requireComplete) {
+				throw new Error(
+					`restoreWorkspace: per-file cap (${MAX_WORKSPACE_FILE_BYTES}) exceeded: ${rel} (${obj.size} bytes)`,
+				);
+			}
 			console.warn(
 				`restoreWorkspace: per-file cap (${MAX_WORKSPACE_FILE_BYTES}) exceeded; skipping ${rel} (${obj.size} bytes)`,
 			);
@@ -166,7 +179,12 @@ export async function restoreWorkspace(
 	for (const batch of batchByBytes(wanted, RESTORE_BATCH_BYTES)) {
 		const fetched = await mapWithConcurrency(batch, RESTORE_FETCH_CONCURRENCY, async (f) => {
 			const body = await bucket.get(f.key);
-			if (!body) return;
+			if (!body) {
+				if (options.requireComplete) {
+					throw new Error(`restoreWorkspace: listed object is missing: ${f.key}`);
+				}
+				return;
+			}
 			return { path: f.dest, content: await body.bytes() };
 		});
 		const files = fetched.filter((f) => f !== undefined);

--- a/packages/core/src/specs/bucketSpec.ts
+++ b/packages/core/src/specs/bucketSpec.ts
@@ -67,6 +67,14 @@ interface BucketObject {
 	tag: string;
 }
 
+interface BucketArtifact {
+	name: string;
+	key: string;
+	summary: string;
+	mutability: Mutability;
+	tag: string;
+}
+
 const project = paths.project(PID);
 const notebook = project.notebook(NID);
 const proposal = notebook.proposal(PROPOSAL_ID);
@@ -279,6 +287,16 @@ const OBJECTS: BucketObject[] = [
 	},
 ];
 
+const ARTIFACTS: BucketArtifact[] = [
+	{
+		name: 'GitDirectoryFile',
+		key: notebook.version(VID).gitFile('{relative_path}'),
+		summary: 'Immutable pull-source Git metadata file, addressed relative to `.git`.',
+		mutability: 'immutable',
+		tag: 'notebook',
+	},
+];
+
 function jsonSchema(schema: z.ZodType): Record<string, unknown> {
 	// `io: 'input'` — the stored bytes are what parse must accept, so defaulted
 	// fields stay optional and transforms describe their pre-parse shape.
@@ -346,6 +364,34 @@ export function buildBucketSpec(): Record<string, unknown> {
 		};
 	}
 
+	for (const artifact of ARTIFACTS) {
+		const opSuffix = artifact.key
+			.replaceAll(/\{[a-z_]+\}/g, '')
+			.replaceAll(/[^a-zA-Z0-9]+/g, '_')
+			.replaceAll(/^_+|_+$/g, '');
+		const content = {
+			'application/octet-stream': { schema: { type: 'string', format: 'binary' } },
+		};
+		specPaths[`/${artifact.key}`] = {
+			summary: artifact.summary,
+			parameters: pathParams(artifact.key),
+			'x-mutability': artifact.mutability,
+			get: {
+				operationId: `read_${opSuffix}`,
+				summary: `Read ${artifact.name}`,
+				tags: [artifact.tag],
+				responses: { '200': { description: 'The stored artifact.', content } },
+			},
+			put: {
+				operationId: `write_${opSuffix}`,
+				summary: `Write ${artifact.name}`,
+				tags: [artifact.tag],
+				requestBody: { required: true, content },
+				responses: { '204': { description: 'Stored.' } },
+			},
+		};
+	}
+
 	return {
 		openapi: '3.1.0',
 		info: {
@@ -353,7 +399,8 @@ export function buildBucketSpec(): Record<string, unknown> {
 			version: '1.0.0',
 			description: [
 				'Machine-checkable description of every JSON object marimohub persists in',
-				'its storage bucket, generated from the zod schemas in',
+				'its storage bucket plus artifact families with contractual storage',
+				'semantics, generated from the zod schemas in',
 				'`packages/core/src/schema.ts` and the key templates in',
 				'`packages/core/src/paths.ts`. This is not an HTTP API: paths are bucket',
 				'key templates, GET models what readers must accept, PUT models what',
@@ -361,10 +408,11 @@ export function buildBucketSpec(): Record<string, unknown> {
 				'invariants in AGENTS.md and development_docs/bucket_spec.md.',
 				'',
 				'Deliberately excluded (no zod schema; internal operational records or',
-				'non-JSON artifacts): idempotency records, integration name claims,',
+				'other non-JSON artifacts): idempotency records, integration name claims,',
 				'reconcile orphan markers, advisory locks, and version/workspace file',
 				'artifacts (notebook.py, pyproject.toml, notebook.html, session.json,',
-				'README.md, workspace files).',
+				'README.md, workspace files). Pull-source Git metadata is included because',
+				'its immutable version-scoped location is part of the sync contract.',
 			].join('\n'),
 		},
 		tags: [

--- a/packages/duckdb-wasm-runtime/src/node.test.ts
+++ b/packages/duckdb-wasm-runtime/src/node.test.ts
@@ -49,7 +49,7 @@ function dataQuery(
 	};
 }
 
-describe('DuckDB-Wasm worker lifecycle', () => {
+describe('DuckDB-Wasm worker lifecycle', { timeout: 15_000 }, () => {
 	it('caps the worker V8 heap and stack', () => {
 		expect(DUCKDB_WORKER_RESOURCE_LIMITS).toEqual({
 			maxOldGenerationSizeMb: 256,

--- a/packages/source-control-github/package.json
+++ b/packages/source-control-github/package.json
@@ -19,7 +19,8 @@
 	},
 	"dependencies": {
 		"@marimo-hub/core": "workspace:*",
-		"fflate": "^0.8.2"
+		"fflate": "^0.8.2",
+		"isomorphic-git": "catalog:"
 	},
 	"devDependencies": {
 		"@marimo-hub/tsconfig": "workspace:*",

--- a/packages/source-control-github/src/githubGitDirectory.test.ts
+++ b/packages/source-control-github/src/githubGitDirectory.test.ts
@@ -1,0 +1,181 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { BadRequestError, MAX_WORKSPACE_FILE_BYTES } from '@marimo-hub/core';
+import type { GitHubFetch } from './githubClient';
+import { materializeGitDirectory } from './githubGitDirectory';
+
+const temporaryDirectories: string[] = [];
+
+function git(cwd: string, args: string[], input?: string | Uint8Array): string {
+	return execFileSync('git', args, {
+		cwd,
+		input,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			GIT_AUTHOR_NAME: 'Test Author',
+			GIT_AUTHOR_EMAIL: 'author@example.com',
+			GIT_COMMITTER_NAME: 'Test Committer',
+			GIT_COMMITTER_EMAIL: 'committer@example.com',
+		},
+	}).trim();
+}
+
+async function temporaryDirectory(prefix: string): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), prefix));
+	temporaryDirectories.push(directory);
+	return directory;
+}
+
+function packetLine(text: string): Uint8Array<ArrayBuffer> {
+	return new TextEncoder().encode(
+		`${(Buffer.byteLength(text) + 4).toString(16).padStart(4, '0')}${text}`,
+	);
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array<ArrayBuffer> {
+	const result = new Uint8Array(parts.reduce((sum, part) => sum + part.byteLength, 0));
+	let offset = 0;
+	for (const part of parts) {
+		result.set(part, offset);
+		offset += part.byteLength;
+	}
+	return result;
+}
+
+function uploadPackFetcher(repository: string): GitHubFetch {
+	return async (url, init) => {
+		if (url.includes('/info/refs')) {
+			const advertised = execFileSync('git', [
+				'upload-pack',
+				'--stateless-rpc',
+				'--advertise-refs',
+				repository,
+			]);
+			const body = concat(
+				packetLine('# service=git-upload-pack\n'),
+				new TextEncoder().encode('0000'),
+				new Uint8Array(advertised),
+			);
+			return new Response(body.buffer, {
+				headers: { 'content-type': 'application/x-git-upload-pack-advertisement' },
+			});
+		}
+		const request = init?.body
+			? new Uint8Array(await new Response(init.body).arrayBuffer())
+			: undefined;
+		const result = execFileSync('git', ['upload-pack', '--stateless-rpc', repository], {
+			input: request,
+		});
+		return new Response(new Uint8Array(result), {
+			headers: { 'content-type': 'application/x-git-upload-pack-result' },
+		});
+	};
+}
+
+afterEach(async () => {
+	await Promise.all(
+		temporaryDirectories
+			.splice(0)
+			.map((directory) => rm(directory, { recursive: true, force: true })),
+	);
+});
+
+describe('materializeGitDirectory', () => {
+	it('preserves an exact signed commit and produces a clean credential-free working tree', async () => {
+		const source = await temporaryDirectory('marimohub-git-source-');
+		git(source, ['init', '-b', 'main']);
+		await writeFile(join(source, 'app.py'), 'print("signed")\n');
+		git(source, ['add', 'app.py']);
+		const tree = git(source, ['write-tree']);
+		const commitBody = [
+			`tree ${tree}`,
+			'author Test Author <author@example.com> 1700000000 +0000',
+			'committer Test Committer <committer@example.com> 1700000000 +0000',
+			'gpgsig -----BEGIN PGP SIGNATURE-----',
+			' fake-signature-fixture',
+			' -----END PGP SIGNATURE-----',
+			'',
+			'Signed fixture',
+			'',
+		].join('\n');
+		const commit = git(source, ['hash-object', '-t', 'commit', '-w', '--stdin'], commitBody);
+		git(source, ['update-ref', 'refs/heads/main', commit]);
+
+		const files = await materializeGitDirectory({
+			repository: 'owner/repo',
+			owner: 'owner',
+			repo: 'repo',
+			commit,
+			branch: 'main',
+			token: 'installation-secret',
+			fetcher: uploadPackFetcher(source),
+		});
+		expect(files.map((file) => file.path)).toEqual(
+			expect.arrayContaining(['HEAD', 'config', 'index', 'shallow']),
+		);
+		const config = new TextDecoder().decode(files.find((file) => file.path === 'config')?.bytes);
+		expect(config).toContain('https://github.com/owner/repo.git');
+		expect(config).not.toContain('installation-secret');
+
+		const restored = await temporaryDirectory('marimohub-git-restored-');
+		await writeFile(join(restored, 'app.py'), 'print("signed")\n');
+		for (const file of files) {
+			const path = join(restored, '.git', file.path);
+			await mkdir(join(path, '..'), { recursive: true });
+			await writeFile(path, file.bytes);
+		}
+		expect(git(restored, ['rev-parse', 'HEAD'])).toBe(commit);
+		expect(git(restored, ['status', '--porcelain'])).toBe('');
+	});
+
+	it('rejects a smart-HTTP response beyond the Git pack limit', async () => {
+		const fetcher: GitHubFetch = async () =>
+			new Response('too large', {
+				headers: { 'content-length': String(MAX_WORKSPACE_FILE_BYTES + 1) },
+			});
+		await expect(
+			materializeGitDirectory({
+				repository: 'owner/large-repo',
+				owner: 'owner',
+				repo: 'large-repo',
+				commit: 'a'.repeat(40),
+				branch: 'main',
+				token: 'token',
+				fetcher,
+			}),
+		).rejects.toBeInstanceOf(BadRequestError);
+	});
+
+	it('preserves a symlink index entry when the workspace omits the symlink', async () => {
+		const source = await temporaryDirectory('marimohub-git-symlink-source-');
+		git(source, ['init', '-b', 'main']);
+		await writeFile(join(source, 'app.py'), 'print("app")\n');
+		await symlink('app.py', join(source, 'app-link.py'));
+		git(source, ['add', 'app.py', 'app-link.py']);
+		git(source, ['commit', '-m', 'Add app and symlink']);
+		const commit = git(source, ['rev-parse', 'HEAD']);
+
+		const files = await materializeGitDirectory({
+			repository: 'owner/repo',
+			owner: 'owner',
+			repo: 'repo',
+			commit,
+			branch: 'main',
+			token: 'installation-secret',
+			fetcher: uploadPackFetcher(source),
+		});
+		const restored = await temporaryDirectory('marimohub-git-symlink-restored-');
+		await writeFile(join(restored, 'app.py'), 'print("app")\n');
+		for (const file of files) {
+			const path = join(restored, '.git', file.path);
+			await mkdir(join(path, '..'), { recursive: true });
+			await writeFile(path, file.bytes);
+		}
+
+		expect(git(restored, ['status', '--porcelain'])).toBe('D app-link.py');
+	});
+});

--- a/packages/source-control-github/src/githubGitDirectory.test.ts
+++ b/packages/source-control-github/src/githubGitDirectory.test.ts
@@ -153,6 +153,36 @@ describe('materializeGitDirectory', () => {
 		expect(git(restored, ['status', '--porcelain'])).toBe('');
 	});
 
+	it('produces valid Git metadata for a branch containing a double quote', async () => {
+		const branch = 'feature/"quoted';
+		const source = await temporaryDirectory('marimohub-git-quoted-branch-source-');
+		git(source, ['init', '-b', branch]);
+		await writeFile(join(source, 'app.py'), 'print("quoted branch")\n');
+		git(source, ['add', 'app.py']);
+		git(source, ['commit', '-m', 'Add app']);
+		const commit = git(source, ['rev-parse', 'HEAD']);
+
+		const files = await materializeGitDirectory({
+			repository: 'owner/repo',
+			owner: 'owner',
+			repo: 'repo',
+			commit,
+			branch,
+			token: 'installation-secret',
+			fetcher: uploadPackFetcher(source),
+		});
+		const restored = await temporaryDirectory('marimohub-git-quoted-branch-restored-');
+		await writeFile(join(restored, 'app.py'), 'print("quoted branch")\n');
+		for (const file of files) {
+			const path = join(restored, '.git', file.path);
+			await mkdir(join(path, '..'), { recursive: true });
+			await writeFile(path, file.bytes);
+		}
+
+		expect(git(restored, ['branch', '--show-current'])).toBe(branch);
+		expect(git(restored, ['status', '--porcelain'])).toBe('');
+	});
+
 	it('rejects a smart-HTTP response beyond the Git pack limit', async () => {
 		const fetcher: GitHubFetch = async () =>
 			new Response('too large', {

--- a/packages/source-control-github/src/githubGitDirectory.test.ts
+++ b/packages/source-control-github/src/githubGitDirectory.test.ts
@@ -1,11 +1,24 @@
 import { execFileSync } from 'node:child_process';
-import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, symlink, truncate, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
-import { BadRequestError, MAX_WORKSPACE_FILE_BYTES } from '@marimo-hub/core';
+import {
+	BadRequestError,
+	MAX_GIT_DIRECTORY_BYTES,
+	MAX_GIT_DIRECTORY_FILES,
+	MAX_GIT_EXPANDED_BYTES,
+	MAX_GIT_EXPANDED_FILES,
+	MAX_GIT_FETCH_BYTES,
+	MAX_WORKSPACE_FILE_BYTES,
+} from '@marimo-hub/core';
 import type { GitHubFetch } from './githubClient';
-import { materializeGitDirectory } from './githubGitDirectory';
+import {
+	assertGitCheckoutLimits,
+	collectGitDirectoryFiles,
+	GitFetchByteLimit,
+	materializeGitDirectory,
+} from './githubGitDirectory';
 
 const temporaryDirectories: string[] = [];
 
@@ -85,6 +98,14 @@ afterEach(async () => {
 });
 
 describe('materializeGitDirectory', () => {
+	it('caps the combined bytes from all smart-HTTP responses', () => {
+		const limit = new GitFetchByteLimit('owner/repo');
+		limit.record(Math.ceil(MAX_GIT_FETCH_BYTES / 2));
+		expect(() => limit.record(Math.floor(MAX_GIT_FETCH_BYTES / 2) + 1)).toThrow(
+			`${MAX_GIT_FETCH_BYTES}-byte pull-source limit`,
+		);
+	});
+
 	it('preserves an exact signed commit and produces a clean credential-free working tree', async () => {
 		const source = await temporaryDirectory('marimohub-git-source-');
 		git(source, ['init', '-b', 'main']);
@@ -135,7 +156,7 @@ describe('materializeGitDirectory', () => {
 	it('rejects a smart-HTTP response beyond the Git pack limit', async () => {
 		const fetcher: GitHubFetch = async () =>
 			new Response('too large', {
-				headers: { 'content-length': String(MAX_WORKSPACE_FILE_BYTES + 1) },
+				headers: { 'content-length': String(MAX_GIT_FETCH_BYTES + 1) },
 			});
 		await expect(
 			materializeGitDirectory({
@@ -148,6 +169,67 @@ describe('materializeGitDirectory', () => {
 				fetcher,
 			}),
 		).rejects.toBeInstanceOf(BadRequestError);
+	});
+
+	it('rejects a file beyond the expanded-object per-file cap', async () => {
+		const checkout = await temporaryDirectory('marimohub-git-expanded-file-');
+		const file = join(checkout, 'large.bin');
+		await writeFile(file, '');
+		await truncate(file, MAX_WORKSPACE_FILE_BYTES + 1);
+
+		await expect(assertGitCheckoutLimits(checkout, 'owner/expanded')).rejects.toThrow(
+			`${MAX_WORKSPACE_FILE_BYTES}-byte limit`,
+		);
+	});
+
+	it('rejects too many files after Git pack expansion', async () => {
+		const checkout = await temporaryDirectory('marimohub-git-expanded-files-');
+		for (let index = 0; index < MAX_GIT_EXPANDED_FILES + 1; index++) {
+			await writeFile(join(checkout, `file-${index}`), '');
+		}
+
+		await expect(assertGitCheckoutLimits(checkout, 'owner/expanded')).rejects.toThrow(
+			`${MAX_GIT_EXPANDED_FILES}-file limit`,
+		);
+	});
+
+	it('rejects cumulative bytes after Git pack expansion', async () => {
+		const checkout = await temporaryDirectory('marimohub-git-expanded-bytes-');
+		const fileSize = Math.floor(MAX_GIT_EXPANDED_BYTES / 5) + 1;
+		for (let index = 0; index < 5; index++) {
+			const path = join(checkout, `file-${index}`);
+			await writeFile(path, '');
+			await truncate(path, fileSize);
+		}
+
+		await expect(assertGitCheckoutLimits(checkout, 'owner/expanded')).rejects.toThrow(
+			`${MAX_GIT_EXPANDED_BYTES}-byte limit`,
+		);
+	});
+
+	it('rejects a materialized Git directory beyond the file-count cap', async () => {
+		const gitdir = await temporaryDirectory('marimohub-git-many-files-');
+		for (let index = 0; index < MAX_GIT_DIRECTORY_FILES + 1; index++) {
+			await writeFile(join(gitdir, `object-${index}`), '');
+		}
+
+		await expect(collectGitDirectoryFiles(gitdir, 'owner/many-files')).rejects.toThrow(
+			`${MAX_GIT_DIRECTORY_FILES}-file limit`,
+		);
+	});
+
+	it('rejects cumulative materialized bytes beyond the cap', async () => {
+		const gitdir = await temporaryDirectory('marimohub-git-expanded-');
+		const fileSize = Math.floor(MAX_GIT_DIRECTORY_BYTES / 5) + 1;
+		for (let index = 0; index < 5; index++) {
+			const path = join(gitdir, `object-${index}`);
+			await writeFile(path, '');
+			await truncate(path, fileSize);
+		}
+
+		await expect(collectGitDirectoryFiles(gitdir, 'owner/expanded')).rejects.toThrow(
+			`${MAX_GIT_DIRECTORY_BYTES}-byte limit`,
+		);
 	});
 
 	it('preserves a symlink index entry when the workspace omits the symlink', async () => {

--- a/packages/source-control-github/src/githubGitDirectory.ts
+++ b/packages/source-control-github/src/githubGitDirectory.ts
@@ -1,0 +1,169 @@
+import fs from 'node:fs';
+import { mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import { tmpdir } from 'node:os';
+import git from 'isomorphic-git';
+import type { GitHttpRequest, HttpClient } from 'isomorphic-git';
+import { BadRequestError, MAX_WORKSPACE_FILE_BYTES, UnavailableError } from '@marimo-hub/core';
+import type { SourceWorkspaceFile } from '@marimo-hub/core';
+import type { GitHubFetch } from './githubClient';
+
+function repositorySizeError(repository: string): BadRequestError {
+	return new BadRequestError(
+		`The Git data for ${repository} exceeds the ${MAX_WORKSPACE_FILE_BYTES}-byte pull-source limit; reduce the repository history or use push sync`,
+	);
+}
+
+async function requestBody(
+	body: GitHttpRequest['body'],
+): Promise<Uint8Array<ArrayBuffer> | undefined> {
+	if (!body) return undefined;
+	const chunks: Uint8Array[] = [];
+	let size = 0;
+	for await (const chunk of body) {
+		chunks.push(chunk);
+		size += chunk.byteLength;
+	}
+	const bytes = new Uint8Array(size);
+	let offset = 0;
+	for (const chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return bytes;
+}
+
+function responseBody(response: Response, repository: string): AsyncIterableIterator<Uint8Array> {
+	const body = response.body;
+	return (async function* () {
+		if (!body) return;
+		const reader = body.getReader();
+		let received = 0;
+		try {
+			for (;;) {
+				const next = await reader.read();
+				if (next.done) break;
+				received += next.value.byteLength;
+				if (received > MAX_WORKSPACE_FILE_BYTES) throw repositorySizeError(repository);
+				yield next.value;
+			}
+		} finally {
+			await reader.cancel().catch(() => {});
+		}
+	})();
+}
+
+function gitHttp(fetcher: GitHubFetch, repository: string): HttpClient {
+	return {
+		request: async (request) => {
+			const body = await requestBody(request.body);
+			const response = await fetcher(request.url, {
+				method: request.method,
+				headers: request.headers,
+				body: body?.buffer,
+			});
+			const contentLength = Number(response.headers.get('content-length'));
+			if (Number.isFinite(contentLength) && contentLength > MAX_WORKSPACE_FILE_BYTES) {
+				throw repositorySizeError(repository);
+			}
+			return {
+				url: response.url || request.url,
+				method: request.method,
+				statusCode: response.status,
+				statusMessage: response.statusText,
+				headers: Object.fromEntries(response.headers.entries()),
+				body: responseBody(response, repository),
+			};
+		},
+	};
+}
+
+async function collectFiles(root: string, repository: string): Promise<SourceWorkspaceFile[]> {
+	const files: SourceWorkspaceFile[] = [];
+	async function visit(directory: string): Promise<void> {
+		for (const entry of await readdir(directory, { withFileTypes: true })) {
+			const path = join(directory, entry.name);
+			if (entry.isDirectory()) {
+				await visit(path);
+				continue;
+			}
+			if (!entry.isFile()) continue;
+			const info = await stat(path);
+			if (info.size > MAX_WORKSPACE_FILE_BYTES) throw repositorySizeError(repository);
+			files.push({
+				path: relative(root, path).split('\\').join('/'),
+				bytes: new Uint8Array(await readFile(path)),
+			});
+		}
+	}
+	await visit(root);
+	return files;
+}
+
+export async function materializeGitDirectory(options: {
+	repository: string;
+	owner: string;
+	repo: string;
+	commit: string;
+	branch: string;
+	token: string;
+	fetcher: GitHubFetch;
+}): Promise<SourceWorkspaceFile[]> {
+	const directory = await mkdtemp(join(tmpdir(), 'marimohub-git-'));
+	const gitdir = join(directory, '.git');
+	const remoteUrl = `https://github.com/${options.owner}/${options.repo}.git`;
+	try {
+		await git.init({ fs, dir: directory, defaultBranch: options.branch });
+		await git.addRemote({ fs, dir: directory, remote: 'origin', url: remoteUrl });
+		const result = await git.fetch({
+			fs,
+			http: gitHttp(options.fetcher, options.repository),
+			dir: directory,
+			url: remoteUrl,
+			ref: options.branch,
+			remoteRef: options.commit,
+			singleBranch: true,
+			depth: 1,
+			tags: false,
+			headers: {
+				authorization: `Basic ${Buffer.from(`x-access-token:${options.token}`).toString('base64')}`,
+			},
+		});
+		if (result.fetchHead !== options.commit) {
+			throw new UnavailableError('GitHub returned a different commit than requested');
+		}
+		await git.writeRef({
+			fs,
+			dir: directory,
+			ref: `refs/heads/${options.branch}`,
+			value: options.commit,
+			force: true,
+		});
+		await git.writeRef({
+			fs,
+			dir: directory,
+			ref: `refs/remotes/origin/${options.branch}`,
+			value: options.commit,
+			force: true,
+		});
+		await git.setConfig({
+			fs,
+			dir: directory,
+			path: `branch.${options.branch}.remote`,
+			value: 'origin',
+		});
+		await git.setConfig({
+			fs,
+			dir: directory,
+			path: `branch.${options.branch}.merge`,
+			value: `refs/heads/${options.branch}`,
+		});
+		await git.checkout({ fs, dir: directory, ref: options.branch, force: true });
+		return await collectFiles(gitdir, options.repository);
+	} catch (error) {
+		if (error instanceof BadRequestError || error instanceof UnavailableError) throw error;
+		throw new UnavailableError('GitHub Git data could not be fetched', { cause: error });
+	} finally {
+		await rm(directory, { recursive: true, force: true });
+	}
+}

--- a/packages/source-control-github/src/githubGitDirectory.ts
+++ b/packages/source-control-github/src/githubGitDirectory.ts
@@ -226,18 +226,6 @@ export async function materializeGitDirectory(options: {
 			value: options.commit,
 			force: true,
 		});
-		await git.setConfig({
-			fs,
-			dir: directory,
-			path: `branch.${options.branch}.remote`,
-			value: 'origin',
-		});
-		await git.setConfig({
-			fs,
-			dir: directory,
-			path: `branch.${options.branch}.merge`,
-			value: `refs/heads/${options.branch}`,
-		});
 		await git.checkout({ fs, dir: directory, ref: options.branch, force: true });
 		await assertGitCheckoutLimits(directory, options.repository);
 		return await collectGitDirectoryFiles(gitdir, options.repository);

--- a/packages/source-control-github/src/githubGitDirectory.ts
+++ b/packages/source-control-github/src/githubGitDirectory.ts
@@ -1,17 +1,42 @@
 import fs from 'node:fs';
-import { mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises';
+import { lstat, mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { tmpdir } from 'node:os';
 import git from 'isomorphic-git';
 import type { GitHttpRequest, HttpClient } from 'isomorphic-git';
-import { BadRequestError, MAX_WORKSPACE_FILE_BYTES, UnavailableError } from '@marimo-hub/core';
+import {
+	BadRequestError,
+	GitDirectoryLimitTracker,
+	MAX_GIT_EXPANDED_BYTES,
+	MAX_GIT_EXPANDED_FILES,
+	MAX_GIT_FETCH_BYTES,
+	MAX_WORKSPACE_FILE_BYTES,
+	UnavailableError,
+} from '@marimo-hub/core';
 import type { SourceWorkspaceFile } from '@marimo-hub/core';
 import type { GitHubFetch } from './githubClient';
 
-function repositorySizeError(repository: string): BadRequestError {
+function repositorySizeError(repository: string, limit: number): BadRequestError {
 	return new BadRequestError(
-		`The Git data for ${repository} exceeds the ${MAX_WORKSPACE_FILE_BYTES}-byte pull-source limit; reduce the repository history or use push sync`,
+		`The Git data for ${repository} exceeds the ${limit}-byte pull-source limit; reduce the repository history or use push sync`,
 	);
+}
+
+export class GitFetchByteLimit {
+	private received = 0;
+
+	constructor(private readonly repository: string) {}
+
+	assertFits(size: number): void {
+		if (!Number.isSafeInteger(size) || size < 0 || this.received + size > MAX_GIT_FETCH_BYTES) {
+			throw repositorySizeError(this.repository, MAX_GIT_FETCH_BYTES);
+		}
+	}
+
+	record(size: number): void {
+		this.assertFits(size);
+		this.received += size;
+	}
 }
 
 async function requestBody(
@@ -33,18 +58,19 @@ async function requestBody(
 	return bytes;
 }
 
-function responseBody(response: Response, repository: string): AsyncIterableIterator<Uint8Array> {
+function responseBody(
+	response: Response,
+	recordBytes: (size: number) => void,
+): AsyncIterableIterator<Uint8Array> {
 	const body = response.body;
 	return (async function* () {
 		if (!body) return;
 		const reader = body.getReader();
-		let received = 0;
 		try {
 			for (;;) {
 				const next = await reader.read();
 				if (next.done) break;
-				received += next.value.byteLength;
-				if (received > MAX_WORKSPACE_FILE_BYTES) throw repositorySizeError(repository);
+				recordBytes(next.value.byteLength);
 				yield next.value;
 			}
 		} finally {
@@ -54,6 +80,7 @@ function responseBody(response: Response, repository: string): AsyncIterableIter
 }
 
 function gitHttp(fetcher: GitHubFetch, repository: string): HttpClient {
+	const limit = new GitFetchByteLimit(repository);
 	return {
 		request: async (request) => {
 			const body = await requestBody(request.body);
@@ -63,8 +90,8 @@ function gitHttp(fetcher: GitHubFetch, repository: string): HttpClient {
 				body: body?.buffer,
 			});
 			const contentLength = Number(response.headers.get('content-length'));
-			if (Number.isFinite(contentLength) && contentLength > MAX_WORKSPACE_FILE_BYTES) {
-				throw repositorySizeError(repository);
+			if (Number.isFinite(contentLength) && contentLength >= 0) {
+				limit.assertFits(contentLength);
 			}
 			return {
 				url: response.url || request.url,
@@ -72,31 +99,84 @@ function gitHttp(fetcher: GitHubFetch, repository: string): HttpClient {
 				statusCode: response.status,
 				statusMessage: response.statusText,
 				headers: Object.fromEntries(response.headers.entries()),
-				body: responseBody(response, repository),
+				body: responseBody(response, (size) => limit.record(size)),
 			};
 		},
 	};
 }
 
-async function collectFiles(root: string, repository: string): Promise<SourceWorkspaceFile[]> {
-	const files: SourceWorkspaceFile[] = [];
-	async function visit(directory: string): Promise<void> {
+export async function assertGitCheckoutLimits(root: string, repository: string): Promise<void> {
+	let fileCount = 0;
+	let totalBytes = 0;
+	async function scan(directory: string): Promise<void> {
+		for (const entry of await readdir(directory, { withFileTypes: true })) {
+			if (directory === root && entry.name === '.git') continue;
+			const path = join(directory, entry.name);
+			if (entry.isDirectory()) {
+				await scan(path);
+				continue;
+			}
+			if (!entry.isFile() && !entry.isSymbolicLink()) continue;
+			const info = await lstat(path);
+			fileCount += 1;
+			totalBytes += info.size;
+			if (info.size > MAX_WORKSPACE_FILE_BYTES) {
+				throw new BadRequestError(
+					`The expanded Git data for ${repository} contains a file beyond the ${MAX_WORKSPACE_FILE_BYTES}-byte limit; reduce the repository history or use push sync`,
+				);
+			}
+			if (fileCount > MAX_GIT_EXPANDED_FILES) {
+				throw new BadRequestError(
+					`The expanded Git data for ${repository} exceeds the ${MAX_GIT_EXPANDED_FILES}-file limit; reduce the repository history or use push sync`,
+				);
+			}
+			if (totalBytes > MAX_GIT_EXPANDED_BYTES) {
+				throw new BadRequestError(
+					`The expanded Git data for ${repository} exceeds the ${MAX_GIT_EXPANDED_BYTES}-byte limit; reduce the repository history or use push sync`,
+				);
+			}
+		}
+	}
+	await scan(root);
+}
+
+export async function collectGitDirectoryFiles(
+	root: string,
+	repository: string,
+): Promise<SourceWorkspaceFile[]> {
+	const entries: { path: string; relativePath: string }[] = [];
+	const limits = new GitDirectoryLimitTracker();
+	async function scan(directory: string): Promise<void> {
 		for (const entry of await readdir(directory, { withFileTypes: true })) {
 			const path = join(directory, entry.name);
 			if (entry.isDirectory()) {
-				await visit(path);
+				await scan(path);
 				continue;
 			}
 			if (!entry.isFile()) continue;
 			const info = await stat(path);
-			if (info.size > MAX_WORKSPACE_FILE_BYTES) throw repositorySizeError(repository);
-			files.push({
-				path: relative(root, path).split('\\').join('/'),
-				bytes: new Uint8Array(await readFile(path)),
-			});
+			const relativePath = relative(root, path).split('\\').join('/');
+			try {
+				limits.add(relativePath, info.size);
+			} catch (error) {
+				if (error instanceof BadRequestError) {
+					throw new BadRequestError(
+						`The Git data for ${repository} is outside pull-source limits: ${error.message}; reduce the repository history or use push sync`,
+					);
+				}
+				throw error;
+			}
+			entries.push({ path, relativePath });
 		}
 	}
-	await visit(root);
+	await scan(root);
+	const files: SourceWorkspaceFile[] = [];
+	for (const { path, relativePath } of entries) {
+		files.push({
+			path: relativePath,
+			bytes: new Uint8Array(await readFile(path)),
+		});
+	}
 	return files;
 }
 
@@ -159,7 +239,8 @@ export async function materializeGitDirectory(options: {
 			value: `refs/heads/${options.branch}`,
 		});
 		await git.checkout({ fs, dir: directory, ref: options.branch, force: true });
-		return await collectFiles(gitdir, options.repository);
+		await assertGitCheckoutLimits(directory, options.repository);
+		return await collectGitDirectoryFiles(gitdir, options.repository);
 	} catch (error) {
 		if (error instanceof BadRequestError || error instanceof UnavailableError) throw error;
 		throw new UnavailableError('GitHub Git data could not be fetched', { cause: error });

--- a/packages/source-control-github/src/githubReader.test.ts
+++ b/packages/source-control-github/src/githubReader.test.ts
@@ -232,7 +232,7 @@ describe('GitHubAppPublisher reader', () => {
 		await expect(
 			whole.fetchWorkspace('owner/repo', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', ''),
 		).rejects.toThrow(/Decompressed archive exceeds the size limit/);
-	});
+	}, 15_000);
 
 	it('supports github.com repositories only', () => {
 		const github = reader(() => null);

--- a/packages/source-control-github/src/index.test.ts
+++ b/packages/source-control-github/src/index.test.ts
@@ -1438,7 +1438,7 @@ describe('GitHubAppPublisher', () => {
 		expect(fetcher).not.toHaveBeenCalled();
 	});
 
-	it.each(['feature+one', 'release@2026', 'topic#1', 'δοκιμή', 'a'.repeat(256)])(
+	it.each(['feature+one', 'feature/"quoted', 'release@2026', 'topic#1', 'δοκιμή', 'a'.repeat(256)])(
 		'accepts valid Git branch name %j',
 		async (branch) => {
 			const fetcher = vi.fn(async () => response({}, 404));

--- a/packages/source-control-github/src/index.ts
+++ b/packages/source-control-github/src/index.ts
@@ -28,6 +28,7 @@ import {
 	validateUpdateInput,
 } from './githubValidation';
 import { collectTarballWorkspace, validateCommit, validateRootPath } from './githubWorkspace';
+import { materializeGitDirectory } from './githubGitDirectory';
 
 export type { GitHubAppPublisherOptions, GitHubAppPublisherRuntime } from './githubClient';
 
@@ -39,9 +40,11 @@ interface GitHubPublicationContext {
 export class GitHubAppPublisher implements SourceControlPublisher, SourceControlReader {
 	readonly provider = 'github' as const;
 	private readonly client: GitHubClient;
+	private readonly fetcher: NonNullable<GitHubAppPublisherRuntime['fetcher']>;
 
 	constructor(options: GitHubAppPublisherOptions, runtime: GitHubAppPublisherRuntime = {}) {
 		this.client = new GitHubClient(options, runtime);
+		this.fetcher = runtime.fetcher ?? fetch;
 	}
 
 	private async atStage<T>(stage: SourceControlPublishStage, action: () => Promise<T>): Promise<T> {
@@ -111,6 +114,25 @@ export class GitHubAppPublisher implements SourceControlPublisher, SourceControl
 			token,
 		);
 		return collectTarballWorkspace(response, rootPath);
+	}
+
+	async fetchGitDirectory(
+		repository: string,
+		commit: string,
+		branch: string,
+	): Promise<SourceWorkspaceFile[]> {
+		validateCommit(commit);
+		validateBranch(branch);
+		const { owner, repo } = parseRepository(repository);
+		return materializeGitDirectory({
+			repository,
+			owner,
+			repo,
+			commit,
+			branch,
+			token: await this.client.installationToken(owner, repo),
+			fetcher: this.fetcher,
+		});
 	}
 
 	async openChangeRequest(input: OpenChangeRequestInput): Promise<OpenChangeRequestResult> {

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -1271,7 +1271,6 @@ export function useDuplicateNotebook(projectId: string) {
 	);
 }
 
-/** Create a git-synced notebook; the response carries its write-once sync token. */
 export function useCreateSyncedNotebook(projectId: string) {
 	return useApiMutation(
 		(body: {
@@ -1281,6 +1280,7 @@ export function useCreateSyncedNotebook(projectId: string) {
 			branch: string;
 			root_path?: string;
 			entry_notebook: string;
+			sync_mode?: 'push' | 'pull';
 		}) =>
 			apiData(
 				apiClient.POST('/api/v1/projects/{pid}/notebooks/git', {

--- a/packages/web/src/components/Notebook/GitSourcePopover.test.tsx
+++ b/packages/web/src/components/Notebook/GitSourcePopover.test.tsx
@@ -25,6 +25,7 @@ function renderPopover(
 					source_control: {
 						change_request_providers: [],
 						sync_providers: options.syncProviders ?? [],
+						pull_source_providers: [],
 					},
 				});
 			}

--- a/packages/web/src/components/Notebook/SyncSettingsDialog.test.tsx
+++ b/packages/web/src/components/Notebook/SyncSettingsDialog.test.tsx
@@ -32,9 +32,15 @@ function setup(options: {
 	driftError?: boolean;
 	driftNotConfigured?: boolean;
 	syncError?: boolean;
+	syncMode?: 'push' | 'pull';
 }) {
 	const calls: { method: string; url: string; body?: unknown }[] = [];
-	const base = { ...activeSource, provider: options.provider ?? activeSource.provider };
+	const base = {
+		...activeSource,
+		provider: options.provider ?? activeSource.provider,
+		sync_mode: options.syncMode ?? activeSource.sync_mode,
+		root_path: options.syncMode === 'pull' ? '' : activeSource.root_path,
+	};
 	const source = options.pending
 		? {
 				...base,
@@ -63,6 +69,7 @@ function setup(options: {
 								source_control: {
 									change_request_providers: [],
 									sync_providers: options.syncProviders ?? [],
+									pull_source_providers: [],
 								},
 							},
 				);
@@ -138,6 +145,17 @@ describe('SyncSettingsDialog', () => {
 		expect(screen.getByText(/last synced/i)).toBeInTheDocument();
 	});
 
+	it('shows Sync now but no token, URL, or subtree controls for a pull source', async () => {
+		setup({ syncMode: 'pull', syncProviders: ['github'], remoteCommit: 'fedcba9876543210' });
+
+		await waitFor(() => expect(screen.getByLabelText('Repository')).toHaveValue('acme/analytics'));
+		expect(screen.queryByLabelText('Folder in repo (optional)')).not.toBeInTheDocument();
+		expect(screen.queryByLabelText('Sync URL')).not.toBeInTheDocument();
+		expect(screen.queryByText('Sync credentials')).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Sync now' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Rotate token' })).not.toBeInTheDocument();
+	});
+
 	it('shows desired settings while explaining which active source remains served', async () => {
 		setup({ pending: true });
 
@@ -191,7 +209,7 @@ describe('SyncSettingsDialog', () => {
 	it('rotates the token after confirmation and displays it once', async () => {
 		const user = userEvent.setup();
 		const { calls } = setup({});
-		await screen.findByLabelText('Repository');
+		await waitFor(() => expect(screen.getByLabelText('Repository')).toHaveValue('acme/analytics'));
 
 		await user.click(screen.getByRole('button', { name: 'Rotate token' }));
 		await user.click(screen.getByRole('button', { name: 'Rotate' }));

--- a/packages/web/src/components/Notebook/SyncSettingsDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncSettingsDialog.tsx
@@ -34,7 +34,7 @@ interface SyncSettingsDialogProps {
 	projectId: string;
 	notebookId: string;
 	title: string;
-	syncUrl: string;
+	syncUrl?: string;
 	canEdit: boolean;
 	initialToken?: string;
 }
@@ -78,6 +78,7 @@ export function SyncSettingsDialog({
 	const [token, setToken] = useState(initialToken);
 	const [confirmRotate, setConfirmRotate] = useState(false);
 	const source = detail.data?.source.type === 'git' ? detail.data.source : undefined;
+	const isPull = source?.sync_mode === 'pull';
 	const desired = source?.pending_config ?? source;
 	const values = desired
 		? {
@@ -103,7 +104,7 @@ export function SyncSettingsDialog({
 				});
 				toast.success(
 					data.source.pending_config
-						? 'Sync settings saved; current content stays active until the next matching push'
+						? `Sync settings saved; current content stays active until the next ${isPull ? 'Sync now' : 'matching push'}`
 						: 'Sync settings saved',
 				);
 				onClose();
@@ -138,7 +139,7 @@ export function SyncSettingsDialog({
 					</Button>
 				)}
 			</div>
-			<CopyField label="Sync URL" value={syncUrl} />
+			{syncUrl && <CopyField label="Sync URL" value={syncUrl} />}
 			{token ? (
 				<>
 					<CopyField label="Sync token" value={token} />
@@ -167,8 +168,8 @@ export function SyncSettingsDialog({
 		source.pending_config ? (
 			<p className="rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
 				Changes are pending. The notebook continues serving{' '}
-				<span className="font-medium text-foreground">{activeSourceLabel(source)}</span> until a
-				push matches the settings above.
+				<span className="font-medium text-foreground">{activeSourceLabel(source)}</span> until{' '}
+				{isPull ? 'Sync now applies the settings above.' : 'a push matches the settings above.'}
 			</p>
 		) : (
 			<p className="text-xs text-muted-foreground">
@@ -210,15 +211,17 @@ export function SyncSettingsDialog({
 				<form.AppField name="branch">
 					{(f) => <f.TextField label="Branch" placeholder="main" isDisabled={!source} />}
 				</form.AppField>
-				<form.AppField name="rootPath">
-					{(f) => (
-						<f.TextField
-							label="Folder in repo (optional)"
-							placeholder="apps"
-							isDisabled={!source}
-						/>
-					)}
-				</form.AppField>
+				{!isPull && (
+					<form.AppField name="rootPath">
+						{(f) => (
+							<f.TextField
+								label="Folder in repo (optional)"
+								placeholder="apps"
+								isDisabled={!source}
+							/>
+						)}
+					</form.AppField>
+				)}
 				<form.AppField name="entryNotebook">
 					{(f) => (
 						<f.TextField label="Notebook file" placeholder="dashboard.py" isDisabled={!source} />
@@ -227,7 +230,7 @@ export function SyncSettingsDialog({
 			</div>
 			{sourceStatus}
 			{serverSync}
-			{credentials}
+			{source?.sync_mode === 'push' && credentials}
 		</FormDialog>
 	) : (
 		<DialogModal isOpen={isOpen} onClose={onClose} title={`Sync settings — ${title}`} width="lg">
@@ -235,12 +238,12 @@ export function SyncSettingsDialog({
 				<div className="grid gap-4 sm:grid-cols-2">
 					<TextField label="Repository" value={values.repo} isReadOnly />
 					<TextField label="Branch" value={values.branch} isReadOnly />
-					<TextField label="Folder in repo" value={values.rootPath} isReadOnly />
+					{!isPull && <TextField label="Folder in repo" value={values.rootPath} isReadOnly />}
 					<TextField label="Notebook file" value={values.entryNotebook} isReadOnly />
 				</div>
 				{sourceStatus}
 				{serverSync}
-				{credentials}
+				{source?.sync_mode === 'push' && credentials}
 				<div className="flex justify-end pt-2">
 					<Button variant="primary" onPress={onClose}>
 						Done
@@ -253,24 +256,26 @@ export function SyncSettingsDialog({
 	return (
 		<>
 			{dialog}
-			<ConfirmDialog
-				isOpen={confirmRotate}
-				onClose={() => setConfirmRotate(false)}
-				title="Rotate Sync Token"
-				description="The current token stops working immediately and any pusher using it must be updated."
-				confirmLabel="Rotate"
-				pendingLabel="Rotating..."
-				isPending={rotateToken.isPending}
-				onConfirm={() => {
-					rotateToken.mutate(notebookId, {
-						onSuccess: (data) => {
-							setToken(data.sync_token);
-							setConfirmRotate(false);
-							toast.success(`Rotated sync token for "${title}"`);
-						},
-					});
-				}}
-			/>
+			{source?.sync_mode === 'push' && (
+				<ConfirmDialog
+					isOpen={confirmRotate}
+					onClose={() => setConfirmRotate(false)}
+					title="Rotate Sync Token"
+					description="The current token stops working immediately and any pusher using it must be updated."
+					confirmLabel="Rotate"
+					pendingLabel="Rotating..."
+					isPending={rotateToken.isPending}
+					onConfirm={() => {
+						rotateToken.mutate(notebookId, {
+							onSuccess: (data) => {
+								setToken(data.sync_token);
+								setConfirmRotate(false);
+								toast.success(`Rotated sync token for "${title}"`);
+							},
+						});
+					}}
+				/>
+			)}
 		</>
 	);
 }

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
@@ -149,6 +149,12 @@ describe('SyncedNotebookDialog', () => {
 
 		expect(await screen.findByText('Connect to GitHub')).toBeInTheDocument();
 		expect(screen.getByText('Push from CI')).toBeInTheDocument();
+		expect(screen.getByRole('dialog').closest('.max-w-md')).not.toBeNull();
+		const pullDescription = screen.getByText(
+			'The server pulls the repository; no CI setup is required.',
+		);
+		expect(pullDescription).toHaveClass('whitespace-normal', 'break-words');
+		expect(pullDescription).not.toHaveClass('truncate');
 		expect(screen.queryByLabelText('Folder in repo (optional)')).not.toBeInTheDocument();
 		await user.type(screen.getByLabelText('Notebook name'), 'Connected');
 		await user.type(screen.getByLabelText('Repository'), 'acme/analytics');

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
@@ -6,8 +6,26 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { SyncedNotebookDialog } from './SyncedNotebookDialog';
 
-function renderDialog(fetchImpl = vi.fn()) {
-	vi.stubGlobal('fetch', fetchImpl);
+function renderDialog(fetchImpl = vi.fn(), pullAvailable = false) {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+			if (String(url).endsWith('/api/v1/capabilities')) {
+				return new Response(
+					JSON.stringify({
+						success: true,
+						data: {
+							source_control: {
+								pull_source_providers: pullAvailable ? ['github'] : [],
+							},
+						},
+					}),
+					{ headers: { 'content-type': 'application/json' } },
+				);
+			}
+			return fetchImpl(url, init);
+		}),
+	);
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	const onClose = vi.fn();
 	const onCreated = vi.fn();
@@ -103,12 +121,50 @@ describe('SyncedNotebookDialog', () => {
 			branch: 'main',
 			root_path: 'apps',
 			entry_notebook: 'dashboard.py',
+			sync_mode: 'push',
 		});
 		expect(onCreated).toHaveBeenCalledWith({
 			notebookId: 'nb-9',
 			title: 'Dash',
 			syncUrl: 'https://host/api/sync/git/v1/projects/proj-x/notebooks/nb-9',
 			token: 'mhsync_secret',
+			syncMode: 'push',
+		});
+	});
+
+	it('offers GitHub pull mode and creates without CI credentials', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = vi.fn(
+			async (_url: RequestInfo | URL, _init?: RequestInit) =>
+				new Response(
+					JSON.stringify({
+						success: true,
+						data: { notebook: { id: 'nb-pull', title: 'Connected', status: 'active' } },
+					}),
+					{ headers: { 'content-type': 'application/json' } },
+				),
+		);
+		const { onCreated } = renderDialog(fetchImpl, true);
+
+		expect(await screen.findByText('Connect to GitHub')).toBeInTheDocument();
+		expect(screen.getByText('Push from CI')).toBeInTheDocument();
+		expect(screen.queryByLabelText('Folder in repo (optional)')).not.toBeInTheDocument();
+		await user.type(screen.getByLabelText('Notebook name'), 'Connected');
+		await user.type(screen.getByLabelText('Repository'), 'acme/analytics');
+		await user.type(screen.getByLabelText('Notebook file'), 'dashboard.py');
+		await user.click(screen.getByRole('button', { name: 'Create' }));
+
+		const [, init] = fetchImpl.mock.calls[0];
+		expect(JSON.parse(init!.body as string)).toMatchObject({
+			root_path: '',
+			sync_mode: 'pull',
+		});
+		expect(onCreated).toHaveBeenCalledWith({
+			notebookId: 'nb-pull',
+			title: 'Connected',
+			syncUrl: undefined,
+			token: undefined,
+			syncMode: 'pull',
 		});
 	});
 });

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
@@ -6,17 +6,18 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { SyncedNotebookDialog } from './SyncedNotebookDialog';
 
-function renderDialog(fetchImpl = vi.fn(), pullAvailable = false) {
+function renderDialog(fetchImpl = vi.fn(), pullAvailable: boolean | Promise<boolean> = false) {
 	vi.stubGlobal(
 		'fetch',
 		vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
 			if (String(url).endsWith('/api/v1/capabilities')) {
+				const available = await pullAvailable;
 				return new Response(
 					JSON.stringify({
 						success: true,
 						data: {
 							source_control: {
-								pull_source_providers: pullAvailable ? ['github'] : [],
+								pull_source_providers: available ? ['github'] : [],
 							},
 						},
 					}),
@@ -166,6 +167,25 @@ describe('SyncedNotebookDialog', () => {
 			token: undefined,
 			syncMode: 'pull',
 		});
+	});
+
+	it('selects pull mode when capabilities load after the dialog opens', async () => {
+		const user = userEvent.setup();
+		let resolveCapabilities: (available: boolean) => void = () => {};
+		const pullAvailable = new Promise<boolean>((resolve) => {
+			resolveCapabilities = resolve;
+		});
+		renderDialog(vi.fn(), pullAvailable);
+
+		await user.type(screen.getByLabelText('Notebook name'), 'Connected');
+		expect(screen.getByLabelText('Notebook name')).toHaveValue('Connected');
+		expect(screen.getByLabelText('Folder in repo (optional)')).toBeInTheDocument();
+
+		resolveCapabilities(true);
+
+		expect(await screen.findByText('Connect to GitHub')).toBeInTheDocument();
+		expect(screen.getByLabelText('Notebook name')).toHaveValue('Connected');
+		expect(screen.queryByLabelText('Folder in repo (optional)')).not.toBeInTheDocument();
 	});
 
 	it.each([

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
@@ -167,4 +167,48 @@ describe('SyncedNotebookDialog', () => {
 			syncMode: 'pull',
 		});
 	});
+
+	it.each([
+		['GitLab', 'https://gitlab.com/acme/analytics'],
+		['GitHub Enterprise', 'https://github.mycompany.com/acme/analytics'],
+	])('rejects %s repositories in pull mode', async (_label, repository) => {
+		const user = userEvent.setup();
+		const fetchImpl = vi.fn();
+		renderDialog(fetchImpl, true);
+
+		await user.type(screen.getByLabelText('Repository'), repository);
+		await user.tab();
+
+		expect(screen.getByText(/pull mode supports github\.com repositories/i)).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+
+	it('revalidates the repository when switching between pull and push modes', async () => {
+		const user = userEvent.setup();
+		renderDialog(vi.fn(), true);
+
+		await user.type(screen.getByLabelText('Notebook name'), 'Dash');
+		await user.type(
+			screen.getByLabelText('Repository'),
+			'https://gitlab.example.com/acme/analytics',
+		);
+		await user.type(screen.getByLabelText('Notebook file'), 'dashboard.py');
+		await user.tab();
+
+		expect(screen.getByText(/pull mode supports github\.com repositories/i)).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+
+		await user.click(screen.getByText('Push from CI'));
+
+		expect(
+			screen.queryByText(/pull mode supports github\.com repositories/i),
+		).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
+
+		await user.click(screen.getByText('Connect to GitHub'));
+
+		expect(screen.getByText(/pull mode supports github\.com repositories/i)).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+	});
 });

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
@@ -1,5 +1,6 @@
 import { toast } from 'sonner';
 import { z } from 'zod';
+import { useSelector } from '@tanstack/react-store';
 import {
 	FormDialog,
 	optionalText,
@@ -8,7 +9,7 @@ import {
 	useAppForm,
 	useSeedOnOpen,
 } from '@/components/form';
-import { useCreateSyncedNotebook } from '@/api/hooks';
+import { useCapabilitiesQuery, useCreateSyncedNotebook } from '@/api/hooks';
 import {
 	ENTRY_NOTEBOOK_HINT,
 	ENTRY_NOTEBOOK_PATTERN,
@@ -19,19 +20,20 @@ import {
 export interface SyncedNotebookCreated {
 	notebookId: string;
 	title: string;
-	syncUrl: string;
-	token: string;
+	syncUrl?: string;
+	token?: string;
+	syncMode: 'push' | 'pull';
 }
 
 export interface SyncedNotebookDialogProps {
 	isOpen: boolean;
 	onClose: () => void;
 	projectId: string;
-	/** Fired after a successful create, with the write-once sync credentials. */
 	onCreated: (result: SyncedNotebookCreated) => void;
 }
 
 const syncedSchema = z.object({
+	syncMode: z.enum(['push', 'pull']),
 	title: requiredText('Notebook name'),
 	repo: requiredText('Repository').refine(isRepoInput, REPO_INPUT_HINT),
 	branch: requiredText('Branch'),
@@ -39,23 +41,29 @@ const syncedSchema = z.object({
 	entryNotebook: requiredText('Notebook file').regex(ENTRY_NOTEBOOK_PATTERN, ENTRY_NOTEBOOK_HINT),
 });
 
-const EMPTY = { title: '', repo: '', branch: 'main', rootPath: '', entryNotebook: '' };
+const emptyValues = (syncMode: 'push' | 'pull') => ({
+	syncMode,
+	title: '',
+	repo: '',
+	branch: 'main',
+	rootPath: '',
+	entryNotebook: '',
+});
 
-/**
- * Create a git-synced notebook. A repo subtree is mirrored in by an external
- * pusher (e.g. a CI workflow); see `docs/syncing.md`. The resulting write-once
- * token is handed to `onCreated` for the caller to surface (the server never
- * returns it again).
- */
 export function SyncedNotebookDialog({
 	isOpen,
 	onClose,
 	projectId,
 	onCreated,
 }: SyncedNotebookDialogProps) {
+	const { data: capabilities } = useCapabilitiesQuery();
+	const pullAvailable = (capabilities?.source_control?.pull_source_providers ?? []).includes(
+		'github',
+	);
+	const initialValues = emptyValues(pullAvailable ? 'pull' : 'push');
 	const createSynced = useCreateSyncedNotebook(projectId);
 	const form = useAppForm({
-		defaultValues: EMPTY,
+		defaultValues: initialValues,
 		validators: schemaValidators(syncedSchema),
 		onSubmit: async ({ value }) => {
 			try {
@@ -64,22 +72,31 @@ export function SyncedNotebookDialog({
 					description: value.title.trim(),
 					repo: value.repo.trim(),
 					branch: value.branch.trim(),
-					root_path: value.rootPath.trim() || undefined,
+					root_path: value.syncMode === 'pull' ? '' : value.rootPath.trim() || undefined,
 					entry_notebook: value.entryNotebook.trim(),
+					sync_mode: value.syncMode,
 				});
-				toast.success(`Created "${data.notebook.title}"`);
+				if (data.sync_error) {
+					toast.warning(`Created "${data.notebook.title}", but the first sync failed`, {
+						description: data.sync_error.message,
+					});
+				} else {
+					toast.success(`Created "${data.notebook.title}"`);
+				}
 				onCreated({
 					notebookId: data.notebook.id,
 					title: data.notebook.title,
 					syncUrl: data.sync_url,
 					token: data.sync_token,
+					syncMode: value.syncMode,
 				});
 			} catch {
 				return;
 			}
 		},
 	});
-	useSeedOnOpen(form, isOpen, EMPTY);
+	useSeedOnOpen(form, isOpen, initialValues);
+	const syncMode = useSelector(form.store, (state) => state.values.syncMode);
 
 	return (
 		<FormDialog
@@ -87,10 +104,31 @@ export function SyncedNotebookDialog({
 			isPending={createSynced.isPending}
 			isOpen={isOpen}
 			onClose={onClose}
-			title="Sync from a git repository"
+			title="Add a git repository"
 			submitLabel="Create"
 			pendingLabel="Creating..."
 		>
+			{pullAvailable && (
+				<form.AppField name="syncMode">
+					{(f) => (
+						<f.RadioGroupField
+							label="How content is synced"
+							options={[
+								{
+									value: 'pull',
+									label: 'Connect to GitHub',
+									description: 'The server pulls the repository; no CI setup is required.',
+								},
+								{
+									value: 'push',
+									label: 'Push from CI',
+									description: 'An external workflow pushes repository archives.',
+								},
+							]}
+						/>
+					)}
+				</form.AppField>
+			)}
 			<form.AppField name="title">
 				{(f) => <f.TextField label="Notebook name" placeholder="my_dashboard" autoFocus />}
 			</form.AppField>
@@ -98,16 +136,22 @@ export function SyncedNotebookDialog({
 				{(f) => (
 					<f.TextField
 						label="Repository"
-						placeholder="owner/repo or https://gitlab.example.com/group/project"
+						placeholder={
+							syncMode === 'pull'
+								? 'owner/repo'
+								: 'owner/repo or https://gitlab.example.com/group/project'
+						}
 					/>
 				)}
 			</form.AppField>
 			<form.AppField name="branch">
 				{(f) => <f.TextField label="Branch" placeholder="main" />}
 			</form.AppField>
-			<form.AppField name="rootPath">
-				{(f) => <f.TextField label="Folder in repo (optional)" placeholder="apps" />}
-			</form.AppField>
+			{syncMode === 'push' && (
+				<form.AppField name="rootPath">
+					{(f) => <f.TextField label="Folder in repo (optional)" placeholder="apps" />}
+				</form.AppField>
+			)}
 			<form.AppField name="entryNotebook">
 				{(f) => <f.TextField label="Notebook file" placeholder="dashboard.py" />}
 			</form.AppField>

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { useSelector } from '@tanstack/react-store';
@@ -108,6 +109,9 @@ export function SyncedNotebookDialog({
 		},
 	});
 	useSeedOnOpen(form, isOpen, initialValues);
+	useEffect(() => {
+		if (isOpen && pullAvailable) form.setFieldValue('syncMode', 'pull');
+	}, [form, isOpen, pullAvailable]);
 	const syncMode = useSelector(form.store, (state) => state.values.syncMode);
 
 	return (

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
@@ -121,6 +121,7 @@ export function SyncedNotebookDialog({
 			isOpen={isOpen}
 			onClose={onClose}
 			title="Add a git repository"
+			width="md"
 			submitLabel="Create"
 			pendingLabel="Creating..."
 		>

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
@@ -13,6 +13,8 @@ import { useCapabilitiesQuery, useCreateSyncedNotebook } from '@/api/hooks';
 import {
 	ENTRY_NOTEBOOK_HINT,
 	ENTRY_NOTEBOOK_PATTERN,
+	GITHUB_REPO_INPUT_HINT,
+	isGitHubRepoInput,
 	isRepoInput,
 	REPO_INPUT_HINT,
 } from '@/lib/git';
@@ -32,14 +34,24 @@ export interface SyncedNotebookDialogProps {
 	onCreated: (result: SyncedNotebookCreated) => void;
 }
 
-const syncedSchema = z.object({
-	syncMode: z.enum(['push', 'pull']),
-	title: requiredText('Notebook name'),
-	repo: requiredText('Repository').refine(isRepoInput, REPO_INPUT_HINT),
-	branch: requiredText('Branch'),
-	rootPath: optionalText(),
-	entryNotebook: requiredText('Notebook file').regex(ENTRY_NOTEBOOK_PATTERN, ENTRY_NOTEBOOK_HINT),
-});
+const syncedSchema = z
+	.object({
+		syncMode: z.enum(['push', 'pull']),
+		title: requiredText('Notebook name'),
+		repo: requiredText('Repository').refine(isRepoInput, REPO_INPUT_HINT),
+		branch: requiredText('Branch'),
+		rootPath: optionalText(),
+		entryNotebook: requiredText('Notebook file').regex(ENTRY_NOTEBOOK_PATTERN, ENTRY_NOTEBOOK_HINT),
+	})
+	.superRefine((value, context) => {
+		if (value.syncMode === 'pull' && isRepoInput(value.repo) && !isGitHubRepoInput(value.repo)) {
+			context.addIssue({
+				code: 'custom',
+				path: ['repo'],
+				message: GITHUB_REPO_INPUT_HINT,
+			});
+		}
+	});
 
 const emptyValues = (syncMode: 'push' | 'pull') => ({
 	syncMode,

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -421,11 +421,13 @@ export function Project() {
 
 	const handleSyncedCreated = (result: SyncedNotebookCreated) => {
 		syncedCreateModal.close();
-		syncSettings.open({
-			notebookId: result.notebookId,
-			title: result.title,
-			token: result.token,
-		});
+		if (result.syncMode === 'push') {
+			syncSettings.open({
+				notebookId: result.notebookId,
+				title: result.title,
+				token: result.token,
+			});
+		}
 	};
 
 	const notebookActions = (nb: NotebookEntry): DropdownMenuOption[] => {

--- a/packages/web/src/components/form/fields/RadioGroupField.tsx
+++ b/packages/web/src/components/form/fields/RadioGroupField.tsx
@@ -50,7 +50,7 @@ export function RadioGroupField({ label, options }: RadioGroupFieldProps) {
 									<span className="flex min-w-0 flex-col">
 										<span className="truncate text-foreground">{option.label}</span>
 										{option.description && (
-											<span className="truncate text-xs text-muted-foreground">
+											<span className="whitespace-normal break-words text-xs leading-4 text-muted-foreground">
 												{option.description}
 											</span>
 										)}

--- a/packages/web/src/lib/git.test.ts
+++ b/packages/web/src/lib/git.test.ts
@@ -193,6 +193,8 @@ describe('isGitHubRepoInput', () => {
 			'acme/analytics',
 			'acme/analytics.git',
 			'https://github.com/acme/analytics',
+			'github.com/acme/analytics',
+			'GitHub.com/acme/analytics.git',
 			'HTTPS://GitHub.COM/acme/analytics.git/',
 		]) {
 			expect(isGitHubRepoInput(repo), repo).toBe(true);
@@ -209,7 +211,6 @@ describe('isGitHubRepoInput', () => {
 			'https://github.com/acme/team/analytics',
 			'https://github.com/acme/analytics?tab=readme',
 			'https://github.com/acme/analytics#readme',
-			'github.com/acme/analytics',
 			'git@github.com:acme/analytics.git',
 			'ssh://git@github.com/acme/analytics.git',
 			'-acme/analytics',

--- a/packages/web/src/lib/git.test.ts
+++ b/packages/web/src/lib/git.test.ts
@@ -7,6 +7,7 @@ import {
 	gitCoords,
 	gitEntryPath,
 	gitSourceUrl,
+	isGitHubRepoInput,
 	isRepoInput,
 	providerLabel,
 	shortCommit,
@@ -183,6 +184,38 @@ describe('isRepoInput', () => {
 		expect(isRepoInput('https://gitlab.com/only-group')).toBe(false);
 		expect(isRepoInput('https://oauth2:token@gitlab.com/group/project')).toBe(false);
 		expect(isRepoInput('ftp://gitlab.com/group/project')).toBe(false);
+	});
+});
+
+describe('isGitHubRepoInput', () => {
+	it('accepts GitHub shorthand and HTTPS URL forms', () => {
+		for (const repo of [
+			'acme/analytics',
+			'acme/analytics.git',
+			'https://github.com/acme/analytics',
+			'HTTPS://GitHub.COM/acme/analytics.git/',
+		]) {
+			expect(isGitHubRepoInput(repo), repo).toBe(true);
+		}
+	});
+
+	it('rejects other providers and unsupported GitHub hosts or coordinates', () => {
+		for (const repo of [
+			'https://gitlab.com/acme/analytics',
+			'https://github.mycompany.com/acme/analytics',
+			'https://github.com:444/acme/analytics',
+			'http://github.com/acme/analytics',
+			'https://notgithub.com/acme/analytics',
+			'https://github.com/acme/team/analytics',
+			'https://github.com/acme/analytics?tab=readme',
+			'https://github.com/acme/analytics#readme',
+			'github.com/acme/analytics',
+			'git@github.com:acme/analytics.git',
+			'ssh://git@github.com/acme/analytics.git',
+			'-acme/analytics',
+		]) {
+			expect(isGitHubRepoInput(repo), repo).toBe(false);
+		}
 	});
 });
 

--- a/packages/web/src/lib/git.ts
+++ b/packages/web/src/lib/git.ts
@@ -23,6 +23,51 @@ export interface GitSourceCoords {
 // OWNER_REPO_PATTERN (core gitRepo.ts), including the dot-only repo-name
 // rejection (`owner/..` would escape the owner in a built URL).
 const OWNER_REPO_PATTERN = /^[A-Za-z0-9_-]+\/(?!\.+$)[A-Za-z0-9._-]+$/;
+// Pull support is narrower than the generic source shape. Keep these rules in
+// sync with source-control-github's parseRepository boundary.
+const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const GITHUB_REPO_PATTERN = /^(?!\.+$)[A-Za-z0-9_.-]{1,100}$/;
+
+interface ParsedRepoInput {
+	path: string;
+	url: URL | null;
+}
+
+function parseRepoInput(input: string): ParsedRepoInput | null {
+	const trimmed = input.trim();
+	if (!trimmed) return null;
+	const bare = trimmed.replace(/\.git$/, '');
+	if (OWNER_REPO_PATTERN.test(bare)) return { path: bare, url: null };
+
+	let candidate = trimmed;
+	const ssh =
+		/^ssh:\/\/git@([^/:\s]+)(?::\d+)?\/(.+)$/i.exec(candidate) ??
+		/^git@([^/:\s]+):(.+)$/.exec(candidate);
+	if (ssh) {
+		candidate = `https://${ssh[1]}/${ssh[2]}`;
+	} else if (!/^https?:\/\//i.test(candidate)) {
+		const [firstSegment] = candidate.split('/', 1);
+		if (!firstSegment?.includes('.')) return null;
+		candidate = `https://${candidate}`;
+	}
+	let url: URL;
+	try {
+		url = new URL(candidate);
+	} catch {
+		return null;
+	}
+	if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+	if (!url.hostname || url.username || url.password) return null;
+	const segments = url.pathname
+		.replace(/\/+$/, '')
+		.replace(/\.git$/, '')
+		.split('/')
+		.filter(Boolean);
+	if (segments.length < 2 || segments.some((segment) => segment === '.' || segment === '..')) {
+		return null;
+	}
+	return { path: segments.join('/'), url };
+}
 
 /**
  * Percent-encode each segment while keeping `/` separators — branches and
@@ -151,38 +196,43 @@ export function versionCommit(version: Pick<NotebookVersion, 'message' | 'commit
  * scheme-less `host.tld/group/repo`, or an SSH remote.
  */
 export function isRepoInput(input: string): boolean {
-	const trimmed = input.trim();
-	if (!trimmed) return false;
-	if (OWNER_REPO_PATTERN.test(trimmed.replace(/\.git$/, ''))) return true;
-	let candidate = trimmed;
-	const ssh =
-		/^ssh:\/\/git@([^/:\s]+)(?::\d+)?\/(.+)$/i.exec(candidate) ??
-		/^git@([^/:\s]+):(.+)$/.exec(candidate);
-	if (ssh) {
-		candidate = `https://${ssh[1]}/${ssh[2]}`;
-	} else if (!/^https?:\/\//i.test(candidate)) {
-		const [firstSegment] = candidate.split('/', 1);
-		if (!firstSegment?.includes('.')) return false;
-		candidate = `https://${candidate}`;
-	}
-	let url: URL;
-	try {
-		url = new URL(candidate);
-	} catch {
-		return false;
-	}
-	if (url.protocol !== 'https:' && url.protocol !== 'http:') return false;
-	if (!url.hostname || url.username || url.password) return false;
-	const segments = url.pathname
-		.replace(/\/+$/, '')
-		.replace(/\.git$/, '')
-		.split('/')
-		.filter(Boolean);
-	return segments.length >= 2 && !segments.some((s) => s === '.' || s === '..');
+	return parseRepoInput(input) !== null;
 }
 
 export const REPO_INPUT_HINT =
 	'Use owner/repo or a repository URL, e.g. acme/analytics or https://gitlab.example.com/group/project';
+
+export function isGitHubRepoInput(input: string): boolean {
+	let path = input.trim();
+	if (/^https:\/\//i.test(path)) {
+		let url: URL;
+		try {
+			url = new URL(path);
+		} catch {
+			return false;
+		}
+		if (
+			url.hostname.toLowerCase() !== 'github.com' ||
+			url.port ||
+			url.username ||
+			url.password ||
+			url.search ||
+			url.hash
+		) {
+			return false;
+		}
+		path = url.pathname.replaceAll(/^\/+|\/+$/g, '');
+	}
+	const parts = path.replace(/\.git$/, '').split('/');
+	return (
+		parts.length === 2 &&
+		GITHUB_OWNER_PATTERN.test(parts[0] ?? '') &&
+		GITHUB_REPO_PATTERN.test(parts[1] ?? '')
+	);
+}
+
+export const GITHUB_REPO_INPUT_HINT =
+	'Pull mode supports github.com repositories, e.g. acme/analytics or https://github.com/acme/analytics';
 
 // Mirrors the server's notebook-extension gate (core `isNotebookFilePath`),
 // including its non-empty-stem rule: a bare dotfile like `.md` is not a notebook.

--- a/packages/web/src/lib/git.ts
+++ b/packages/web/src/lib/git.ts
@@ -204,6 +204,7 @@ export const REPO_INPUT_HINT =
 
 export function isGitHubRepoInput(input: string): boolean {
 	let path = input.trim();
+	if (/^github\.com\//i.test(path)) path = `https://${path}`;
 	if (/^https:\/\//i.test(path)) {
 		let url: URL;
 		try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ catalogs:
     hyparquet:
       specifier: ^1.26.2
       version: 1.26.2
+    isomorphic-git:
+      specifier: ^1.40.0
+      version: 1.40.0
     jose:
       specifier: ^6.1.3
       version: 6.2.3
@@ -1323,6 +1326,9 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
+      isomorphic-git:
+        specifier: 'catalog:'
+        version: 1.40.0
     devDependencies:
       '@marimo-hub/tsconfig':
         specifier: workspace:*
@@ -3929,6 +3935,10 @@ packages:
   abort-controller-x@0.5.0:
     resolution: {integrity: sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -3998,8 +4008,15 @@ packages:
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
@@ -4095,12 +4112,23 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   capnweb@0.8.0:
@@ -4150,6 +4178,9 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  clean-git-ref@2.0.1:
+    resolution: {integrity: sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -4207,6 +4238,11 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
   crelt@1.0.7:
     resolution: {integrity: sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==}
 
@@ -4250,6 +4286,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
     engines: {node: '>=18'}
@@ -4257,6 +4297,10 @@ packages:
   default-browser@5.5.0:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
 
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
@@ -4279,6 +4323,9 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff3@0.0.3:
+    resolution: {integrity: sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==}
 
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
@@ -4383,6 +4430,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
@@ -4446,6 +4497,10 @@ packages:
 
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -4525,6 +4580,9 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
@@ -4575,6 +4633,13 @@ packages:
   hyparquet@1.26.2:
     resolution: {integrity: sha512-6qjyK7R2tZ4vnYP1J8NpcCeDPK1UIYk3xh5XgtQUnUM1iwkYbvI6Mz3xtmpMd6AfCCeoUoJVbEq29k5GReZRWA==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -4583,9 +4648,16 @@ packages:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   ip-address@10.3.1:
     resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -4612,6 +4684,10 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
+
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
@@ -4620,8 +4696,16 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-git@1.40.0:
+    resolution: {integrity: sha512-/CbnxwZqIm17y3c/z0INbkgEKSvFerXtO/NGgaRxZ8nvL3eoMtbjuAS7f4Pj7lZzj8HaultvDD1ClJTBVDl89g==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
@@ -4970,6 +5054,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
@@ -4981,6 +5069,12 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minimisted@2.0.1:
+    resolution: {integrity: sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
@@ -5140,6 +5234,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parse-json@8.3.0:
     resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
     engines: {node: '>=18'}
@@ -5175,6 +5272,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
   pixelmatch@7.2.0:
     resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
     hasBin: true
@@ -5200,6 +5301,10 @@ packages:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5214,6 +5319,10 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
@@ -5285,6 +5394,10 @@ packages:
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -5368,6 +5481,15 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -5389,6 +5511,12 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
   simple-icons@16.27.0:
     resolution: {integrity: sha512-Rk2dCRVCPHnla9/mHmztJOlbkfncPDUMSOPozQO3+c+vr6Uwy9jhNHeuxxvNZgbF9ZwpoT1BCu1LNB4Q07VmZQ==}
@@ -5454,6 +5582,9 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -5555,6 +5686,10 @@ packages:
     resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
     hasBin: true
 
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
+
   tokenx@1.3.0:
     resolution: {integrity: sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==}
 
@@ -5596,6 +5731,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  typed-array-buffer@1.0.3:
+    resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
+    engines: {node: '>= 0.4'}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -5859,6 +5998,10 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -8149,6 +8292,10 @@ snapshots:
 
   abort-controller-x@0.5.0: {}
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   agent-base@7.1.4: {}
 
   ai@7.0.42(zod@4.4.3):
@@ -8227,7 +8374,13 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  async-lock@1.4.1: {}
+
   asynckit@0.4.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   aws4fetch@1.0.20: {}
 
@@ -8298,6 +8451,11 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -8306,6 +8464,18 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   capnweb@0.8.0: {}
 
@@ -8353,6 +8523,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  clean-git-ref@2.0.1: {}
 
   client-only@0.0.1: {}
 
@@ -8414,6 +8586,8 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
+  crc-32@1.2.2: {}
+
   crelt@1.0.7: {}
 
   cross-spawn@7.0.6:
@@ -8454,12 +8628,22 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   default-browser-id@5.0.1: {}
 
   default-browser@5.5.0:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   define-lazy-prop@3.0.0: {}
 
@@ -8474,6 +8658,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff3@0.0.3: {}
 
   diff@8.0.3: {}
 
@@ -8620,6 +8806,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  event-target-shim@5.0.1: {}
+
   events-universal@1.0.1:
     dependencies:
       bare-events: 2.9.1
@@ -8678,6 +8866,10 @@ snapshots:
   focus-trap@7.8.0:
     dependencies:
       tabbable: 6.4.0
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
 
   foreground-child@3.3.1:
     dependencies:
@@ -8777,6 +8969,10 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
   has-symbols@1.1.0: {}
 
   has-tostringtag@1.0.2:
@@ -8837,11 +9033,19 @@ snapshots:
 
   hyparquet@1.26.2: {}
 
+  ieee754@1.2.1: {}
+
+  ignore@5.3.2: {}
+
   indent-string@4.0.0: {}
 
   index-to-position@1.2.0: {}
 
+  inherits@2.0.4: {}
+
   ip-address@10.3.1: {}
+
+  is-callable@1.2.7: {}
 
   is-docker@3.0.0: {}
 
@@ -8857,13 +9061,33 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.22
+
   is-what@5.5.0: {}
 
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@2.0.5: {}
+
   isexe@2.0.0: {}
+
+  isomorphic-git@1.40.0:
+    dependencies:
+      async-lock: 1.4.1
+      clean-git-ref: 2.0.1
+      crc-32: 1.2.2
+      diff3: 0.0.3
+      ignore: 5.3.2
+      minimisted: 2.0.1
+      pako: 1.0.11
+      pify: 4.0.1
+      readable-stream: 4.7.0
+      sha.js: 2.4.12
+      simple-get: 4.0.1
 
   isomorphic-ws@5.0.0(ws@8.21.0):
     dependencies:
@@ -9306,6 +9530,8 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mimic-response@3.1.0: {}
+
   min-indent@1.0.1: {}
 
   minimatch@10.2.5:
@@ -9315,6 +9541,12 @@ snapshots:
   minimatch@5.1.9:
     dependencies:
       brace-expansion: 2.1.4
+
+  minimist@1.2.8: {}
+
+  minimisted@2.0.1:
+    dependencies:
+      minimist: 1.2.8
 
   minipass@7.1.3: {}
 
@@ -9610,6 +9842,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@1.0.11: {}
+
   parse-json@8.3.0:
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -9639,6 +9873,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pify@4.0.1: {}
+
   pixelmatch@7.2.0:
     dependencies:
       pngjs: 7.0.0
@@ -9657,6 +9893,8 @@ snapshots:
 
   pngjs@7.0.0: {}
 
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.23:
     dependencies:
       nanoid: 3.3.18
@@ -9672,6 +9910,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  process@0.11.10: {}
 
   property-information@7.2.0: {}
 
@@ -9762,6 +10002,14 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.7)
 
   react@19.2.7: {}
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
 
   redent@3.0.0:
     dependencies:
@@ -9894,6 +10142,21 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -9925,6 +10188,14 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   simple-icons@16.27.0: {}
 
@@ -9989,6 +10260,10 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
@@ -10103,6 +10378,12 @@ snapshots:
     dependencies:
       tldts-core: 7.4.2
 
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
+
   tokenx@1.3.0: {}
 
   totalist@3.0.1: {}
@@ -10134,6 +10415,12 @@ snapshots:
   tw-animate-css@1.4.0: {}
 
   type-fest@4.41.0: {}
+
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
 
   typescript@6.0.3: {}
 
@@ -10536,6 +10823,16 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,6 +60,7 @@ catalog:
   google-auth-library: ^11.0.0
   hono: ^4.12.34
   hyparquet: ^1.26.2
+  isomorphic-git: ^1.40.0
   jose: ^6.1.3
   jsdom: ^29.1.1
   lucide-react: ^1.17.0


### PR DESCRIPTION
Adds a `pull` sync_mode for git sources. Pull-mode readers materialize a credential-free `.git` directory (`fetchGitDirectory` / `githubGitDirectory`), and sync ships `git_files` alongside the workspace tree so the sandbox gets a real working tree. Pull-source providers are surfaced through the source-control registry, config, API, and sync dialogs.

Also removes the source-control publish-stage failure telemetry and the unused core `logs.ts`/otel scaffolding.

Closes #183