### PR TITLE
fix(cli): validate release artifacts and document setup action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,8 +282,30 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: mohub-*
-          path: release-assets
+          path: release-downloads
           merge-multiple: true
+
+      - name: Stage and validate CLI artifacts
+        run: |
+          mkdir release-assets
+          find release-downloads -type f -exec cp {} release-assets/ \;
+          EXPECTED=(
+            mohub-aarch64-apple-darwin.tar.gz
+            mohub-aarch64-unknown-linux-gnu.tar.gz
+            mohub-x86_64-apple-darwin.tar.gz
+            mohub-x86_64-pc-windows-msvc.zip
+            mohub-x86_64-unknown-linux-gnu.tar.gz
+          )
+          for archive in "${EXPECTED[@]}"; do
+            test -f "release-assets/$archive" || {
+              echo "::error::Missing CLI archive: $archive"
+              exit 1
+            }
+            test -f "release-assets/$archive.sha256" || {
+              echo "::error::Missing CLI checksum: $archive.sha256"
+              exit 1
+            }
+          done
 
       - name: Create checksums and dependency SBOM
         run: |

--- a/apps/cli/dist-workspace.toml
+++ b/apps/cli/dist-workspace.toml
@@ -12,7 +12,7 @@ targets = [
 	"x86_64-pc-windows-msvc",
 	"x86_64-unknown-linux-gnu",
 ]
-installers = ["shell", "powershell", "homebrew", "msi", "npm"]
+installers = ["shell", "powershell", "homebrew", "npm"]
 include = ["generated/completions", "generated/man"]
 install-path = "~/.local/bin"
 install-updater = true

--- a/development_docs/releasing.md
+++ b/development_docs/releasing.md
@@ -23,7 +23,7 @@ The x86-64 Linux build uses a glibc 2.28 image. Each native archive contains
 shell completions and man pages.
 
 [`apps/cli/dist-workspace.toml`](../apps/cli/dist-workspace.toml) defines shell,
-PowerShell, Homebrew, MSI, and npm installers. It also defines the standalone
+PowerShell, Homebrew, and npm installers. It also defines the standalone
 `mohub-update` program. Run `dist plan --allow-dirty` from `apps/cli` to check
 this configuration. The existing workflow remains the release owner while the
 team creates the Homebrew tap and configures npm credentials.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,38 @@ uv tool run --from ./marimohub_cli-*.whl mohub --version
 If you do not use `uv`, download the standalone archive. Extract it and put
 `mohub` (`mohub.exe` on Windows) on your `PATH`.
 
+### GitHub Actions
+
+Use [`setup-marimohub-cli`](https://github.com/marimo-team/setup-marimohub-cli)
+to install a pinned CLI version in a workflow:
+
+```yaml
+- uses: marimo-team/setup-marimohub-cli@v1
+  with:
+    version: '0.3.5'
+```
+
+The CLI reads automation credentials from `MARIMOHUB_URL` and
+`MARIMOHUB_TOKEN`. Store the token as a GitHub Actions secret.
+
+To synchronize a git-backed notebook after a push, configure
+`MARIMOHUB_PROJECT_ID` and `MARIMOHUB_NOTEBOOK_ID` as repository variables and
+run:
+
+```yaml
+- name: Sync notebook
+  run: >-
+    mohub notebooks source sync
+    --pid "$MARIMOHUB_PROJECT_ID"
+    --nid "$MARIMOHUB_NOTEBOOK_ID"
+    --yes
+```
+
+Synchronization is server-initiated, so the job does not need to check out the
+repository. It is a no-op when the notebook already matches the configured
+branch head. For production, keep the variables and token in a protected GitHub
+Environment.
+
 ## Sign in
 
 Sign in to marimohub in your browser. Open the user menu, select **API tokens**,


### PR DESCRIPTION
## Summary

- remove the broken MSI target from cargo-dist
- flatten and validate all five CLI archives before publishing a release
- document the setup-marimohub-cli GitHub Action and notebook sync workflow

## Verification

- `pnpm check`