### PR TITLE
release: 0.3.6

### DIFF
--- a/apps/cli/Cargo.lock
+++ b/apps/cli/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "mohub"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mohub"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/marimo-team/marimohub"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,7 @@ to install a pinned CLI version in a workflow:
 ```yaml
 - uses: marimo-team/setup-marimohub-cli@v1
   with:
-    version: '0.3.5'
+    version: '0.3.6'
 ```
 
 The CLI reads automation credentials from `MARIMOHUB_URL` and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "marimohub",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",


### PR DESCRIPTION
Merging this PR tags `v0.3.6` and publishes the container image, Helm chart, and mohub CLI.