### PR TITLE
fix(release): make CLI publication recoverable

### DIFF
--- a/.github/workflows/recover-cli-release.yml
+++ b/.github/workflows/recover-cli-release.yml
@@ -1,0 +1,131 @@
+name: Recover CLI release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to recover, for example v0.3.6
+        required: true
+        type: string
+      source-run-id:
+        description: Release workflow run containing the CLI artifacts
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: recover-cli-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  recover:
+    name: Recover ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      attestations: write
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+      SOURCE_RUN_ID: ${{ inputs.source-run-id }}
+    steps:
+      - name: Validate recovery source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid release tag: $RELEASE_TAG"
+            exit 1
+          fi
+          if [[ ! "$SOURCE_RUN_ID" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid source run ID: $SOURCE_RUN_ID"
+            exit 1
+          fi
+          SOURCE_RUN=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$SOURCE_RUN_ID")
+          SOURCE_TAG=$(jq -r '.head_branch' <<< "$SOURCE_RUN")
+          SOURCE_WORKFLOW=$(jq -r '.name' <<< "$SOURCE_RUN")
+          SOURCE_EVENT=$(jq -r '.event' <<< "$SOURCE_RUN")
+          if [[ "$SOURCE_TAG" != "$RELEASE_TAG" ]]; then
+            echo "::error::Run $SOURCE_RUN_ID built $SOURCE_TAG, not $RELEASE_TAG"
+            exit 1
+          fi
+          if [[ "$SOURCE_WORKFLOW" != "Release" || "$SOURCE_EVENT" != "push" ]]; then
+            echo "::error::Run $SOURCE_RUN_ID is not a tag-triggered Release workflow"
+            exit 1
+          fi
+
+      - name: Checkout recovery workflow
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: main
+
+      - name: Checkout release source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.tag }}
+          path: release-source
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.source-run-id }}
+          pattern: mohub-*
+          path: release-downloads
+
+      - name: Stage and validate CLI artifacts
+        run: scripts/stage-cli-release-assets.sh release-downloads release-assets
+
+      - name: Create or reuse GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in 1 2 3 4; do
+            if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+              echo "Release $RELEASE_TAG already exists; keeping its release notes."
+              break
+            fi
+            if gh release create "$RELEASE_TAG" \
+              --verify-tag \
+              --generate-notes \
+              --title "$RELEASE_TAG"; then
+              break
+            fi
+            if [[ "$attempt" == 4 ]]; then
+              exit 1
+            fi
+            sleep $((2 ** attempt))
+          done
+
+      - name: Attach validated CLI artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          scripts/retry.sh gh release upload "$RELEASE_TAG"
+          release-assets/* --clobber
+
+      - name: Create checksums and dependency SBOM
+        env:
+          CARGO_NET_RETRY: 5
+        run: |
+          scripts/retry.sh cargo install cargo-cyclonedx --locked --version 0.5.7
+          (cd release-source/apps/cli && cargo cyclonedx \
+            --format json --override-filename mohub.cdx)
+          cp release-source/apps/cli/mohub.cdx.json release-assets/mohub.cdx.json
+          (cd release-assets && sha256sum ./* > SHA256SUMS)
+
+      - name: Attest CLI artifacts
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: 'release-assets/*'
+
+      - name: Attach release metadata
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          scripts/retry.sh gh release upload "$RELEASE_TAG"
+          release-assets/mohub.cdx.json release-assets/SHA256SUMS --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,15 +264,13 @@ jobs:
           VERSION: ${{ steps.v.outputs.version }}
         run: helm push "marimohub-$VERSION.tgz" "$CHART_REGISTRY"
 
-  release-notes:
-    name: Publish GitHub release notes
+  publish-cli-release:
+    name: Publish CLI release
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [cli, cli-linux-x64, cli-installers]
     permissions:
       contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -283,35 +281,63 @@ jobs:
         with:
           pattern: mohub-*
           path: release-downloads
-          merge-multiple: true
 
       - name: Stage and validate CLI artifacts
+        run: scripts/stage-cli-release-assets.sh release-downloads release-assets
+
+      - name: Generate changelog and create GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir release-assets
-          find release-downloads -type f -exec cp {} release-assets/ \;
-          EXPECTED=(
-            mohub-aarch64-apple-darwin.tar.gz
-            mohub-aarch64-unknown-linux-gnu.tar.gz
-            mohub-x86_64-apple-darwin.tar.gz
-            mohub-x86_64-pc-windows-msvc.zip
-            mohub-x86_64-unknown-linux-gnu.tar.gz
-          )
-          for archive in "${EXPECTED[@]}"; do
-            test -f "release-assets/$archive" || {
-              echo "::error::Missing CLI archive: $archive"
+          for attempt in 1 2 3 4; do
+            if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+              echo "Release $GITHUB_REF_NAME already exists; keeping its release notes."
+              break
+            fi
+            if npx changelogithub@14.0.0; then
+              break
+            fi
+            if [[ "$attempt" == 4 ]]; then
               exit 1
-            }
-            test -f "release-assets/$archive.sha256" || {
-              echo "::error::Missing CLI checksum: $archive.sha256"
-              exit 1
-            }
+            fi
+            sleep $((2 ** attempt))
           done
 
+      - name: Attach CLI artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          scripts/retry.sh gh release upload "$GITHUB_REF_NAME"
+          release-assets/* --clobber
+
+  cli-release-metadata:
+    name: Publish CLI release metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [publish-cli-release]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: mohub-*
+          path: release-downloads
+
+      - name: Stage and validate CLI artifacts
+        run: scripts/stage-cli-release-assets.sh release-downloads release-assets
+
       - name: Create checksums and dependency SBOM
+        env:
+          CARGO_NET_RETRY: 5
         run: |
-          cargo install cargo-cyclonedx --locked --version 0.5.7
+          scripts/retry.sh cargo install cargo-cyclonedx --locked --version 0.5.7
           (cd apps/cli && cargo cyclonedx \
-            --format json --override-filename mohub.cdx.json)
+            --format json --override-filename mohub.cdx)
           cp apps/cli/mohub.cdx.json release-assets/mohub.cdx.json
           (cd release-assets && sha256sum ./* > SHA256SUMS)
 
@@ -320,22 +346,20 @@ jobs:
         with:
           subject-path: 'release-assets/*'
 
-      - name: Generate changelog and create GitHub release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx changelogithub@14.0.0
-
-      - name: Attach CLI artifacts
+      - name: Attach release metadata
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" release-assets/* --clobber
+        run: >-
+          scripts/retry.sh gh release upload "$GITHUB_REF_NAME"
+          release-assets/mohub.cdx.json release-assets/SHA256SUMS --clobber
 
   notify:
     name: Notify Slack
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Report the overall outcome once every release job has finished.
-    needs: [cli, cli-linux-x64, cli-installers, image, chart, release-notes]
+    needs:
+      [cli, cli-linux-x64, cli-installers, image, chart, publish-cli-release, cli-release-metadata]
     if: always()
     steps:
       - name: Notify Slack - Release Success

--- a/development_docs/releasing.md
+++ b/development_docs/releasing.md
@@ -28,6 +28,17 @@ PowerShell, Homebrew, and npm installers. It also defines the standalone
 this configuration. The existing workflow remains the release owner while the
 team creates the Homebrew tap and configures npm credentials.
 
+## Recover a CLI release
+
+If a publication job fails, first use **Re-run failed jobs** on the release workflow.
+The publication jobs reuse the successful build artifacts and do not rebuild the CLI.
+
+If the workflow file caused the failure, run the **Recover CLI release** workflow from `main`.
+Provide the release tag and the run ID of the failed release workflow.
+The recovery workflow checks that the run built the specified tag.
+It then publishes the stored artifacts and recreates missing release metadata.
+You can run the recovery workflow more than once for the same tag.
+
 End users then upgrade with:
 
 ```sh

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -u
+
+attempts="${RETRY_ATTEMPTS:-4}"
+delay="${RETRY_DELAY_SECONDS:-2}"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+	if "$@"; then
+		exit 0
+	fi
+	if ((attempt == attempts)); then
+		exit 1
+	fi
+	echo "Command failed on attempt $attempt; retrying in $delay seconds." >&2
+	sleep "$delay"
+	delay=$((delay * 2))
+done

--- a/scripts/stage-cli-release-assets.sh
+++ b/scripts/stage-cli-release-assets.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source_dir="${1:?source directory is required}"
+destination_dir="${2:?destination directory is required}"
+
+if [[ -e "$destination_dir" ]]; then
+	echo "Destination already exists: $destination_dir" >&2
+	exit 1
+fi
+mkdir -p "$destination_dir"
+
+while IFS= read -r -d '' source_file; do
+	filename="$(basename "$source_file")"
+	destination_file="$destination_dir/$filename"
+	if [[ -e "$destination_file" ]]; then
+		echo "Duplicate CLI artifact filename: $filename" >&2
+		exit 1
+	fi
+	cp "$source_file" "$destination_file"
+done < <(find "$source_dir" -type f -print0)
+
+expected_archives=(
+	mohub-aarch64-apple-darwin.tar.gz
+	mohub-aarch64-unknown-linux-gnu.tar.gz
+	mohub-x86_64-apple-darwin.tar.gz
+	mohub-x86_64-pc-windows-msvc.zip
+	mohub-x86_64-unknown-linux-gnu.tar.gz
+)
+
+for archive in "${expected_archives[@]}"; do
+	if [[ ! -f "$destination_dir/$archive" ]]; then
+		echo "Missing CLI archive: $archive" >&2
+		exit 1
+	fi
+	if [[ ! -f "$destination_dir/$archive.sha256" ]]; then
+		echo "Missing CLI checksum: $archive.sha256" >&2
+		exit 1
+	fi
+done


### PR DESCRIPTION
## Summary

- publish validated CLI archives before SBOM and attestation metadata
- fix the cargo-cyclonedx output filename and retry transient publication commands
- add an idempotent recovery workflow that reuses artifacts from a tag release run
- validate all required archives and reject duplicate artifact names
- document the recovery procedure

## Validation

- `pnpm check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `actionlint .github/workflows/release.yml .github/workflows/recover-cli-release.yml`
- staged the preserved artifacts from release run 32771140490 with the new validation script