### PR TITLE
docs: pin setup action to v1.0.0 commit

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,7 +32,7 @@ Use [`setup-marimohub-cli`](https://github.com/marimo-team/setup-marimohub-cli)
 to install a pinned CLI version in a workflow:
 
 ```yaml
-- uses: marimo-team/setup-marimohub-cli@v1
+- uses: marimo-team/setup-marimohub-cli@05c7d2bf3eb69f735ee6b56c7af9cfd10fe6678e # v1.0.0
   with:
     version: '0.3.6'
 ```


### PR DESCRIPTION
Pins the production notebook synchronization example to the immutable commit behind `v1.0.0`, while retaining the version comment for Dependabot and human readers.