### PR TITLE
docs: pin setup action to v1.0.1

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,7 +57,7 @@ jobs:
       MARIMOHUB_PROJECT_ID: ${{ vars.MARIMOHUB_PROJECT_ID }}
       MARIMOHUB_NOTEBOOK_ID: ${{ vars.MARIMOHUB_NOTEBOOK_ID }}
     steps:
-      - uses: marimo-team/setup-marimohub-cli@05c7d2bf3eb69f735ee6b56c7af9cfd10fe6678e # v1.0.0
+      - uses: marimo-team/setup-marimohub-cli@15f7152034cdf6728c02be77d39526360ce60ec2 # v1.0.1
         with:
           version: '0.3.6'
 


### PR DESCRIPTION
Updates the synchronization recipe to the immutable `v1.0.1` action commit.