### PR TITLE
feat(cli): browser-based hub login flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ ETag compare-and-swap (conditional PUT) with retries.
 These CAS-managed records also have one writer each:
 
 - `IdentityService` owns each identity at `_system/identities/{user-id}.json`.
+- `CliAuthorizationService` owns each short-lived CLI login grant at
+  `_system/cli-authorizations/{authorization-id}.json`.
 - `ProjectAlertStore` owns each project alert configuration at
   `projects/{pid}/alerts.json`.
 - `SessionService` owns each editor claim at

--- a/apps/cli/Cargo.lock
+++ b/apps/cli/Cargo.lock
@@ -146,6 +146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,7 +218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core",
 ]
 
@@ -353,6 +362,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -394,6 +412,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -472,6 +500,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "directories"
@@ -671,6 +709,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1136,6 +1184,7 @@ name = "mohub"
 version = "0.3.6"
 dependencies = [
  "assert_cmd",
+ "base64 0.22.1",
  "clap",
  "clap_complete",
  "clap_complete_nushell",
@@ -1143,6 +1192,7 @@ dependencies = [
  "csv",
  "directories",
  "fs2",
+ "getrandom 0.4.3",
  "indicatif",
  "inquire",
  "keyring",
@@ -1151,6 +1201,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sha2",
  "tabled",
  "tempfile",
  "thiserror",
@@ -1774,6 +1825,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2145,6 +2207,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -17,7 +17,9 @@ clap_complete_nushell = "4.6.2"
 clap_mangen = "0.3.2"
 csv = "1.3.1"
 directories = "6.0.0"
+base64 = "0.22.1"
 fs2 = "0.4.3"
+getrandom = "0.4.3"
 indicatif = "0.18.6"
 inquire = { version = "0.9.4", default-features = false, features = ["crossterm"] }
 keyring = { version = "3.6.2", features = [
@@ -30,6 +32,7 @@ miette = { version = "7.6.0", features = ["fancy"] }
 secrecy = "0.10.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+sha2 = "0.10.9"
 tabled = { version = "0.21.0", default-features = false, features = ["std"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -193,13 +193,19 @@ fn profile_command() -> Command {
 
 fn login_command() -> Command {
     Command::new("login")
-        .about("Validate and store a token for the selected profile")
+        .about("Sign in through the Hub UI and store the token securely")
         .arg(
             Arg::new("token-stdin")
                 .long("token-stdin")
                 .action(ArgAction::SetTrue)
                 .conflicts_with_all(["token", "token-file"])
                 .help("Read the token from stdin instead of an argument or file"),
+        )
+        .arg(
+            Arg::new("no-browser")
+                .long("no-browser")
+                .action(ArgAction::SetTrue)
+                .help("Print the sign-in URL for a browser on this machine"),
         )
 }
 

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -205,6 +205,7 @@ fn login_command() -> Command {
             Arg::new("no-browser")
                 .long("no-browser")
                 .action(ArgAction::SetTrue)
+                .conflicts_with_all(["token-stdin", "token", "token-file"])
                 .help("Print the sign-in URL for a browser on this machine"),
         )
 }
@@ -332,5 +333,26 @@ mod tests {
             .unwrap();
 
         assert_eq!(body.get_long(), Some("body-body"));
+    }
+
+    #[test]
+    fn login_rejects_no_browser_with_token_supply_flags() {
+        for arguments in [
+            vec!["mohub", "login", "--no-browser", "--token-stdin"],
+            vec!["mohub", "login", "--no-browser", "--token", "secret"],
+            vec![
+                "mohub",
+                "login",
+                "--no-browser",
+                "--token-file",
+                "token.txt",
+            ],
+        ] {
+            let error = build(&crate::manifest::load())
+                .try_get_matches_from(arguments)
+                .expect_err("token supply flags must conflict with --no-browser");
+
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
     }
 }

--- a/apps/cli/src/client.rs
+++ b/apps/cli/src/client.rs
@@ -545,6 +545,45 @@ pub fn current_user(manifest: &Manifest, runtime: &Runtime<'_>) -> Result<Value,
         .ok_or_else(|| Error::Http("response envelope has no data".into()))
 }
 
+pub fn exchange_cli_authorization(
+    base_url: &str,
+    timeout: Duration,
+    code: &str,
+    code_verifier: &str,
+) -> Result<SecretString, Error> {
+    let url = Url::parse(&format!(
+        "{}/api/cli/v1/token",
+        base_url.trim_end_matches('/')
+    ))?;
+    let body = serde_json::to_vec(&serde_json::json!({
+        "code": code,
+        "code_verifier": code_verifier,
+    }))?;
+    let runtime = Runtime {
+        base_url,
+        token: None,
+        timeout,
+        output: "json",
+        raw_envelope: false,
+    };
+    let agent = ureq::AgentBuilder::new().timeout(timeout).build();
+    let response = send_once(
+        &agent,
+        &runtime,
+        "POST",
+        &url,
+        &BTreeMap::new(),
+        Some(&body),
+    )?;
+    let envelope = ensure_success(&response)?;
+    let token = envelope
+        .pointer("/data/token")
+        .and_then(Value::as_str)
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| Error::Http("CLI token exchange returned no token".into()))?;
+    Ok(SecretString::from(token.to_owned()))
+}
+
 pub fn execute(
     manifest: &Manifest,
     runtime: &Runtime<'_>,
@@ -704,6 +743,48 @@ mod tests {
         (format!("http://{address}"), handle)
     }
 
+    fn serve_cli_exchange(body: &str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let address = listener.local_addr().expect("test server address");
+        let body = body.to_owned();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut reader = BufReader::new(stream.try_clone().expect("clone test stream"));
+            let mut request = String::new();
+            let mut content_length = 0;
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).expect("read request header");
+                assert!(!line.is_empty(), "request ended before its headers");
+                if let Some((name, value)) = line.split_once(':') {
+                    if name.eq_ignore_ascii_case("content-length") {
+                        content_length = value.trim().parse().expect("numeric content length");
+                    }
+                }
+                request.push_str(&line);
+                if line == "\r\n" {
+                    break;
+                }
+            }
+            let mut request_body = vec![0; content_length];
+            reader
+                .read_exact(&mut request_body)
+                .expect("read request body");
+            request.push_str(std::str::from_utf8(&request_body).expect("UTF-8 request body"));
+            assert!(request.starts_with("POST /api/cli/v1/token HTTP/1.1"));
+            assert!(!request.to_ascii_lowercase().contains("authorization:"));
+            assert!(request.contains(r#""code":"mhub_cli_code""#));
+            assert!(request.contains(r#""code_verifier":"verifier""#));
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .expect("write response");
+        });
+        (format!("http://{address}"), handle)
+    }
+
     #[test]
     fn current_user_validates_the_token_with_me() {
         let (base_url, server) = serve_once(
@@ -742,6 +823,23 @@ mod tests {
         let error = current_user(&crate::manifest::load(), &runtime).expect_err("invalid token");
         server.join().expect("test server");
         assert!(matches!(error, Error::Http(message) if message.contains("HTTP 401 UNAUTHORIZED")));
+    }
+
+    #[test]
+    fn cli_authorization_exchange_returns_the_one_time_token() {
+        let (base_url, server) =
+            serve_cli_exchange(r#"{"success":true,"data":{"token":"mhub_pat_returned"}}"#);
+
+        let token = exchange_cli_authorization(
+            &base_url,
+            Duration::from_secs(1),
+            "mhub_cli_code",
+            "verifier",
+        )
+        .expect("exchange succeeds");
+
+        server.join().expect("test server");
+        assert_eq!(token.expose_secret(), "mhub_pat_returned");
     }
 
     #[test]

--- a/apps/cli/src/config.rs
+++ b/apps/cli/src/config.rs
@@ -491,32 +491,68 @@ fn delete_credential(account: &str) -> Result<(), Error> {
     }
 }
 
-pub fn set_profile_token(profile: &str, base_url: &str, token: &SecretString) -> Result<(), Error> {
+pub fn complete_browser_login(
+    profile: &str,
+    base_url: &str,
+    expected_base_url: Option<&str>,
+    token: &SecretString,
+) -> Result<(), Error> {
     let path = path()?;
-    set_profile_token_at(&path, profile, base_url, token, set_credential)
+    complete_browser_login_at(
+        &path,
+        profile,
+        base_url,
+        expected_base_url,
+        token,
+        set_credential,
+        delete_credential,
+    )
 }
 
-fn set_profile_token_at(
+fn complete_browser_login_at(
     path: &Path,
     profile: &str,
     base_url: &str,
+    expected_base_url: Option<&str>,
     token: &SecretString,
     mut store_credential: impl FnMut(&str, &SecretString) -> Result<(), Error>,
+    mut remove_credential: impl FnMut(&str) -> Result<(), Error>,
 ) -> Result<(), Error> {
     let _lock = lock_for(path)?;
-    let config = load_from(path)?;
-    let configured = config
+    let mut config = load_from(path)?;
+    let configured_base_url = config
         .profiles
         .get(profile)
-        .ok_or_else(|| Error::Config(format!("profile {profile:?} does not exist")))?;
-    let configured_base_url = normalize_base_url(&configured.base_url)?;
-    let base_url = normalize_base_url(base_url)?;
-    if configured_base_url != base_url {
+        .map(|profile| normalize_base_url(&profile.base_url))
+        .transpose()?;
+    let expected_base_url = expected_base_url.map(normalize_base_url).transpose()?;
+    if configured_base_url != expected_base_url {
         return Err(Error::Config(format!(
             "profile {profile:?} changed while authentication was in progress"
         )));
     }
-    store_credential(&credential_account(profile, &base_url), token)
+
+    let base_url = normalize_base_url(base_url)?;
+    let account = credential_account(profile, &base_url);
+    store_credential(&account, token)?;
+    config.profiles.insert(
+        profile.to_owned(),
+        Profile {
+            base_url: base_url.clone(),
+        },
+    );
+    if config.current_profile.is_none() {
+        config.current_profile = Some(profile.to_owned());
+    }
+    save_to(path, &config)?;
+
+    if let Some(previous_base_url) = configured_base_url {
+        let previous_account = credential_account(profile, &previous_base_url);
+        if previous_account != account {
+            remove_credential(&previous_account)?;
+        }
+    }
+    Ok(())
 }
 
 pub fn delete_profile_token(profile: &str, base_url: &str) -> Result<(), Error> {
@@ -1033,14 +1069,47 @@ mod tests {
     }
 
     #[test]
-    fn login_rejects_a_profile_url_changed_during_validation() {
+    fn browser_login_creates_the_profile_only_when_completed() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("config.json");
+        let token = SecretString::from("new-token".to_owned());
+        let stored_account = RefCell::new(None);
+
+        complete_browser_login_at(
+            &path,
+            "default",
+            "https://hub.example.com",
+            None,
+            &token,
+            |account, _| {
+                stored_account.replace(Some(account.to_owned()));
+                Ok(())
+            },
+            |_| Ok(()),
+        )
+        .unwrap();
+
+        let config = load_from(&path).unwrap();
+        assert_eq!(config.current_profile.as_deref(), Some("default"));
+        assert_eq!(
+            config.profiles["default"].base_url,
+            "https://hub.example.com"
+        );
+        assert_eq!(
+            stored_account.into_inner(),
+            Some(credential_account("default", "https://hub.example.com"))
+        );
+    }
+
+    #[test]
+    fn browser_login_rejects_a_profile_changed_during_authentication() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("config.json");
         update_at(&path, |config| {
             config.profiles.insert(
                 "default".into(),
                 Profile {
-                    base_url: "https://new.example.com".into(),
+                    base_url: "https://changed.example.com".into(),
                 },
             );
             Ok(())
@@ -1049,12 +1118,17 @@ mod tests {
         let token = SecretString::from("new-token".to_owned());
         let credential_changed = Cell::new(false);
 
-        let result = set_profile_token_at(
+        let result = complete_browser_login_at(
             &path,
             "default",
-            "https://old.example.com",
+            "https://new.example.com",
+            Some("https://old.example.com"),
             &token,
             |_, _| {
+                credential_changed.set(true);
+                Ok(())
+            },
+            |_| {
                 credential_changed.set(true);
                 Ok(())
             },
@@ -1062,41 +1136,62 @@ mod tests {
 
         assert!(matches!(result, Err(Error::Config(_))));
         assert!(!credential_changed.get());
+        assert_eq!(
+            load_from(&path).unwrap().profiles["default"].base_url,
+            "https://changed.example.com"
+        );
     }
 
     #[test]
-    fn login_accepts_a_canonical_match_for_a_stored_trailing_slash() {
+    fn browser_login_replaces_the_previous_profile_after_authentication() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("config.json");
         update_at(&path, |config| {
             config.profiles.insert(
                 "default".into(),
                 Profile {
-                    base_url: "https://hub.example.com/".into(),
+                    base_url: "https://old.example.com/".into(),
                 },
             );
             Ok(())
         })
         .unwrap();
+        let old_account = credential_account("default", "https://old.example.com");
+        let new_account = credential_account("default", "https://new.example.com");
+        let credentials = RefCell::new(BTreeMap::from([(
+            old_account.clone(),
+            "old-token".to_owned(),
+        )]));
         let token = SecretString::from("new-token".to_owned());
-        let stored_account = RefCell::new(None);
 
-        set_profile_token_at(
+        complete_browser_login_at(
             &path,
             "default",
-            "https://hub.example.com",
+            "https://new.example.com",
+            Some("https://old.example.com"),
             &token,
-            |account, _| {
-                stored_account.replace(Some(account.to_owned()));
+            |account, token| {
+                credentials
+                    .borrow_mut()
+                    .insert(account.to_owned(), token.expose_secret().to_owned());
+                Ok(())
+            },
+            |account| {
+                credentials.borrow_mut().remove(account);
                 Ok(())
             },
         )
         .unwrap();
 
         assert_eq!(
-            stored_account.into_inner(),
-            Some(credential_account("default", "https://hub.example.com"))
+            load_from(&path).unwrap().profiles["default"].base_url,
+            "https://new.example.com"
         );
+        assert_eq!(
+            credentials.borrow().get(&new_account).map(String::as_str),
+            Some("new-token")
+        );
+        assert!(!credentials.borrow().contains_key(&old_account));
     }
 
     #[test]

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -28,7 +28,7 @@ pub enum Error {
     #[error("authentication failed for {server}: {reason}")]
     #[diagnostic(
         code(mohub::authentication),
-        help("Create a token in Account → API tokens, then run `mohub login --token-stdin`.")
+        help("Run `mohub login` again, or use `mohub login --token-stdin` with an API token.")
     )]
     Authentication { server: String, reason: String },
     #[error("operation cancelled")]

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,14 +1,20 @@
 use std::fs;
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, IsTerminal, Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::path::Path;
-use std::process::ExitCode;
-use std::time::Duration;
+use std::process::{Command, ExitCode};
+use std::thread;
+use std::time::{Duration, Instant};
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::ArgMatches;
-use inquire::Password;
 use mohub::{cli, client, config, manifest, Error};
 use secrecy::SecretString;
+use sha2::{Digest, Sha256};
 use update_informer::{registry, Check};
+use url::Url;
+
+const CLI_LOGIN_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 fn write_stdout(arguments: std::fmt::Arguments<'_>) -> Result<(), Error> {
     match io::stdout().lock().write_fmt(arguments) {
@@ -189,6 +195,253 @@ fn user_label(user: &serde_json::Value) -> &str {
         .unwrap_or("unknown user")
 }
 
+fn random_base64url(byte_length: usize) -> Result<String, Error> {
+    let mut bytes = vec![0_u8; byte_length];
+    getrandom::fill(&mut bytes).map_err(|error| {
+        Error::Config(format!("could not generate secure random data: {error}"))
+    })?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn browser_login_origin(base_url: &str) -> Result<Url, Error> {
+    let url = Url::parse(base_url)?;
+    if url.path() != "/" {
+        return Err(Error::Usage(
+            "browser login requires a Hub URL without a path; use `mohub login --token-stdin` for a path-prefixed deployment"
+                .into(),
+        ));
+    }
+    Ok(url)
+}
+
+fn cli_login_url(
+    base_url: &str,
+    callback_uri: &str,
+    state: &str,
+    code_challenge: &str,
+) -> Result<Url, Error> {
+    let mut url = browser_login_origin(base_url)?;
+    url.set_path("/cli/login");
+    url.set_query(None);
+    url.set_fragment(None);
+    url.query_pairs_mut()
+        .append_pair("callback_uri", callback_uri)
+        .append_pair("state", state)
+        .append_pair("code_challenge", code_challenge);
+    Ok(url)
+}
+
+fn open_browser(url: &str) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    let status = Command::new("open").arg(url).status()?;
+    #[cfg(target_os = "windows")]
+    let status = Command::new("explorer.exe").arg(url).status()?;
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let status = Command::new("xdg-open").arg(url).status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(
+            "browser launcher returned a failure status",
+        ))
+    }
+}
+
+fn callback_response(stream: &mut TcpStream, success: bool) -> io::Result<()> {
+    let (status, title, message) = if success {
+        (
+            "200 OK",
+            "CLI connected",
+            "You are signed in. You can close this tab and return to your terminal.",
+        )
+    } else {
+        (
+            "400 Bad Request",
+            "CLI sign-in failed",
+            "Return to your terminal for details, then run mohub login again.",
+        )
+    };
+    let body = format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width\"><title>{title}</title><style>body{{font:16px system-ui;display:grid;min-height:100vh;place-items:center;margin:0;background:#f7f7f8;color:#18181b}}main{{max-width:32rem;padding:2rem;text-align:center}}h1{{font-size:1.4rem}}p{{color:#52525b;line-height:1.5}}</style></head><body><main><h1>{title}</h1><p>{message}</p></main></body></html>"
+    );
+    write!(
+        stream,
+        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nCache-Control: no-store\r\nContent-Security-Policy: default-src 'none'; style-src 'unsafe-inline'\r\nReferrer-Policy: no-referrer\r\nX-Content-Type-Options: nosniff\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    )?;
+    stream.flush()
+}
+
+fn read_callback_request(stream: &mut TcpStream) -> io::Result<String> {
+    stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+    let mut request = Vec::with_capacity(1024);
+    let mut chunk = [0_u8; 1024];
+    loop {
+        let read = stream.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&chunk[..read]);
+        if request.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+        if request.len() >= 8192 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "callback request headers are too large",
+            ));
+        }
+    }
+    String::from_utf8(request)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "callback request is not UTF-8"))
+}
+
+struct AuthorizationCallback {
+    stream: TcpStream,
+    code: String,
+}
+
+struct BrowserCredential {
+    token: SecretString,
+    callback: TcpStream,
+}
+
+fn wait_for_authorization(
+    listener: &TcpListener,
+    expected_state: &str,
+) -> Result<AuthorizationCallback, Error> {
+    listener.set_nonblocking(true)?;
+    let deadline = Instant::now() + CLI_LOGIN_TIMEOUT;
+    while Instant::now() < deadline {
+        let (mut stream, _) = match listener.accept() {
+            Ok(connection) => connection,
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let request = match read_callback_request(&mut stream) {
+            Ok(request) => request,
+            Err(_) => {
+                let _ = callback_response(&mut stream, false);
+                continue;
+            }
+        };
+        let Some(request_line) = request.lines().next() else {
+            let _ = callback_response(&mut stream, false);
+            continue;
+        };
+        let mut parts = request_line.split_whitespace();
+        let method = parts.next();
+        let target = parts.next();
+        if method != Some("GET") {
+            let _ = callback_response(&mut stream, false);
+            continue;
+        }
+        let Some(target) = target else {
+            let _ = callback_response(&mut stream, false);
+            continue;
+        };
+        let Ok(url) = Url::parse(&format!("http://127.0.0.1{target}")) else {
+            let _ = callback_response(&mut stream, false);
+            continue;
+        };
+        if url.path() != "/callback"
+            || url
+                .query_pairs()
+                .find(|(name, _)| name == "state")
+                .is_none_or(|(_, state)| state != expected_state)
+        {
+            let _ = callback_response(&mut stream, false);
+            continue;
+        }
+        let parameters = url
+            .query_pairs()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        if parameters.get("error").map(|value| value.as_ref()) == Some("access_denied") {
+            let _ = callback_response(&mut stream, false);
+            return Err(Error::Cancelled);
+        }
+        let Some(code) = parameters.get("code").filter(|code| !code.is_empty()) else {
+            let _ = callback_response(&mut stream, false);
+            continue;
+        };
+        return Ok(AuthorizationCallback {
+            stream,
+            code: code.to_string(),
+        });
+    }
+    Err(Error::Authentication {
+        server: "the configured server".into(),
+        reason: "browser sign-in timed out".into(),
+    })
+}
+
+fn browser_login(
+    matches: &ArgMatches,
+    base_url: &str,
+    no_browser: bool,
+) -> Result<BrowserCredential, Error> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let callback_uri = format!("http://{}/callback", listener.local_addr()?);
+    let state = random_base64url(24)?;
+    let code_verifier = random_base64url(32)?;
+    let code_challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(code_verifier.as_bytes()));
+    let login_url = cli_login_url(base_url, &callback_uri, &state, &code_challenge)?;
+
+    if no_browser || open_browser(login_url.as_str()).is_err() {
+        eprintln!("Open this URL to sign in:\n\n{login_url}\n");
+    } else {
+        eprintln!("Opening {base_url} in your browser…");
+    }
+    eprintln!("Waiting for approval…");
+
+    let mut callback = wait_for_authorization(&listener, &state)?;
+    let timeout = Duration::from_secs(
+        *matches
+            .get_one::<u64>("timeout")
+            .expect("defaulted by clap"),
+    );
+    match client::exchange_cli_authorization(base_url, timeout, &callback.code, &code_verifier) {
+        Ok(token) => Ok(BrowserCredential {
+            token,
+            callback: callback.stream,
+        }),
+        Err(error) => {
+            let _ = callback_response(&mut callback.stream, false);
+            Err(Error::Authentication {
+                server: server_label(base_url),
+                reason: error.to_string(),
+            })
+        }
+    }
+}
+
+fn selected_login_target(matches: &ArgMatches) -> Result<(String, String), Error> {
+    let config = config::load()?;
+    let name = matches
+        .get_one::<String>("profile-name")
+        .cloned()
+        .or(config.current_profile)
+        .unwrap_or_else(|| "default".into());
+    let override_url = matches
+        .get_one::<String>("base-url")
+        .map(|value| normalize_base_url(value))
+        .transpose()?;
+    let profile_url = config
+        .profiles
+        .get(&name)
+        .map(|profile| normalize_base_url(&profile.base_url))
+        .transpose()?;
+    let base_url = override_url.or(profile_url).ok_or_else(|| {
+        Error::Config(
+            "no server URL; pass --base-url, set MARIMOHUB_URL, or configure a profile".into(),
+        )
+    })?;
+    Ok((name, base_url))
+}
+
 fn upgrade_hint(executable: &Path) -> &'static str {
     let path = executable.to_string_lossy();
     let parent = executable.parent();
@@ -232,32 +485,31 @@ fn handle_login(
     matches: &ArgMatches,
     leaf: &ArgMatches,
 ) -> Result<(), Error> {
-    let (profile, base_url) = selected_profile(matches)?;
-    let token = match supplied_token(leaf)? {
-        Some(token) => token,
-        None if io::stdin().is_terminal() => SecretString::from(
-            Password::new("Token:")
-                .without_confirmation()
-                .prompt()
-                .map_err(|error| Error::Prompt(error.to_string()))?,
-        ),
-        None => {
-            return Err(Error::Usage(
-                "no token supplied; pipe one to `mohub login --token-stdin` or use --token-file"
-                    .into(),
-            ));
-        }
-    };
-    let user = client::current_user(manifest, &auth_runtime(matches, &base_url, &token)).map_err(
-        |error| Error::Authentication {
-            server: server_label(&base_url),
-            reason: error.to_string(),
-        },
-    )?;
-    config::set_profile_token(&profile, &base_url, &token)?;
+    let (profile, base_url) = selected_login_target(matches)?;
+    if let Some(token) = supplied_token(leaf)? {
+        let user = client::current_user(manifest, &auth_runtime(matches, &base_url, &token))
+            .map_err(|error| Error::Authentication {
+                server: server_label(&base_url),
+                reason: error.to_string(),
+            })?;
+        config::set_profile(&profile, base_url.clone(), Some(&token))?;
+        write_stdout(format_args!(
+            "Logged in to {base_url} as {} (profile {profile}).\n",
+            user_label(&user),
+        ))?;
+        return Ok(());
+    }
+
+    browser_login_origin(&base_url)?;
+    config::set_profile(&profile, base_url.clone(), None)?;
+    let mut credential = browser_login(matches, &base_url, leaf.get_flag("no-browser"))?;
+    if let Err(error) = config::set_profile_token(&profile, &base_url, &credential.token) {
+        let _ = callback_response(&mut credential.callback, false);
+        return Err(error);
+    }
+    let _ = callback_response(&mut credential.callback, true);
     write_stdout(format_args!(
-        "Logged in to {base_url} as {} (profile {profile}).\n",
-        user_label(&user),
+        "Logged in to {base_url} (profile {profile}).\n"
     ))?;
     Ok(())
 }
@@ -282,7 +534,7 @@ fn handle_status(manifest: &manifest::Manifest, matches: &ArgMatches) -> Result<
     require_matching_profile_server(matches, &profile, &base_url)?;
     let token = supplied.or(selected.token).ok_or_else(|| {
         Error::Config(format!(
-            "not logged in for profile {profile:?}; run `mohub login --token-stdin`"
+            "not logged in for profile {profile:?}; run `mohub login`"
         ))
     })?;
     let user = client::current_user(manifest, &auth_runtime(matches, &base_url, &token))?;
@@ -552,6 +804,60 @@ mod tests {
 
         assert_eq!(path, ["login"]);
         assert!(leaf.get_flag("token-stdin"));
+    }
+
+    #[test]
+    fn login_supports_a_headless_browser_flow() {
+        let matches = cli::build(&manifest::load())
+            .try_get_matches_from([
+                "mohub",
+                "--base-url",
+                "https://hub.example.com",
+                "login",
+                "--no-browser",
+            ])
+            .expect("valid login command");
+        let (path, leaf) = selected_command(&matches);
+
+        assert_eq!(path, ["login"]);
+        assert!(leaf.get_flag("no-browser"));
+    }
+
+    #[test]
+    fn browser_login_url_rejects_a_hub_base_path() {
+        let result = cli_login_url(
+            "https://example.com/hub",
+            "http://127.0.0.1:49152/callback",
+            &"s".repeat(32),
+            &"c".repeat(43),
+        );
+
+        assert!(matches!(result, Err(Error::Usage(message)) if message.contains("without a path")));
+    }
+
+    #[test]
+    fn loopback_callback_requires_the_expected_state() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind callback");
+        let address = listener.local_addr().expect("callback address");
+        let state = "s".repeat(32);
+        let client_state = state.clone();
+        let browser = thread::spawn(move || {
+            let mut stream = TcpStream::connect(address).expect("connect callback");
+            write!(
+                stream,
+                "GET /callback?code=mhub_cli_code&state={client_state} HTTP/1.1\r\nHost: {address}\r\nConnection: close\r\n\r\n"
+            )
+            .expect("write callback");
+            let mut response = String::new();
+            stream.read_to_string(&mut response).expect("read response");
+            assert!(response.starts_with("HTTP/1.1 200 OK"));
+        });
+
+        let mut callback = wait_for_authorization(&listener, &state).expect("valid callback");
+        assert_eq!(callback.code, "mhub_cli_code");
+        callback_response(&mut callback.stream, true).expect("write completion page");
+        drop(callback);
+        browser.join().expect("browser completed");
     }
 
     #[test]

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -418,7 +418,7 @@ fn browser_login(
     }
 }
 
-fn selected_login_target(matches: &ArgMatches) -> Result<(String, String), Error> {
+fn selected_login_target(matches: &ArgMatches) -> Result<(String, String, Option<String>), Error> {
     let config = config::load()?;
     let name = matches
         .get_one::<String>("profile-name")
@@ -434,12 +434,14 @@ fn selected_login_target(matches: &ArgMatches) -> Result<(String, String), Error
         .get(&name)
         .map(|profile| normalize_base_url(&profile.base_url))
         .transpose()?;
-    let base_url = override_url.or(profile_url).ok_or_else(|| {
-        Error::Config(
-            "no server URL; pass --base-url, set MARIMOHUB_URL, or configure a profile".into(),
-        )
-    })?;
-    Ok((name, base_url))
+    let base_url = override_url
+        .or_else(|| profile_url.clone())
+        .ok_or_else(|| {
+            Error::Config(
+                "no server URL; pass --base-url, set MARIMOHUB_URL, or configure a profile".into(),
+            )
+        })?;
+    Ok((name, base_url, profile_url))
 }
 
 fn upgrade_hint(executable: &Path) -> &'static str {
@@ -485,7 +487,7 @@ fn handle_login(
     matches: &ArgMatches,
     leaf: &ArgMatches,
 ) -> Result<(), Error> {
-    let (profile, base_url) = selected_login_target(matches)?;
+    let (profile, base_url, expected_base_url) = selected_login_target(matches)?;
     if let Some(token) = supplied_token(leaf)? {
         let user = client::current_user(manifest, &auth_runtime(matches, &base_url, &token))
             .map_err(|error| Error::Authentication {
@@ -501,9 +503,13 @@ fn handle_login(
     }
 
     browser_login_origin(&base_url)?;
-    config::set_profile(&profile, base_url.clone(), None)?;
     let mut credential = browser_login(matches, &base_url, leaf.get_flag("no-browser"))?;
-    if let Err(error) = config::set_profile_token(&profile, &base_url, &credential.token) {
+    if let Err(error) = config::complete_browser_login(
+        &profile,
+        &base_url,
+        expected_base_url.as_deref(),
+        &credential.token,
+    ) {
         let _ = callback_response(&mut credential.callback, false);
         return Err(error);
     }

--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -101,6 +101,8 @@ s3-bucket/
 │   │   └── {user-id}.json                  ← user display identity (mutable, CAS-managed)
 │   ├── tokens/
 │   │   └── {token-id}.json                 ← personal access token record (mutable, last-writer-wins)
+│   ├── cli-authorizations/
+│   │   └── {authorization-id}.json         ← short-lived PKCE login grant (CAS-claimed)
 │   ├── integrations/                       ← organization-wide integrations (§4.12)
 │   │   ├── _names/
 │   │   │   └── {name}.json                 ← name claim (CAS, app-claim pattern)
@@ -184,6 +186,7 @@ selected version and cannot write changes back.
 | `_system/editors/{pid}/{nid}.json`                                        | JSON     | Per-notebook persistent-editor claim. Records the shared/exclusive mode, names the only session allowed to save, and records idempotent takeover phases. All writes go through `SessionService`. See §4.8.2.                                                                                                                                                                                                                                                                                           |
 | `_system/identities/{user-id}.json`                                       | JSON     | User display identity (`{ id, email, name, picture_url?, suspended_at? }`). Owned and CAS-updated by `IdentityService`. Resolves opaque `author`/`user_id` IDs to a person and gates suspended users at authentication time.                                                                                                                                                                                                                                                                           |
 | `_system/tokens/{token-id}.json`                                          | JSON     | Personal access token record (`{ id, user_id, name, hash, … }`) keyed by the ULID embedded in the presented `mhub_pat_` bearer, so verification is a single GET. Stores only the SHA-256 of the secret. Mutable, last-writer-wins (coarse `last_used_at` refresh); revocation deletes the object. See §4.11.                                                                                                                                                                                           |
+| `_system/cli-authorizations/{authorization-id}.json`                      | JSON     | Ten-minute browser-to-CLI PKCE grant. Stores hashes/challenges, never a PAT or plaintext authorization secret. `CliAuthorizationService` CAS-claims it before minting one token, then deletes it. See §4.11.1.                                                                                                                                                                                                                                                                                         |
 | `_system/events/{YYYY-MM-DD}/{event-id}.json`                             | JSON     | Structured event log. One immutable object per event, keyed by a monotonic ULID under a per-day prefix. Primary audit trail.                                                                                                                                                                                                                                                                                                                                                                           |
 | `_system/idempotency/{digest}.json`                                       | JSON     | Recorded `POST`-create response for an `Idempotency-Key`, keyed by `sha256(user:route\nkey)`. Replayed on retry; pruned after 24h. See [`idempotency.md`](./idempotency.md).                                                                                                                                                                                                                                                                                                                           |
 | `_system/reconcile/orphans/{sandbox-id}.json`                             | JSON     | First-seen Unix timestamp for an active sandbox that has no session record and no provider creation time. The reconciler creates and deletes these markers.                                                                                                                                                                                                                                                                                                                                            |
@@ -563,6 +566,20 @@ A personal access token record — the machine-credential counterpart of a sessi
 
 **Mutability & write semantics.** Creation is a plain PUT to a fresh, unique token-id key. The only rewrite is the `last_used_at` refresh, and it is **conditional** — an `If-Match` on the ETag read at load time — so a token revoked (deleted) between load and the touch is not resurrected by a stale write; the touch is also coalesced to once per UTC day, keeping the request hot path read-only. Revocation is a plain DELETE. Positive verifications are cached per process with a short TTL (`TokenService.CACHE_TTL_MS`), which also bounds the cross-replica revocation lag.
 
+### 4.11.1 `_system/cli-authorizations/{authorization-id}.json`
+
+An approved CLI login grant binds the signed-in user, requested PAT lifetime,
+and PKCE S256 challenge to a one-time `mhub_cli_…` authorization code. The
+stored record contains only the code's SHA-256 hash. It expires after ten
+minutes.
+
+`CliAuthorizationService` is the only writer. Exchange verifies both the code
+secret and the CLI-held verifier, then changes `pending` to `claimed` with an
+ETag compare-and-swap before minting the PAT. A competing or replayed exchange
+cannot mint another token. Successful exchanges delete the claimed record;
+each new approval also prunes at most 100 expired or abandoned records from the
+oldest page, keeping request-path cleanup bounded.
+
 ### 4.12 `projects/{pid}/integrations/{iid}/…`
 
 A project integration instance — a named, versioned configuration of a code-registered _kind_ (`postgres`, `iceberg_rest`, …) rendered into every session's sandbox as env vars + files. Two records:
@@ -914,7 +931,7 @@ Schema migrations are a first-class concern because there is no database to run 
 | `_system/events/**`                          | Never migrated — event records are immutable history. New event shapes get a bumped `schema_version` field. Consumers must handle multiple versions.                                                                                                                              |
 | `catalog.json`                               | Migrated in place during the first write after a deployment that changes the catalog version. Its strict `version` value is not forward-tolerant.                                                                                                                                 |
 
-> **No `schema_version` by design:** mutable operational records — sessions (`_system/sessions/**`), identities (`_system/identities/**`), tokens (`_system/tokens/**`), and `fs_snapshot.json` — carry no `schema_version`. They are rewritten on every write or reaped shortly after creation, so they never need a migration; a shape change is absorbed with optional fields + defaults on read. API response bodies are likewise unversioned per-object — the contract is versioned at the route level (`/api/v1`).
+> **No `schema_version` by design:** mutable operational records — sessions (`_system/sessions/**`), identities (`_system/identities/**`), tokens (`_system/tokens/**`), CLI authorizations (`_system/cli-authorizations/**`), and `fs_snapshot.json` — carry no `schema_version`. They are rewritten on every write or reaped shortly after creation, so they never need a migration; a shape change is absorbed with optional fields + defaults on read. API response bodies are likewise unversioned per-object — the contract is versioned at the route level (`/api/v1`).
 
 ### Migration job pseudocode
 

--- a/docs/api-tokens.md
+++ b/docs/api-tokens.md
@@ -9,6 +9,11 @@ Personal access tokens (PATs) let CI jobs, scripts, and the CLI call the
 created it: it inherits their project memberships and roles unchanged, and it
 works on every deployment — there is nothing to configure.
 
+For an interactive CLI, run `mohub login`. The browser approval flow creates a
+token with a 30-day lifetime by default and lets you choose a different lifetime
+before approving. Manual token creation is intended for automation and other
+clients that cannot use the browser flow.
+
 ## Create a token
 
 In the app, open the user menu (top right) → **API tokens** → **Create a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,22 +76,46 @@ Environment.
 
 ## Sign in
 
-Sign in to marimohub in your browser. Open the user menu, select **API tokens**,
-and create a token with an expiry date. The app shows the token one time.
-
 Create a profile for your server:
 
 ```bash
 mohub profile set default --base-url https://hub.example.com
 ```
 
-Run `mohub login` and paste the token at the hidden prompt:
+Run `mohub login`:
 
 ```bash
 mohub login
 ```
 
-For a script, send the token through standard input:
+The CLI starts a temporary loopback server and opens the selected marimohub in
+your browser. Review the account and token lifetime (30 days by default), then
+select **Authorize CLI**. The Hub returns a short-lived, single-use code to the
+loopback server; the CLI exchanges it for a token and stores the token in the
+operating system credential store. The token is never placed in a browser URL.
+
+If a browser is available on the same machine but cannot be opened automatically,
+print the approval URL instead:
+
+```bash
+mohub login --no-browser
+```
+
+The browser must run on the same machine as the CLI because authorization returns
+to a temporary loopback listener. For a remote or fully headless shell, create an
+API token in the Hub and use `mohub login --token-stdin`.
+
+You can also create the default profile and sign in in one command:
+
+```bash
+mohub --base-url https://hub.example.com login
+```
+
+Browser login requires an origin URL without a path prefix. Path-prefixed Hub
+deployments can use the non-interactive token flow below.
+
+For non-interactive automation, create an API token in the Hub and send it
+through standard input:
 
 ```bash
 printf '%s' "$MARIMOHUB_TOKEN" | mohub login --token-stdin

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -42,33 +42,6 @@ components:
         /api/v1/me/tokens, for CI/CLI/service callers. Acts as the issuing user;
         cannot manage tokens.
   schemas:
-    Me:
-      type: object
-      properties:
-        id:
-          type: string
-        email:
-          type: string
-        name:
-          type:
-            - string
-            - 'null'
-        picture_url:
-          type:
-            - string
-            - 'null'
-          format: uri
-        logout_url:
-          type:
-            - string
-            - 'null'
-        is_super_admin:
-          type: boolean
-      required:
-        - id
-        - email
-        - logout_url
-        - is_super_admin
     ErrorResponse:
       type: object
       properties:
@@ -125,6 +98,33 @@ components:
       required:
         - success
         - error
+    Me:
+      type: object
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        name:
+          type:
+            - string
+            - 'null'
+        picture_url:
+          type:
+            - string
+            - 'null'
+          format: uri
+        logout_url:
+          type:
+            - string
+            - 'null'
+        is_super_admin:
+          type: boolean
+      required:
+        - id
+        - email
+        - logout_url
+        - is_super_admin
     DeploymentInfo:
       type: object
       properties:
@@ -2514,6 +2514,108 @@ components:
         - created_at
   parameters: {}
 paths:
+  /api/cli/v1/token:
+    post:
+      operationId: auth.cli.exchange
+      x-cli-hidden: true
+      tags:
+        - Auth
+      summary: Exchange a CLI authorization code
+      description: Public PKCE exchange for the mohub loopback login. The
+        authorization code is single-use, short-lived, and useless without the
+        verifier held by the CLI.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                  minLength: 1
+                  maxLength: 100
+                code_verifier:
+                  type: string
+                  pattern: ^[A-Za-z0-9_-]{43,128}$
+              required:
+                - code
+                - code_verifier
+      responses:
+        '200':
+          description: The new personal access token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      token:
+                        type: string
+                    required:
+                      - token
+                required:
+                  - success
+                  - data
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /api/v1/me:
     get:
       operationId: me
@@ -11585,6 +11687,139 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '422':
           description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/me/cli-authorizations:
+    post:
+      operationId: auth.cli.approve
+      x-cli-hidden: true
+      tags:
+        - Auth
+      summary: Approve a CLI login
+      description: Creates a short-lived, one-time authorization code bound to the CLI
+        PKCE challenge. Requires a browser session; the personal access token is
+        minted only during exchange.
+      security: *a2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                callback_uri:
+                  type: string
+                  maxLength: 300
+                  format: uri
+                state:
+                  type: string
+                  pattern: ^[A-Za-z0-9_-]{32,128}$
+                code_challenge:
+                  type: string
+                  pattern: ^[A-Za-z0-9_-]{43}$
+                token_name:
+                  type: string
+                  minLength: 1
+                  maxLength: 100
+                expires_in_days:
+                  type: integer
+                  minimum: 1
+                  maximum: 3650
+              required:
+                - callback_uri
+                - state
+                - code_challenge
+                - token_name
+                - expires_in_days
+      responses:
+        '201':
+          description: Loopback callback carrying the one-time authorization code
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      redirect_uri:
+                        type: string
+                        format: uri
+                      expires_at:
+                        type: string
+                        format: date-time
+                    required:
+                      - redirect_uri
+                      - expires_at
+                required:
+                  - success
+                  - data
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Resource limit reached
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
           content:
             application/json:
               schema:

--- a/packages/api/src/cliManifest.spec.test.ts
+++ b/packages/api/src/cliManifest.spec.test.ts
@@ -195,4 +195,22 @@ describe('CLI manifest', () => {
 
 		expect(manifest.operations[0]?.destructive).toBe(true);
 	});
+
+	it('omits operations handled by a custom CLI flow', () => {
+		const manifest = generateCliManifest({
+			openapi: '3.1.0',
+			info: { title: 'Test', version: '1.0.0' },
+			paths: {
+				'/token': {
+					post: {
+						operationId: 'auth.cli.exchange',
+						'x-cli-hidden': true,
+						responses: { 200: { description: 'Token' } },
+					},
+				},
+			},
+		});
+
+		expect(manifest.operations).toEqual([]);
+	});
 });

--- a/packages/api/src/cliManifest.ts
+++ b/packages/api/src/cliManifest.ts
@@ -234,6 +234,7 @@ export function generateCliManifest(documentValue: Record<string, unknown>): Cli
 			const operationValue = pathItem[method];
 			if (!operationValue) continue;
 			const operation = object(operationValue, `${method.toUpperCase()} ${path}`);
+			if (operation['x-cli-hidden'] === true) continue;
 			if (typeof operation.operationId !== 'string') {
 				throw new TypeError(`${method.toUpperCase()} ${path} has no operationId`);
 			}

--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -151,6 +151,36 @@ describe('createApi rejected request observability', () => {
 		});
 	});
 
+	it('observes rejected public CLI token exchanges', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const metrics = { increment: vi.fn(), gauge: vi.fn() };
+		const { app } = createTestApi({ deps: { metrics } });
+
+		const res = await app.request('/api/cli/v1/token', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				'X-Request-Id': 'rejected-cli-exchange',
+			},
+			body: JSON.stringify({ code: 'c'.repeat(32), code_verifier: 'v'.repeat(64) }),
+		});
+
+		expect(res.status).toBe(400);
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			level: 'warn',
+			event: 'request_rejected',
+			route: '/api/cli/v1/token',
+			method: 'POST',
+			status: 400,
+			code: 'BAD_REQUEST',
+			request_id: 'rejected-cli-exchange',
+		});
+		expect(metrics.increment).toHaveBeenCalledWith('requests.rejected', 1, {
+			route: '/api/cli/v1/token',
+			code: 'BAD_REQUEST',
+		});
+	});
+
 	it('observes request-schema 422 responses returned without throwing', async () => {
 		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 		const metrics = { increment: vi.fn(), gauge: vi.fn() };

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -30,6 +30,7 @@ import integrationsApp from './routes/integrations';
 import sessionsApp from './routes/sessions';
 import systemApp from './routes/system';
 import tokensApp from './routes/tokens';
+import cliAuthorizationsApp, { cliTokenApp } from './routes/cliAuthorizations';
 import usersApp from './routes/users';
 import { createOidcDiscovery } from './oidcDiscovery';
 import { sandboxProxyMiddleware } from './sandboxProxy';
@@ -224,6 +225,7 @@ export function createApi(rawDeps: ApiDeps) {
 	// response header, and thread it into error envelopes + logs for tracing.
 	app.use(`${API_PREFIX}/*`, requestId());
 	app.use('/api/sync/*', requestId());
+	app.use('/api/cli/*', requestId());
 
 	const observeRejection: MiddlewareHandler<HonoEnv> = async (c, next) => {
 		await next();
@@ -276,6 +278,19 @@ export function createApi(rawDeps: ApiDeps) {
 	);
 	app.use(
 		'/api/sync/*',
+		bodyLimit({
+			maxSize: MAX_REQUEST_BYTES,
+			onError: (c) =>
+				fail(
+					c,
+					'PAYLOAD_TOO_LARGE',
+					`Request body exceeds the ${MAX_REQUEST_BYTES}-byte limit`,
+					413,
+				),
+		}),
+	);
+	app.use(
+		'/api/cli/*',
 		bodyLimit({
 			maxSize: MAX_REQUEST_BYTES,
 			onError: (c) =>
@@ -350,6 +365,8 @@ export function createApi(rawDeps: ApiDeps) {
 	// notebook-scoped bearer token, not the browser cookie, so it lives outside the
 	// `/api/v1/*` auth/CSRF chain.
 	app.route('/api/sync/git/v1', gitSyncApp);
+
+	app.route('/api/cli/v1', cliTokenApp);
 
 	// CSRF defense-in-depth. The session cookie is already SameSite=Lax (so a
 	// browser won't attach it to a cross-site POST/PUT/DELETE), and there is no
@@ -476,6 +493,7 @@ export function createApi(rawDeps: ApiDeps) {
 	app.route(API_PREFIX, integrationsApp);
 	app.route(API_PREFIX, usersApp);
 	app.route(API_PREFIX, tokensApp);
+	app.route(API_PREFIX, cliAuthorizationsApp);
 
 	// Declare the cookie-session auth scheme the global `security` requirement
 	// (OPENAPI_DOC) points at, so generated clients know the API is authenticated.

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -257,6 +257,7 @@ export function createApi(rawDeps: ApiDeps) {
 	};
 	app.use(`${API_PREFIX}/*`, observeRejection);
 	app.use('/api/sync/*', observeRejection);
+	app.use('/api/cli/*', observeRejection);
 
 	// Body-size cap: the API buffers request bodies in full (Hono parses JSON in
 	// memory), so an unbounded POST could OOM the service. Reject anything past

--- a/packages/api/src/routes/cliAuthorizations.test.ts
+++ b/packages/api/src/routes/cliAuthorizations.test.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
 import { ACTOR } from '@marimo-hub/core/testing';
-import { composeAuthenticators } from '@marimo-hub/core';
+import { composeAuthenticators, createCliAuthorizationId } from '@marimo-hub/core';
 import { createApi, generateOpenApiDocument } from '../createApi';
 import {
 	createInitializedBucket,
@@ -113,33 +113,6 @@ describe('CLI authorization routes', () => {
 		).toHaveProperty('status', 200);
 	});
 
-	it('rate-limits exchanges before reading authorization storage', async () => {
-		const realNow = Date.now();
-		vi.useFakeTimers({ now: realNow + 61_000 });
-		try {
-			const deps = makeTestDeps(bucket);
-			const exchange = vi.spyOn(deps.services.cliAuthorizations, 'exchange');
-			const limitedApi = createApi(deps);
-			const exchangeRequest = () =>
-				limitedApi.request('/api/cli/v1/token', {
-					method: 'POST',
-					headers: { 'content-type': 'application/json' },
-					body: JSON.stringify({ code: 'missing', code_verifier: VERIFIER }),
-				});
-
-			for (let attempt = 0; attempt < 60; attempt += 1) {
-				await expectError(await exchangeRequest(), 400, 'BAD_REQUEST');
-			}
-			const response = await exchangeRequest();
-			await expectError(response, 429, 'RESOURCE_EXHAUSTED');
-			expect(response.headers.get('Retry-After')).toBe('5');
-			expect(exchange).toHaveBeenCalledTimes(60);
-		} finally {
-			vi.setSystemTime(realNow);
-			vi.useRealTimers();
-		}
-	});
-
 	it('requires a session to approve and never accepts a PAT there', async () => {
 		const deny = createApi(makeTestDeps(bucket));
 		await expectError(
@@ -221,6 +194,55 @@ describe('CLI authorization routes', () => {
 				expect.objectContaining({ event: 'token.create', actor: ACTOR, token_name: 'mohub CLI' }),
 			]),
 		);
+	});
+
+	it('isolates authorization attempts while retaining a global storage cap', async () => {
+		const realNow = Date.now();
+		vi.useFakeTimers({ now: realNow + 61_000 });
+		try {
+			const approved = await approve();
+			const validCode = new URL(approved.redirect_uri).searchParams.get('code')!;
+			const deps = makeTestDeps(bucket);
+			const exchange = vi.spyOn(deps.services.cliAuthorizations, 'exchange');
+			const limitedApi = createApi(deps);
+			const exchangeRequest = (code: string) =>
+				limitedApi.request('/api/cli/v1/token', {
+					method: 'POST',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ code, code_verifier: VERIFIER }),
+				});
+			const randomCode = () => `mhub_cli_${createCliAuthorizationId()}_${'x'.repeat(32)}`;
+			const targetedId = createCliAuthorizationId();
+
+			for (let attempt = 0; attempt < 5; attempt += 1) {
+				const secret = String(attempt).padStart(32, 'x');
+				await expectError(
+					await exchangeRequest(`mhub_cli_${targetedId}_${secret}`),
+					400,
+					'BAD_REQUEST',
+				);
+			}
+			const targetedResponse = await exchangeRequest(`mhub_cli_${targetedId}_${'y'.repeat(32)}`);
+			await expectError(targetedResponse, 429, 'RESOURCE_EXHAUSTED');
+			expect(targetedResponse.headers.get('Retry-After')).toBe('5');
+			expect(exchange).toHaveBeenCalledTimes(5);
+
+			for (let attempt = 0; attempt < 60; attempt += 1) {
+				await expectError(await exchangeRequest(randomCode()), 400, 'BAD_REQUEST');
+			}
+			await expectOk(await exchangeRequest(validCode));
+
+			for (let attempt = 66; attempt < 600; attempt += 1) {
+				await expectError(await exchangeRequest(randomCode()), 400, 'BAD_REQUEST');
+			}
+			const globalResponse = await exchangeRequest(randomCode());
+			await expectError(globalResponse, 429, 'RESOURCE_EXHAUSTED');
+			expect(globalResponse.headers.get('Retry-After')).toBe('5');
+			expect(exchange).toHaveBeenCalledTimes(600);
+		} finally {
+			vi.setSystemTime(realNow);
+			vi.useRealTimers();
+		}
 	});
 });
 

--- a/packages/api/src/routes/cliAuthorizations.test.ts
+++ b/packages/api/src/routes/cliAuthorizations.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
 import { ACTOR } from '@marimo-hub/core/testing';
 import { composeAuthenticators } from '@marimo-hub/core';
@@ -111,6 +111,33 @@ describe('CLI authorization routes', () => {
 				body: JSON.stringify({ code, code_verifier: VERIFIER }),
 			}),
 		).toHaveProperty('status', 200);
+	});
+
+	it('rate-limits exchanges before reading authorization storage', async () => {
+		const realNow = Date.now();
+		vi.useFakeTimers({ now: realNow + 61_000 });
+		try {
+			const deps = makeTestDeps(bucket);
+			const exchange = vi.spyOn(deps.services.cliAuthorizations, 'exchange');
+			const limitedApi = createApi(deps);
+			const exchangeRequest = () =>
+				limitedApi.request('/api/cli/v1/token', {
+					method: 'POST',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ code: 'missing', code_verifier: VERIFIER }),
+				});
+
+			for (let attempt = 0; attempt < 60; attempt += 1) {
+				await expectError(await exchangeRequest(), 400, 'BAD_REQUEST');
+			}
+			const response = await exchangeRequest();
+			await expectError(response, 429, 'RESOURCE_EXHAUSTED');
+			expect(response.headers.get('Retry-After')).toBe('5');
+			expect(exchange).toHaveBeenCalledTimes(60);
+		} finally {
+			vi.setSystemTime(realNow);
+			vi.useRealTimers();
+		}
 	});
 
 	it('requires a session to approve and never accepts a PAT there', async () => {

--- a/packages/api/src/routes/cliAuthorizations.test.ts
+++ b/packages/api/src/routes/cliAuthorizations.test.ts
@@ -1,0 +1,208 @@
+import { createHash } from 'node:crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { MemoryBucket } from '@marimo-hub/core/testing';
+import { ACTOR } from '@marimo-hub/core/testing';
+import { composeAuthenticators } from '@marimo-hub/core';
+import { createApi, generateOpenApiDocument } from '../createApi';
+import {
+	createInitializedBucket,
+	createTestApi,
+	expectError,
+	expectOk,
+	makeTestDeps,
+} from '../testing';
+
+const CALLBACK = 'http://127.0.0.1:49152/callback';
+const STATE = 's'.repeat(32);
+const VERIFIER = 'v'.repeat(64);
+const CHALLENGE = createHash('sha256').update(VERIFIER).digest('base64url');
+
+describe('CLI authorization routes', () => {
+	let bucket: MemoryBucket;
+	let request: ReturnType<typeof createTestApi>['request'];
+	let app: ReturnType<typeof createApi>;
+
+	beforeEach(async () => {
+		bucket = await createInitializedBucket();
+		const testApi = createTestApi({ bucket, userId: ACTOR });
+		request = testApi.request;
+		app = testApi.app;
+		await request('GET', '/me');
+	});
+
+	async function approve(overrides: Record<string, unknown> = {}) {
+		return expectOk<{ redirect_uri: string; expires_at: string }>(
+			await request('POST', '/me/cli-authorizations', {
+				callback_uri: CALLBACK,
+				state: STATE,
+				code_challenge: CHALLENGE,
+				token_name: 'mohub CLI',
+				expires_in_days: 30,
+				...overrides,
+			}),
+			201,
+		);
+	}
+
+	it('approves in the browser and exchanges through the public PKCE endpoint', async () => {
+		const approved = await approve();
+		const redirect = new URL(approved.redirect_uri);
+		expect(redirect.origin + redirect.pathname).toBe(CALLBACK);
+		expect(redirect.searchParams.get('state')).toBe(STATE);
+		const code = redirect.searchParams.get('code')!;
+
+		const exchanged = await expectOk<{ token: string }>(
+			await app.request('/api/cli/v1/token', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ code, code_verifier: VERIFIER }),
+			}),
+		);
+		expect(exchanged.token).toMatch(/^mhub_pat_/);
+
+		const patApp = createApi({
+			...makeTestDeps(bucket),
+			authenticator: testApiAuthenticator(bucket),
+		});
+		const me = await expectOk<{ id: string }>(
+			await patApp.request('/api/v1/me', {
+				headers: { authorization: `Bearer ${exchanged.token}` },
+			}),
+		);
+		expect(me.id).toBe(ACTOR);
+	});
+
+	it('rejects non-loopback and decorated callback URLs', async () => {
+		for (const callback_uri of [
+			'https://evil.example/callback',
+			'http://localhost:49152/callback',
+			'http://127.0.0.1:49152/other',
+			'http://127.0.0.1:49152/callback?next=evil',
+		]) {
+			await expectError(
+				await request('POST', '/me/cli-authorizations', {
+					callback_uri,
+					state: STATE,
+					code_challenge: CHALLENGE,
+					token_name: 'mohub CLI',
+					expires_in_days: 30,
+				}),
+				400,
+				'BAD_REQUEST',
+			);
+		}
+	});
+
+	it('does not consume a code when the PKCE verifier is wrong', async () => {
+		const code = new URL((await approve()).redirect_uri).searchParams.get('code')!;
+		await expectError(
+			await app.request('/api/cli/v1/token', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ code, code_verifier: 'x'.repeat(64) }),
+			}),
+			400,
+			'BAD_REQUEST',
+		);
+		expect(
+			await app.request('/api/cli/v1/token', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ code, code_verifier: VERIFIER }),
+			}),
+		).toHaveProperty('status', 200);
+	});
+
+	it('requires a session to approve and never accepts a PAT there', async () => {
+		const deny = createApi(makeTestDeps(bucket));
+		await expectError(
+			await deny.request('/api/v1/me/cli-authorizations', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					callback_uri: CALLBACK,
+					state: STATE,
+					code_challenge: CHALLENGE,
+					token_name: 'mohub CLI',
+					expires_in_days: 30,
+				}),
+			}),
+			401,
+			'UNAUTHORIZED',
+		);
+
+		const created = await expectOk<{ token: string }>(
+			await request('POST', '/me/tokens', { name: 'existing' }),
+			201,
+		);
+		const deps = makeTestDeps(bucket);
+		const patApp = createApi({
+			...deps,
+			authenticator: composeAuthenticators(deps.services.tokens, {
+				authenticate: async () => null,
+			}),
+		});
+		await expectError(
+			await patApp.request('/api/v1/me/cli-authorizations', {
+				method: 'POST',
+				headers: {
+					'content-type': 'application/json',
+					authorization: `Bearer ${created.token}`,
+				},
+				body: JSON.stringify({
+					callback_uri: CALLBACK,
+					state: STATE,
+					code_challenge: CHALLENGE,
+					token_name: 'mohub CLI',
+					expires_in_days: 30,
+				}),
+			}),
+			403,
+			'FORBIDDEN',
+		);
+	});
+
+	it('documents browser approval as session-only and PKCE exchange as public', () => {
+		const paths = (
+			generateOpenApiDocument() as {
+				paths: Record<string, Record<string, { security?: unknown }>>;
+			}
+		).paths;
+		expect(paths['/api/v1/me/cli-authorizations'].post.security).toEqual([{ cookieAuth: [] }]);
+		expect(paths['/api/cli/v1/token'].post.security).toEqual([]);
+	});
+
+	it('records the exchanged PAT in the token list and audit log', async () => {
+		const code = new URL((await approve()).redirect_uri).searchParams.get('code')!;
+		await app.request('/api/cli/v1/token', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ code, code_verifier: VERIFIER }),
+		});
+
+		const listed = await expectOk<{ name: string; expires_at?: string }[]>(
+			await request('GET', '/me/tokens'),
+		);
+		expect(listed).toHaveLength(1);
+		expect(listed[0]).toMatchObject({ name: 'mohub CLI' });
+		expect(listed[0].expires_at).toBeTruthy();
+		const events = await createTestApi({ bucket }).deps.services.events.getEvents(
+			new Date().toISOString().slice(0, 10),
+		);
+		expect(events).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ event: 'token.create', actor: ACTOR, token_name: 'mohub CLI' }),
+			]),
+		);
+	});
+});
+
+function testApiAuthenticator(bucket: MemoryBucket) {
+	const deps = makeTestDeps(bucket);
+	return {
+		authenticate: (request: Request) => {
+			const token = request.headers.get('authorization')?.replace(/^Bearer /, '') ?? '';
+			return deps.services.tokens.verify(token);
+		},
+	};
+}

--- a/packages/api/src/routes/cliAuthorizations.ts
+++ b/packages/api/src/routes/cliAuthorizations.ts
@@ -32,15 +32,26 @@ const ExchangeBodySchema = z.object({
 	code_verifier: z.string().regex(/^[A-Za-z0-9_-]{43,128}$/),
 });
 
-const EXCHANGE_LIMIT = 60;
+const AUTHORIZATION_EXCHANGE_LIMIT = 5;
+const GLOBAL_EXCHANGE_LIMIT = 600;
 const EXCHANGE_WINDOW_MS = 60_000;
-const exchangeBudget = createSlidingWindowBudget<'deployment'>({
-	limit: EXCHANGE_LIMIT,
+const AUTHORIZATION_CODE_RE = /^mhub_cli_([0-9A-Z]{26})_[0-9a-z]{32}$/;
+const authorizationExchangeBudget = createSlidingWindowBudget<string>({
+	limit: AUTHORIZATION_EXCHANGE_LIMIT,
+	windowMs: EXCHANGE_WINDOW_MS,
+});
+const globalExchangeBudget = createSlidingWindowBudget<'deployment'>({
+	limit: GLOBAL_EXCHANGE_LIMIT,
 	windowMs: EXCHANGE_WINDOW_MS,
 });
 
-function assertExchangeAllowed(): void {
-	if (!exchangeBudget.consume('deployment')) {
+function assertExchangeAllowed(code: string): void {
+	const authorizationId = AUTHORIZATION_CODE_RE.exec(code)?.[1];
+	if (authorizationId === undefined) return;
+	if (!authorizationExchangeBudget.consume(authorizationId)) {
+		throw new ResourceExhaustedError('Too many attempts for this CLI authorization code.');
+	}
+	if (!globalExchangeBudget.consume('deployment')) {
 		throw new ResourceExhaustedError('Too many CLI token exchanges; try again later.');
 	}
 }
@@ -147,7 +158,7 @@ export const cliTokenApp = createApp();
 cliTokenApp.openapi(exchangeAuthorization, async (c) => {
 	const body = c.req.valid('json');
 	const deps = c.get('deps');
-	assertExchangeAllowed();
+	assertExchangeAllowed(body.code);
 	const { token, record } = await deps.services.cliAuthorizations.exchange(
 		body.code,
 		body.code_verifier,

--- a/packages/api/src/routes/cliAuthorizations.ts
+++ b/packages/api/src/routes/cliAuthorizations.ts
@@ -1,0 +1,156 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import { BadRequestError } from '@marimo-hub/core';
+import { appendAudit } from '../log';
+import {
+	assertSessionAuthenticated,
+	commonErrors,
+	createApp,
+	errorResponses,
+	jsonBody,
+	jsonContent,
+	SESSION_ONLY_SECURITY,
+} from '../shared';
+
+const CallbackUriSchema = z.url().max(300);
+const StateSchema = z.string().regex(/^[A-Za-z0-9_-]{32,128}$/);
+const CodeChallengeSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/);
+
+const ApproveBodySchema = z.object({
+	callback_uri: CallbackUriSchema,
+	state: StateSchema,
+	code_challenge: CodeChallengeSchema,
+	token_name: z.string().trim().min(1).max(100),
+	expires_in_days: z.number().int().min(1).max(3650),
+});
+
+const ExchangeBodySchema = z.object({
+	code: z.string().min(1).max(100),
+	code_verifier: z.string().regex(/^[A-Za-z0-9_-]{43,128}$/),
+});
+
+function loopbackCallback(raw: string): URL {
+	const url = new URL(raw);
+	const loopback = url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+	if (
+		url.protocol !== 'http:' ||
+		!loopback ||
+		!url.port ||
+		url.username ||
+		url.password ||
+		url.pathname !== '/callback' ||
+		url.search ||
+		url.hash
+	) {
+		throw new BadRequestError('callback_uri must be an HTTP loopback URL ending in /callback');
+	}
+	return url;
+}
+
+const approveAuthorization = createRoute({
+	method: 'post',
+	path: '/me/cli-authorizations',
+	operationId: 'auth.cli.approve',
+	'x-cli-hidden': true,
+	tags: ['Auth'],
+	summary: 'Approve a CLI login',
+	description:
+		'Creates a short-lived, one-time authorization code bound to the CLI PKCE challenge. ' +
+		'Requires a browser session; the personal access token is minted only during exchange.',
+	security: SESSION_ONLY_SECURITY,
+	request: { body: jsonBody(ApproveBodySchema) },
+	responses: {
+		201: jsonContent(
+			z.object({
+				success: z.literal(true),
+				data: z.object({
+					redirect_uri: z.url(),
+					expires_at: z.string().openapi({ format: 'date-time' }),
+				}),
+			}),
+			'Loopback callback carrying the one-time authorization code',
+		),
+		...commonErrors(),
+		...errorResponses(400, 403, 429),
+	},
+});
+
+const exchangeAuthorization = createRoute({
+	method: 'post',
+	path: '/token',
+	operationId: 'auth.cli.exchange',
+	'x-cli-hidden': true,
+	tags: ['Auth'],
+	summary: 'Exchange a CLI authorization code',
+	description:
+		'Public PKCE exchange for the mohub loopback login. The authorization code is single-use, ' +
+		'short-lived, and useless without the verifier held by the CLI.',
+	security: [],
+	request: { body: jsonBody(ExchangeBodySchema) },
+	responses: {
+		200: jsonContent(
+			z.object({
+				success: z.literal(true),
+				data: z.object({ token: z.string() }),
+			}),
+			'The new personal access token',
+		),
+		...errorResponses(400, 413, 422, 429, 500, 503),
+	},
+});
+
+const app = createApp();
+
+app.openapi(approveAuthorization, async (c) => {
+	assertSessionAuthenticated(c, 'approve CLI logins');
+	const body = c.req.valid('json');
+	const callback = loopbackCallback(body.callback_uri);
+	const approved = await c.get('deps').services.cliAuthorizations.approve(
+		{
+			codeChallenge: body.code_challenge,
+			tokenName: body.token_name,
+			expiresInDays: body.expires_in_days,
+		},
+		c.get('user').id,
+	);
+	callback.searchParams.set('code', approved.code);
+	callback.searchParams.set('state', body.state);
+	c.header('Cache-Control', 'no-store');
+	c.header('Pragma', 'no-cache');
+	return c.json(
+		{
+			success: true as const,
+			data: { redirect_uri: callback.toString(), expires_at: approved.expiresAt },
+		},
+		201,
+	);
+});
+
+export const cliTokenApp = createApp();
+
+cliTokenApp.openapi(exchangeAuthorization, async (c) => {
+	const body = c.req.valid('json');
+	const { token, record } = await c
+		.get('deps')
+		.services.cliAuthorizations.exchange(body.code, body.code_verifier);
+	await appendAudit(
+		{
+			requestId: c.get('requestId'),
+			method: c.req.method,
+			path: c.req.path,
+			userId: record.user_id,
+		},
+		'token.create',
+		() =>
+			c.get('deps').services.events.append({
+				event: 'token.create',
+				actor: record.user_id,
+				token_id: record.id,
+				token_name: record.name,
+			}),
+	);
+	c.header('Cache-Control', 'no-store');
+	c.header('Pragma', 'no-cache');
+	return c.json({ success: true as const, data: { token } }, 200);
+});
+
+export default app;

--- a/packages/api/src/routes/cliAuthorizations.ts
+++ b/packages/api/src/routes/cliAuthorizations.ts
@@ -1,5 +1,9 @@
 import { createRoute, z } from '@hono/zod-openapi';
-import { BadRequestError } from '@marimo-hub/core';
+import {
+	BadRequestError,
+	createSlidingWindowBudget,
+	ResourceExhaustedError,
+} from '@marimo-hub/core';
 import { appendAudit } from '../log';
 import {
 	assertSessionAuthenticated,
@@ -27,6 +31,19 @@ const ExchangeBodySchema = z.object({
 	code: z.string().min(1).max(100),
 	code_verifier: z.string().regex(/^[A-Za-z0-9_-]{43,128}$/),
 });
+
+const EXCHANGE_LIMIT = 60;
+const EXCHANGE_WINDOW_MS = 60_000;
+const exchangeBudget = createSlidingWindowBudget<'deployment'>({
+	limit: EXCHANGE_LIMIT,
+	windowMs: EXCHANGE_WINDOW_MS,
+});
+
+function assertExchangeAllowed(): void {
+	if (!exchangeBudget.consume('deployment')) {
+		throw new ResourceExhaustedError('Too many CLI token exchanges; try again later.');
+	}
+}
 
 function loopbackCallback(raw: string): URL {
 	const url = new URL(raw);
@@ -129,9 +146,12 @@ export const cliTokenApp = createApp();
 
 cliTokenApp.openapi(exchangeAuthorization, async (c) => {
 	const body = c.req.valid('json');
-	const { token, record } = await c
-		.get('deps')
-		.services.cliAuthorizations.exchange(body.code, body.code_verifier);
+	const deps = c.get('deps');
+	assertExchangeAllowed();
+	const { token, record } = await deps.services.cliAuthorizations.exchange(
+		body.code,
+		body.code_verifier,
+	);
 	await appendAudit(
 		{
 			requestId: c.get('requestId'),
@@ -141,7 +161,7 @@ cliTokenApp.openapi(exchangeAuthorization, async (c) => {
 		},
 		'token.create',
 		() =>
-			c.get('deps').services.events.append({
+			deps.services.events.append({
 				event: 'token.create',
 				actor: record.user_id,
 				token_id: record.id,

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -4,6 +4,26 @@
  */
 
 export interface paths {
+	'/api/cli/v1/token': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Exchange a CLI authorization code
+		 * @description Public PKCE exchange for the mohub loopback login. The authorization code is single-use, short-lived, and useless without the verifier held by the CLI.
+		 */
+		post: operations['auth.cli.exchange'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/me': {
 		parameters: {
 			query?: never;
@@ -1237,19 +1257,30 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/me/cli-authorizations': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Approve a CLI login
+		 * @description Creates a short-lived, one-time authorization code bound to the CLI PKCE challenge. Requires a browser session; the personal access token is minted only during exchange.
+		 */
+		post: operations['auth.cli.approve'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 }
 export type webhooks = Record<string, never>;
 export interface components {
 	schemas: {
-		Me: {
-			id: string;
-			email: string;
-			name?: string | null;
-			/** Format: uri */
-			picture_url?: string | null;
-			logout_url: string | null;
-			is_super_admin: boolean;
-		};
 		ErrorResponse: {
 			/** @enum {boolean} */
 			success: false;
@@ -1284,6 +1315,15 @@ export interface components {
 				}[];
 				request_id?: string;
 			};
+		};
+		Me: {
+			id: string;
+			email: string;
+			name?: string | null;
+			/** Format: uri */
+			picture_url?: string | null;
+			logout_url: string | null;
+			is_super_admin: boolean;
 		};
 		DeploymentInfo: {
 			version: string;
@@ -2319,6 +2359,97 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+	'auth.cli.exchange': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': {
+					code: string;
+					code_verifier: string;
+				};
+			};
+		};
+		responses: {
+			/** @description The new personal access token */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						/** @enum {boolean} */
+						success: true;
+						data: {
+							token: string;
+						};
+					};
+				};
+			};
+			/** @description Bad request */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Request body too large */
+			413: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Validation error */
+			422: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Resource limit reached */
+			429: {
+				headers: {
+					/** @description Seconds to wait before retrying. */
+					'Retry-After': string;
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Internal server error */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Service unavailable */
+			503: {
+				headers: {
+					/** @description Seconds to wait before retrying. */
+					'Retry-After': string;
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
 	me: {
 		parameters: {
 			query?: never;
@@ -11041,6 +11172,122 @@ export interface operations {
 			/** @description Validation error */
 			422: {
 				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Internal server error */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Service unavailable */
+			503: {
+				headers: {
+					/** @description Seconds to wait before retrying. */
+					'Retry-After': string;
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	'auth.cli.approve': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': {
+					/** Format: uri */
+					callback_uri: string;
+					state: string;
+					code_challenge: string;
+					token_name: string;
+					expires_in_days: number;
+				};
+			};
+		};
+		responses: {
+			/** @description Loopback callback carrying the one-time authorization code */
+			201: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						/** @enum {boolean} */
+						success: true;
+						data: {
+							/** Format: uri */
+							redirect_uri: string;
+							/** Format: date-time */
+							expires_at: string;
+						};
+					};
+				};
+			};
+			/** @description Bad request */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Authentication required */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Access forbidden */
+			403: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Request body too large */
+			413: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Validation error */
+			422: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Resource limit reached */
+			429: {
+				headers: {
+					/** @description Seconds to wait before retrying. */
+					'Retry-After': string;
 					[name: string]: unknown;
 				};
 				content: {

--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -14,6 +14,7 @@ export type VersionId = string & { __brand: 'VersionId' };
 export type ProposalId = string & { __brand: 'ProposalId' };
 export type SessionId = string & { __brand: 'SessionId' };
 export type TokenId = string & { __brand: 'TokenId' };
+export type CliAuthorizationId = string & { __brand: 'CliAuthorizationId' };
 export type IntegrationId = string & { __brand: 'IntegrationId' };
 export type AlertDestinationId = string & { __brand: 'AlertDestinationId' };
 
@@ -61,6 +62,8 @@ const nextVersionUlid = monotonicFactory();
 // Token ids are bare ULIDs (no `tok_` prefix): they ride inside the PAT string
 // (`mhub_pat_<tokenId>_<secret>`), where `_` is the field separator.
 const nextTokenUlid = monotonicFactory();
+
+const nextCliAuthorizationUlid = monotonicFactory();
 
 // --- Id namespaces (guard / assert / parse / create) ---
 //
@@ -141,6 +144,11 @@ export const SessionId = defineId<SessionId>(
 	() => `sess-${randomBody()}`,
 );
 export const TokenId = defineId<TokenId>('TokenId', /^[0-9A-Z]{26}$/, () => nextTokenUlid());
+export const CliAuthorizationId = defineId<CliAuthorizationId>(
+	'CliAuthorizationId',
+	/^[0-9A-Z]{26}$/,
+	() => nextCliAuthorizationUlid(),
+);
 export const IntegrationId = defineId<IntegrationId>(
 	'IntegrationId',
 	/^intg-[0-9a-z]{16}$/,
@@ -196,6 +204,7 @@ export const createVersionId = VersionId.create;
 export const createProposalId = ProposalId.create;
 export const createSessionId = SessionId.create;
 export const createTokenId = TokenId.create;
+export const createCliAuthorizationId = CliAuthorizationId.create;
 export const createIntegrationId = IntegrationId.create;
 export const createAlertDestinationId = AlertDestinationId.create;
 

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -1,4 +1,5 @@
 import type {
+	CliAuthorizationId,
 	IntegrationId,
 	NotebookId,
 	ProposalId,
@@ -198,6 +199,8 @@ export const paths = {
 	// the presented token so verification is a single GET (no index object).
 	token: (tokenId: TokenId) => `_system/tokens/${tokenId}.json`,
 	tokensPrefix: '_system/tokens/',
+	cliAuthorization: (id: CliAuthorizationId) => `_system/cli-authorizations/${id}.json`,
+	cliAuthorizationsPrefix: '_system/cli-authorizations/',
 	eventsPrefix: '_system/events/',
 	eventsForDate: (date: string) => `_system/events/${date}/`,
 	event: (date: string, id: string) => `_system/events/${date}/${id}.json`,

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -15,12 +15,14 @@ import { NotebookProposalService } from './content/NotebookProposalService';
 import { ProjectService } from './content/ProjectService';
 import { SessionService } from './runtime/SessionService';
 import { TokenService } from './tokens/TokenService';
+import { CliAuthorizationService } from './tokens/CliAuthorizationService';
 
 export { CatalogService } from './catalog/CatalogService';
 export { EventService, MAX_EVENT_RANGE_DAYS } from './catalog/EventService';
 export { IdempotencyService } from './catalog/IdempotencyService';
 export { SyncedNotebookService } from './content/SyncedNotebookService';
 export { IdentityService } from './identity/IdentityService';
+export { CliAuthorizationService } from './tokens/CliAuthorizationService';
 export { MaintenanceService } from './catalog/MaintenanceService';
 export type { ExpireSnapshotsOptions, PruneEventsOptions } from './catalog/MaintenanceService';
 export { MaintenanceLock } from './catalog/MaintenanceLock';
@@ -399,6 +401,10 @@ export function createServices(
 		list: user,
 		revoke: (userId, tokenId) => ({ ...user(userId), 'marimohub.token_id': tokenId }),
 	});
+	const cliAuthorizations = wrap(
+		'CliAuthorizationService',
+		new CliAuthorizationService(bucket, tokens),
+	);
 	const maintenance = wrap('MaintenanceService', new MaintenanceService(bucket, metrics));
 	const idempotency = wrap('IdempotencyService', new IdempotencyService(bucket), {
 		lookup: scope,
@@ -413,6 +419,7 @@ export function createServices(
 		sessions,
 		identities,
 		tokens,
+		cliAuthorizations,
 		maintenance,
 		idempotency,
 	};

--- a/packages/core/src/services/tokens/CliAuthorizationService.test.ts
+++ b/packages/core/src/services/tokens/CliAuthorizationService.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { encodeTime } from 'ulidx';
+import { advanceTime, MemoryBucket, restoreClock, uid } from '../../testing';
+import { CliAuthorizationId } from '../../ids';
+import { toBase64Url } from '../../internal/base64url';
+import { paths } from '../../paths';
+import { IdentityService } from '../identity/IdentityService';
+import { TokenService } from './TokenService';
+import { CliAuthorizationService } from './CliAuthorizationService';
+
+const OWNER = uid('cli-owner');
+const VERIFIER = 'v'.repeat(64);
+
+async function challenge(verifier = VERIFIER): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+	return toBase64Url(new Uint8Array(digest));
+}
+
+describe('CliAuthorizationService', () => {
+	let bucket: MemoryBucket;
+	let tokens: TokenService;
+	let authorizations: CliAuthorizationService;
+
+	beforeEach(async () => {
+		bucket = new MemoryBucket();
+		const identities = new IdentityService(bucket);
+		await identities.upsert({ id: OWNER, email: 'owner@example.com', name: 'Owner' });
+		tokens = new TokenService(bucket, identities);
+		authorizations = new CliAuthorizationService(bucket, tokens);
+	});
+
+	afterEach(restoreClock);
+
+	it('exchanges an approved PKCE code for a bounded PAT exactly once', async () => {
+		const approved = await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'mohub CLI', expiresInDays: 30 },
+			OWNER,
+		);
+
+		const created = await authorizations.exchange(approved.code, VERIFIER);
+		expect(created.token).toMatch(/^mhub_pat_/);
+		expect(created.record).toMatchObject({ name: 'mohub CLI', user_id: OWNER });
+		expect(new Date(created.record.expires_at!).getTime()).toBe(
+			new Date(created.record.created_at).getTime() + 30 * 24 * 60 * 60 * 1000,
+		);
+		expect(await tokens.verify(created.token)).toMatchObject({ id: OWNER });
+		await expect(authorizations.exchange(approved.code, VERIFIER)).rejects.toThrow(
+			/invalid or expired/,
+		);
+	});
+
+	it('stores only the authorization-code hash', async () => {
+		const approved = await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'mohub CLI', expiresInDays: 30 },
+			OWNER,
+		);
+		const id = approved.code.split('_')[2];
+		const object = await bucket.get(paths.cliAuthorization(id as never));
+		const stored = await object!.text();
+
+		expect(stored).not.toContain(approved.code);
+		expect(stored).not.toContain(approved.code.slice(approved.code.lastIndexOf('_') + 1));
+	});
+
+	it('rejects the wrong PKCE verifier without consuming the code', async () => {
+		const approved = await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'mohub CLI', expiresInDays: 30 },
+			OWNER,
+		);
+
+		await expect(authorizations.exchange(approved.code, 'wrong')).rejects.toThrow(
+			/invalid or expired/,
+		);
+		await expect(authorizations.exchange(approved.code, VERIFIER)).resolves.toBeTruthy();
+	});
+
+	it('rejects and prunes expired authorizations', async () => {
+		const approved = await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'mohub CLI', expiresInDays: 30 },
+			OWNER,
+		);
+		advanceTime(CliAuthorizationService.AUTHORIZATION_TTL_MS + 1);
+
+		await expect(authorizations.exchange(approved.code, VERIFIER)).rejects.toThrow(
+			/invalid or expired/,
+		);
+		await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'next', expiresInDays: 7 },
+			OWNER,
+		);
+		expect((await bucket.list({ prefix: paths.cliAuthorizationsPrefix })).objects).toHaveLength(1);
+	});
+
+	it('allows only one winner when exchanges race', async () => {
+		const approved = await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'mohub CLI', expiresInDays: 30 },
+			OWNER,
+		);
+		const results = await Promise.allSettled([
+			authorizations.exchange(approved.code, VERIFIER),
+			authorizations.exchange(approved.code, VERIFIER),
+		]);
+
+		expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+		expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+	});
+
+	it('does not reopen a consumed code when best-effort cleanup fails', async () => {
+		const approved = await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'mohub CLI', expiresInDays: 30 },
+			OWNER,
+		);
+		vi.spyOn(bucket, 'delete').mockRejectedValueOnce(new Error('storage unavailable'));
+
+		await expect(authorizations.exchange(approved.code, VERIFIER)).resolves.toBeTruthy();
+		await expect(authorizations.exchange(approved.code, VERIFIER)).rejects.toThrow(
+			/invalid or expired/,
+		);
+		expect(await tokens.list(OWNER)).toHaveLength(1);
+	});
+
+	it('burns a claimed code when token minting fails', async () => {
+		const approved = await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'mohub CLI', expiresInDays: 30 },
+			OWNER,
+		);
+		const create = vi
+			.spyOn(tokens, 'create')
+			.mockRejectedValueOnce(new Error('storage unavailable'));
+
+		await expect(authorizations.exchange(approved.code, VERIFIER)).rejects.toThrow(
+			'storage unavailable',
+		);
+		await expect(authorizations.exchange(approved.code, VERIFIER)).rejects.toThrow(
+			/invalid or expired/,
+		);
+		expect(create).toHaveBeenCalledOnce();
+	});
+
+	it('bounds request-path pruning and does not read grant bodies', async () => {
+		const timestamp = encodeTime(Date.now() - CliAuthorizationService.AUTHORIZATION_TTL_MS - 1, 10);
+		for (let index = 0; index <= CliAuthorizationService.PRUNE_LIMIT; index++) {
+			const oldId = CliAuthorizationId.parse(`${timestamp}${index.toString().padStart(16, '0')}`);
+			await bucket.put(paths.cliAuthorization(oldId), 'body must not be read');
+		}
+		const get = vi.spyOn(bucket, 'get');
+		const list = vi.spyOn(bucket, 'list');
+
+		await authorizations.approve(
+			{ codeChallenge: await challenge(), tokenName: 'new', expiresInDays: 30 },
+			OWNER,
+		);
+
+		expect(get).not.toHaveBeenCalled();
+		expect(list).toHaveBeenCalledOnce();
+		expect(list).toHaveBeenCalledWith({
+			prefix: paths.cliAuthorizationsPrefix,
+			limit: CliAuthorizationService.PRUNE_LIMIT,
+		});
+		expect((await bucket.list({ prefix: paths.cliAuthorizationsPrefix })).objects).toHaveLength(2);
+	});
+});

--- a/packages/core/src/services/tokens/CliAuthorizationService.ts
+++ b/packages/core/src/services/tokens/CliAuthorizationService.ts
@@ -1,0 +1,195 @@
+import { z } from 'zod';
+import { decodeTime } from 'ulidx';
+import type { Bucket, BucketObjectBody } from '../../ports/bucket';
+import { BadRequestError, PreconditionFailedError } from '../../errors';
+import { CliAuthorizationId, createCliAuthorizationId } from '../../ids';
+import type { UserId } from '../../ids';
+import { toBase64Url } from '../../internal/base64url';
+import { timingSafeEqual } from '../../internal/hmac';
+import { toHex } from '../../internal/hex';
+import { paths } from '../../paths';
+import { logOperationalError } from '../../operationalLog';
+import { readStored, UserIdSchema } from '../../schema';
+import type { CreatedToken, TokenService } from './TokenService';
+
+const AUTHORIZATION_PREFIX = 'mhub_cli_';
+const AUTHORIZATION_RE = /^mhub_cli_([0-9A-Z]{26})_([0-9a-z]{32})$/;
+const SECRET_ALPHABET = '0123456789abcdefghjkmnpqrstvwxyz';
+const SECRET_LENGTH = 32;
+
+const CliAuthorizationSchema = z.looseObject({
+	id: z.string().refine(CliAuthorizationId.is),
+	user_id: UserIdSchema,
+	code_hash: z.string().regex(/^[0-9a-f]{64}$/),
+	code_challenge: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+	token_name: z.string().min(1).max(100),
+	expires_in_days: z.number().int().min(1).max(3650),
+	created_at: z.iso.datetime(),
+	expires_at: z.iso.datetime(),
+	status: z.enum(['pending', 'claimed']),
+});
+
+type CliAuthorization = z.infer<typeof CliAuthorizationSchema>;
+
+export interface ApproveCliAuthorizationInput {
+	codeChallenge: string;
+	tokenName: string;
+	expiresInDays: number;
+}
+
+export interface ApprovedCliAuthorization {
+	code: string;
+	expiresAt: string;
+}
+
+function generateSecret(): string {
+	const bytes = new Uint8Array(SECRET_LENGTH);
+	crypto.getRandomValues(bytes);
+	let secret = '';
+	for (let i = 0; i < SECRET_LENGTH; i++) secret += SECRET_ALPHABET[bytes[i] & 31];
+	return secret;
+}
+
+async function sha256(value: string): Promise<Uint8Array> {
+	return new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value)));
+}
+
+async function hash(value: string): Promise<string> {
+	return toHex(await sha256(value));
+}
+
+async function readAuthorization(
+	object: BucketObjectBody,
+	key: string,
+): Promise<CliAuthorization | null> {
+	try {
+		return await readStored(CliAuthorizationSchema, object, key);
+	} catch (error) {
+		logOperationalError(
+			'stored_object_skipped',
+			{ operation: 'cli_authorization.read', object: key },
+			error,
+		);
+		return null;
+	}
+}
+
+function invalidAuthorization(): BadRequestError {
+	return new BadRequestError('CLI authorization code is invalid or expired');
+}
+
+function authorizationCreatedAt(key: string): number | null {
+	if (!key.endsWith('.json')) return null;
+	const encodedId = key.slice(paths.cliAuthorizationsPrefix.length, -'.json'.length);
+	if (!CliAuthorizationId.is(encodedId)) return null;
+	try {
+		return decodeTime(encodedId);
+	} catch {
+		return null;
+	}
+}
+
+export class CliAuthorizationService {
+	static readonly AUTHORIZATION_TTL_MS = 10 * 60 * 1000;
+	static readonly PRUNE_LIMIT = 100;
+
+	constructor(
+		private bucket: Bucket,
+		private tokens: TokenService,
+	) {}
+
+	async approve(
+		input: ApproveCliAuthorizationInput,
+		userId: UserId,
+	): Promise<ApprovedCliAuthorization> {
+		await this.pruneExpired();
+		const id = createCliAuthorizationId();
+		const secret = generateSecret();
+		const now = new Date();
+		const expiresAt = new Date(now.getTime() + CliAuthorizationService.AUTHORIZATION_TTL_MS);
+		const record: CliAuthorization = {
+			id,
+			user_id: userId,
+			code_hash: await hash(secret),
+			code_challenge: input.codeChallenge,
+			token_name: input.tokenName,
+			expires_in_days: input.expiresInDays,
+			created_at: now.toISOString(),
+			expires_at: expiresAt.toISOString(),
+			status: 'pending',
+		};
+		await this.bucket.put(paths.cliAuthorization(id), JSON.stringify(record), {
+			onlyIfNotExists: true,
+		});
+		return {
+			code: `${AUTHORIZATION_PREFIX}${id}_${secret}`,
+			expiresAt: expiresAt.toISOString(),
+		};
+	}
+
+	async exchange(code: string, codeVerifier: string): Promise<CreatedToken> {
+		const match = AUTHORIZATION_RE.exec(code);
+		if (!match) throw invalidAuthorization();
+		const id = CliAuthorizationId.parse(match[1]);
+		const key = paths.cliAuthorization(id);
+		const object = await this.bucket.get(key);
+		if (!object) throw invalidAuthorization();
+		const record = await readAuthorization(object, key);
+		if (record?.status !== 'pending' || new Date(record.expires_at).getTime() <= Date.now()) {
+			throw invalidAuthorization();
+		}
+
+		const encoder = new TextEncoder();
+		const presentedHash = encoder.encode(await hash(match[2]));
+		if (!timingSafeEqual(presentedHash, encoder.encode(record.code_hash))) {
+			throw invalidAuthorization();
+		}
+		const challenge = toBase64Url(await sha256(codeVerifier));
+		if (!timingSafeEqual(encoder.encode(challenge), encoder.encode(record.code_challenge))) {
+			throw invalidAuthorization();
+		}
+
+		try {
+			await this.bucket.put(key, JSON.stringify({ ...record, status: 'claimed' }), {
+				onlyIfEtagMatches: object.etag,
+			});
+		} catch (error) {
+			if (error instanceof PreconditionFailedError) throw invalidAuthorization();
+			throw error;
+		}
+
+		try {
+			return await this.tokens.create(
+				{ name: record.token_name, expiresInDays: record.expires_in_days },
+				record.user_id,
+			);
+		} finally {
+			try {
+				await this.bucket.delete(key);
+			} catch (error) {
+				logOperationalError(
+					'cli_authorization_cleanup_failed',
+					{ operation: 'cli_authorization.exchange', object: key },
+					error,
+				);
+			}
+		}
+	}
+
+	private async pruneExpired(): Promise<void> {
+		const now = Date.now();
+		const page = await this.bucket.list({
+			prefix: paths.cliAuthorizationsPrefix,
+			limit: CliAuthorizationService.PRUNE_LIMIT,
+		});
+		const expired = page.objects
+			.filter((entry) => {
+				const createdAt = authorizationCreatedAt(entry.key);
+				return (
+					createdAt === null || createdAt + CliAuthorizationService.AUTHORIZATION_TTL_MS <= now
+				);
+			})
+			.map((entry) => entry.key);
+		if (expired.length > 0) await this.bucket.delete(expired);
+	}
+}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -19,6 +19,9 @@ const AuditLogPage = lazy(() => import('@/components/AuditLog/AuditLogPage'));
 const DataBrowserPage = lazy(() => import('@/components/DataBrowser/DataBrowserPage'));
 const AdminUsersPage = lazy(() => import('@/components/Admin/AdminUsersPage'));
 const AdminSettingsPage = lazy(() => import('@/components/Admin/AdminSettingsPage'));
+const CliLoginPage = lazy(() =>
+	import('@/components/Account/CliLoginPage').then((module) => ({ default: module.CliLoginPage })),
+);
 
 function AppErrorBoundary({ children }: { children: React.ReactNode }) {
 	return (
@@ -141,6 +144,7 @@ function AppContent() {
 			<AppErrorBoundary>
 				<Suspense fallback={<PageFallback />}>
 					<Routes>
+						<Route path="/cli/login" element={<CliLoginPage />} />
 						<Route path="/projects/:pid/notebooks/:nid" element={<NotebookPage />} />
 						{/* The shared app, full-screen like the editor (outside StandardLayout). */}
 						<Route

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -110,6 +110,19 @@ export function useRevokeApiToken() {
 	);
 }
 
+export function useApproveCliAuthorization() {
+	return useApiMutation(
+		(body: {
+			callback_uri: string;
+			state: string;
+			code_challenge: string;
+			token_name: string;
+			expires_in_days: number;
+		}) => apiData(apiClient.POST('/api/v1/me/cli-authorizations', { body })),
+		() => [userKeys.tokens()],
+	);
+}
+
 // System
 
 /** Deployment metadata for the footer info popover. */

--- a/packages/web/src/components/Account/CliLoginPage.test.tsx
+++ b/packages/web/src/components/Account/CliLoginPage.test.tsx
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthProvider } from '@/context/AuthContext';
+import { installMatchMedia, jsonOk, renderWithClient } from '@/test/render';
+import { CliLoginPage, parseCliLoginRequest } from './CliLoginPage';
+
+const CALLBACK = 'http://127.0.0.1:49152/callback';
+const STATE = 's'.repeat(32);
+const CHALLENGE = 'c'.repeat(43);
+
+function loginPath(callback = CALLBACK): string {
+	const query = new URLSearchParams({
+		callback_uri: callback,
+		state: STATE,
+		code_challenge: CHALLENGE,
+	});
+	return `/cli/login?${query}`;
+}
+
+function setup() {
+	const calls: { url: string; body?: unknown }[] = [];
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input);
+			const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+			calls.push({ url, body });
+			if (url === '/api/v1/me') {
+				return jsonOk({ id: 'user-one', email: 'dev@example.com', logout_url: null });
+			}
+			if (url === '/api/v1/me/cli-authorizations') {
+				return jsonOk(
+					{
+						redirect_uri: `${CALLBACK}?code=mhub_cli_code&state=${STATE}`,
+						expires_at: '2026-08-24T12:10:00.000Z',
+					},
+					{ status: 201 },
+				);
+			}
+			throw new Error(`unexpected request: ${url}`);
+		}),
+	);
+	const navigate = vi.fn();
+	renderWithClient(
+		<AuthProvider>
+			<CliLoginPage navigate={navigate} />
+		</AuthProvider>,
+	);
+	return { calls, navigate };
+}
+
+beforeEach(() => {
+	installMatchMedia(false);
+	window.history.replaceState({}, '', loginPath());
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	window.history.replaceState({}, '', '/');
+});
+
+describe('CliLoginPage', () => {
+	it('shows the signed-in account and a 30-day default', async () => {
+		setup();
+
+		expect(await screen.findByText(/dev@example.com/)).toBeInTheDocument();
+		expect(screen.getByLabelText('Token lifetime (days)')).toHaveValue('30');
+		expect(
+			screen.getByText(/credential returns only to the local CLI callback/i),
+		).toBeInTheDocument();
+	});
+
+	it('approves with the configurable lifetime and returns to the loopback callback', async () => {
+		const user = userEvent.setup();
+		const { calls, navigate } = setup();
+		await screen.findByText(/dev@example.com/);
+
+		await user.clear(screen.getByLabelText('Token lifetime (days)'));
+		await user.type(screen.getByLabelText('Token lifetime (days)'), '45');
+		await user.click(screen.getByRole('button', { name: 'Authorize CLI' }));
+
+		expect(navigate).toHaveBeenCalledWith(`${CALLBACK}?code=mhub_cli_code&state=${STATE}`);
+		expect(calls).toContainEqual({
+			url: '/api/v1/me/cli-authorizations',
+			body: {
+				callback_uri: CALLBACK,
+				state: STATE,
+				code_challenge: CHALLENGE,
+				token_name: 'mohub CLI',
+				expires_in_days: 45,
+			},
+		});
+	});
+
+	it('offers quick lifetime presets', async () => {
+		const user = userEvent.setup();
+		setup();
+		await screen.findByText(/dev@example.com/);
+
+		await user.click(screen.getByRole('button', { name: '90d' }));
+		expect(screen.getByLabelText('Token lifetime (days)')).toHaveValue('90');
+	});
+
+	it('returns an access-denied callback when cancelled', async () => {
+		const user = userEvent.setup();
+		const { navigate } = setup();
+		await screen.findByText(/dev@example.com/);
+
+		await user.click(screen.getByRole('button', { name: 'Cancel' }));
+		expect(navigate).toHaveBeenCalledWith(`${CALLBACK}?error=access_denied&state=${STATE}`);
+	});
+
+	it.each([
+		'https://evil.example/callback',
+		'http://localhost:49152/callback',
+		'http://127.0.0.1:49152/not-callback',
+	])('rejects an unsafe callback: %s', (callback) => {
+		expect(parseCliLoginRequest(loginPath(callback).slice('/cli/login'.length))).toBeNull();
+	});
+
+	it('renders a safe failure state for malformed requests', () => {
+		window.history.replaceState({}, '', '/cli/login?state=missing-everything-else');
+		setup();
+
+		expect(screen.getByRole('heading', { name: 'Invalid CLI login request' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Authorize CLI' })).not.toBeInTheDocument();
+	});
+});

--- a/packages/web/src/components/Account/CliLoginPage.tsx
+++ b/packages/web/src/components/Account/CliLoginPage.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react';
+import { ArrowRight, Check, Clock3, ShieldCheck, Terminal } from 'lucide-react';
+import { toast } from 'sonner';
+import { useApproveCliAuthorization } from '@/api/hooks';
+import { useAuth } from '@/context/AuthContext';
+import { Brand, Button, TextField } from '@/components/ui';
+
+const STATE_RE = /^[A-Za-z0-9_-]{32,128}$/;
+const CHALLENGE_RE = /^[A-Za-z0-9_-]{43}$/;
+
+export interface CliLoginRequest {
+	callbackUri: string;
+	state: string;
+	codeChallenge: string;
+}
+
+export interface CliLoginPageProps {
+	navigate?: (url: string) => void;
+}
+
+function isLoopbackCallback(raw: string): boolean {
+	try {
+		const url = new URL(raw);
+		return (
+			url.protocol === 'http:' &&
+			(url.hostname === '127.0.0.1' || url.hostname === '[::1]') &&
+			Boolean(url.port) &&
+			!url.username &&
+			!url.password &&
+			url.pathname === '/callback' &&
+			!url.search &&
+			!url.hash
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function parseCliLoginRequest(search: string): CliLoginRequest | null {
+	const params = new URLSearchParams(search);
+	const callbackUri = params.get('callback_uri');
+	const state = params.get('state');
+	const codeChallenge = params.get('code_challenge');
+	if (
+		!callbackUri ||
+		!state ||
+		!codeChallenge ||
+		!isLoopbackCallback(callbackUri) ||
+		!STATE_RE.test(state) ||
+		!CHALLENGE_RE.test(codeChallenge)
+	) {
+		return null;
+	}
+	return { callbackUri, state, codeChallenge };
+}
+
+function cancellationUrl(request: CliLoginRequest): string {
+	const callback = new URL(request.callbackUri);
+	callback.searchParams.set('error', 'access_denied');
+	callback.searchParams.set('state', request.state);
+	return callback.toString();
+}
+
+export function CliLoginPage({
+	navigate = (url) => window.location.assign(url),
+}: CliLoginPageProps) {
+	const request = parseCliLoginRequest(window.location.search);
+	const { user } = useAuth();
+	const approve = useApproveCliAuthorization();
+	const [expiresInDays, setExpiresInDays] = useState('30');
+
+	if (!request) {
+		return (
+			<div className="flex min-h-dvh flex-col items-center justify-center gap-8 bg-muted/30 p-6">
+				<title>Invalid CLI request · marimohub</title>
+				<Brand size="lg" />
+				<div className="flex w-full max-w-md flex-col items-center gap-3 rounded-xl border bg-card p-8 text-center shadow-md">
+					<Terminal className="size-8 text-muted-foreground" />
+					<h1 className="text-lg font-semibold">Invalid CLI login request</h1>
+					<p className="text-sm text-muted-foreground">
+						Return to your terminal and run <code>mohub login</code> again.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const submit = async () => {
+		const days = Number(expiresInDays);
+		if (!/^\d+$/.test(expiresInDays) || !Number.isInteger(days) || days < 1 || days > 3650) {
+			toast.error('Choose a token lifetime between 1 and 3650 days.');
+			return;
+		}
+		try {
+			const result = await approve.mutateAsync({
+				callback_uri: request.callbackUri,
+				state: request.state,
+				code_challenge: request.codeChallenge,
+				token_name: 'mohub CLI',
+				expires_in_days: days,
+			});
+			navigate(result.redirect_uri);
+		} catch {
+			return;
+		}
+	};
+
+	return (
+		<div className="flex min-h-dvh flex-col items-center justify-center gap-8 bg-muted/30 p-6">
+			<title>Connect the mohub CLI · marimohub</title>
+			<Brand size="lg" />
+
+			<div className="flex w-full max-w-lg flex-col overflow-hidden rounded-xl border bg-card shadow-lg">
+				<div className="flex flex-col items-center gap-3 border-b px-8 py-7 text-center">
+					<div className="flex size-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+						<Terminal className="size-6" />
+					</div>
+					<div className="flex flex-col gap-1">
+						<h1 className="text-xl font-semibold">Connect the mohub CLI</h1>
+						<p className="text-sm text-muted-foreground">
+							Authorize the CLI on this computer to access {window.location.host} as{' '}
+							<span className="font-medium text-foreground">{user?.email ?? user?.id}</span>.
+						</p>
+					</div>
+				</div>
+
+				<form
+					className="flex flex-col gap-5 px-8 py-6"
+					onSubmit={(event) => {
+						event.preventDefault();
+						void submit();
+					}}
+				>
+					<div className="flex items-start gap-3 rounded-lg border bg-muted/40 p-4">
+						<ShieldCheck className="mt-0.5 size-5 shrink-0 text-primary" />
+						<div className="flex flex-col gap-2 text-sm">
+							<span className="font-medium">What you’re approving</span>
+							<ul className="flex flex-col gap-1.5 text-muted-foreground">
+								<li className="flex items-start gap-2">
+									<Check className="mt-0.5 size-3.5 shrink-0" />
+									The CLI will act with your current account permissions.
+								</li>
+								<li className="flex items-start gap-2">
+									<Check className="mt-0.5 size-3.5 shrink-0" />
+									The credential returns only to the local CLI callback.
+								</li>
+								<li className="flex items-start gap-2">
+									<Check className="mt-0.5 size-3.5 shrink-0" />
+									You can revoke it any time from API tokens.
+								</li>
+							</ul>
+						</div>
+					</div>
+
+					<div className="flex items-end gap-3">
+						<Clock3 className="mb-2 size-5 shrink-0 text-muted-foreground" />
+						<TextField
+							className="flex-1"
+							label="Token lifetime (days)"
+							value={expiresInDays}
+							onChange={setExpiresInDays}
+							inputMode="numeric"
+						/>
+						<div className="mb-1 flex gap-1">
+							{['7', '30', '90'].map((days) => (
+								<Button
+									key={days}
+									type="button"
+									size="sm"
+									variant={expiresInDays === days ? 'primary' : 'default'}
+									onPress={() => setExpiresInDays(days)}
+								>
+									{days}d
+								</Button>
+							))}
+						</div>
+					</div>
+
+					<div className="flex justify-end gap-2 border-t pt-5">
+						<Button
+							type="button"
+							isDisabled={approve.isPending}
+							onPress={() => navigate(cancellationUrl(request))}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" variant="primary" isDisabled={approve.isPending}>
+							{approve.isPending ? 'Connecting…' : 'Authorize CLI'}
+							{!approve.isPending && <ArrowRight className="size-4" />}
+						</Button>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
Adds a browser-based device authorization flow so `cli login` can mint a token without pasting one in.

- `CliAuthorizationService` owns short-lived login grants at `_system/cli-authorizations/{id}.json` (CAS-managed).
- New API route to create and poll authorizations.
- Web approval page at the login route.
- CLI opens the browser, polls for approval, and stores the issued token.