### PR TITLE
chore(release): check tools, auth, and ref collisions before mutating

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -5,6 +5,10 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 
 const run = (cmd, ...args) => execFileSync(cmd, args, { encoding: 'utf8' }).trim();
+const fail = (message) => {
+	console.error(message);
+	process.exit(1);
+};
 
 const arg = process.argv[2];
 if (!arg) {
@@ -30,32 +34,71 @@ if (arg === 'patch' || arg === 'minor' || arg === 'major') {
 	process.exit(1);
 }
 
+// Everything below and up to the checkout is read-only, so a failed
+// precondition leaves the repository untouched.
+const missing = ['git', 'gh', 'cargo'].filter((tool) => {
+	try {
+		execFileSync(tool, ['--version'], { stdio: 'ignore' });
+		return false;
+	} catch {
+		return true;
+	}
+});
+if (missing.length > 0) {
+	fail(`missing required tools: ${missing.join(', ')} (cargo: https://rustup.rs)`);
+}
+try {
+	execFileSync('gh', ['auth', 'status'], { stdio: 'ignore' });
+} catch {
+	fail("gh is not authenticated — run 'gh auth login'");
+}
+
 if (run('git', 'status', '--porcelain') !== '') {
 	console.error('working tree is not clean — commit or stash first');
 	process.exit(1);
 }
 
+const cargoPattern = /^version = "[^"]+"$/m;
+if (!cargoPattern.test(readFileSync(cargoPath, 'utf8'))) {
+	fail('could not find the current Cargo package version');
+}
+
+const branch = `release/${version}`;
+const tag = `v${version}`;
 run('git', 'fetch', 'origin', 'main');
-run('git', 'checkout', '-b', `release/${version}`, 'origin/main');
+const localRefExists = (ref) => {
+	try {
+		run('git', 'show-ref', '--verify', '--quiet', ref);
+		return true;
+	} catch {
+		return false;
+	}
+};
+const remoteRefExists = (ref) => run('git', 'ls-remote', 'origin', ref) !== '';
+if (localRefExists(`refs/tags/${tag}`) || remoteRefExists(`refs/tags/${tag}`)) {
+	fail(`tag ${tag} already exists`);
+}
+if (localRefExists(`refs/heads/${branch}`)) {
+	fail(`local branch ${branch} already exists — delete it with 'git branch -D ${branch}'`);
+}
+if (remoteRefExists(`refs/heads/${branch}`)) {
+	fail(`remote branch origin/${branch} already exists`);
+}
+
+run('git', 'checkout', '-b', branch, 'origin/main');
 
 pkg.version = version;
 writeFileSync(pkgPath, `${JSON.stringify(pkg, null, '\t')}\n`);
 
-const replaceVersion = (path, pattern, replacement, label) => {
-	const current = readFileSync(path, 'utf8');
-	if (!pattern.test(current)) {
-		console.error(`could not find the current ${label} version`);
-		process.exit(1);
-	}
-	writeFileSync(path, current.replace(pattern, replacement));
-};
-
-replaceVersion(cargoPath, /^version = "[^"]+"$/m, `version = "${version}"`, 'Cargo package');
+writeFileSync(
+	cargoPath,
+	readFileSync(cargoPath, 'utf8').replace(cargoPattern, `version = "${version}"`),
+);
 run('cargo', 'update', '--manifest-path', 'apps/cli/Cargo.toml', '--package', 'mohub');
 
 run('git', 'add', 'package.json', 'apps/cli/Cargo.toml', 'apps/cli/Cargo.lock');
 run('git', 'commit', '-m', `release: ${version}`);
-run('git', 'push', '-u', 'origin', `release/${version}`);
+run('git', 'push', '-u', 'origin', branch);
 execFileSync(
 	'gh',
 	[
@@ -64,7 +107,7 @@ execFileSync(
 		'--title',
 		`release: ${version}`,
 		'--body',
-		`Merging this PR tags \`v${version}\` and publishes the container image, Helm chart, and mohub CLI.`,
+		`Merging this PR tags \`${tag}\` and publishes the container image, Helm chart, and mohub CLI.`,
 	],
 	{ stdio: 'inherit' },
 );

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -2,7 +2,7 @@
 // origin/main and open a PR titled "release: X.Y.Z". Merging that PR triggers
 // the tag + publish workflows — see development_docs/releasing.md.
 import { execFileSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 
 const run = (cmd, ...args) => execFileSync(cmd, args, { encoding: 'utf8' }).trim();
 const fail = (message) => {
@@ -16,26 +16,6 @@ if (!arg) {
 	process.exit(1);
 }
 
-const pkgPath = new URL('../package.json', import.meta.url);
-const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
-const cargoPath = new URL('../apps/cli/Cargo.toml', import.meta.url);
-
-let version = arg;
-if (arg === 'patch' || arg === 'minor' || arg === 'major') {
-	const [major, minor, patch] = pkg.version.split('.').map(Number);
-	version =
-		arg === 'major'
-			? `${major + 1}.0.0`
-			: arg === 'minor'
-				? `${major}.${minor + 1}.0`
-				: `${major}.${minor}.${patch + 1}`;
-} else if (!/^\d+\.\d+\.\d+$/.test(version)) {
-	console.error(`invalid version "${version}" — expected X.Y.Z, patch, minor, or major`);
-	process.exit(1);
-}
-
-// Everything below and up to the checkout is read-only, so a failed
-// precondition leaves the repository untouched.
 const missing = ['git', 'gh', 'cargo'].filter((tool) => {
 	try {
 		execFileSync(tool, ['--version'], { stdio: 'ignore' });
@@ -58,14 +38,34 @@ if (run('git', 'status', '--porcelain') !== '') {
 	process.exit(1);
 }
 
+// The release branch is cut from origin/main, so validate and bump the files
+// as they exist there — the local checkout may be on an older commit.
+run('git', 'fetch', 'origin', 'main');
+const pkgPath = new URL('../package.json', import.meta.url);
+const pkg = JSON.parse(run('git', 'show', 'origin/main:package.json'));
+const cargoPath = new URL('../apps/cli/Cargo.toml', import.meta.url);
+const cargoToml = run('git', 'show', 'origin/main:apps/cli/Cargo.toml');
 const cargoPattern = /^version = "[^"]+"$/m;
-if (!cargoPattern.test(readFileSync(cargoPath, 'utf8'))) {
+if (!cargoPattern.test(cargoToml)) {
 	fail('could not find the current Cargo package version');
+}
+
+let version = arg;
+if (arg === 'patch' || arg === 'minor' || arg === 'major') {
+	const [major, minor, patch] = pkg.version.split('.').map(Number);
+	version =
+		arg === 'major'
+			? `${major + 1}.0.0`
+			: arg === 'minor'
+				? `${major}.${minor + 1}.0`
+				: `${major}.${minor}.${patch + 1}`;
+} else if (!/^\d+\.\d+\.\d+$/.test(version)) {
+	console.error(`invalid version "${version}" — expected X.Y.Z, patch, minor, or major`);
+	process.exit(1);
 }
 
 const branch = `release/${version}`;
 const tag = `v${version}`;
-run('git', 'fetch', 'origin', 'main');
 const localRefExists = (ref) => {
 	try {
 		run('git', 'show-ref', '--verify', '--quiet', ref);
@@ -90,10 +90,7 @@ run('git', 'checkout', '-b', branch, 'origin/main');
 pkg.version = version;
 writeFileSync(pkgPath, `${JSON.stringify(pkg, null, '\t')}\n`);
 
-writeFileSync(
-	cargoPath,
-	readFileSync(cargoPath, 'utf8').replace(cargoPattern, `version = "${version}"`),
-);
+writeFileSync(cargoPath, cargoToml.replace(cargoPattern, `version = "${version}"`));
 run('cargo', 'update', '--manifest-path', 'apps/cli/Cargo.toml', '--package', 'mohub');
 
 run('git', 'add', 'package.json', 'apps/cli/Cargo.toml', 'apps/cli/Cargo.lock');

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -15,6 +15,11 @@ if (!arg) {
 	console.error('usage: pnpm release <X.Y.Z | patch | minor | major>');
 	process.exit(1);
 }
+const isBump = arg === 'patch' || arg === 'minor' || arg === 'major';
+if (!isBump && !/^\d+\.\d+\.\d+$/.test(arg)) {
+	console.error(`invalid version "${arg}" — expected X.Y.Z, patch, minor, or major`);
+	process.exit(1);
+}
 
 const missing = ['git', 'gh', 'cargo'].filter((tool) => {
 	try {
@@ -44,14 +49,16 @@ run('git', 'fetch', 'origin', 'main');
 const pkgPath = new URL('../package.json', import.meta.url);
 const pkg = JSON.parse(run('git', 'show', 'origin/main:package.json'));
 const cargoPath = new URL('../apps/cli/Cargo.toml', import.meta.url);
-const cargoToml = run('git', 'show', 'origin/main:apps/cli/Cargo.toml');
+const cargoToml = execFileSync('git', ['show', 'origin/main:apps/cli/Cargo.toml'], {
+	encoding: 'utf8',
+});
 const cargoPattern = /^version = "[^"]+"$/m;
 if (!cargoPattern.test(cargoToml)) {
 	fail('could not find the current Cargo package version');
 }
 
 let version = arg;
-if (arg === 'patch' || arg === 'minor' || arg === 'major') {
+if (isBump) {
 	const [major, minor, patch] = pkg.version.split('.').map(Number);
 	version =
 		arg === 'major'
@@ -59,9 +66,6 @@ if (arg === 'patch' || arg === 'minor' || arg === 'major') {
 			: arg === 'minor'
 				? `${major}.${minor + 1}.0`
 				: `${major}.${minor}.${patch + 1}`;
-} else if (!/^\d+\.\d+\.\d+$/.test(version)) {
-	console.error(`invalid version "${version}" — expected X.Y.Z, patch, minor, or major`);
-	process.exit(1);
 }
 
 const branch = `release/${version}`;


### PR DESCRIPTION
`pnpm release` now verifies `git`/`gh`/`cargo` are installed, `gh` is authenticated, `Cargo.toml` has a package version, and neither `vX.Y.Z` nor `release/X.Y.Z` already exists (locally or on origin) before creating the branch. Previously a missing `cargo` failed midway and left a dirty tree on the new branch, and the rerun then tripped the clean-tree check.