### PR TITLE
feat(runtime): fatal, timed Python env setup before kernel launch

### DIFF
--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -59,6 +59,10 @@ uv sync --inexact --no-compile-bytecode   # add the notebook's deps to the base 
 uv run --no-sync marimo edit notebook.py --headless --no-token --host 0.0.0.0 --port 2718
 ```
 
+Before `uv sync`, marimohub records the pinned marimo version from
+`MARIMO_VERSION` or the installed package. If uv replaces the environment to
+change Python versions, marimohub reinstalls that version before the kernel starts.
+
 If a git-synced notebook's entry file contains
 [PEP 723](https://peps.python.org/pep-0723/) inline metadata, marimohub runs three
 more setup commands. These commands run after the project sync and install the
@@ -70,10 +74,10 @@ uv export --script notebook.py --format requirements-txt --no-hashes -o "${UV_PR
 uv pip install --python "${UV_PROJECT_ENVIRONMENT:-.venv}" --no-build -r "${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"
 ```
 
-A failed project sync does not stop the session. In contrast, a failure in these
-three commands stops the session, so marimohub never ignores inline dependencies.
-If the metadata pins `marimo`, it replaces the image's version for that sandbox.
-The replacement can be incompatible with a frontend served through `--asset-url`.
+A setup failure stops the session with `PYTHON_ENV_SETUP_FAILED` before the kernel
+starts. A `marimo` pin in the metadata replaces the image version for that
+sandbox. This version can be incompatible with a frontend served through
+`--asset-url`.
 
 So your image must provide:
 
@@ -85,10 +89,10 @@ So your image must provide:
 3. **A POSIX shell (`sh`) + coreutils** — `base64`, `mkdir`, `rm`, `cat`, `true`.
    marimohub transfers notebook files and probes reachability with these.
 4. **`git`** — only if notebooks use git checkouts, but cheap to include.
-5. **A writable working directory** (`/workspace`) **and a writable
-   `UV_PROJECT_ENVIRONMENT`**, so `uv sync --inexact` can add a notebook's extra
-   deps. If your image's non-root user can't write `/workspace`, set
-   `MARIMOHUB_COMPUTE_WORKDIR` to a directory it can.
+5. **A writable working directory** (`/workspace`) and a writable parent for
+   `UV_PROJECT_ENVIRONMENT`. uv can replace the whole environment to change
+   Python versions. If the user cannot write to `/workspace`, set
+   `MARIMOHUB_COMPUTE_WORKDIR` to a writable directory.
 6. **PyPI egress at runtime** for notebooks that use libraries beyond the
    pre-installed base.
 
@@ -118,7 +122,7 @@ bump it deliberately. Encode the Python + marimo version in the image tag (e.g.
 The [`examples/sandbox-image/`](https://github.com/marimo-team/marimohub/tree/main/examples/sandbox-image)
 directory is a ready-to-fork starting point. marimo is pinned via the
 `MARIMO_VERSION` build arg and installed alongside the libraries in
-`warm/pyproject.toml` into `/opt/venv`:
+`warm/pyproject.toml` into `/opt/marimohub/venv`:
 
 ```dockerfile
 FROM python:3.13-slim
@@ -127,15 +131,15 @@ ENV MARIMO_VERSION=${MARIMO_VERSION}
 COPY --from=ghcr.io/astral-sh/uv:0.10.9 /uv /uvx /usr/local/bin/
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
  && rm -rf /var/lib/apt/lists/*
-ENV UV_PROJECT_ENVIRONMENT=/opt/venv UV_LINK_MODE=copy
+ENV UV_PROJECT_ENVIRONMENT=/opt/marimohub/venv UV_LINK_MODE=copy
 # Skip marimo's PyPI version ping, and continuously snapshot the notebook to
 # __marimo__/notebook.html so the host captures it on teardown.
 ENV MARIMO_SKIP_UPDATE_CHECK=1 _MARIMO_APP_OVERLOAD_AUTO_DOWNLOAD=[html]
 RUN useradd -m appuser && mkdir -p /workspace && chown -R appuser:appuser /workspace
 COPY warm/pyproject.toml /tmp/base/pyproject.toml
 RUN cd /tmp/base && uv add --compile-bytecode "marimo[recommended]==${MARIMO_VERSION}" \
- && uv cache clean && rm -rf /tmp/base && chown -R appuser:appuser /opt/venv
-ENV VIRTUAL_ENV=/opt/venv PATH=/opt/venv/bin:$PATH
+ && uv cache clean && rm -rf /tmp/base && chown -R appuser:appuser /opt/marimohub
+ENV VIRTUAL_ENV=/opt/marimohub/venv PATH=/opt/marimohub/venv/bin:$PATH
 USER appuser
 WORKDIR /workspace
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -121,6 +121,16 @@ provide, or the namespace may lack sufficient quota. Check the Pod's
 out-of-memory during dependency installation, use a larger compute profile and
 start a new session.
 
+### Session fails with `PYTHON_ENV_SETUP_FAILED`
+
+The sandbox started, but uv could not prepare the notebook's Python environment.
+The error identifies permissions, an invalid `pyproject.toml`, a missing Python
+interpreter, or incompatible dependencies. uv can replace the whole environment
+to change Python versions.
+
+If the error identifies permissions, make the sandbox user own the parent of
+`UV_PROJECT_ENVIRONMENT`.
+
 ### Session fails with a uv resolver error
 
 When a git-synced notebook contains [PEP 723](https://peps.python.org/pep-0723/)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -124,9 +124,9 @@ start a new session.
 ### Session fails with `PYTHON_ENV_SETUP_FAILED`
 
 The sandbox started, but uv could not prepare the notebook's Python environment.
-The error identifies permissions, an invalid `pyproject.toml`, a missing Python
-interpreter, or incompatible dependencies. uv can replace the whole environment
-to change Python versions.
+The error identifies permissions, an invalid `pyproject.toml`, a missing TOML
+parser or Python interpreter, or incompatible dependencies. uv can replace the
+whole environment to change Python versions.
 
 If the error identifies permissions, make the sandbox user own the parent of
 `UV_PROJECT_ENVIRONMENT`.
@@ -174,6 +174,7 @@ Every API error returns `{ "success": false, "error": { "code", "message" } }`.
 | `RESOURCE_EXHAUSTED`               | 429       | Per-user concurrent-session cap hit — free one or retry.                   |
 | `PAYLOAD_TOO_LARGE`                | 413       | Request body exceeds the limit.                                            |
 | `SERVICE_UNAVAILABLE`              | 503       | A compute/storage dependency is down — transient.                          |
+| `PYTHON_ENV_SETUP_FAILED`          | 503       | Notebook Python setup failed — fix the reported environment error.         |
 | `INTERNAL_ERROR`                   | 500       | Unexpected; check `level: error` logs (the cause is logged, not returned). |
 
 ## Still stuck?

--- a/examples/sandbox-image/Dockerfile
+++ b/examples/sandbox-image/Dockerfile
@@ -25,8 +25,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ca-certific
 # UV_COMPILE_BYTECODE here — bytecode is a build-time CLI flag below; the
 # provisioner passes `--no-compile-bytecode` on the startup sync, which uv rejects
 # if this env is also set. UV_LINK_MODE is left unset (default: hardlink); the
-# `uv cache clean` below still yields a self-contained /opt/venv.
-ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+# `uv cache clean` below still yields a self-contained environment.
+ENV UV_PROJECT_ENVIRONMENT=/opt/marimohub/venv
 
 # marimo kernel config baked into the image. SKIP_UPDATE_CHECK: no PyPI version
 # ping on startup. AUTO_DOWNLOAD=[html]: continuously snapshot the notebook to
@@ -40,25 +40,27 @@ RUN useradd -m appuser \
  && chown -R appuser:appuser /workspace
 
 # Pre-install marimo (pinned) + the popular libraries in warm/pyproject.toml into
-# /opt/venv with bytecode compiled (fast imports), so the base-case kernel needs no
-# install. Cache is dropped to keep the image lean (the env is self-contained);
-# appuser owns /opt/venv so the startup `uv sync --inexact` can add extra deps.
+# the project environment with bytecode compiled (fast imports), so the base-case
+# kernel needs no install. Cache is dropped to keep the image lean (the env is
+# self-contained); appuser owns its parent so uv can replace the environment for
+# another Python version.
 COPY warm/pyproject.toml /tmp/base/pyproject.toml
 RUN cd /tmp/base \
  && uv add --compile-bytecode "marimo[recommended]==${MARIMO_VERSION}" \
  && uv cache clean \
  && rm -rf /tmp/base \
- && chown -R appuser:appuser /opt/venv
+ && chown -R appuser:appuser /opt/marimohub
 
 # Pre-compile the stdlib to bytecode: the slim base ships it uncompiled, so the
 # kernel otherwise pays lazy .pyc compilation on first import (uv's
 # --compile-bytecode covers installed packages, not the interpreter's stdlib).
 RUN python3 -m compileall -j 0 -q /usr/local/lib/python3.13 || true
 
-# Activate /opt/venv so marimo runs straight from it even for a notebook with no
-# pyproject.toml (where `uv run --no-sync` would otherwise ignore the env).
-ENV VIRTUAL_ENV=/opt/venv \
-    PATH=/opt/venv/bin:$PATH
+# Activate the project environment so marimo runs straight from it even for a
+# notebook with no pyproject.toml (where `uv run --no-sync` would otherwise
+# ignore the env).
+ENV VIRTUAL_ENV=/opt/marimohub/venv \
+    PATH=/opt/marimohub/venv/bin:$PATH
 
 USER appuser
 WORKDIR /workspace

--- a/examples/sandbox-image/README.md
+++ b/examples/sandbox-image/README.md
@@ -41,7 +41,7 @@ uv sync --inexact --no-compile-bytecode   # add the notebook's deps, keep the pr
 uv run --no-sync marimo edit notebook.py …
 ```
 
-marimo + the base libraries are already installed in `/opt/venv`
+marimo and the base libraries are installed in `/opt/marimohub/venv`
 (`UV_PROJECT_ENVIRONMENT`), so a notebook that only uses them starts with no
 install. The notebook's `pyproject.toml` lists only its own extra libraries.
 

--- a/examples/sandbox-image/acceptance-test.sh
+++ b/examples/sandbox-image/acceptance-test.sh
@@ -7,9 +7,8 @@
 # cache hit, `--convert` opens non-marimo files, and a bare `docker run` works.
 #
 # The launch flow mirrors the active strategy in
-# packages/core/src/services/marimoLaunch.ts (`uv-sync-edit`):
-#   [ -s pyproject.toml ] && uv sync || true
-#   uv run --with marimo marimo edit notebook.py --convert --headless --no-token …
+# packages/core/src/services/runtime/marimoLaunch.ts (`uv-sync-edit`): checked
+# `uv sync`, followed by `uv run --no-sync marimo edit`.
 #
 # Usage:  acceptance-test.sh [IMAGE_TAG] [CONTEXT_DIR]
 #   IMAGE_TAG    tag to build/test          (default: marimo-sandbox:acceptance)
@@ -96,12 +95,33 @@ dependencies = ["polars", "narwhals"]
 TOML
 }
 
+provision_python314_notebook() { # $1 = container id
+	docker exec -i "$1" sh -lc 'cd /workspace && cat > notebook.py' <<'PY'
+# /// script
+# requires-python = ">=3.14"
+# dependencies = ["click"]
+# ///
+
+import marimo
+PY
+	docker exec -i "$1" sh -lc 'cd /workspace && cat > pyproject.toml' <<'TOML'
+[project]
+name = "python-314-notebook"
+version = "0.1.0"
+requires-python = ">=3.14"
+dependencies = ["requests"]
+TOML
+}
+
 # Start marimo via the active `uv-sync-edit` launch flow (mirrors marimoLaunch.ts),
 # detached, logging to /tmp/m.log.
 launch_kernel() { # $1 = container id
+	docker exec "$1" sh -lc '
+		cd /workspace
+		[ ! -s pyproject.toml ] || uv sync --inexact --no-compile-bytecode --no-build
+	'
 	docker exec -d "$1" sh -lc '
 		cd /workspace
-		[ -s pyproject.toml ] && uv sync --inexact || true
 		uv run --no-sync marimo edit notebook.py \
 			--convert --headless --no-token --host 0.0.0.0 --port 2718 >/tmp/m.log 2>&1
 	'
@@ -152,6 +172,29 @@ mv="$(docker run --rm "$IMAGE" sh -lc 'printf %s "$MARIMO_VERSION"')"
 got="$(docker run --rm "$IMAGE" sh -lc 'cd /workspace && uv run --no-sync python -c "import marimo; print(marimo.__version__)" 2>/dev/null | tail -1')"
 [ "$got" = "$mv" ] || fail "pre-installed marimo is ${got:-none}, expected pinned $mv"
 ok "marimo pinned to $mv (pre-installed; launch never upgrades it)"
+
+# --- 2c. a notebook may replace the warm env with a newer Python ------------
+echo "==> 2c. Python-version replacement"
+cid="$(run_detached "$IMAGE" sleep infinity)"
+provision_python314_notebook "$cid"
+docker exec "$cid" sh -lc '
+	set -e
+	cd /workspace
+	marimohub_marimo_version="${MARIMO_VERSION:-$(python3 -c "import importlib.metadata as m;print(m.version(\"marimo\"))")}"
+	uv sync --inexact --no-compile-bytecode --no-build
+	installed_marimo="$(uv run --no-sync python -c "import importlib.metadata as m;print(m.version(\"marimo\"))" 2>/dev/null || true)"
+	[ "$installed_marimo" = "$marimohub_marimo_version" ] || \
+		uv pip install --python "$UV_PROJECT_ENVIRONMENT" --no-build \
+			"marimo==$marimohub_marimo_version"
+	uv export --script notebook.py --format requirements-txt --no-hashes \
+		-o "$UV_PROJECT_ENVIRONMENT/marimohub-script-requirements.txt"
+	uv pip install --python "$UV_PROJECT_ENVIRONMENT" --no-build \
+		-r "$UV_PROJECT_ENVIRONMENT/marimohub-script-requirements.txt"
+	uv run --no-sync python -c \
+		"import click,marimo,os,sys; assert sys.version_info[:2] >= (3,14); assert marimo.__version__ == os.environ[\"MARIMO_VERSION\"]"
+' || fail "uv could not replace the warm environment with Python 3.14"
+ok "Python 3.14 replaces the warm environment and starts with script pins"
+docker rm -f "$cid" >/dev/null 2>&1
 
 # --- 3. provisioner flow: kernel serves HTTP 200 on 2718 ---------------------
 echo "==> 3. Kernel serves via the uv-sync-edit launch flow"

--- a/examples/sandbox-image/warm/pyproject.toml
+++ b/examples/sandbox-image/warm/pyproject.toml
@@ -1,4 +1,4 @@
-# Popular libraries pre-installed into the image's project env (/opt/venv) at build
+# Popular libraries pre-installed into the image's project environment at build
 # time. marimo itself is added separately, pinned to $MARIMO_VERSION, by the
 # Dockerfile. Edit this list to change what's pre-installed.
 [project]

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends git ca-certific
 ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LANGUAGE=en_US:en \
-    UV_PROJECT_ENVIRONMENT=/opt/venv \
-    UV_CACHE_DIR=/opt/uv-cache \
+    UV_PROJECT_ENVIRONMENT=/opt/marimohub/venv \
+    UV_CACHE_DIR=/opt/marimohub/uv-cache \
     MARIMO_SKIP_UPDATE_CHECK=1 \
     _MARIMO_APP_OVERLOAD_AUTO_DOWNLOAD=[html]
 
@@ -58,13 +58,13 @@ RUN cd /tmp \
       openpyxl \
       sqlglot \
  && rm -rf /tmp/base \
- && chown -R appuser:appuser /opt/venv /opt/uv-cache
+ && chown -R appuser:appuser /opt/marimohub
 
 # uv compiles installed packages, but not the interpreter's standard library.
 RUN python3 -m compileall -j 0 -q /usr/local/lib/python3.13 || true
 
-ENV VIRTUAL_ENV=/opt/venv \
-    PATH=/opt/venv/bin:$PATH
+ENV VIRTUAL_ENV=/opt/marimohub/venv \
+    PATH=/opt/marimohub/venv/bin:$PATH
 
 # The hub's compute adapters exec commands via a login shell (`sh -lc`), and
 # /etc/profile resets PATH — dropping the venv set by ENV above. profile.d runs

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -95,6 +95,7 @@ components:
                 - SYNC_NOT_CONFIGURED
                 - NOT_INITIALIZED
                 - SERVICE_UNAVAILABLE
+                - PYTHON_ENV_SETUP_FAILED
                 - RESOURCE_EXHAUSTED
                 - UNAUTHORIZED
                 - USER_SUSPENDED

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -7,7 +7,7 @@ import {
 	Millis,
 	paths,
 } from '@marimo-hub/core';
-import type { NotebookId, ProjectId, Session, SessionId } from '@marimo-hub/core';
+import type { NotebookId, ProjectId, SandboxInstance, Session, SessionId } from '@marimo-hub/core';
 import {
 	ACTOR,
 	fakeComputeFrom,
@@ -186,7 +186,7 @@ describe('Session routes', () => {
 			const synced = await createSyncedNotebook(INLINE_CODE);
 			const { sb, post } = await startSessionApi(synced);
 			await expectOk<ApiSession>(await post());
-			const cmd = sb.calls.startProcess[0].cmd;
+			const cmd = sb.calls.exec.find((command) => command.includes('uv sync --inexact'))!;
 			expect(cmd).toContain("uv export --script 'apps/dash.py'");
 			expect(cmd).toContain('uv pip install');
 			// The repo pyproject layer still applies underneath the pins.
@@ -197,8 +197,8 @@ describe('Session routes', () => {
 			const synced = await createSyncedNotebook('import marimo');
 			const { sb, post } = await startSessionApi(synced);
 			await expectOk<ApiSession>(await post());
-			expect(sb.calls.startProcess[0].cmd).toContain('uv sync --inexact');
-			expect(sb.calls.startProcess[0].cmd).not.toContain('uv export');
+			const setup = sb.calls.exec.find((command) => command.includes('uv sync --inexact'))!;
+			expect(setup).not.toContain('uv export');
 		});
 
 		it('ignores inline metadata in a local notebook (deps live in pyproject.toml)', async () => {
@@ -210,8 +210,8 @@ describe('Session routes', () => {
 			);
 			const { sb, post } = await startSessionApi(local.id as NotebookId);
 			await expectOk<ApiSession>(await post());
-			expect(sb.calls.startProcess[0].cmd).toContain('uv sync --inexact');
-			expect(sb.calls.startProcess[0].cmd).not.toContain('uv export');
+			const setup = sb.calls.exec.find((command) => command.includes('uv sync --inexact'))!;
+			expect(setup).not.toContain('uv export');
 		});
 
 		it('does not re-read the entry file when reusing an existing session', async () => {
@@ -232,8 +232,8 @@ describe('Session routes', () => {
 			await bucket.delete(entryKey);
 			const { sb, post } = await startSessionApi(synced);
 			await expectOk<ApiSession>(await post());
-			expect(sb.calls.startProcess[0].cmd).toContain('uv sync --inexact');
-			expect(sb.calls.startProcess[0].cmd).not.toContain('uv export');
+			const setup = sb.calls.exec.find((command) => command.includes('uv sync --inexact'))!;
+			expect(setup).not.toContain('uv export');
 		});
 
 		it('rejects an unsynced notebook before reading any entry file', async () => {
@@ -1950,6 +1950,45 @@ describe('Session routes', () => {
 		expect(calls.destroy).toBeGreaterThanOrEqual(1);
 		const all = await createServices(bucket).sessions.listSessions(nid);
 		expect(all.every((s) => s.status === 'failed')).toBe(true);
+	});
+
+	it('POST /sessions: Python setup failure is specific and stored on the session', async () => {
+		const { instance: base, calls } = makeFakeSandbox();
+		const instance: SandboxInstance = {
+			...base,
+			async exec(command) {
+				if (!command.includes('uv sync')) return base.exec(command);
+				calls.exec.push(command);
+				return {
+					success: false,
+					stdout: '',
+					stderr: 'failed to remove directory: Permission denied',
+					error: { code: 'COMMAND_FAILED' },
+				};
+			},
+		};
+		const api = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: fakeComputeFrom(instance),
+		}).request;
+
+		const error = await expectError(
+			await api('POST', sessionsPath()),
+			503,
+			'PYTHON_ENV_SETUP_FAILED',
+		);
+		expect(error.message).toContain('does not allow replacing');
+		const all = await createServices(bucket).sessions.listSessions(nid);
+		expect(all).toHaveLength(1);
+		expect(all[0]).toMatchObject({
+			status: 'failed',
+			error: {
+				code: 'PYTHON_ENV_SETUP_FAILED',
+				message: expect.stringContaining('does not allow replacing'),
+			},
+		});
+		expect(calls.startProcess).toHaveLength(0);
 	});
 
 	describe('viewer mode', () => {

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1462,6 +1462,7 @@ app.openapi(createSession, async (c) => {
 		// markFailed no-ops if a concurrent stop already made it terminal.
 		if (session) {
 			const safeError = toSessionError(err);
+			observer.tag('provision_error_code', safeError.code);
 			const failed = await sessions
 				.markFailedWithOutcome(pid, session.session_id, safeError)
 				.catch(() => null);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -86,6 +86,7 @@ const KNOWN_SERVER_ERROR_CODES = {
 	NOT_INITIALIZED: true,
 	NO_HTML_SNAPSHOT: true,
 	SERVICE_UNAVAILABLE: true,
+	PYTHON_ENV_SETUP_FAILED: true,
 	INTERNAL_ERROR: true,
 } satisfies Record<ServerErrorCode, true>;
 

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -1269,6 +1269,7 @@ export interface components {
 					| 'SYNC_NOT_CONFIGURED'
 					| 'NOT_INITIALIZED'
 					| 'SERVICE_UNAVAILABLE'
+					| 'PYTHON_ENV_SETUP_FAILED'
 					| 'RESOURCE_EXHAUSTED'
 					| 'UNAUTHORIZED'
 					| 'USER_SUSPENDED'

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -97,6 +97,15 @@ describe('CloudflareSandboxProvider', () => {
 				error: { code: 'COMMAND_FAILED' },
 			});
 		});
+
+		it('passes an extended command timeout to the SDK', async () => {
+			fakeSandbox.exec.mockClear();
+			fakeSandbox.exec.mockResolvedValueOnce({ success: true, stdout: '', stderr: '' });
+
+			await makeProvider().create(SANDBOX_ID).exec('uv sync', { timeout: 300_000 });
+
+			expect(fakeSandbox.exec).toHaveBeenCalledWith('uv sync', { timeout: 300_000 });
+		});
 	});
 
 	describe('instance.writeFiles() bytes', () => {

--- a/packages/compute-cloudflare/src/index.ts
+++ b/packages/compute-cloudflare/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from '@marimo-hub/compute-commons';
 import type { SandboxId } from '@marimo-hub/core';
 import type {
+	ExecOptions,
 	ExecResult,
 	ExecStreamOptions,
 	ExposePortOptions,
@@ -75,8 +76,12 @@ class CloudflareSandboxInstance implements SandboxInstance {
 		this.useTunnel = useTunnel;
 	}
 
-	async exec(cmd: string): Promise<ExecResult> {
-		const res = await this.sandbox.exec(this.withDefaults(cmd));
+	async exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
+		const command = this.withDefaults(cmd);
+		const res =
+			options?.timeout === undefined
+				? await this.sandbox.exec(command)
+				: await this.sandbox.exec(command, { timeout: options.timeout });
 		return execResult(res.success, res.stdout, res.stderr);
 	}
 

--- a/packages/compute-container/src/docker.ts
+++ b/packages/compute-container/src/docker.ts
@@ -7,7 +7,10 @@ export interface DockerRunResult {
 }
 
 export interface DockerRunner {
-	run(args: string[], options?: { stdin?: string | Uint8Array }): Promise<DockerRunResult>;
+	run(
+		args: string[],
+		options?: { stdin?: string | Uint8Array; timeout?: number },
+	): Promise<DockerRunResult>;
 }
 
 export interface DockerConfig {

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -20,6 +20,7 @@ import type {
 	ActiveSandbox,
 	ComputeResources,
 	CreateSandboxOptions,
+	ExecOptions,
 	ExecResult,
 	ExecStreamOptions,
 	ExposePortOptions,
@@ -44,6 +45,16 @@ const KERNEL_PORT = 2718;
 const NAME_PREFIX = 'marimohub-sbx-';
 const DEFAULT_LABEL_KEY = 'marimohub.sandbox';
 const DEFAULT_IMAGE = 'ghcr.io/marimo-team/marimo:latest';
+const EXEC_TIMEOUT_GRACE_MS = 100;
+const EXEC_TIMEOUT_SUPERVISOR = `import os, signal, subprocess, sys
+process = subprocess.Popen(['sh', '-lc', sys.argv[2]], start_new_session=True)
+try:
+	code = process.wait(timeout=float(sys.argv[1]) / 1000)
+except subprocess.TimeoutExpired:
+	os.killpg(process.pid, signal.SIGKILL)
+	process.wait()
+	code = 124
+sys.exit(code)`;
 
 export interface ContainerRunResult {
 	stdout: string;
@@ -56,7 +67,10 @@ export interface ContainerRunResult {
  * hermetic while production spawns the selected engine binary on PATH.
  */
 export interface ContainerRunner {
-	run(args: string[], options?: { stdin?: string | Uint8Array }): Promise<ContainerRunResult>;
+	run(
+		args: string[],
+		options?: { stdin?: string | Uint8Array; timeout?: number },
+	): Promise<ContainerRunResult>;
 }
 
 export function spawnContainerRunner(bin: string): ContainerRunner {
@@ -66,12 +80,31 @@ export function spawnContainerRunner(bin: string): ContainerRunner {
 				const child = spawn(bin, args);
 				let stdout = '';
 				let stderr = '';
+				let timedOut = false;
+				const timer =
+					options?.timeout !== undefined && options.timeout > 0
+						? setTimeout(() => {
+								timedOut = true;
+								child.kill('SIGKILL');
+							}, options.timeout)
+						: undefined;
+				timer?.unref();
 				child.stdout?.on('data', (d) => (stdout += d.toString()));
 				child.stderr?.on('data', (d) => (stderr += d.toString()));
-				child.on('error', (err) =>
-					resolve({ stdout, stderr: stderr + String(err), exitCode: 127 }),
-				);
-				child.on('close', (code) => resolve({ stdout, stderr, exitCode: code ?? 1 }));
+				child.on('error', (err) => {
+					clearTimeout(timer);
+					resolve({ stdout, stderr: stderr + String(err), exitCode: 127 });
+				});
+				child.on('close', (code) => {
+					clearTimeout(timer);
+					resolve({
+						stdout,
+						stderr: timedOut
+							? [stderr, `command timed out after ${options?.timeout}ms`].filter(Boolean).join('\n')
+							: stderr,
+						exitCode: timedOut ? 124 : (code ?? 1),
+					});
+				});
 				if (options?.stdin !== undefined) {
 					child.stdin?.end(options.stdin);
 				} else {
@@ -162,13 +195,31 @@ class ContainerSandboxInstance implements SandboxInstance {
 		return withEnvPrefix(cmd, this.env, this.envDefaults);
 	}
 
-	private async dexec(cmd: string, flags: string[] = []): Promise<ContainerRunResult> {
+	private async dexec(
+		cmd: string,
+		flags: string[] = [],
+		options?: ExecOptions,
+	): Promise<ContainerRunResult> {
 		await this.ensure();
-		return this.runner.run(['exec', ...flags, this.name, 'sh', '-lc', this.withEnv(cmd)]);
+		const command =
+			options?.timeout !== undefined && options.timeout > 0
+				? [
+						'python3',
+						'-c',
+						EXEC_TIMEOUT_SUPERVISOR,
+						String(
+							Math.max(1, options.timeout - Math.min(EXEC_TIMEOUT_GRACE_MS, options.timeout / 10)),
+						),
+						this.withEnv(cmd),
+					]
+				: ['sh', '-lc', this.withEnv(cmd)];
+		return this.runner.run(['exec', ...flags, this.name, ...command], {
+			timeout: options?.timeout,
+		});
 	}
 
-	async exec(cmd: string): Promise<ExecResult> {
-		const res = await this.dexec(cmd);
+	async exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
+		const res = await this.dexec(cmd, [], options);
 		return execResult(res.exitCode === 0, res.stdout, res.stderr);
 	}
 

--- a/packages/compute-container/src/podman.ts
+++ b/packages/compute-container/src/podman.ts
@@ -7,7 +7,10 @@ export interface PodmanRunResult {
 }
 
 export interface PodmanRunner {
-	run(args: string[], options?: { stdin?: string | Uint8Array }): Promise<PodmanRunResult>;
+	run(
+		args: string[],
+		options?: { stdin?: string | Uint8Array; timeout?: number },
+	): Promise<PodmanRunResult>;
 }
 
 export interface PodmanConfig {

--- a/packages/compute-container/src/testing.ts
+++ b/packages/compute-container/src/testing.ts
@@ -231,7 +231,7 @@ export function containerCliContract(
 		});
 
 		it('kills a stalled engine client when its timeout expires', async () => {
-			const result = await spawnRunner('sh').run(['-c', 'sleep 10'], { timeout: 20 });
+			const result = await spawnRunner('sh').run(['-c', 'exec sleep 10'], { timeout: 20 });
 
 			expect(result).toMatchObject({
 				exitCode: 124,

--- a/packages/compute-container/src/testing.ts
+++ b/packages/compute-container/src/testing.ts
@@ -10,6 +10,7 @@ const CONTAINER_NAME = 'marimohub-sbx-sb-aaaaaaaaaaaaaaaa';
 export interface ContainerCliCall {
 	args: string[];
 	stdin?: string | Uint8Array;
+	timeout?: number;
 }
 
 export function createRecordingContainerRunner(
@@ -20,7 +21,7 @@ export function createRecordingContainerRunner(
 		calls,
 		runner: {
 			async run(args, options) {
-				calls.push({ args, stdin: options?.stdin });
+				calls.push({ args, stdin: options?.stdin, timeout: options?.timeout });
 				return handler(args, options?.stdin) ?? { stdout: '', stderr: '', exitCode: 0 };
 			},
 		},
@@ -206,6 +207,36 @@ export function containerCliContract(
 			const result = await spawnRunner(`marimohub-no-such-${engine}-binary-xyz`).run(['ps']);
 			expect(result.exitCode).toBe(127);
 			expect(result.stderr).toBeTruthy();
+		});
+
+		it('bounds both the engine client and the in-container command', async () => {
+			const { runner, calls } = createRecordingContainerRunner(defaultContainerCliHandler);
+
+			await makeProvider({}, runner).create(SANDBOX_ID).exec('uv sync', { timeout: 250 });
+
+			const call = calls.find((candidate) => candidate.args[0] === 'exec');
+			expect(call).toEqual({
+				args: [
+					'exec',
+					CONTAINER_NAME,
+					'python3',
+					'-c',
+					expect.stringContaining('os.killpg(process.pid, signal.SIGKILL)'),
+					'225',
+					'uv sync',
+				],
+				stdin: undefined,
+				timeout: 250,
+			});
+		});
+
+		it('kills a stalled engine client when its timeout expires', async () => {
+			const result = await spawnRunner('sh').run(['-c', 'sleep 10'], { timeout: 20 });
+
+			expect(result).toMatchObject({
+				exitCode: 124,
+				stderr: expect.stringContaining('command timed out after 20ms'),
+			});
 		});
 	});
 }

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -506,11 +506,10 @@ describe('CoreWeaveCompute', () => {
 			expect(entry.fake.startCalls.at(-1)).toEqual(['sh', '-lc', 'uv run marimo edit --port 2718']);
 		});
 
-		// Launch setup rides the kernel command, so a broken env kills the process
-		// outright; the port then never opens and the wait would otherwise run the
-		// full (2 minute) timeout. The SDK records an exit code ONLY on a clean exit,
-		// so `failed` (a gRPC stream reset — see RUNBOOK H1) and `cancelled` have to
-		// be recognised by status or they sail past a poll()-based check.
+		// A broken kernel command can exit before opening the port, and the wait would
+		// otherwise run the full (2 minute) timeout. The SDK records an exit code ONLY
+		// on a clean exit, so `failed` (a gRPC stream reset — see RUNBOOK H1) and
+		// `cancelled` have to be recognised by status or they sail past a poll()-based check.
 		it.each(['exited', 'failed', 'cancelled'] as const)(
 			'a %s kernel is reported without burning the timeout',
 			async (status) => {

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -68,6 +68,7 @@ import type {
 } from '@marimo-hub/core';
 import type {
 	CreateSandboxOptions,
+	ExecOptions,
 	ExecResult,
 	ExecStreamOptions,
 	ExposePortOptions,
@@ -254,7 +255,10 @@ export interface CoreWeaveSandbox {
 	/** Block until the sandbox reaches `running`; see `BOOT_POLL_INTERVAL_MS`. */
 	wait(options?: { intervalMs?: number }): Promise<unknown>;
 	readonly commands: {
-		run(command: readonly string[], options?: { cwd?: string }): Promise<ProcessResult>;
+		run(
+			command: readonly string[],
+			options?: { cwd?: string; timeoutMs?: number },
+		): Promise<ProcessResult>;
 		start(command: readonly string[], options?: { cwd?: string }): Promise<CommandProcess>;
 	};
 	readonly files: {
@@ -462,10 +466,12 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		return withEnvPrefix(this.takeBootstrap(cmd), this.env, this.envDefaults);
 	}
 
-	async exec(cmd: string): Promise<ExecResult> {
+	async exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
 		const sandbox = await this.ensure();
 		this.execCount++;
-		const res = await sandbox.commands.run(['sh', '-lc', this.withEnv(cmd)]);
+		const res = await sandbox.commands.run(['sh', '-lc', this.withEnv(cmd)], {
+			timeoutMs: options?.timeout,
+		});
 		return execResult(res.exitCode === 0, res.stdout, res.stderr);
 	}
 

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -29,6 +29,7 @@ import { SandboxId, Seconds } from '@marimo-hub/core';
 import type {
 	ActiveSandbox,
 	CreateSandboxOptions,
+	ExecOptions,
 	ExecResult,
 	ExecStreamOptions,
 	ExposePortOptions,
@@ -72,7 +73,7 @@ export interface E2bSandboxHandle {
 	commands: {
 		run(
 			cmd: string,
-			options?: { cwd?: string; envs?: Record<string, string> },
+			options?: { cwd?: string; envs?: Record<string, string>; timeoutMs?: number },
 		): Promise<E2bExecResult>;
 		runBackground(
 			cmd: string,
@@ -194,11 +195,14 @@ class E2bSandboxInstance implements SandboxInstance {
 		return promise;
 	}
 
-	async exec(cmd: string): Promise<ExecResult> {
+	async exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
 		const sb = await this.ensure();
 		// Forced vars ride the SDK's per-command `envs`; defaults can't (that channel
 		// always overwrites), so they go in as a guarded shell prefix instead.
-		const res = await sb.commands.run(this.withDefaults(cmd), { envs: this.env });
+		const res = await sb.commands.run(this.withDefaults(cmd), {
+			envs: this.env,
+			timeoutMs: options?.timeout,
+		});
 		return execResult(res.exitCode === 0, res.stdout, res.stderr);
 	}
 

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -552,6 +552,41 @@ describe('createK8sClient', () => {
 		]);
 	});
 
+	it('preserves exec socket errors when both listener APIs are available', async () => {
+		const client = createK8sClient({ namespace: 'kernels' });
+		const socket = Object.assign(new EventEmitter(), {
+			addEventListener: vi.fn(),
+			close: vi.fn(),
+		});
+		k8sMock.exec.mockImplementationOnce(async () => {
+			setTimeout(() => socket.emit('error', new Error('socket connection failed')), 0);
+			return socket;
+		});
+
+		await expect(client.exec('pod-1', ['sh', '-lc', 'cmd'])).rejects.toThrow(
+			'socket connection failed',
+		);
+		expect(socket.addEventListener).not.toHaveBeenCalled();
+	});
+
+	it('unwraps errors from EventTarget exec sockets', async () => {
+		const client = createK8sClient({ namespace: 'kernels' });
+		const socket = Object.assign(new EventTarget(), { close: vi.fn() });
+		k8sMock.exec.mockImplementationOnce(async () => {
+			setTimeout(() => {
+				const event = Object.assign(new Event('error'), {
+					error: new Error('native socket failed'),
+				});
+				socket.dispatchEvent(event);
+			}, 0);
+			return socket;
+		});
+
+		await expect(client.exec('pod-1', ['sh', '-lc', 'cmd'])).rejects.toThrow(
+			'native socket failed',
+		);
+	});
+
 	it('closes the exec WebSocket when the command times out', async () => {
 		const client = createK8sClient({ namespace: 'kernels' });
 		const socket = Object.assign(new EventTarget(), { close: vi.fn() });

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -552,15 +552,33 @@ describe('createK8sClient', () => {
 		]);
 	});
 
-	it('terminates the exec WebSocket when the command times out', async () => {
+	it('closes the exec WebSocket when the command times out', async () => {
 		const client = createK8sClient({ namespace: 'kernels' });
-		const socket = Object.assign(new EventEmitter(), { terminate: vi.fn() });
+		const socket = Object.assign(new EventTarget(), { close: vi.fn() });
 		k8sMock.exec.mockResolvedValueOnce(socket);
 
 		await expect(
 			client.exec('pod-1', ['sh', '-lc', 'uv sync'], undefined, { timeout: 10 }),
 		).rejects.toThrow('command timed out after 10ms');
-		expect(socket.terminate).toHaveBeenCalledOnce();
+		expect(socket.close).toHaveBeenCalledOnce();
+	});
+
+	it('closes an exec WebSocket that connects after the command times out', async () => {
+		const client = createK8sClient({ namespace: 'kernels' });
+		const socket = Object.assign(new EventTarget(), { close: vi.fn() });
+		let connect: ((connectedSocket: typeof socket) => void) | undefined;
+		k8sMock.exec.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					connect = resolve;
+				}),
+		);
+
+		await expect(
+			client.exec('pod-1', ['sh', '-lc', 'uv sync'], undefined, { timeout: 10 }),
+		).rejects.toThrow('command timed out after 10ms');
+		connect?.(socket);
+		await vi.waitFor(() => expect(socket.close).toHaveBeenCalledOnce());
 	});
 
 	it('rethrows a 403 RBAC-forbidden pod create (only 409 is tolerated)', async () => {

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -552,6 +552,17 @@ describe('createK8sClient', () => {
 		]);
 	});
 
+	it('terminates the exec WebSocket when the command times out', async () => {
+		const client = createK8sClient({ namespace: 'kernels' });
+		const socket = Object.assign(new EventEmitter(), { terminate: vi.fn() });
+		k8sMock.exec.mockResolvedValueOnce(socket);
+
+		await expect(
+			client.exec('pod-1', ['sh', '-lc', 'uv sync'], undefined, { timeout: 10 }),
+		).rejects.toThrow('command timed out after 10ms');
+		expect(socket.terminate).toHaveBeenCalledOnce();
+	});
+
 	it('rethrows a 403 RBAC-forbidden pod create (only 409 is tolerated)', async () => {
 		k8sMock.core.createNamespacedPod.mockRejectedValueOnce({ code: 403 });
 		const client = createK8sClient({ namespace: 'kernels' });

--- a/packages/compute-kubernetes/src/client.ts
+++ b/packages/compute-kubernetes/src/client.ts
@@ -34,6 +34,7 @@ import {
 import type {
 	EnsureSandboxOptions,
 	K8sClient,
+	K8sExecOptions,
 	K8sExecResult,
 	K8sPodPhaseInfo,
 	K8sSandboxInfo,
@@ -44,6 +45,12 @@ import type {
 const SANDBOX_NAME_LABEL = 'marimohub.io/sandbox-name';
 /** The single container name in each kernel Pod (the exec target). */
 const CONTAINER_NAME = 'marimo';
+
+interface ExecSocket {
+	on(event: 'close', listener: () => void): void;
+	on(event: 'error', listener: (error: unknown) => void): void;
+	terminate(): void;
+}
 
 /** True when an error is a k8s API error with the given HTTP status code. */
 function hasCode(err: unknown, code: number): boolean {
@@ -362,6 +369,7 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 			name: string,
 			command: string[],
 			stdin?: string | Uint8Array,
+			options?: K8sExecOptions,
 		): Promise<K8sExecResult> {
 			const { exec } = await apis();
 			const out = collector();
@@ -373,6 +381,29 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 
 			return new Promise<K8sExecResult>((resolve, reject) => {
 				let status: V1Status | undefined;
+				let settled = false;
+				let socket: ExecSocket | undefined;
+				const finish = (result: K8sExecResult) => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timer);
+					resolve(result);
+				};
+				const fail = (error: unknown) => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timer);
+					reject(error instanceof Error ? error : new Error(String(error)));
+				};
+				const timer =
+					options?.timeout !== undefined && options.timeout > 0
+						? setTimeout(() => {
+								stdinStream?.destroy();
+								fail(new Error(`command timed out after ${options.timeout}ms`));
+								socket?.terminate();
+							}, options.timeout)
+						: undefined;
+				timer?.unref();
 				exec
 					.exec(
 						namespace,
@@ -387,17 +418,22 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 							status = s;
 						},
 					)
-					.then((socket) => {
-						socket.on('close', () =>
-							resolve({
+					.then((connectedSocket: ExecSocket) => {
+						socket = connectedSocket;
+						if (settled) {
+							connectedSocket.terminate();
+							return;
+						}
+						connectedSocket.on('close', () =>
+							finish({
 								stdout: out.text(),
 								stderr: errc.text(),
 								exitCode: exitCodeFromStatus(status),
 							}),
 						);
-						socket.on('error', reject);
+						connectedSocket.on('error', fail);
 					})
-					.catch(reject);
+					.catch(fail);
 			});
 		},
 

--- a/packages/compute-kubernetes/src/client.ts
+++ b/packages/compute-kubernetes/src/client.ts
@@ -47,9 +47,25 @@ const SANDBOX_NAME_LABEL = 'marimohub.io/sandbox-name';
 const CONTAINER_NAME = 'marimo';
 
 interface ExecSocket {
-	on(event: 'close', listener: () => void): void;
-	on(event: 'error', listener: (error: unknown) => void): void;
-	terminate(): void;
+	on?(event: 'close' | 'error', listener: (event?: unknown) => void): void;
+	addEventListener?(event: 'close' | 'error', listener: (event?: unknown) => void): void;
+	close(): void;
+}
+
+function addExecSocketListener(
+	socket: ExecSocket,
+	event: 'close' | 'error',
+	listener: (value?: unknown) => void,
+): void {
+	if (socket.addEventListener) {
+		socket.addEventListener(event, listener);
+		return;
+	}
+	if (socket.on) {
+		socket.on(event, listener);
+		return;
+	}
+	throw new Error('exec WebSocket does not support event listeners');
 }
 
 /** True when an error is a k8s API error with the given HTTP status code. */
@@ -400,7 +416,7 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 						? setTimeout(() => {
 								stdinStream?.destroy();
 								fail(new Error(`command timed out after ${options.timeout}ms`));
-								socket?.terminate();
+								socket?.close();
 							}, options.timeout)
 						: undefined;
 				timer?.unref();
@@ -421,17 +437,17 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 					.then((connectedSocket: ExecSocket) => {
 						socket = connectedSocket;
 						if (settled) {
-							connectedSocket.terminate();
+							connectedSocket.close();
 							return;
 						}
-						connectedSocket.on('close', () =>
+						addExecSocketListener(connectedSocket, 'close', () =>
 							finish({
 								stdout: out.text(),
 								stderr: errc.text(),
 								exitCode: exitCodeFromStatus(status),
 							}),
 						);
-						connectedSocket.on('error', fail);
+						addExecSocketListener(connectedSocket, 'error', fail);
 					})
 					.catch(fail);
 			});

--- a/packages/compute-kubernetes/src/client.ts
+++ b/packages/compute-kubernetes/src/client.ts
@@ -57,15 +57,27 @@ function addExecSocketListener(
 	event: 'close' | 'error',
 	listener: (value?: unknown) => void,
 ): void {
-	if (socket.addEventListener) {
-		socket.addEventListener(event, listener);
-		return;
-	}
 	if (socket.on) {
 		socket.on(event, listener);
 		return;
 	}
+	if (socket.addEventListener) {
+		socket.addEventListener(event, listener);
+		return;
+	}
 	throw new Error('exec WebSocket does not support event listeners');
+}
+
+function execSocketError(value: unknown): Error {
+	if (value instanceof Error) return value;
+	if (typeof value === 'object' && value !== null) {
+		const event = value as { error?: unknown; message?: unknown };
+		if (event.error instanceof Error) return event.error;
+		if (typeof event.message === 'string' && event.message) return new Error(event.message);
+		if (typeof event.error === 'string' && event.error) return new Error(event.error);
+		return new Error('exec WebSocket error');
+	}
+	return new Error(String(value));
 }
 
 /** True when an error is a k8s API error with the given HTTP status code. */
@@ -409,7 +421,7 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 					if (settled) return;
 					settled = true;
 					clearTimeout(timer);
-					reject(error instanceof Error ? error : new Error(String(error)));
+					reject(execSocketError(error));
 				};
 				const timer =
 					options?.timeout !== undefined && options.timeout > 0

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -21,6 +21,7 @@ import {
 import type {
 	EnsureSandboxOptions,
 	K8sClient,
+	K8sExecOptions,
 	K8sExecResult,
 	K8sPodPhaseInfo,
 	KubernetesConfig,
@@ -65,7 +66,12 @@ function makeWorld(opts?: {
 }) {
 	const ensured: EnsureSandboxOptions[] = [];
 	const deleted: string[] = [];
-	const execCalls: { name: string; command: string[]; stdin?: string | Uint8Array }[] = [];
+	const execCalls: {
+		name: string;
+		command: string[];
+		stdin?: string | Uint8Array;
+		options?: K8sExecOptions;
+	}[] = [];
 	const pods = new Map<string, { sandboxId: SandboxId; phase: string }>();
 
 	const client: K8sClient = {
@@ -81,8 +87,8 @@ function makeWorld(opts?: {
 		},
 		getSchedulingFailure: async () => opts?.schedulingFailure,
 		getImagePullMessage: async () => opts?.imagePullMessage,
-		exec: async (name, command, stdin) => {
-			execCalls.push({ name, command, stdin });
+		exec: async (name, command, stdin, options) => {
+			execCalls.push({ name, command, stdin, options });
 			return opts?.execImpl?.(command, stdin) ?? { stdout: '', stderr: '', exitCode: 0 };
 		},
 		delete: async (name) => {
@@ -153,6 +159,21 @@ describe('KubernetesCompute', () => {
 			});
 			const result = await makeCompute(world).create(SANDBOX_ID).exec('bad');
 			expectExecResult(result, { success: false, stderr: 'boom' });
+		});
+
+		it('passes the exec timeout to the Kubernetes client', async () => {
+			const world = makeWorld();
+
+			await makeCompute(world).create(SANDBOX_ID).exec('uv sync', { timeout: 300_000 });
+
+			expect(world.execCalls.at(-1)?.options).toEqual({ timeout: 300_000 });
+			expect(world.execCalls.at(-1)?.command).toEqual([
+				'python3',
+				'-c',
+				expect.stringContaining('os.killpg(process.pid, signal.SIGKILL)'),
+				'299900',
+				'uv sync',
+			]);
 		});
 	});
 

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
+import {
+	NOT_A_DIRECTORY_EXIT_CODE,
+	NOT_A_DIRECTORY_MARKER,
+	shellQuote,
+} from '@marimo-hub/compute-commons';
 import { Millis } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
@@ -161,19 +165,28 @@ describe('KubernetesCompute', () => {
 			expectExecResult(result, { success: false, stderr: 'boom' });
 		});
 
-		it('passes the exec timeout to the Kubernetes client', async () => {
+		it('runs the timeout supervisor in the login shell and passes the client deadline', async () => {
 			const world = makeWorld();
 
 			await makeCompute(world).create(SANDBOX_ID).exec('uv sync', { timeout: 300_000 });
 
 			expect(world.execCalls.at(-1)?.options).toEqual({ timeout: 300_000 });
-			expect(world.execCalls.at(-1)?.command).toEqual([
-				'python3',
-				'-c',
-				expect.stringContaining('os.killpg(process.pid, signal.SIGKILL)'),
-				'299900',
-				'uv sync',
-			]);
+			const command = world.execCalls.at(-1)?.command;
+			expect(command?.slice(0, 2)).toEqual(['sh', '-lc']);
+			expect(command?.[2]).toContain('exec python3 -c ');
+			expect(command?.[2]).toContain('os.killpg(process.pid, signal.SIGKILL)');
+			expect(command?.[2]).toContain(`${shellQuote('299900')} ${shellQuote('uv sync')}`);
+		});
+
+		it('quotes hostile command text passed to the timeout supervisor', async () => {
+			const world = makeWorld();
+			const hostile = `printf '%s' "$(id)"; touch /tmp/escaped; echo \`whoami\``;
+
+			await makeCompute(world).create(SANDBOX_ID).exec(hostile, { timeout: 5000 });
+
+			const command = world.execCalls.at(-1)?.command;
+			expect(command?.slice(0, 2)).toEqual(['sh', '-lc']);
+			expect(command?.[2]).toContain(`${shellQuote('4900')} ${shellQuote(hostile)}`);
 		});
 	});
 

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -117,7 +117,11 @@ function execCommand(cmd: string, login: boolean, timeout?: number): string[] {
 		return ['sh', login ? '-lc' : '-c', cmd];
 	}
 	const supervisorTimeout = Math.max(1, timeout - Math.min(EXEC_TIMEOUT_GRACE_MS, timeout / 10));
-	return ['python3', '-c', EXEC_TIMEOUT_SUPERVISOR, String(supervisorTimeout), cmd];
+	return [
+		'sh',
+		'-lc',
+		`exec python3 -c ${shellQuote(EXEC_TIMEOUT_SUPERVISOR)} ${shellQuote(String(supervisorTimeout))} ${shellQuote(cmd)}`,
+	];
 }
 
 /**

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -61,6 +61,7 @@ import type {
 	ActiveSandbox,
 	ComputeResources,
 	CreateSandboxOptions,
+	ExecOptions,
 	ExecResult,
 	ExecStreamOptions,
 	ExposePortOptions,
@@ -100,6 +101,24 @@ const PORT_WAIT_FIRST_CHUNK_MS = 2_000;
  * must never delay a sandbox that is already Running.
  */
 const POST_BOOT_READ_TIMEOUT_MS = 250;
+const EXEC_TIMEOUT_GRACE_MS = 100;
+const EXEC_TIMEOUT_SUPERVISOR = `import os, signal, subprocess, sys
+process = subprocess.Popen(['sh', '-lc', sys.argv[2]], start_new_session=True)
+try:
+	code = process.wait(timeout=float(sys.argv[1]) / 1000)
+except subprocess.TimeoutExpired:
+	os.killpg(process.pid, signal.SIGKILL)
+	process.wait()
+	code = 124
+sys.exit(code)`;
+
+function execCommand(cmd: string, login: boolean, timeout?: number): string[] {
+	if (!login || timeout === undefined || timeout <= 0) {
+		return ['sh', login ? '-lc' : '-c', cmd];
+	}
+	const supervisorTimeout = Math.max(1, timeout - Math.min(EXEC_TIMEOUT_GRACE_MS, timeout / 10));
+	return ['python3', '-c', EXEC_TIMEOUT_SUPERVISOR, String(supervisorTimeout), cmd];
+}
 
 /**
  * Milliseconds from a kubelet `Pulled` event message — `Successfully pulled
@@ -360,15 +379,25 @@ class KubernetesSandboxInstance implements SandboxInstance {
 	 */
 	private execInPod(
 		cmd: string,
-		opts?: { login?: boolean; stdin?: string | Uint8Array },
+		opts?: { login?: boolean; stdin?: string | Uint8Array; timeout?: number },
 	): Promise<K8sExecResult> {
 		this.execCount++;
-		return this.client.exec(this.name, ['sh', opts?.login ? '-lc' : '-c', cmd], opts?.stdin);
+		return this.client.exec(
+			this.name,
+			execCommand(cmd, opts?.login ?? false, opts?.timeout),
+			opts?.stdin,
+			{
+				timeout: opts?.timeout,
+			},
+		);
 	}
 
-	async exec(cmd: string): Promise<ExecResult> {
+	async exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
 		await this.ensure();
-		const res = await this.execInPod(this.withEnv(cmd), { login: true });
+		const res = await this.execInPod(this.withEnv(cmd), {
+			login: true,
+			timeout: options?.timeout,
+		});
 		return execResult(res.exitCode === 0, res.stdout, res.stderr);
 	}
 

--- a/packages/compute-kubernetes/src/shared.ts
+++ b/packages/compute-kubernetes/src/shared.ts
@@ -210,6 +210,10 @@ export interface K8sSandboxInfo {
 	createdAt?: string;
 }
 
+export interface K8sExecOptions {
+	timeout?: number;
+}
+
 /**
  * The slice of the cluster API this adapter uses. Declaring it as an interface
  * (rather than depending on `@kubernetes/client-node` directly) is the injection
@@ -232,7 +236,12 @@ export interface K8sClient {
 	 */
 	getImagePullMessage(name: string, uid?: string): Promise<string | undefined>;
 	/** Run a command in the Pod; `stdin` is piped to the process when provided. */
-	exec(name: string, command: string[], stdin?: string | Uint8Array): Promise<K8sExecResult>;
+	exec(
+		name: string,
+		command: string[],
+		stdin?: string | Uint8Array,
+		options?: K8sExecOptions,
+	): Promise<K8sExecResult>;
 	/** Delete the Pod + Service + Ingress for a session. Idempotent (tolerates 404). */
 	delete(name: string): Promise<void>;
 	/** List sandboxes THIS deployment owns (label-scoped), for the reconciler. */

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -167,11 +167,7 @@ describe('uv-script-pins setup execution', () => {
 		'uv-script-pins',
 	).setup.join(' && ');
 
-	async function runSetup(
-		extraEnv: Record<string, string>,
-		pyproject?: string,
-		parserExit?: number,
-	) {
+	async function runSetup(extraEnv: NodeJS.ProcessEnv, pyproject?: string, parserExit?: number) {
 		const dir = await mkdtemp(path.join(os.tmpdir(), 'marimohub-uvstub-'));
 		const workdir = path.join(dir, 'work');
 		const logFile = path.join(dir, 'uv.log');
@@ -181,11 +177,11 @@ describe('uv-script-pins setup execution', () => {
 			'#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$UV_LOG"\nif [ "$1" = venv ]; then mkdir -p "$2"; fi\n',
 			{ mode: 0o755 },
 		);
-		if (parserExit !== undefined) {
-			await writeFile(path.join(dir, 'python3'), `#!/bin/sh\nexit ${parserExit}\n`, {
-				mode: 0o755,
-			});
-		}
+		await writeFile(
+			path.join(dir, 'python3'),
+			`#!/bin/sh\ncase "$2" in\n*importlib.metadata*) printf '\\n';;\n*) exit ${parserExit ?? 2};;\nesac\n`,
+			{ mode: 0o755 },
+		);
 		if (pyproject !== undefined) await writeFile(path.join(workdir, 'pyproject.toml'), pyproject);
 		const env: NodeJS.ProcessEnv = {
 			...process.env,
@@ -226,7 +222,13 @@ describe('uv-script-pins setup execution', () => {
 		}
 	});
 
-	it('propagates a pyproject.toml parser failure before starting uv', async () => {
+	it('continues when neither MARIMO_VERSION nor installed marimo metadata provides a pin', async () => {
+		const { log } = await runSetup({ MARIMO_VERSION: undefined });
+		expect(log).not.toContain('marimo==');
+		expect(log).toContain('export --script app.py');
+	});
+
+	it('propagates a missing or failed TOML parser before starting uv', async () => {
 		await expect(runSetup({}, '[project]\ndependencies = [', 1)).rejects.toBeDefined();
 	});
 });
@@ -244,6 +246,23 @@ describe('rewriteWorkspace (pure)', () => {
 });
 
 describe('LocalCompute file ops', () => {
+	it('kills the command process group when exec times out', async () => {
+		const sb = newSandbox();
+		const result = await sb.exec('mkdir -p /workspace; sleep 0.15; touch /workspace/late.txt', {
+			timeout: 20,
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			stderr: expect.stringContaining('command timed out after 20ms'),
+		});
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		expectFileResult(await sb.readFile('/workspace/late.txt'), {
+			success: false,
+			error: { code: 'NOT_FOUND' },
+		});
+	});
+
 	it('places sandboxes beneath the configured root', async () => {
 		const root = await mkdtemp(path.join(os.tmpdir(), 'marimohub-local-root-'));
 		const local = new LocalCompute({ root });

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -167,7 +167,11 @@ describe('uv-script-pins setup execution', () => {
 		'uv-script-pins',
 	).setup.join(' && ');
 
-	async function runSetup(extraEnv: Record<string, string>) {
+	async function runSetup(
+		extraEnv: Record<string, string>,
+		pyproject?: string,
+		parserExit?: number,
+	) {
 		const dir = await mkdtemp(path.join(os.tmpdir(), 'marimohub-uvstub-'));
 		const workdir = path.join(dir, 'work');
 		const logFile = path.join(dir, 'uv.log');
@@ -177,8 +181,15 @@ describe('uv-script-pins setup execution', () => {
 			'#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$UV_LOG"\nif [ "$1" = venv ]; then mkdir -p "$2"; fi\n',
 			{ mode: 0o755 },
 		);
+		if (parserExit !== undefined) {
+			await writeFile(path.join(dir, 'python3'), `#!/bin/sh\nexit ${parserExit}\n`, {
+				mode: 0o755,
+			});
+		}
+		if (pyproject !== undefined) await writeFile(path.join(workdir, 'pyproject.toml'), pyproject);
 		const env: NodeJS.ProcessEnv = {
 			...process.env,
+			MARIMO_VERSION: '0.0-test',
 			PATH: `${dir}:${process.env.PATH}`,
 			UV_LOG: logFile,
 		};
@@ -213,6 +224,10 @@ describe('uv-script-pins setup execution', () => {
 		} finally {
 			await rm(envDir, { recursive: true, force: true });
 		}
+	});
+
+	it('propagates a pyproject.toml parser failure before starting uv', async () => {
+		await expect(runSetup({}, '[project]\ndependencies = [', 1)).rejects.toBeDefined();
 	});
 });
 

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -35,6 +35,7 @@ import { Utf8TailBuffer } from '@marimo-hub/compute-commons/node';
 import type { SandboxId } from '@marimo-hub/core';
 import type {
 	ActiveSandbox,
+	ExecOptions,
 	ExecResult,
 	ExecStreamOptions,
 	ExposePortOptions,
@@ -304,18 +305,39 @@ class LocalSandboxInstance implements SandboxInstance {
 		return child;
 	}
 
-	async exec(cmd: string): Promise<ExecResult> {
+	async exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
 		await this.ensureRoot();
 		return new Promise((resolve) => {
 			const child = this.trackChild(this.spawnShell(this.rewriteCmd(cmd), { detached: true }));
 			const { stdout, stderr } = captureOutput(child);
+			let timedOut = false;
+			const timer =
+				options?.timeout !== undefined && options.timeout > 0
+					? setTimeout(
+							() => {
+								timedOut = true;
+								killProcessGroup(child, 'SIGKILL');
+							},
+							Math.max(1, options.timeout - Math.min(100, options.timeout / 10)),
+						)
+					: undefined;
+			timer?.unref();
 			child.on('error', (err) => {
+				clearTimeout(timer);
 				resolve(
 					execResult(false, stdout.toString(), stderr.toString() + String(err), 'SPAWN_FAILED'),
 				);
 			});
 			child.on('close', (code) => {
-				resolve(execResult(code === 0, stdout.toString(), stderr.toString()));
+				clearTimeout(timer);
+				const timeoutMessage = timedOut ? `command timed out after ${options?.timeout}ms` : '';
+				resolve(
+					execResult(
+						!timedOut && code === 0,
+						stdout.toString(),
+						[stderr.toString(), timeoutMessage].filter(Boolean).join('\n'),
+					),
+				);
 			});
 		});
 	}

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -17,6 +17,7 @@ import type {
 	ActiveSandbox,
 	ComputeResources,
 	CreateSandboxOptions,
+	ExecOptions,
 	ExecResult,
 	ExecStreamOptions,
 	ExposePortOptions,
@@ -273,8 +274,10 @@ class ModalSandboxInstance implements SandboxInstance {
 		});
 	}
 
-	async exec(cmd: string): Promise<ExecResult> {
-		return runProcess(await this.spawn(['sh', '-lc', this.withDefaults(cmd)]));
+	async exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
+		return runProcess(
+			await this.spawn(['sh', '-lc', this.withDefaults(cmd)], { timeout: options?.timeout }),
+		);
 	}
 
 	async execStream(cmd: string, options?: ExecStreamOptions): Promise<ReadableStream> {

--- a/packages/core/src/errors.test.ts
+++ b/packages/core/src/errors.test.ts
@@ -8,6 +8,7 @@ import {
 	NotInitializedError,
 	PreconditionFailedError,
 	ProposalRetryRequiredError,
+	PythonEnvironmentSetupError,
 	ResourceExhaustedError,
 	UnavailableError,
 	ValidationError,
@@ -35,6 +36,12 @@ const CASES = [
 	{ Err: ForbiddenError, status: 403, name: 'ForbiddenError', def: 'Forbidden' },
 	{ Err: NotInitializedError, status: 409, name: 'NotInitializedError', def: 'Not initialized' },
 	{ Err: UnavailableError, status: 503, name: 'UnavailableError', def: 'Service unavailable' },
+	{
+		Err: PythonEnvironmentSetupError,
+		status: 503,
+		name: 'PythonEnvironmentSetupError',
+		def: 'Failed to prepare the notebook Python environment',
+	},
 	{
 		Err: ResourceExhaustedError,
 		status: 429,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -17,6 +17,7 @@ export const DOMAIN_ERROR_CODES = [
 	'SYNC_NOT_CONFIGURED',
 	'NOT_INITIALIZED',
 	'SERVICE_UNAVAILABLE',
+	'PYTHON_ENV_SETUP_FAILED',
 	'RESOURCE_EXHAUSTED',
 ] as const;
 
@@ -160,6 +161,15 @@ export class UnavailableError extends DomainError {
 	constructor(message = 'Service unavailable', options?: ErrorOptions) {
 		super(message, options);
 		this.name = 'UnavailableError';
+	}
+}
+
+export class PythonEnvironmentSetupError extends DomainError {
+	readonly code = 'PYTHON_ENV_SETUP_FAILED';
+	readonly status = 503;
+	constructor(message = 'Failed to prepare the notebook Python environment') {
+		super(message);
+		this.name = 'PythonEnvironmentSetupError';
 	}
 }
 

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -121,6 +121,10 @@ export interface ExecStreamOptions {
 	timeout?: number;
 }
 
+export interface ExecOptions {
+	timeout?: number;
+}
+
 /** One file to write into a sandbox. `Uint8Array` content is written verbatim. */
 export interface SandboxFileWrite {
 	path: string;
@@ -142,7 +146,7 @@ export interface SandboxInstance {
 	 * the same resolution at the cost of a command round-trip.
 	 */
 	ready?(): Promise<void>;
-	exec(cmd: string): Promise<ExecResult>;
+	exec(cmd: string, options?: ExecOptions): Promise<ExecResult>;
 	execStream(cmd: string, options?: ExecStreamOptions): Promise<ReadableStream>;
 	readFile(path: string): Promise<ReadFileResult>;
 	/**

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -102,7 +102,7 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess[0].cmd).toContain('--host 0.0.0.0');
 		});
 
-		it('honors a resolved launch strategy, setup layers ordered before the kernel', async () => {
+		it('runs resolved launch setup before starting the kernel', async () => {
 			const { instance, calls } = makeFakeSandbox();
 			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
 
@@ -116,16 +116,18 @@ describe('SandboxProvisioner', () => {
 				launchStrategy: 'uv-script-pins',
 			});
 
-			// Pins apply last so they win: pyproject → export → install → kernel.
-			const cmd = calls.startProcess[0].cmd;
+			// Pins apply last within the checked setup command, before marimo starts.
+			const cmd = calls.exec.find((command) => command.includes('uv sync --inexact'))!;
 			const order = [
 				cmd.indexOf('uv sync --inexact'),
+				cmd.indexOf('marimo==$MARIMOHUB_MARIMO_VERSION'),
 				cmd.indexOf("uv export --script 'apps/dash.py'"),
-				cmd.indexOf('uv pip install'),
-				cmd.indexOf('marimo edit'),
+				cmd.lastIndexOf('uv pip install'),
 			];
 			expect(Math.min(...order)).toBeGreaterThanOrEqual(0);
 			expect(order).toEqual([...order].sort((a, b) => a - b));
+			expect(calls.startProcess[0].cmd).toContain("marimo edit 'apps/dash.py'");
+			expect(calls.startProcess[0].cmd).not.toContain('uv sync');
 		});
 
 		it('defaults to the project-managed env when no launch strategy is given', async () => {
@@ -140,10 +142,10 @@ describe('SandboxProvisioner', () => {
 				bucket: bucketConfig,
 			});
 
-			const cmd = calls.startProcess[0].cmd;
+			const cmd = calls.exec.find((command) => command.includes('uv sync --inexact'))!;
 			expect(cmd).toContain('uv sync --inexact');
 			expect(cmd).not.toContain('uv export');
-			expect(cmd).not.toContain('uv pip install');
+			expect(cmd).not.toContain('marimohub-script-requirements.txt');
 		});
 
 		it('accepts sessionEnv as a promise, injecting it once resolved', async () => {
@@ -254,7 +256,7 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess[0].cmd).toContain(`--asset-url="${assetUrl}"`);
 		});
 
-		it('waits for the kernel port with the configured startup timeout (default 2 minutes)', async () => {
+		it('gives the remaining startup timeout to the kernel port wait', async () => {
 			const defaulted = makeFakeSandbox();
 			await new SandboxProvisioner(fakeComputeFrom(defaulted.instance)).provision({
 				sandboxId,
@@ -263,7 +265,10 @@ describe('SandboxProvisioner', () => {
 				hostname: 'localhost',
 				bucket: bucketConfig,
 			});
-			expect(defaulted.calls.waitForPortOptions).toEqual([{ timeout: 120_000 }]);
+			expect(defaulted.calls.waitForPortOptions).toHaveLength(1);
+			const defaultTimeout = defaulted.calls.waitForPortOptions[0]!.timeout;
+			expect(defaultTimeout).toBeGreaterThan(119_000);
+			expect(defaultTimeout).toBeLessThanOrEqual(120_000);
 
 			const configured = makeFakeSandbox();
 			await new SandboxProvisioner(fakeComputeFrom(configured.instance)).provision({
@@ -274,7 +279,17 @@ describe('SandboxProvisioner', () => {
 				bucket: bucketConfig,
 				startupTimeoutMs: Millis.seconds(300),
 			});
-			expect(configured.calls.waitForPortOptions).toEqual([{ timeout: 300_000 }]);
+			expect(configured.calls.waitForPortOptions).toHaveLength(1);
+			const configuredTimeout = configured.calls.waitForPortOptions[0]!.timeout;
+			expect(configuredTimeout).toBeGreaterThan(299_000);
+			expect(configuredTimeout).toBeLessThanOrEqual(300_000);
+			const setupIndex = configured.calls.exec.findIndex((command) =>
+				command.includes('uv sync --inexact'),
+			);
+			expect(setupIndex).toBeGreaterThanOrEqual(0);
+			const setupTimeout = configured.calls.execOptions[setupIndex]?.timeout;
+			expect(setupTimeout).toBeGreaterThan(299_000);
+			expect(setupTimeout).toBeLessThanOrEqual(300_000);
 		});
 
 		it('names the startup timeout (and the config var) when the port wait consumes the full window', async () => {
@@ -518,11 +533,9 @@ describe('SandboxProvisioner', () => {
 		});
 
 		// A command round-trip is the dominant unit of startup cost on a remote
-		// backend (~220ms each on CoreWeave), so these lock in the count. Each was a
-		// measured regression: a duplicate mkdir, a reachability no-op, and a setup
-		// exec that the kernel command can carry itself.
+		// backend (~220ms each on CoreWeave), so these lock in the count.
 		describe('command round-trips', () => {
-			it('a copy-path provision spends no exec at all', async () => {
+			it('a copy-path provision spends one checked setup exec', async () => {
 				const { instance, calls } = makeFakeSandbox({ failMount: true });
 				const bucketHandle = new MemoryBucket();
 				const nb = paths.project(projectId).notebook(notebookId);
@@ -540,9 +553,9 @@ describe('SandboxProvisioner', () => {
 					bucketHandle,
 				});
 
-				// writeFiles creates parents, ready() replaces the exec('true') probe,
-				// and setup rides the kernel command.
-				expect(calls.exec).toEqual([]);
+				// writeFiles creates parents and ready() replaces the reachability exec.
+				expect(calls.exec).toHaveLength(1);
+				expect(calls.exec[0]).toContain('uv sync');
 				expect(calls.startProcess).toHaveLength(1);
 			});
 
@@ -573,7 +586,7 @@ describe('SandboxProvisioner', () => {
 				expect(withoutReady.calls.exec).toContain('true');
 			});
 
-			it('carries launch setup on the kernel command instead of a separate exec', async () => {
+			it('checks launch setup before starting the kernel process', async () => {
 				const { instance, calls } = makeFakeSandbox();
 				instance.ready = async () => {};
 
@@ -585,14 +598,79 @@ describe('SandboxProvisioner', () => {
 					bucket: bucketConfig,
 				});
 
-				expect(calls.exec).toEqual([]);
-				// `uv sync` (setup) and `marimo edit` (start) travel together, joined by
-				// `&&` so a failed setup cannot leave marimo on a half-built env.
-				const cmd = calls.startProcess[0].cmd;
-				expect(cmd).toContain('uv sync');
-				expect(cmd).toContain('marimo edit');
-				expect(cmd).toMatch(/uv sync[\s\S]*&&[\s\S]*marimo edit/);
+				expect(calls.exec).toHaveLength(1);
+				expect(calls.exec[0]).toContain('uv sync');
+				expect(calls.startProcess[0].cmd).toContain('marimo edit');
+				expect(calls.startProcess[0].cmd).not.toContain('uv sync');
 			});
+		});
+
+		it('reports a checked setup failure without starting the kernel', async () => {
+			const { instance: base, calls } = makeFakeSandbox();
+			const instance: SandboxInstance = {
+				...base,
+				async exec(command) {
+					if (!command.includes('uv sync')) return base.exec(command);
+					calls.exec.push(command);
+					return {
+						success: false,
+						stdout: '',
+						stderr: 'failed to remove directory: Permission denied',
+						error: { code: 'COMMAND_FAILED' },
+					};
+				},
+			};
+
+			const failure = await new SandboxProvisioner(fakeComputeFrom(instance))
+				.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				})
+				.catch((error: unknown) => error);
+
+			expect(failure).toMatchObject({
+				name: 'PythonEnvironmentSetupError',
+				code: 'PYTHON_ENV_SETUP_FAILED',
+				status: 503,
+			});
+			expect((failure as Error).message).toContain('does not allow replacing');
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
+		});
+
+		it('classifies a malformed pyproject as a checked setup failure', async () => {
+			const { instance: base, calls } = makeFakeSandbox();
+			const instance: SandboxInstance = {
+				...base,
+				async exec(command) {
+					if (!command.includes('uv sync')) return base.exec(command);
+					calls.exec.push(command);
+					return {
+						success: false,
+						stdout: '',
+						stderr: 'tomllib.TOMLDecodeError: Invalid value (at end of document)',
+						error: { code: 'COMMAND_FAILED' },
+					};
+				},
+			};
+
+			const failure = await new SandboxProvisioner(fakeComputeFrom(instance))
+				.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				})
+				.catch((error: unknown) => error);
+
+			expect(failure).toMatchObject({ code: 'PYTHON_ENV_SETUP_FAILED', status: 503 });
+			expect((failure as Error).message).toContain('pyproject.toml could not be parsed');
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
 		});
 
 		it('mount failure without a bucket handle rejects instead of starting an empty workspace', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -270,26 +270,38 @@ describe('SandboxProvisioner', () => {
 			expect(defaultTimeout).toBeGreaterThan(119_000);
 			expect(defaultTimeout).toBeLessThanOrEqual(120_000);
 
-			const configured = makeFakeSandbox();
-			await new SandboxProvisioner(fakeComputeFrom(configured.instance)).provision({
-				sandboxId,
-				projectId,
-				notebookId,
-				hostname: 'localhost',
-				bucket: bucketConfig,
-				startupTimeoutMs: Millis.seconds(300),
-			});
-			expect(configured.calls.waitForPortOptions).toHaveLength(1);
-			const configuredTimeout = configured.calls.waitForPortOptions[0]!.timeout;
-			expect(configuredTimeout).toBeGreaterThan(299_000);
-			expect(configuredTimeout).toBeLessThanOrEqual(300_000);
-			const setupIndex = configured.calls.exec.findIndex((command) =>
-				command.includes('uv sync --inexact'),
-			);
-			expect(setupIndex).toBeGreaterThanOrEqual(0);
-			const setupTimeout = configured.calls.execOptions[setupIndex]?.timeout;
-			expect(setupTimeout).toBeGreaterThan(299_000);
-			expect(setupTimeout).toBeLessThanOrEqual(300_000);
+			vi.useFakeTimers();
+			try {
+				const configured = makeFakeSandbox();
+				const exec = configured.instance.exec.bind(configured.instance);
+				configured.instance.exec = async (command, options) => {
+					const result = await exec(command, options);
+					if (command.includes('uv sync --inexact')) {
+						await new Promise((resolve) => setTimeout(resolve, 30_000));
+					}
+					return result;
+				};
+
+				const provision = new SandboxProvisioner(fakeComputeFrom(configured.instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					startupTimeoutMs: Millis.seconds(300),
+				});
+				await vi.advanceTimersByTimeAsync(30_000);
+				await provision;
+
+				const setupIndex = configured.calls.exec.findIndex((command) =>
+					command.includes('uv sync --inexact'),
+				);
+				expect(setupIndex).toBeGreaterThanOrEqual(0);
+				expect(configured.calls.execOptions[setupIndex]?.timeout).toBe(300_000);
+				expect(configured.calls.waitForPortOptions).toEqual([{ timeout: 270_000 }]);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it('names the startup timeout (and the config var) when the port wait consumes the full window', async () => {
@@ -589,6 +601,18 @@ describe('SandboxProvisioner', () => {
 			it('checks launch setup before starting the kernel process', async () => {
 				const { instance, calls } = makeFakeSandbox();
 				instance.ready = async () => {};
+				const exec = instance.exec.bind(instance);
+				const startProcess = instance.startProcess.bind(instance);
+				let setupComplete = false;
+				instance.exec = async (command, options) => {
+					const result = await exec(command, options);
+					if (command.includes('uv sync')) setupComplete = true;
+					return result;
+				};
+				instance.startProcess = async (command, options) => {
+					expect(setupComplete).toBe(true);
+					return startProcess(command, options);
+				};
 
 				await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
 					sandboxId,
@@ -641,7 +665,18 @@ describe('SandboxProvisioner', () => {
 			expect(calls.destroy).toBe(1);
 		});
 
-		it('classifies a malformed pyproject as a checked setup failure', async () => {
+		it.each([
+			[
+				'a malformed pyproject',
+				'tomllib.TOMLDecodeError: Invalid value (at end of document)',
+				'pyproject.toml could not be parsed',
+			],
+			[
+				'a missing TOML parser',
+				"ModuleNotFoundError: No module named 'tomllib'",
+				'sandbox Python does not include the tomllib parser',
+			],
+		])('classifies %s as a checked setup failure', async (_case, stderr, expectedMessage) => {
 			const { instance: base, calls } = makeFakeSandbox();
 			const instance: SandboxInstance = {
 				...base,
@@ -651,7 +686,7 @@ describe('SandboxProvisioner', () => {
 					return {
 						success: false,
 						stdout: '',
-						stderr: 'tomllib.TOMLDecodeError: Invalid value (at end of document)',
+						stderr,
 						error: { code: 'COMMAND_FAILED' },
 					};
 				},
@@ -668,7 +703,7 @@ describe('SandboxProvisioner', () => {
 				.catch((error: unknown) => error);
 
 			expect(failure).toMatchObject({ code: 'PYTHON_ENV_SETUP_FAILED', status: 503 });
-			expect((failure as Error).message).toContain('pyproject.toml could not be parsed');
+			expect((failure as Error).message).toContain(expectedMessage);
 			expect(calls.startProcess).toHaveLength(0);
 			expect(calls.destroy).toBe(1);
 		});

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -51,6 +51,8 @@ function pythonEnvironmentSetupFailure(result: ExecResult): PythonEnvironmentSet
 		reason = 'the sandbox image does not allow replacing its Python environment';
 	} else if (/TOMLDecodeError/i.test(output)) {
 		reason = 'pyproject.toml could not be parsed';
+	} else if (/No module named ['"]tomllib['"]/i.test(output)) {
+		reason = 'the sandbox Python does not include the tomllib parser';
 	} else if (/no (virtual environment|interpreter)|python installation not found/i.test(output)) {
 		reason = 'uv could not find or create the required Python environment';
 	} else if (/no solution found|resolution failed|requirements are unsatisfiable/i.test(output)) {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -1,9 +1,10 @@
 import { all, allSettled } from 'better-all';
+import { withDeadline } from '../../async';
 import type { Bucket } from '../../ports/bucket';
 import { MARIMO_PORT } from '../../constants';
 import type { SessionMode } from '../../constants';
 import { Millis } from '../../duration';
-import { UnavailableError } from '../../errors';
+import { PythonEnvironmentSetupError, UnavailableError } from '../../errors';
 import type { NotebookId, ProjectId, SandboxId, UserId } from '../../ids';
 import { workspaceSourcePolicy } from '../../integrations/remoteWorkspace';
 import type { WorkspaceLoadMode } from '../../integrations/remoteWorkspace';
@@ -11,6 +12,7 @@ import { paths } from '../../paths';
 import { logOperationalError } from '../../operationalLog';
 import type {
 	ComputeResources,
+	ExecResult,
 	SandboxUserHome,
 	SandboxInstance,
 	SandboxProcess,
@@ -21,6 +23,7 @@ import type { Timings } from '../../timing';
 import { captureFilesystemSnapshot, createOrRestoreSandbox } from '../content/filesystemSnapshots';
 import { buildMarimoLaunch } from './marimoLaunch';
 import type { MarimoLaunchStrategyName } from './marimoLaunch';
+import { shellQuote } from './shell';
 import type { NotebookService } from '../content/NotebookService';
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
 import type { WorkspaceRestoreStats } from './sandboxFiles';
@@ -40,6 +43,23 @@ export const DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS = Millis.minutes(2);
  * `/workspace`, so writes there fail with a permission/file-IO error.
  */
 const DEFAULT_WORKDIR = '/workspace';
+
+function pythonEnvironmentSetupFailure(result: ExecResult): PythonEnvironmentSetupError {
+	const output = `${result.stdout}\n${result.stderr}`;
+	let reason = 'uv exited unsuccessfully';
+	if (/permission denied/i.test(output)) {
+		reason = 'the sandbox image does not allow replacing its Python environment';
+	} else if (/TOMLDecodeError/i.test(output)) {
+		reason = 'pyproject.toml could not be parsed';
+	} else if (/no (virtual environment|interpreter)|python installation not found/i.test(output)) {
+		reason = 'uv could not find or create the required Python environment';
+	} else if (/no solution found|resolution failed|requirements are unsatisfiable/i.test(output)) {
+		reason = 'the notebook dependency constraints could not be resolved';
+	}
+	return new PythonEnvironmentSetupError(
+		`Failed to prepare the notebook Python environment: ${reason}`,
+	);
+}
 
 export interface BucketConfig {
 	/** Storage bucket name, or a provider-managed bucket handle when `endpoint` is omitted. */
@@ -122,9 +142,8 @@ export interface ProvisionOptions {
 	/** Per-source launch strategy (see launchStrategy.ts). Defaults to the project-managed env. */
 	launchStrategy?: MarimoLaunchStrategyName;
 	/**
-	 * How long to wait for the marimo kernel to bind its port before failing the
-	 * provision. Covers setup too (a cold env may install/build first). Defaults
-	 * to `DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS`.
+	 * How long Python-environment setup and the kernel-port wait may take in total
+	 * before failing the provision. Defaults to `DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS`.
 	 */
 	startupTimeoutMs?: Millis;
 	/**
@@ -491,19 +510,43 @@ export class SandboxProvisioner {
 			options.launchStrategy,
 		);
 		const startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS;
+		const startupStart = Date.now();
+		if (launch.setup.length > 0) {
+			const command = `cd ${shellQuote(mountPath)} && ${launch.setup.join(' && ')}`;
+			const setupTimeoutMs =
+				startupTimeoutMs === 0 ? 0 : Math.max(0, startupTimeoutMs - (Date.now() - startupStart));
+			try {
+				const setup = await sw.time('setup', () => {
+					const pending = sandbox.exec(command, { timeout: setupTimeoutMs });
+					return startupTimeoutMs === 0
+						? pending
+						: withDeadline(pending, {
+								timeoutMs: setupTimeoutMs,
+								timeoutError: () =>
+									new PythonEnvironmentSetupError(
+										`Failed to prepare the notebook Python environment within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`,
+									),
+							});
+				});
+				if (!setup.success) throw pythonEnvironmentSetupFailure(setup);
+			} catch (error) {
+				if (error instanceof PythonEnvironmentSetupError) throw error;
+				throw provisionFailure('preparing the notebook Python environment', error);
+			}
+		}
 		let process: SandboxProcess | undefined;
 		let portWaitStart: number | undefined;
 		try {
-			// Setup rides the kernel command instead of spending its own exec, and
-			// failures still surface through the process log read below. `&&` so a
-			// failed setup never leaves marimo running against a half-built env;
-			// marimoLaunch decides what is fatal.
-			const command = [...launch.setup, launch.start].join(' && ');
-			const proc = await sw.time('start', () => sandbox.startProcess(command, { cwd: mountPath }));
+			const proc = await sw.time('start', () =>
+				sandbox.startProcess(launch.start, { cwd: mountPath }),
+			);
 			process = proc;
 			portWaitStart = Date.now();
-			// Covers setup as well, so a slow kernel env (install/build) shows up here.
-			await sw.time('waitport', () => proc.waitForPort(MARIMO_PORT, { timeout: startupTimeoutMs }));
+			const portWaitTimeoutMs =
+				startupTimeoutMs === 0 ? 0 : Math.max(0, startupTimeoutMs - (portWaitStart - startupStart));
+			await sw.time('waitport', () =>
+				proc.waitForPort(MARIMO_PORT, { timeout: portWaitTimeoutMs }),
+			);
 		} catch (err) {
 			// Surface the kernel's own output so a startup crash isn't an opaque
 			// "exited before ready". Best-effort.
@@ -533,7 +576,7 @@ export class SandboxProvisioner {
 			const attribution = err instanceof Error ? err.message.split('\n', 1)[0] : '';
 			const crashed = /before port \d+/.test(attribution);
 			const timedOut =
-				!crashed && portWaitStart !== undefined && Date.now() - portWaitStart >= startupTimeoutMs;
+				!crashed && portWaitStart !== undefined && Date.now() - startupStart >= startupTimeoutMs;
 			const step = timedOut
 				? `starting the marimo kernel: not ready within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`
 				: 'starting the marimo kernel';

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -86,14 +86,22 @@ describe('buildMarimoLaunch', () => {
 
 	it('restores the image marimo pin if project sync replaced the environment', () => {
 		const [capture, , ensure] = buildMarimoLaunch(BASE).setup;
-		expect(capture).toContain('MARIMOHUB_MARIMO_VERSION=');
-		expect(capture).toContain('MARIMO_VERSION');
+		expect(capture).toContain("${MARIMO_VERSION:-$(python3 -c 'import importlib.metadata as m;");
+		expect(capture).toContain('m.distributions()');
 		expect(ensure).toContain('uv pip install');
 		expect(ensure).toContain('marimo==$MARIMOHUB_MARIMO_VERSION');
 	});
 
+	it('continues without restoring marimo when the image provides no version', () => {
+		const [capture, , ensure] = buildMarimoLaunch(BASE).setup;
+		expect(capture).toContain('), ""))');
+		expect(ensure).toContain('[ -z "$MARIMOHUB_MARIMO_VERSION" ] ||');
+	});
+
 	it('reserves exit code 2 for no dependencies and propagates TOML parse failures', () => {
 		const [, pyproject] = buildMarimoLaunch(BASE).setup;
+		expect(pyproject).toContain('import pathlib,sys,tomllib');
+		expect(pyproject).not.toContain("find_spec('tomllib')");
 		expect(pyproject).toContain('else 2');
 		expect(pyproject).toContain('elif [ "$status" -eq 2 ]');
 		expect(pyproject).toContain('else exit "$status"');

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -76,7 +76,7 @@ describe('buildMarimoLaunch', () => {
 	});
 
 	it('initializes only a pyproject with marimohub metadata', () => {
-		const [setup] = buildMarimoLaunch(BASE).setup;
+		const [, setup] = buildMarimoLaunch(BASE).setup;
 		expect(setup).toContain('uv init');
 		expect(setup).toContain('--bare');
 		expect(setup).toContain('--no-package');
@@ -84,13 +84,29 @@ describe('buildMarimoLaunch', () => {
 		expect(setup).toContain('--description "Built in marimohub"');
 	});
 
+	it('restores the image marimo pin if project sync replaced the environment', () => {
+		const [capture, , ensure] = buildMarimoLaunch(BASE).setup;
+		expect(capture).toContain('MARIMOHUB_MARIMO_VERSION=');
+		expect(capture).toContain('MARIMO_VERSION');
+		expect(ensure).toContain('uv pip install');
+		expect(ensure).toContain('marimo==$MARIMOHUB_MARIMO_VERSION');
+	});
+
+	it('reserves exit code 2 for no dependencies and propagates TOML parse failures', () => {
+		const [, pyproject] = buildMarimoLaunch(BASE).setup;
+		expect(pyproject).toContain('else 2');
+		expect(pyproject).toContain('elif [ "$status" -eq 2 ]');
+		expect(pyproject).toContain('else exit "$status"');
+	});
+
 	describe('uv-script-pins', () => {
 		const plan = buildMarimoLaunch({ ...BASE, notebookFile: 'apps/my app.py' }, 'uv-script-pins');
 
 		it('layers pyproject first, then exports and installs the script pins', () => {
-			expect(plan.setup).toHaveLength(4);
-			const [pyproject, ensureEnv, exportCmd, installCmd] = plan.setup;
+			expect(plan.setup).toHaveLength(6);
+			const [, pyproject, ensureEnv, ensureMarimo, exportCmd, installCmd] = plan.setup;
 			expect(pyproject).toContain('uv sync --inexact');
+			expect(ensureMarimo).toContain('marimo==$MARIMOHUB_MARIMO_VERSION');
 			expect(ensureEnv).toContain('uv venv');
 			expect(exportCmd).toContain("uv export --script 'apps/my app.py'");
 			expect(exportCmd).toContain('--format requirements-txt');
@@ -105,7 +121,7 @@ describe('buildMarimoLaunch', () => {
 		it('writes the requirements file inside the pin env', () => {
 			// Per-sandbox and lifecycle-managed on every backend — nothing left on a
 			// shared host /tmp, no clobbering between concurrent local launches.
-			const [, , exportCmd, installCmd] = plan.setup;
+			const [, , , , exportCmd, installCmd] = plan.setup;
 			const [, exportTarget] = /-o (\S+)/.exec(exportCmd) ?? [];
 			expect(exportTarget).toBe(
 				'"${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"',
@@ -113,16 +129,12 @@ describe('buildMarimoLaunch', () => {
 			expect(installCmd).toContain(`-r ${exportTarget}`);
 		});
 
-		it('keeps the pyproject layer lenient and the pin layers strict', () => {
-			const [pyproject, ensureEnv, exportCmd, installCmd] = plan.setup;
-			expect(pyproject).toContain('|| true');
-			expect(ensureEnv).not.toContain('|| true');
-			expect(exportCmd).not.toContain('|| true');
-			expect(installCmd).not.toContain('|| true');
+		it('keeps every environment setup layer strict', () => {
+			for (const command of plan.setup) expect(command).not.toContain('|| true');
 		});
 
 		it('reuses the exact uv-sync-edit pyproject layer', () => {
-			expect(plan.setup[0]).toBe(buildMarimoLaunch(BASE, 'uv-sync-edit').setup[0]);
+			expect(plan.setup[1]).toBe(buildMarimoLaunch(BASE, 'uv-sync-edit').setup[1]);
 		});
 
 		it('installs the pins in app mode too (setup is mode-invariant)', () => {
@@ -139,7 +151,7 @@ describe('buildMarimoLaunch', () => {
 				{ ...BASE, notebookFile: "apps/it's a && b.py" },
 				'uv-script-pins',
 			);
-			expect(hostile.setup[2]).toContain(`--script 'apps/it'\\''s a && b.py'`);
+			expect(hostile.setup[4]).toContain(`--script 'apps/it'\\''s a && b.py'`);
 		});
 	});
 });

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -80,7 +80,7 @@ function marimoCommand(p: MarimoLaunchParams, extraFlags = ''): string {
 // stall the launch. The image must NOT set UV_COMPILE_BYTECODE (it would
 // conflict with --no-compile-bytecode). A failure is fatal: the provisioner
 // reports it as PYTHON_ENV_SETUP_FAILED before starting the kernel.
-const PYPROJECT_LAYER_SETUP = `{ status=0; python3 -c "import importlib.util,pathlib,sys;sys.exit(2) if importlib.util.find_spec('tomllib') is None else None;import tomllib;path=pathlib.Path('pyproject.toml');data=tomllib.loads(path.read_text()) if path.exists() else {};sys.exit(0 if data.get('project',{}).get('dependencies') else 2)" || status=$?; if [ "$status" -eq 0 ]; then uv sync --inexact --no-compile-bytecode --no-build; elif [ "$status" -eq 2 ]; then if ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then rm -f pyproject.toml && uv init --bare --no-package --vcs none --name notebook --description "Built in marimohub"; fi; else exit "$status"; fi; }`;
+const PYPROJECT_LAYER_SETUP = `{ status=0; python3 -c "import pathlib,sys,tomllib;path=pathlib.Path('pyproject.toml');data=tomllib.loads(path.read_text()) if path.exists() else {};sys.exit(0 if data.get('project',{}).get('dependencies') else 2)" || status=$?; if [ "$status" -eq 0 ]; then uv sync --inexact --no-compile-bytecode --no-build; elif [ "$status" -eq 2 ]; then if ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then rm -f pyproject.toml && uv init --bare --no-package --vcs none --name notebook --description "Built in marimohub"; fi; else exit "$status"; fi; }`;
 
 // The env the kernel's `uv run --no-sync` will use — uv resolves the project
 // env as UV_PROJECT_ENVIRONMENT, else `.venv` in the project dir. Deliberately
@@ -94,8 +94,8 @@ const PIN_ENV = `"${PIN_ENV_EXPANSION}"`;
 // uv replaces the whole environment when requires-python selects another
 // interpreter. Capture the image's marimo pin before sync, then restore it only
 // if the resulting environment no longer contains that version.
-const CAPTURE_MARIMO_VERSION = `MARIMOHUB_MARIMO_VERSION="\${MARIMO_VERSION:-$(python3 -c 'import importlib.metadata as m;print(m.version("marimo"))')}"`;
-const ENSURE_MARIMO = `{ [ "$(uv run --no-sync python -c 'import importlib.metadata as m;print(m.version("marimo"))' 2>/dev/null)" = "$MARIMOHUB_MARIMO_VERSION" ] || uv pip install --python ${PIN_ENV} --no-build "marimo==$MARIMOHUB_MARIMO_VERSION"; }`;
+const CAPTURE_MARIMO_VERSION = `MARIMOHUB_MARIMO_VERSION="\${MARIMO_VERSION:-$(python3 -c 'import importlib.metadata as m;print(next((d.version for d in m.distributions() if (d.metadata["Name"] or "").lower() == "marimo"), ""))')}"`;
+const ENSURE_MARIMO = `{ [ -z "$MARIMOHUB_MARIMO_VERSION" ] || [ "$(uv run --no-sync python -c 'import importlib.metadata as m;print(m.version("marimo"))' 2>/dev/null)" = "$MARIMOHUB_MARIMO_VERSION" ] || uv pip install --python ${PIN_ENV} --no-build "marimo==$MARIMOHUB_MARIMO_VERSION"; }`;
 
 // Inside the pin env: per-sandbox on every backend (a container's env dies
 // with it; a local sandbox's .venv is removed with its root), so nothing

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -74,12 +74,13 @@ function marimoCommand(p: MarimoLaunchParams, extraFlags = ''): string {
 
 // Sync only when the notebook declares real deps; an empty one just gets a
 // `[project]` table (so `uv add` works) and runs from the pre-installed
-// /opt/venv via `--no-sync`. --no-compile-bytecode skips ~5s of compiling
+// image environment via `--no-sync`. --no-compile-bytecode skips ~5s of compiling
 // freshly-added deps on the launch path (lazy-compiled on import instead);
 // --no-build keeps it to wheels so a source build can't run arbitrary code /
 // stall the launch. The image must NOT set UV_COMPILE_BYTECODE (it would
-// conflict with --no-compile-bytecode). `|| true` never blocks launch.
-const PYPROJECT_LAYER_SETUP = `if python3 -c "import tomllib,sys;sys.exit(0 if tomllib.load(open('pyproject.toml','rb')).get('project',{}).get('dependencies') else 1)" 2>/dev/null; then uv sync --inexact --no-compile-bytecode --no-build || true; elif ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then { rm -f pyproject.toml && uv init --bare --no-package --vcs none --name notebook --description "Built in marimohub"; } || true; fi`;
+// conflict with --no-compile-bytecode). A failure is fatal: the provisioner
+// reports it as PYTHON_ENV_SETUP_FAILED before starting the kernel.
+const PYPROJECT_LAYER_SETUP = `{ status=0; python3 -c "import importlib.util,pathlib,sys;sys.exit(2) if importlib.util.find_spec('tomllib') is None else None;import tomllib;path=pathlib.Path('pyproject.toml');data=tomllib.loads(path.read_text()) if path.exists() else {};sys.exit(0 if data.get('project',{}).get('dependencies') else 2)" || status=$?; if [ "$status" -eq 0 ]; then uv sync --inexact --no-compile-bytecode --no-build; elif [ "$status" -eq 2 ]; then if ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then rm -f pyproject.toml && uv init --bare --no-package --vcs none --name notebook --description "Built in marimohub"; fi; else exit "$status"; fi; }`;
 
 // The env the kernel's `uv run --no-sync` will use — uv resolves the project
 // env as UV_PROJECT_ENVIRONMENT, else `.venv` in the project dir. Deliberately
@@ -89,6 +90,12 @@ const PYPROJECT_LAYER_SETUP = `if python3 -c "import tomllib,sys;sys.exit(0 if t
 // whose contract pre-creates UV_PROJECT_ENVIRONMENT.
 const PIN_ENV_EXPANSION = '${UV_PROJECT_ENVIRONMENT:-.venv}';
 const PIN_ENV = `"${PIN_ENV_EXPANSION}"`;
+
+// uv replaces the whole environment when requires-python selects another
+// interpreter. Capture the image's marimo pin before sync, then restore it only
+// if the resulting environment no longer contains that version.
+const CAPTURE_MARIMO_VERSION = `MARIMOHUB_MARIMO_VERSION="\${MARIMO_VERSION:-$(python3 -c 'import importlib.metadata as m;print(m.version("marimo"))')}"`;
+const ENSURE_MARIMO = `{ [ "$(uv run --no-sync python -c 'import importlib.metadata as m;print(m.version("marimo"))' 2>/dev/null)" = "$MARIMOHUB_MARIMO_VERSION" ] || uv pip install --python ${PIN_ENV} --no-build "marimo==$MARIMOHUB_MARIMO_VERSION"; }`;
 
 // Inside the pin env: per-sandbox on every backend (a container's env dies
 // with it; a local sandbox's .venv is removed with its root), so nothing
@@ -106,20 +113,19 @@ export const MARIMO_LAUNCH_STRATEGIES = {
 	// marimo's `--sandbox` (which force-refreshes when a notebook declares no
 	// inline deps), this never refetches.
 	'uv-sync-edit': (p) => ({
-		setup: [PYPROJECT_LAYER_SETUP],
+		setup: [CAPTURE_MARIMO_VERSION, PYPROJECT_LAYER_SETUP, ENSURE_MARIMO],
 		start: `uv run --no-sync ${marimoCommand(p)}`,
 	}),
 
 	// Git-synced notebooks with PEP 723 inline metadata: the pyproject layer runs
-	// first (lenient, as above), then the script's pins install into the same base
-	// env — last, so they win. No `|| true` on the pin steps: declared pins must
-	// fail the launch loudly (uv's error surfaces via the kernel logs), never be
-	// silently ignored. --no-hashes because hash checking rejects the unhashed
-	// base env.
+	// first, then the script's pins install into the same base env — last, so they
+	// win. --no-hashes because hash checking rejects the unhashed base env.
 	'uv-script-pins': (p) => ({
 		setup: [
+			CAPTURE_MARIMO_VERSION,
 			PYPROJECT_LAYER_SETUP,
-			`[ -d ${PIN_ENV} ] || uv venv ${PIN_ENV}`,
+			`{ [ -d ${PIN_ENV} ] || uv venv ${PIN_ENV}; }`,
+			ENSURE_MARIMO,
 			`uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt --no-hashes -o ${SCRIPT_REQUIREMENTS}`,
 			`uv pip install --python ${PIN_ENV} --no-build -r ${SCRIPT_REQUIREMENTS}`,
 		],

--- a/packages/core/src/testing/fakes.ts
+++ b/packages/core/src/testing/fakes.ts
@@ -2,6 +2,7 @@ import type { SandboxId } from '../ids';
 import type {
 	ActiveSandbox,
 	CreateSandboxOptions,
+	ExecOptions,
 	ExecResult,
 	ExposePortOptions,
 	FileInfo,
@@ -24,6 +25,8 @@ export const EXPOSED_URL = 'https://sandbox.example/kernel';
 /** Records every call the provision/teardown paths make against a fake sandbox. */
 export interface SandboxCalls {
 	exec: string[];
+	/** Options of each `exec` call, index-aligned with `exec`. */
+	execOptions: (ExecOptions | undefined)[];
 	mountBucket: MountBucketOptions[];
 	startProcess: { cmd: string; options?: StartProcessOptions }[];
 	exposePort: { port: number; options: ExposePortOptions }[];
@@ -69,6 +72,7 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 	const writtenFiles = new Set<string>();
 	const calls: SandboxCalls = {
 		exec: [],
+		execOptions: [],
 		mountBucket: [],
 		startProcess: [],
 		exposePort: [],
@@ -96,8 +100,9 @@ export function makeFakeSandbox(opts: FakeSandboxOptions = {}): {
 	};
 
 	const instance: SandboxInstance = {
-		exec: async (cmd: string): Promise<ExecResult> => {
+		exec: async (cmd: string, options?: ExecOptions): Promise<ExecResult> => {
 			calls.exec.push(cmd);
+			calls.execOptions.push(options);
 			if (opts.failExec !== undefined && cmd === opts.failExec) {
 				throw new Error('sandbox unreachable');
 			}
@@ -203,6 +208,7 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 	);
 	const calls: SandboxCalls = {
 		exec: [],
+		execOptions: [],
 		mountBucket: [],
 		startProcess: [],
 		exposePort: [],
@@ -222,8 +228,9 @@ export function makeFsSandbox(opts: FsSandboxOptions = {}): {
 		path === root ? '' : path.startsWith(`${root}/`) ? path.slice(root.length + 1) : path;
 
 	const instance = {
-		async exec(cmd: string): Promise<ExecResult> {
+		async exec(cmd: string, options?: ExecOptions): Promise<ExecResult> {
 			calls.exec.push(cmd);
+			calls.execOptions.push(options);
 			// Capture: base64 -w0 '<path>' or the portable base64 < '<path>' form.
 			const capture = cmd.match(/^base64(?: -w0)?(?: <)? (.+)$/);
 			if (capture) {


### PR DESCRIPTION
Splits Python environment setup out of the kernel launch command so a failed `uv sync`/pin install surfaces as a new `PYTHON_ENV_SETUP_FAILED` (503) error with a diagnosed reason, instead of an opaque "exited before ready". Setup now runs as its own `exec` with the startup timeout shared across setup and the port wait; the sandbox `exec` port gains a `timeout` option, threaded through the cloudflare, coreweave, e2b, and modal adapters.

Also handles Python interpreter switching: when a notebook's `requires-python` makes uv rebuild the whole environment, the image's marimo pin is captured before sync and reinstalled if dropped. The image project env moves from `/opt/venv` to `/opt/marimohub/venv` so uv can replace it.