### PR TITLE
feat(cli): deploy notebooks from marimohub.toml/pyproject.toml

### DIFF
--- a/apps/cli/Cargo.lock
+++ b/apps/cli/Cargo.lock
@@ -1205,6 +1205,7 @@ dependencies = [
  "tabled",
  "tempfile",
  "thiserror",
+ "toml",
  "update-informer",
  "ureq 2.12.1",
  "url",
@@ -1813,6 +1814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,6 +2147,45 @@ dependencies = [
  "rustls",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -2677,6 +2726,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "writeable"

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -36,6 +36,7 @@ sha2 = "0.10.9"
 tabled = { version = "0.21.0", default-features = false, features = ["std"] }
 tempfile = "3.20.0"
 thiserror = "2.0.12"
+toml = "1.1.4"
 update-informer = { version = "1.3.0", default-features = false, features = [
 	"github",
 	"ureq",

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -210,6 +210,37 @@ fn login_command() -> Command {
         )
 }
 
+fn deploy_command() -> Command {
+    Command::new("deploy")
+        .about("Deploy local notebooks declared in marimohub.toml or pyproject.toml")
+        .arg(
+            Arg::new("deploy-config")
+                .long("config")
+                .value_name("PATH")
+                .value_hint(ValueHint::FilePath)
+                .help("Configuration file; defaults to discovery from the current directory"),
+        )
+        .arg(
+            Arg::new("deploy-notebook")
+                .long("notebook")
+                .value_name("NAME")
+                .action(ArgAction::Append)
+                .help("Deploy only this named notebook; may be repeated"),
+        )
+        .arg(
+            Arg::new("deploy-dry-run")
+                .long("dry-run")
+                .action(ArgAction::SetTrue)
+                .help("Plan changes without updating notebooks"),
+        )
+        .arg(
+            Arg::new("deploy-message")
+                .long("message")
+                .value_name("TEXT")
+                .help("Version message for notebooks whose code changes"),
+        )
+}
+
 pub fn build(manifest: &Manifest) -> Command {
     let mut root = Node::default();
     for operation in &manifest.operations {
@@ -307,7 +338,15 @@ pub fn build(manifest: &Manifest) -> Command {
         );
 
     for (name, node) in &root.children {
-        command = command.subcommand(command_from_node(name, node));
+        let mut child = command_from_node(name, node);
+        if *name == "notebooks" {
+            assert!(
+                !node.children.contains_key("deploy"),
+                "generated API manifest now defines notebooks deploy"
+            );
+            child = child.subcommand(deploy_command());
+        }
+        command = command.subcommand(child);
     }
     command
 }
@@ -354,5 +393,16 @@ mod tests {
 
             assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
         }
+    }
+
+    #[test]
+    fn notebooks_help_contains_direct_update_and_manifest_deploy() {
+        let command = build(&crate::manifest::load());
+        let notebooks = command
+            .find_subcommand("notebooks")
+            .expect("notebooks command");
+
+        assert!(notebooks.find_subcommand("update").is_some());
+        assert!(notebooks.find_subcommand("deploy").is_some());
     }
 }

--- a/apps/cli/src/client.rs
+++ b/apps/cli/src/client.rs
@@ -23,6 +23,19 @@ struct HttpResponse {
     body: Vec<u8>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NotebookDeploymentState {
+    pub title: String,
+    pub description: String,
+    pub tags: Vec<String>,
+    pub readme: Option<String>,
+    pub base_image: Option<String>,
+    pub compute_profile: Option<String>,
+    pub source_type: String,
+    pub code: String,
+    pub etag: String,
+}
+
 pub struct Runtime<'a> {
     pub base_url: &'a str,
     pub token: Option<&'a SecretString>,
@@ -288,8 +301,28 @@ fn send(
     let retryable = operation.method == "GET"
         || operation.method == "HEAD"
         || headers.contains_key("Idempotency-Key");
+    send_with_retry(
+        agent,
+        runtime,
+        &operation.method,
+        url,
+        headers,
+        body,
+        retryable,
+    )
+}
+
+fn send_with_retry(
+    agent: &ureq::Agent,
+    runtime: &Runtime<'_>,
+    method: &str,
+    url: &Url,
+    headers: &BTreeMap<String, String>,
+    body: Option<&[u8]>,
+    retryable: bool,
+) -> Result<HttpResponse, Error> {
     for attempt in 0..3 {
-        match send_once(agent, runtime, &operation.method, url, headers, body) {
+        match send_once(agent, runtime, method, url, headers, body) {
             Ok(response)
                 if retryable && attempt < 2 && matches!(response.status, 500 | 502 | 503 | 504) => {
             }
@@ -436,6 +469,10 @@ fn write_json(value: &Value, mode: &str) -> Result<(), Error> {
     normalize_stdout_result(write_json_to(&mut writer, value, mode))
 }
 
+pub fn write_output(value: &Value, mode: &str) -> Result<(), Error> {
+    write_json(value, mode)
+}
+
 fn output_rows(value: &Value) -> Vec<&Value> {
     value
         .as_array()
@@ -543,6 +580,116 @@ pub fn current_user(manifest: &Manifest, runtime: &Runtime<'_>) -> Result<Value,
         .get("data")
         .cloned()
         .ok_or_else(|| Error::Http("response envelope has no data".into()))
+}
+
+fn notebook_url(runtime: &Runtime<'_>, project_id: &str, notebook_id: &str) -> Result<Url, Error> {
+    Url::parse(&format!(
+        "{}/api/v1/projects/{}/notebooks/{}",
+        runtime.base_url.trim_end_matches('/'),
+        urlencoding::encode(project_id),
+        urlencoding::encode(notebook_id),
+    ))
+    .map_err(Into::into)
+}
+
+fn required_string(value: &Value, pointer: &str, label: &str) -> Result<String, Error> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| Error::Http(format!("notebook response has no valid {label}")))
+}
+
+fn optional_string(value: &Value, pointer: &str, label: &str) -> Result<Option<String>, Error> {
+    match value.pointer(pointer) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(Error::Http(format!(
+            "notebook response has no valid {label}"
+        ))),
+    }
+}
+
+pub fn notebook_deployment_state(
+    runtime: &Runtime<'_>,
+    project_id: &str,
+    notebook_id: &str,
+) -> Result<NotebookDeploymentState, Error> {
+    let agent = ureq::AgentBuilder::new().timeout(runtime.timeout).build();
+    let url = notebook_url(runtime, project_id, notebook_id)?;
+    let detail_response =
+        send_with_retry(&agent, runtime, "GET", &url, &BTreeMap::new(), None, true)?;
+    let detail = ensure_success(&detail_response)?;
+    let etag = detail_response
+        .headers
+        .get("etag")
+        .cloned()
+        .ok_or_else(|| Error::Http("notebook detail response did not return an ETag".into()))?;
+    let data = detail
+        .get("data")
+        .ok_or_else(|| Error::Http("notebook detail response has no data".into()))?;
+    let tags = data
+        .pointer("/meta/tags")
+        .and_then(Value::as_array)
+        .ok_or_else(|| Error::Http("notebook response has no valid tags".into()))?
+        .iter()
+        .map(|tag| {
+            tag.as_str()
+                .map(str::to_owned)
+                .ok_or_else(|| Error::Http("notebook response has no valid tags".into()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let content_url = Url::parse(&format!("{}/content", url.as_str().trim_end_matches('/')))?;
+    let content_response = send_with_retry(
+        &agent,
+        runtime,
+        "GET",
+        &content_url,
+        &BTreeMap::new(),
+        None,
+        true,
+    )?;
+    let content = ensure_success(&content_response)?;
+
+    Ok(NotebookDeploymentState {
+        title: required_string(data, "/meta/title", "title")?,
+        description: required_string(data, "/meta/description", "description")?,
+        tags,
+        readme: optional_string(data, "/readme", "readme")?,
+        base_image: optional_string(data, "/meta/base_image", "base_image")?,
+        compute_profile: optional_string(data, "/meta/compute_profile", "compute_profile")?,
+        source_type: required_string(data, "/source/type", "source type")?,
+        code: required_string(&content, "/data/code", "code")?,
+        etag,
+    })
+}
+
+pub fn update_notebook_deployment(
+    runtime: &Runtime<'_>,
+    project_id: &str,
+    notebook_id: &str,
+    etag: &str,
+    body: &Value,
+) -> Result<Value, Error> {
+    let agent = ureq::AgentBuilder::new().timeout(runtime.timeout).build();
+    let url = notebook_url(runtime, project_id, notebook_id)?;
+    let headers = BTreeMap::from([("If-Match".to_owned(), etag.to_owned())]);
+    let bytes = serde_json::to_vec(body)?;
+    let response = send_with_retry(
+        &agent,
+        runtime,
+        "PATCH",
+        &url,
+        &headers,
+        Some(&bytes),
+        false,
+    )?;
+    let envelope = ensure_success(&response)?;
+    envelope
+        .get("data")
+        .cloned()
+        .ok_or_else(|| Error::Http("notebook update response has no data".into()))
 }
 
 pub fn exchange_cli_authorization(

--- a/apps/cli/src/deploy.rs
+++ b/apps/cli/src/deploy.rs
@@ -1,0 +1,457 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+
+use crate::client::{self, NotebookDeploymentState, Runtime};
+use crate::deploy_config::{self, DeploymentConfig, DeploymentNotebook};
+use crate::Error;
+
+pub struct DeployOptions {
+    pub config: Option<PathBuf>,
+    pub notebooks: Vec<String>,
+    pub dry_run: bool,
+    pub message: Option<String>,
+}
+
+pub struct PreparedDeployment {
+    config: DeploymentConfig,
+    notebooks: Vec<String>,
+    dry_run: bool,
+    message: Option<String>,
+}
+
+#[derive(Debug)]
+struct PlannedNotebook {
+    name: String,
+    notebook_id: String,
+    etag: String,
+    changes: Vec<String>,
+    patch: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct NotebookResult {
+    name: String,
+    notebook_id: String,
+    action: &'static str,
+    changes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DeployResult {
+    config: String,
+    project_id: String,
+    dry_run: bool,
+    notebooks: Vec<NotebookResult>,
+}
+
+fn selected_notebooks<'a>(
+    config: &'a DeploymentConfig,
+    selectors: &[String],
+) -> Result<Vec<(&'a String, &'a DeploymentNotebook)>, Error> {
+    if selectors.is_empty() {
+        return Ok(config.notebooks.iter().collect());
+    }
+    let selectors = selectors.iter().collect::<BTreeSet<_>>();
+    let unknown = selectors
+        .iter()
+        .filter(|name| !config.notebooks.contains_key(name.as_str()))
+        .map(|name| name.as_str())
+        .collect::<Vec<_>>();
+    if !unknown.is_empty() {
+        return Err(Error::Usage(format!(
+            "unknown notebook selection{} {}; available notebooks: {}",
+            if unknown.len() == 1 { "" } else { "s" },
+            unknown.join(", "),
+            config
+                .notebooks
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
+    Ok(config
+        .notebooks
+        .iter()
+        .filter(|(name, _)| selectors.contains(name))
+        .collect())
+}
+
+fn add_string_change(
+    patch: &mut BTreeMap<String, Value>,
+    field: &str,
+    desired: Option<&String>,
+    current: &str,
+) {
+    if let Some(desired) = desired.filter(|desired| desired.as_str() != current) {
+        patch.insert(field.to_owned(), Value::String(desired.clone()));
+    }
+}
+
+fn add_optional_string_change(
+    patch: &mut BTreeMap<String, Value>,
+    field: &str,
+    desired: Option<&String>,
+    current: Option<&str>,
+) {
+    let Some(desired) = desired else {
+        return;
+    };
+    if desired == "default" {
+        if current.is_some() {
+            patch.insert(field.to_owned(), Value::Null);
+        }
+    } else if current != Some(desired) {
+        patch.insert(field.to_owned(), Value::String(desired.clone()));
+    }
+}
+
+fn plan_notebook(
+    name: &str,
+    local: &DeploymentNotebook,
+    remote: NotebookDeploymentState,
+    message: Option<&str>,
+) -> Result<PlannedNotebook, Error> {
+    if remote.source_type != "local" {
+        return Err(Error::Deployment(format!(
+            "notebook {name:?} ({}) is {}-backed; deploy supports only local notebooks",
+            local.notebook_id, remote.source_type
+        )));
+    }
+
+    let mut patch = BTreeMap::new();
+    if local.code != remote.code {
+        patch.insert("code".to_owned(), Value::String(local.code.clone()));
+        patch.insert(
+            "message".to_owned(),
+            Value::String(
+                message
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| format!("Deploy {}", local.display_path)),
+            ),
+        );
+    }
+    add_string_change(&mut patch, "title", local.title.as_ref(), &remote.title);
+    add_string_change(
+        &mut patch,
+        "description",
+        local.description.as_ref(),
+        &remote.description,
+    );
+    if local.tags.as_ref().is_some_and(|tags| tags != &remote.tags) {
+        patch.insert(
+            "tags".to_owned(),
+            serde_json::to_value(local.tags.as_ref().expect("checked above"))?,
+        );
+    }
+    if local
+        .readme
+        .as_ref()
+        .is_some_and(|readme| Some(readme.as_str()) != remote.readme.as_deref())
+    {
+        patch.insert(
+            "readme".to_owned(),
+            Value::String(local.readme.clone().expect("checked above")),
+        );
+    }
+    add_optional_string_change(
+        &mut patch,
+        "base_image",
+        local.base_image.as_ref(),
+        remote.base_image.as_deref(),
+    );
+    add_optional_string_change(
+        &mut patch,
+        "compute_profile",
+        local.compute_profile.as_ref(),
+        remote.compute_profile.as_deref(),
+    );
+
+    let changes = patch
+        .keys()
+        .filter(|field| field.as_str() != "message")
+        .cloned()
+        .collect();
+    Ok(PlannedNotebook {
+        name: name.to_owned(),
+        notebook_id: local.notebook_id.clone(),
+        etag: remote.etag,
+        changes,
+        patch: Value::Object(Map::from_iter(patch)),
+    })
+}
+
+fn plan(
+    runtime: &Runtime<'_>,
+    config: &DeploymentConfig,
+    selectors: &[String],
+    message: Option<&str>,
+) -> Result<Vec<PlannedNotebook>, Error> {
+    selected_notebooks(config, selectors)?
+        .into_iter()
+        .map(|(name, notebook)| {
+            let remote = client::notebook_deployment_state(
+                runtime,
+                &config.project_id,
+                &notebook.notebook_id,
+            )?;
+            plan_notebook(name, notebook, remote, message)
+        })
+        .collect()
+}
+
+pub fn prepare(options: DeployOptions) -> Result<PreparedDeployment, Error> {
+    let config = deploy_config::load(options.config.as_deref(), &options.notebooks)?;
+    selected_notebooks(&config, &options.notebooks)?;
+    Ok(PreparedDeployment {
+        config,
+        notebooks: options.notebooks,
+        dry_run: options.dry_run,
+        message: options.message,
+    })
+}
+
+pub fn execute(runtime: &Runtime<'_>, prepared: PreparedDeployment) -> Result<(), Error> {
+    let config = prepared.config;
+    let planned = plan(
+        runtime,
+        &config,
+        &prepared.notebooks,
+        prepared.message.as_deref(),
+    )?;
+    let mut results = Vec::with_capacity(planned.len());
+    let mut updated = Vec::new();
+
+    for notebook in planned {
+        let action = if notebook.changes.is_empty() {
+            "unchanged"
+        } else if prepared.dry_run {
+            "planned"
+        } else {
+            if let Err(error) = client::update_notebook_deployment(
+                runtime,
+                &config.project_id,
+                &notebook.notebook_id,
+                &notebook.etag,
+                &notebook.patch,
+            ) {
+                let applied = if updated.is_empty() {
+                    "no earlier notebooks were updated".to_owned()
+                } else {
+                    format!("already updated: {}", updated.join(", "))
+                };
+                return Err(Error::Deployment(format!(
+                    "could not update {:?}: {error}; {applied}",
+                    notebook.name
+                )));
+            }
+            updated.push(notebook.name.clone());
+            "updated"
+        };
+        results.push(NotebookResult {
+            name: notebook.name,
+            notebook_id: notebook.notebook_id,
+            action,
+            changes: notebook.changes,
+        });
+    }
+
+    let result = DeployResult {
+        config: config.path.display().to_string(),
+        project_id: config.project_id,
+        dry_run: prepared.dry_run,
+        notebooks: results,
+    };
+    client::write_output(&serde_json::to_value(result)?, runtime.output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn local() -> DeploymentNotebook {
+        DeploymentNotebook {
+            notebook_id: "nb-7h2k9qm4xz7rp3w8".into(),
+            display_path: "app.py".into(),
+            code: "print('new')".into(),
+            title: Some("New title".into()),
+            description: None,
+            tags: Some(vec!["production".into()]),
+            readme: None,
+            base_image: Some("default".into()),
+            compute_profile: Some("large".into()),
+        }
+    }
+
+    fn remote() -> NotebookDeploymentState {
+        NotebookDeploymentState {
+            title: "Old title".into(),
+            description: "Description".into(),
+            tags: vec![],
+            readme: None,
+            base_image: Some("custom".into()),
+            compute_profile: None,
+            source_type: "local".into(),
+            code: "print('old')".into(),
+            etag: "\"etag-1\"".into(),
+        }
+    }
+
+    #[test]
+    fn plan_contains_only_changed_fields_in_stable_order() {
+        let plan = plan_notebook("app", &local(), remote(), None).unwrap();
+
+        assert_eq!(
+            plan.changes,
+            ["base_image", "code", "compute_profile", "tags", "title"]
+        );
+        assert_eq!(plan.patch["base_image"], Value::Null);
+        assert_eq!(plan.patch["message"], "Deploy app.py");
+        assert_eq!(plan.patch["compute_profile"], "large");
+        assert!(plan.patch.get("description").is_none());
+    }
+
+    #[test]
+    fn matching_configured_values_produce_an_empty_patch() {
+        let mut local = local();
+        let remote = remote();
+        local.code = remote.code.clone();
+        local.title = Some(remote.title.clone());
+        local.tags = Some(remote.tags.clone());
+        local.base_image = None;
+        local.compute_profile = None;
+
+        let plan = plan_notebook("app", &local, remote, None).unwrap();
+        assert!(plan.changes.is_empty());
+        assert_eq!(plan.patch, serde_json::json!({}));
+    }
+
+    #[test]
+    fn a_default_value_is_unchanged_when_remote_already_uses_the_default() {
+        let mut local = local();
+        local.code = "print('old')".into();
+        local.title = None;
+        local.tags = None;
+        local.compute_profile = Some("default".into());
+        let mut remote = remote();
+        remote.base_image = None;
+
+        let plan = plan_notebook("app", &local, remote, None).unwrap();
+        assert!(plan.changes.is_empty());
+    }
+
+    #[test]
+    fn remote_sources_are_rejected() {
+        let mut remote = remote();
+        remote.source_type = "git".into();
+        let error = plan_notebook("app", &local(), remote, None).unwrap_err();
+        assert!(error.to_string().contains("supports only local notebooks"));
+    }
+
+    #[test]
+    fn explicit_message_replaces_the_default_version_message() {
+        let plan = plan_notebook("app", &local(), remote(), Some("Release dashboard")).unwrap();
+        assert_eq!(plan.patch["message"], "Release dashboard");
+    }
+
+    #[test]
+    fn metadata_only_changes_never_add_code_or_a_version_message() {
+        let remote = remote();
+        let mut local = local();
+        local.code = remote.code.clone();
+        local.title = Some("Only metadata changed".into());
+        local.tags = None;
+        local.base_image = None;
+        local.compute_profile = None;
+
+        let plan = plan_notebook("app", &local, remote, Some("Ignored message")).unwrap();
+        assert_eq!(plan.changes, ["title"]);
+        assert_eq!(plan.patch["title"], "Only metadata changed");
+        assert!(plan.patch.get("code").is_none());
+        assert!(plan.patch.get("message").is_none());
+    }
+
+    #[test]
+    fn empty_metadata_and_tag_order_are_meaningful_changes() {
+        let mut remote = remote();
+        remote.tags = vec!["one".into(), "two".into()];
+        remote.readme = Some("Old readme".into());
+        let mut local = local();
+        local.code = remote.code.clone();
+        local.title = None;
+        local.description = Some(String::new());
+        local.tags = Some(vec!["two".into(), "one".into()]);
+        local.readme = Some(String::new());
+        local.base_image = None;
+        local.compute_profile = None;
+
+        let plan = plan_notebook("app", &local, remote, None).unwrap();
+        assert_eq!(plan.changes, ["description", "readme", "tags"]);
+        assert_eq!(plan.patch["description"], "");
+        assert_eq!(plan.patch["readme"], "");
+        assert_eq!(plan.patch["tags"], serde_json::json!(["two", "one"]));
+    }
+
+    #[test]
+    fn default_clears_both_remote_overrides() {
+        let mut remote = remote();
+        remote.compute_profile = Some("large".into());
+        let mut local = local();
+        local.code = remote.code.clone();
+        local.title = None;
+        local.tags = None;
+        local.base_image = Some("default".into());
+        local.compute_profile = Some("default".into());
+
+        let plan = plan_notebook("app", &local, remote, None).unwrap();
+        assert_eq!(plan.changes, ["base_image", "compute_profile"]);
+        assert_eq!(plan.patch["base_image"], Value::Null);
+        assert_eq!(plan.patch["compute_profile"], Value::Null);
+    }
+
+    #[test]
+    fn only_lowercase_default_is_the_clear_sentinel() {
+        let remote = remote();
+        let mut local = local();
+        local.code = remote.code.clone();
+        local.title = None;
+        local.tags = None;
+        local.base_image = Some("Default".into());
+        local.compute_profile = None;
+
+        let plan = plan_notebook("app", &local, remote, None).unwrap();
+        assert_eq!(plan.patch["base_image"], "Default");
+    }
+
+    #[test]
+    fn selectors_are_validated_and_sorted_by_config_key() {
+        let mut notebooks = BTreeMap::new();
+        notebooks.insert("zebra".into(), local());
+        notebooks.insert("alpha".into(), local());
+        let config = DeploymentConfig {
+            path: PathBuf::from("marimohub.toml"),
+            project_id: "proj-7h2k9qm4xz7rp3w8".into(),
+            notebooks,
+        };
+
+        let selected = selected_notebooks(&config, &["zebra".into(), "alpha".into()]).unwrap();
+        assert_eq!(
+            selected
+                .into_iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            ["alpha", "zebra"]
+        );
+        assert!(selected_notebooks(&config, &["missing".into()])
+            .unwrap_err()
+            .to_string()
+            .contains("available notebooks: alpha, zebra"));
+
+        let selected = selected_notebooks(&config, &["zebra".into(), "zebra".into()]).unwrap();
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].0, "zebra");
+    }
+}

--- a/apps/cli/src/deploy.rs
+++ b/apps/cli/src/deploy.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 
 use crate::client::{self, NotebookDeploymentState, Runtime};
-use crate::deploy_config::{self, DeploymentConfig, DeploymentNotebook};
+use crate::deploy_config::{self, DeploymentConfig, DeploymentNotebook, DeploymentOverride};
 use crate::Error;
 
 pub struct DeployOptions {
@@ -94,18 +94,20 @@ fn add_string_change(
 fn add_optional_string_change(
     patch: &mut BTreeMap<String, Value>,
     field: &str,
-    desired: Option<&String>,
+    desired: Option<&DeploymentOverride>,
     current: Option<&str>,
 ) {
     let Some(desired) = desired else {
         return;
     };
-    if desired == "default" {
-        if current.is_some() {
+    match desired {
+        DeploymentOverride::Clear if current.is_some() => {
             patch.insert(field.to_owned(), Value::Null);
         }
-    } else if current != Some(desired) {
-        patch.insert(field.to_owned(), Value::String(desired.clone()));
+        DeploymentOverride::Name(name) if current != Some(name) => {
+            patch.insert(field.to_owned(), Value::String(name.clone()));
+        }
+        DeploymentOverride::Clear | DeploymentOverride::Name(_) => {}
     }
 }
 
@@ -281,8 +283,8 @@ mod tests {
             description: None,
             tags: Some(vec!["production".into()]),
             readme: None,
-            base_image: Some("default".into()),
-            compute_profile: Some("large".into()),
+            base_image: Some(DeploymentOverride::Clear),
+            compute_profile: Some(DeploymentOverride::Name("large".into())),
         }
     }
 
@@ -330,12 +332,12 @@ mod tests {
     }
 
     #[test]
-    fn a_default_value_is_unchanged_when_remote_already_uses_the_default() {
+    fn a_clear_value_is_unchanged_without_a_remote_override() {
         let mut local = local();
         local.code = "print('old')".into();
         local.title = None;
         local.tags = None;
-        local.compute_profile = Some("default".into());
+        local.compute_profile = Some(DeploymentOverride::Clear);
         let mut remote = remote();
         remote.base_image = None;
 
@@ -396,15 +398,15 @@ mod tests {
     }
 
     #[test]
-    fn default_clears_both_remote_overrides() {
+    fn false_clears_both_remote_overrides() {
         let mut remote = remote();
         remote.compute_profile = Some("large".into());
         let mut local = local();
         local.code = remote.code.clone();
         local.title = None;
         local.tags = None;
-        local.base_image = Some("default".into());
-        local.compute_profile = Some("default".into());
+        local.base_image = Some(DeploymentOverride::Clear);
+        local.compute_profile = Some(DeploymentOverride::Clear);
 
         let plan = plan_notebook("app", &local, remote, None).unwrap();
         assert_eq!(plan.changes, ["base_image", "compute_profile"]);
@@ -413,17 +415,17 @@ mod tests {
     }
 
     #[test]
-    fn only_lowercase_default_is_the_clear_sentinel() {
+    fn default_is_a_literal_override_name() {
         let remote = remote();
         let mut local = local();
         local.code = remote.code.clone();
         local.title = None;
         local.tags = None;
-        local.base_image = Some("Default".into());
+        local.base_image = Some(DeploymentOverride::Name("default".into()));
         local.compute_profile = None;
 
         let plan = plan_notebook("app", &local, remote, None).unwrap();
-        assert_eq!(plan.patch["base_image"], "Default");
+        assert_eq!(plan.patch["base_image"], "default");
     }
 
     #[test]

--- a/apps/cli/src/deploy_config.rs
+++ b/apps/cli/src/deploy_config.rs
@@ -1,0 +1,876 @@
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::Error;
+
+const CONFIG_FILE: &str = "marimohub.toml";
+const PYPROJECT_FILE: &str = "pyproject.toml";
+
+#[derive(Clone, Debug)]
+pub struct DeploymentConfig {
+    pub path: PathBuf,
+    pub project_id: String,
+    pub notebooks: BTreeMap<String, DeploymentNotebook>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DeploymentNotebook {
+    pub notebook_id: String,
+    pub display_path: String,
+    pub code: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub tags: Option<Vec<String>>,
+    pub readme: Option<String>,
+    pub base_image: Option<String>,
+    pub compute_profile: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawConfig {
+    project_id: String,
+    notebook_id: Option<String>,
+    path: Option<PathBuf>,
+    title: Option<String>,
+    description: Option<String>,
+    tags: Option<Vec<String>>,
+    readme_path: Option<PathBuf>,
+    base_image: Option<String>,
+    compute_profile: Option<String>,
+    #[serde(default)]
+    notebooks: BTreeMap<String, RawNotebook>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawNotebook {
+    notebook_id: String,
+    path: Option<PathBuf>,
+    title: Option<String>,
+    description: Option<String>,
+    tags: Option<Vec<String>>,
+    readme_path: Option<PathBuf>,
+    base_image: Option<String>,
+    compute_profile: Option<String>,
+}
+
+fn config_error(path: &Path, message: impl std::fmt::Display) -> Error {
+    Error::Config(format!("{}: {message}", path.display()))
+}
+
+fn read_toml(path: &Path) -> Result<toml::Value, Error> {
+    let source = fs::read_to_string(path)
+        .map_err(|error| config_error(path, format!("could not read configuration: {error}")))?;
+    toml::from_str(&source).map_err(|error| config_error(path, error))
+}
+
+fn pyproject_config(value: &toml::Value) -> Option<toml::Value> {
+    value
+        .get("tool")
+        .and_then(|tool| tool.get("marimohub"))
+        .cloned()
+}
+
+fn parse_raw(path: &Path) -> Result<RawConfig, Error> {
+    let value = read_toml(path)?;
+    let config = if path.file_name() == Some(OsStr::new(PYPROJECT_FILE)) {
+        pyproject_config(&value)
+            .ok_or_else(|| config_error(path, "missing required [tool.marimohub] configuration"))?
+    } else {
+        value
+    };
+    config.try_into().map_err(|error| config_error(path, error))
+}
+
+fn has_pyproject_config(path: &Path) -> Result<bool, Error> {
+    Ok(pyproject_config(&read_toml(path)?).is_some())
+}
+
+fn absolute_existing_config(path: &Path, cwd: &Path) -> Result<PathBuf, Error> {
+    let candidate = if path.is_absolute() {
+        path.to_owned()
+    } else {
+        cwd.join(path)
+    };
+    fs::canonicalize(&candidate).map_err(|error| {
+        config_error(
+            &candidate,
+            format!("could not resolve configuration file: {error}"),
+        )
+    })
+}
+
+fn discover_from(
+    cwd: &Path,
+    explicit: Option<&Path>,
+    environment: Option<&OsStr>,
+) -> Result<PathBuf, Error> {
+    if let Some(path) = explicit {
+        return absolute_existing_config(path, cwd);
+    }
+    if let Some(path) = environment {
+        if path.is_empty() {
+            return Err(Error::Config("MARIMOHUB_CONFIG cannot be empty".into()));
+        }
+        return absolute_existing_config(Path::new(path), cwd);
+    }
+
+    for directory in cwd.ancestors() {
+        let standalone = directory.join(CONFIG_FILE);
+        if standalone.is_file() {
+            return absolute_existing_config(&standalone, cwd);
+        }
+        let pyproject = directory.join(PYPROJECT_FILE);
+        if pyproject.is_file() && has_pyproject_config(&pyproject)? {
+            return absolute_existing_config(&pyproject, cwd);
+        }
+    }
+    Err(Error::Config(format!(
+        "no {CONFIG_FILE} or [tool.marimohub] configuration found from {} to the filesystem root",
+        cwd.display()
+    )))
+}
+
+fn require_nonempty(path: &Path, field: &str, value: String) -> Result<String, Error> {
+    if value.trim().is_empty() {
+        Err(config_error(path, format!("{field} cannot be empty")))
+    } else {
+        Ok(value)
+    }
+}
+
+fn require_relative(path: &Path, field: &str, value: PathBuf) -> Result<PathBuf, Error> {
+    if value.is_absolute() {
+        Err(config_error(path, format!("{field} must be relative")))
+    } else {
+        Ok(value)
+    }
+}
+
+fn read_utf8(config_path: &Path, path: &Path, label: &str) -> Result<String, Error> {
+    let metadata = fs::metadata(path).map_err(|error| {
+        config_error(
+            config_path,
+            format!("could not inspect {label} {}: {error}", path.display()),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(config_error(
+            config_path,
+            format!("{label} {} is not a regular file", path.display()),
+        ));
+    }
+    fs::read_to_string(path).map_err(|error| {
+        config_error(
+            config_path,
+            format!(
+                "could not read {label} {} as UTF-8: {error}",
+                path.display()
+            ),
+        )
+    })
+}
+
+fn inferred_python_path(config_path: &Path) -> Result<PathBuf, Error> {
+    let directory = config_path
+        .parent()
+        .expect("canonical configuration path has a parent");
+    let mut candidates = Vec::new();
+    for entry in fs::read_dir(directory).map_err(|error| {
+        config_error(
+            config_path,
+            format!("could not inspect {}: {error}", directory.display()),
+        )
+    })? {
+        let entry = entry.map_err(|error| config_error(config_path, error))?;
+        if entry
+            .file_type()
+            .map_err(|error| config_error(config_path, error))?
+            .is_file()
+            && entry.path().extension() == Some(OsStr::new("py"))
+        {
+            candidates.push(PathBuf::from(entry.file_name()));
+        }
+    }
+    candidates.sort();
+    match candidates.as_slice() {
+        [only] => Ok(only.clone()),
+        [] => Err(config_error(
+            config_path,
+            "no Python file was found; set path for the notebook",
+        )),
+        _ => Err(config_error(
+            config_path,
+            format!(
+                "more than one Python file was found ({}); set path for the notebook",
+                candidates
+                    .iter()
+                    .map(|path| path.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        )),
+    }
+}
+
+fn restrict_to_selectors(
+    raw_notebooks: &mut BTreeMap<String, RawNotebook>,
+    selectors: &[String],
+) -> Result<(), Error> {
+    if selectors.is_empty() {
+        return Ok(());
+    }
+
+    let selectors = selectors.iter().collect::<std::collections::BTreeSet<_>>();
+    let unknown = selectors
+        .iter()
+        .filter(|name| !raw_notebooks.contains_key(name.as_str()))
+        .map(|name| name.as_str())
+        .collect::<Vec<_>>();
+    if !unknown.is_empty() {
+        return Err(Error::Usage(format!(
+            "unknown notebook selection{} {}; available notebooks: {}",
+            if unknown.len() == 1 { "" } else { "s" },
+            unknown.join(", "),
+            raw_notebooks
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )));
+    }
+
+    raw_notebooks.retain(|name, _| selectors.contains(name));
+    Ok(())
+}
+
+fn resolve_selected(
+    path: PathBuf,
+    raw: RawConfig,
+    selectors: &[String],
+) -> Result<DeploymentConfig, Error> {
+    let RawConfig {
+        project_id,
+        notebook_id,
+        path: notebook_path,
+        title,
+        description,
+        tags,
+        readme_path,
+        base_image,
+        compute_profile,
+        notebooks: mut raw_notebooks,
+    } = raw;
+    let project_id = require_nonempty(&path, "project_id", project_id)?;
+    let has_flat_notebook_fields = notebook_id.is_some()
+        || notebook_path.is_some()
+        || title.is_some()
+        || description.is_some()
+        || tags.is_some()
+        || readme_path.is_some()
+        || base_image.is_some()
+        || compute_profile.is_some();
+    let uses_flat_notebook = raw_notebooks.is_empty();
+    if uses_flat_notebook {
+        let notebook_id = notebook_id.ok_or_else(|| {
+            config_error(
+                &path,
+                "notebook_id is required when no named notebooks are declared",
+            )
+        })?;
+        raw_notebooks.insert(
+            "notebook".into(),
+            RawNotebook {
+                notebook_id,
+                path: notebook_path,
+                title,
+                description,
+                tags,
+                readme_path,
+                base_image,
+                compute_profile,
+            },
+        );
+    } else if has_flat_notebook_fields {
+        return Err(config_error(
+            &path,
+            "top-level notebook fields cannot be combined with named notebooks",
+        ));
+    }
+    let is_single = raw_notebooks.len() == 1;
+    for (name, notebook) in &raw_notebooks {
+        if name.trim().is_empty() {
+            return Err(config_error(&path, "notebook names cannot be empty"));
+        }
+        let field = |field_name: &str| {
+            if uses_flat_notebook {
+                field_name.to_owned()
+            } else {
+                format!("notebooks.{name}.{field_name}")
+            }
+        };
+        if notebook.notebook_id.trim().is_empty() {
+            return Err(config_error(
+                &path,
+                format!("{} cannot be empty", field("notebook_id")),
+            ));
+        }
+        if notebook
+            .path
+            .as_ref()
+            .is_some_and(|value| value.is_absolute())
+        {
+            return Err(config_error(
+                &path,
+                format!("{} must be relative", field("path")),
+            ));
+        }
+        if notebook
+            .readme_path
+            .as_ref()
+            .is_some_and(|value| value.is_absolute())
+        {
+            return Err(config_error(
+                &path,
+                format!("{} must be relative", field("readme_path")),
+            ));
+        }
+        if notebook.path.is_none() && !is_single {
+            return Err(config_error(
+                &path,
+                format!(
+                    "notebooks.{name}.path is required when more than one notebook is declared"
+                ),
+            ));
+        }
+    }
+    restrict_to_selectors(&mut raw_notebooks, selectors)?;
+    let directory = path
+        .parent()
+        .expect("canonical configuration path has a parent");
+    let mut notebooks = BTreeMap::new();
+
+    for (name, notebook) in raw_notebooks {
+        let field = |field_name: &str| {
+            if uses_flat_notebook {
+                field_name.to_owned()
+            } else {
+                format!("notebooks.{name}.{field_name}")
+            }
+        };
+        let notebook_id = require_nonempty(&path, &field("notebook_id"), notebook.notebook_id)?;
+        let relative_path = match notebook.path {
+            Some(notebook_path) => require_relative(&path, &field("path"), notebook_path)?,
+            None if is_single => inferred_python_path(&path)?,
+            None => {
+                return Err(config_error(
+                    &path,
+                    format!(
+                        "notebooks.{name}.path is required when more than one notebook is declared"
+                    ),
+                ))
+            }
+        };
+        let source_path = directory.join(&relative_path);
+        let code = read_utf8(&path, &source_path, "notebook")?;
+        let readme = notebook
+            .readme_path
+            .map(|readme_path| {
+                let readme_path = require_relative(&path, &field("readme_path"), readme_path)?;
+                read_utf8(&path, &directory.join(readme_path), "readme")
+            })
+            .transpose()?;
+
+        notebooks.insert(
+            name,
+            DeploymentNotebook {
+                notebook_id,
+                display_path: relative_path.display().to_string(),
+                code,
+                title: notebook.title,
+                description: notebook.description,
+                tags: notebook.tags,
+                readme,
+                base_image: notebook.base_image,
+                compute_profile: notebook.compute_profile,
+            },
+        );
+    }
+
+    Ok(DeploymentConfig {
+        path,
+        project_id,
+        notebooks,
+    })
+}
+
+#[cfg(test)]
+fn resolve(path: PathBuf, raw: RawConfig) -> Result<DeploymentConfig, Error> {
+    resolve_selected(path, raw, &[])
+}
+
+pub fn load(explicit: Option<&Path>, selectors: &[String]) -> Result<DeploymentConfig, Error> {
+    let cwd = std::env::current_dir()?;
+    let path = discover_from(
+        &cwd,
+        explicit,
+        std::env::var_os("MARIMOHUB_CONFIG").as_deref(),
+    )?;
+    let raw = parse_raw(&path)?;
+    resolve_selected(path, raw, selectors)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        fs::write(path, contents).expect("write fixture");
+    }
+
+    fn notebook_config(path: &str) -> String {
+        format!(
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "{path}"
+"#
+        )
+    }
+
+    #[test]
+    fn standalone_and_pyproject_configs_resolve_the_same_shape() {
+        let standalone_dir = TempDir::new().unwrap();
+        write(&standalone_dir.path().join("app.py"), "print('standalone')");
+        write(
+            &standalone_dir.path().join(CONFIG_FILE),
+            &notebook_config("app.py"),
+        );
+        let standalone_path = discover_from(standalone_dir.path(), None, None).unwrap();
+        let standalone = resolve(
+            standalone_path.clone(),
+            parse_raw(&standalone_path).unwrap(),
+        )
+        .unwrap();
+
+        let pyproject_dir = TempDir::new().unwrap();
+        write(&pyproject_dir.path().join("app.py"), "print('pyproject')");
+        write(
+            &pyproject_dir.path().join(PYPROJECT_FILE),
+            r#"[project]
+name = "demo"
+
+[tool.marimohub]
+project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "app.py"
+"#,
+        );
+        let pyproject_path = discover_from(pyproject_dir.path(), None, None).unwrap();
+        let pyproject =
+            resolve(pyproject_path.clone(), parse_raw(&pyproject_path).unwrap()).unwrap();
+
+        assert_eq!(standalone.project_id, pyproject.project_id);
+        assert_eq!(
+            standalone.notebooks.keys().collect::<Vec<_>>(),
+            vec!["notebook"]
+        );
+        assert_eq!(
+            pyproject.notebooks.keys().collect::<Vec<_>>(),
+            vec!["notebook"]
+        );
+    }
+
+    #[test]
+    fn standalone_wins_over_a_colocated_pyproject() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join(CONFIG_FILE), &notebook_config("app.py"));
+        write(
+            &temp.path().join(PYPROJECT_FILE),
+            "[tool.marimohub]\nproject_id = \"other\"\n",
+        );
+
+        assert_eq!(
+            discover_from(temp.path(), None, None).unwrap(),
+            temp.path().join(CONFIG_FILE).canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn explicit_then_environment_then_ancestor_discovery_sets_precedence() {
+        let temp = TempDir::new().unwrap();
+        let nested = temp.path().join("a/b");
+        fs::create_dir_all(&nested).unwrap();
+        let ancestor = temp.path().join(CONFIG_FILE);
+        let environment = temp.path().join("environment.toml");
+        let explicit = temp.path().join("explicit.toml");
+        for path in [&ancestor, &environment, &explicit] {
+            write(path, &notebook_config("app.py"));
+        }
+
+        assert_eq!(
+            discover_from(&nested, Some(&explicit), Some(environment.as_os_str())).unwrap(),
+            explicit.canonicalize().unwrap()
+        );
+        assert_eq!(
+            discover_from(&nested, None, Some(environment.as_os_str())).unwrap(),
+            environment.canonicalize().unwrap()
+        );
+        assert_eq!(
+            discover_from(&nested, None, None).unwrap(),
+            ancestor.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn empty_environment_path_is_rejected() {
+        let temp = TempDir::new().unwrap();
+        let error =
+            discover_from(temp.path(), None, Some(OsString::new().as_os_str())).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("MARIMOHUB_CONFIG cannot be empty"));
+    }
+
+    #[test]
+    fn single_notebook_infers_the_only_sibling_python_file() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("only.py"), "print(1)");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+"#,
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+        let config = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap();
+
+        assert_eq!(config.notebooks["notebook"].display_path, "only.py");
+        assert_eq!(config.notebooks["notebook"].code, "print(1)");
+    }
+
+    #[test]
+    fn omitted_path_reports_zero_and_multiple_candidates() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join(CONFIG_FILE);
+        write(
+            &config_path,
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+"#,
+        );
+        let path = config_path.canonicalize().unwrap();
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("no Python file was found"));
+
+        write(&temp.path().join("b.py"), "b = 1");
+        write(&temp.path().join("a.py"), "a = 1");
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("more than one Python file was found (a.py, b.py)"));
+    }
+
+    #[test]
+    fn every_entry_in_a_multi_notebook_config_requires_a_path() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("a.py"), "a = 1");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+[notebooks.a]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "a.py"
+[notebooks.b]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+"#,
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("notebooks.b.path is required when more than one notebook is declared"));
+    }
+
+    #[test]
+    fn selectors_are_applied_before_local_files_are_read() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("zebra.py"), "zebra = 2");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+[notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "missing.py"
+readme_path = "missing.md"
+[notebooks.zebra]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "zebra.py"
+"#,
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+
+        let config =
+            resolve_selected(path.clone(), parse_raw(&path).unwrap(), &["zebra".into()]).unwrap();
+
+        assert_eq!(config.notebooks.keys().collect::<Vec<_>>(), ["zebra"]);
+        assert_eq!(config.notebooks["zebra"].code, "zebra = 2");
+    }
+
+    #[test]
+    fn flat_and_named_notebook_forms_cannot_be_mixed() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join(CONFIG_FILE);
+        write(
+            &config_path,
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+[notebooks.other]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "other.py"
+"#,
+        );
+        let path = config_path.canonicalize().unwrap();
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("top-level notebook fields cannot be combined with named notebooks"));
+
+        write(&config_path, "project_id = \"proj-7h2k9qm4xz7rp3w8\"\n");
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("notebook_id is required when no named notebooks are declared"));
+    }
+
+    #[test]
+    fn unknown_fields_and_absolute_paths_are_rejected() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join(CONFIG_FILE);
+        write(
+            &config_path,
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+typo = true
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "app.py"
+"#,
+        );
+        let path = config_path.canonicalize().unwrap();
+        assert!(parse_raw(&path)
+            .unwrap_err()
+            .to_string()
+            .contains("unknown field"));
+
+        write(
+            &config_path,
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+[notebooks.app]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "app.py"
+typo = true
+"#,
+        );
+        assert!(parse_raw(&path)
+            .unwrap_err()
+            .to_string()
+            .contains("unknown field `typo`"));
+
+        write(
+            &config_path,
+            &notebook_config(temp.path().join("app.py").to_str().unwrap()),
+        );
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("path must be relative"));
+    }
+
+    #[test]
+    fn notebook_and_readme_paths_require_regular_utf8_files() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join(CONFIG_FILE);
+        write(&config_path, &notebook_config("notebook"));
+        fs::create_dir(temp.path().join("notebook")).unwrap();
+        let path = config_path.canonicalize().unwrap();
+
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("is not a regular file"));
+
+        fs::remove_dir(temp.path().join("notebook")).unwrap();
+        fs::write(temp.path().join("notebook"), [0xff]).unwrap();
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("as UTF-8"));
+
+        write(&temp.path().join("notebook"), "print(1)");
+        write(
+            &config_path,
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "notebook"
+readme_path = "readme.md"
+"#,
+        );
+        fs::write(temp.path().join("readme.md"), [0xff]).unwrap();
+        let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+        assert!(error.to_string().contains("readme"));
+        assert!(error.to_string().contains("as UTF-8"));
+    }
+
+    #[test]
+    fn flat_optional_fields_are_resolved_without_defaults() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("app.py"), "print(1)");
+        write(&temp.path().join("README.md"), "Notebook docs");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "app.py"
+title = "Dashboard"
+description = "Description"
+tags = ["one", "two"]
+readme_path = "README.md"
+base_image = "image"
+compute_profile = "large"
+"#,
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+
+        let config = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap();
+        let notebook = &config.notebooks["notebook"];
+        assert_eq!(notebook.code, "print(1)");
+        assert_eq!(notebook.title.as_deref(), Some("Dashboard"));
+        assert_eq!(notebook.description.as_deref(), Some("Description"));
+        assert_eq!(
+            notebook.tags.as_deref(),
+            Some(["one".into(), "two".into()].as_slice())
+        );
+        assert_eq!(notebook.readme.as_deref(), Some("Notebook docs"));
+        assert_eq!(notebook.base_image.as_deref(), Some("image"));
+        assert_eq!(notebook.compute_profile.as_deref(), Some("large"));
+    }
+
+    #[test]
+    fn empty_required_ids_are_rejected() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("app.py"), "print(1)");
+        let config_path = temp.path().join(CONFIG_FILE);
+        write(
+            &config_path,
+            "project_id = \"   \"\nnotebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\n",
+        );
+        let path = config_path.canonicalize().unwrap();
+        assert!(resolve(path.clone(), parse_raw(&path).unwrap())
+            .unwrap_err()
+            .to_string()
+            .contains("project_id cannot be empty"));
+
+        write(
+            &config_path,
+            "project_id = \"proj-7h2k9qm4xz7rp3w8\"\nnotebook_id = \"\"\npath = \"app.py\"\n",
+        );
+        assert!(resolve(path.clone(), parse_raw(&path).unwrap())
+            .unwrap_err()
+            .to_string()
+            .contains("notebook_id cannot be empty"));
+    }
+
+    #[test]
+    fn inference_ignores_nested_and_non_lowercase_python_files() {
+        let temp = TempDir::new().unwrap();
+        fs::create_dir(temp.path().join("nested")).unwrap();
+        write(&temp.path().join("nested/child.py"), "print('nested')");
+        write(&temp.path().join("upper.PY"), "print('upper')");
+        write(&temp.path().join("notes.txt"), "notes");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            "project_id = \"proj-7h2k9qm4xz7rp3w8\"\nnotebook_id = \"nb-7h2k9qm4xz7rp3w8\"\n",
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+
+        assert!(resolve(path.clone(), parse_raw(&path).unwrap())
+            .unwrap_err()
+            .to_string()
+            .contains("no Python file was found"));
+        write(&temp.path().join("app.py"), "print('app')");
+        let config = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap();
+        assert_eq!(config.notebooks["notebook"].display_path, "app.py");
+    }
+
+    #[test]
+    fn one_named_notebook_can_use_path_inference() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("app.py"), "print(1)");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+[notebooks.app]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+"#,
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+
+        let config = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap();
+        assert_eq!(config.notebooks["app"].display_path, "app.py");
+    }
+
+    #[test]
+    fn explicit_pyproject_requires_the_tool_section_but_other_names_use_the_root() {
+        let temp = TempDir::new().unwrap();
+        let pyproject = temp.path().join(PYPROJECT_FILE);
+        write(&pyproject, "[project]\nname = \"demo\"\n");
+        assert!(parse_raw(&pyproject)
+            .unwrap_err()
+            .to_string()
+            .contains("missing required [tool.marimohub]"));
+
+        let custom = temp.path().join("deploy.toml");
+        write(&custom, &notebook_config("app.py"));
+        let raw = parse_raw(&custom).unwrap();
+        assert_eq!(raw.project_id, "proj-7h2k9qm4xz7rp3w8");
+        assert_eq!(raw.notebook_id.as_deref(), Some("nb-7h2k9qm4xz7rp3w8"));
+    }
+
+    #[test]
+    fn nearest_pyproject_beats_a_parent_standalone_config() {
+        let temp = TempDir::new().unwrap();
+        let child = temp.path().join("child");
+        fs::create_dir(&child).unwrap();
+        write(
+            &temp.path().join(CONFIG_FILE),
+            &notebook_config("parent.py"),
+        );
+        write(
+            &child.join(PYPROJECT_FILE),
+            r#"[tool.marimohub]
+project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "child.py"
+"#,
+        );
+
+        assert_eq!(
+            discover_from(&child, None, None).unwrap(),
+            child.join(PYPROJECT_FILE).canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn schema_version_is_rejected_as_an_unknown_field() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("app.py"), "print(1)");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            &format!("schema_version = 1\n{}", notebook_config("app.py")),
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+
+        let error = parse_raw(&path).unwrap_err();
+        assert!(error.to_string().contains("unknown field `schema_version`"));
+    }
+}

--- a/apps/cli/src/deploy_config.rs
+++ b/apps/cli/src/deploy_config.rs
@@ -3,7 +3,8 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer};
 
 use crate::Error;
 
@@ -26,8 +27,58 @@ pub struct DeploymentNotebook {
     pub description: Option<String>,
     pub tags: Option<Vec<String>>,
     pub readme: Option<String>,
-    pub base_image: Option<String>,
-    pub compute_profile: Option<String>,
+    pub base_image: Option<DeploymentOverride>,
+    pub compute_profile: Option<DeploymentOverride>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DeploymentOverride {
+    Name(String),
+    Clear,
+}
+
+impl<'de> Deserialize<'de> for DeploymentOverride {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct OverrideVisitor;
+
+        impl Visitor<'_> for OverrideVisitor {
+            type Value = DeploymentOverride;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a name or false to clear the override")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(DeploymentOverride::Name(value.to_owned()))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(DeploymentOverride::Name(value))
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if value {
+                    Err(E::invalid_value(de::Unexpected::Bool(value), &self))
+                } else {
+                    Ok(DeploymentOverride::Clear)
+                }
+            }
+        }
+
+        deserializer.deserialize_any(OverrideVisitor)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -40,8 +91,8 @@ struct RawConfig {
     description: Option<String>,
     tags: Option<Vec<String>>,
     readme_path: Option<PathBuf>,
-    base_image: Option<String>,
-    compute_profile: Option<String>,
+    base_image: Option<DeploymentOverride>,
+    compute_profile: Option<DeploymentOverride>,
     #[serde(default)]
     notebooks: BTreeMap<String, RawNotebook>,
 }
@@ -55,8 +106,8 @@ struct RawNotebook {
     description: Option<String>,
     tags: Option<Vec<String>>,
     readme_path: Option<PathBuf>,
-    base_image: Option<String>,
-    compute_profile: Option<String>,
+    base_image: Option<DeploymentOverride>,
+    compute_profile: Option<DeploymentOverride>,
 }
 
 fn config_error(path: &Path, message: impl std::fmt::Display) -> Error {
@@ -141,6 +192,14 @@ fn require_nonempty(path: &Path, field: &str, value: String) -> Result<String, E
         Err(config_error(path, format!("{field} cannot be empty")))
     } else {
         Ok(value)
+    }
+}
+
+fn reject_empty(path: &Path, field: &str, value: Option<&str>) -> Result<(), Error> {
+    if value == Some("") {
+        Err(config_error(path, format!("{field} cannot be empty")))
+    } else {
+        Ok(())
     }
 }
 
@@ -303,6 +362,7 @@ fn resolve_selected(
         ));
     }
     let is_single = raw_notebooks.len() == 1;
+    let mut notebook_ids = BTreeMap::new();
     for (name, notebook) in &raw_notebooks {
         if name.trim().is_empty() {
             return Err(config_error(&path, "notebook names cannot be empty"));
@@ -319,6 +379,27 @@ fn resolve_selected(
                 &path,
                 format!("{} cannot be empty", field("notebook_id")),
             ));
+        }
+        if let Some(existing_name) = notebook_ids.insert(notebook.notebook_id.as_str(), name) {
+            return Err(config_error(
+                &path,
+                format!(
+                    "{} duplicates notebooks.{existing_name}.notebook_id ({})",
+                    field("notebook_id"),
+                    notebook.notebook_id,
+                ),
+            ));
+        }
+        reject_empty(&path, &field("title"), notebook.title.as_deref())?;
+        for (field_name, value) in [
+            ("base_image", notebook.base_image.as_ref()),
+            ("compute_profile", notebook.compute_profile.as_ref()),
+        ] {
+            let value = match value {
+                Some(DeploymentOverride::Name(value)) => Some(value.as_str()),
+                Some(DeploymentOverride::Clear) | None => None,
+            };
+            reject_empty(&path, &field(field_name), value)?;
         }
         if notebook
             .path
@@ -490,6 +571,35 @@ path = "app.py"
     }
 
     #[test]
+    fn pyproject_named_notebooks_use_the_tool_namespace() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("alpha.py"), "alpha = 1");
+        write(&temp.path().join("zebra.py"), "zebra = 1");
+        write(
+            &temp.path().join(PYPROJECT_FILE),
+            r#"[tool.marimohub]
+project_id = "proj-7h2k9qm4xz7rp3w8"
+
+[tool.marimohub.notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "alpha.py"
+
+[tool.marimohub.notebooks.zebra]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "zebra.py"
+"#,
+        );
+        let path = temp.path().join(PYPROJECT_FILE).canonicalize().unwrap();
+
+        let config = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap();
+
+        assert_eq!(
+            config.notebooks.keys().collect::<Vec<_>>(),
+            ["alpha", "zebra"]
+        );
+    }
+
+    #[test]
     fn standalone_wins_over_a_colocated_pyproject() {
         let temp = TempDir::new().unwrap();
         write(&temp.path().join(CONFIG_FILE), &notebook_config("app.py"));
@@ -625,6 +735,81 @@ path = "zebra.py"
     }
 
     #[test]
+    fn empty_server_constrained_values_are_rejected_before_file_reads() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join(CONFIG_FILE);
+        let cases = [
+            ("title", "title = \"\""),
+            ("base_image", "base_image = \"\""),
+            ("compute_profile", "compute_profile = \"\""),
+        ];
+
+        for (field, assignment) in cases {
+            write(
+                &config_path,
+                &format!(
+                    r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+[notebooks.app]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "missing.py"
+{assignment}
+"#,
+                ),
+            );
+            let path = config_path.canonicalize().unwrap();
+
+            let error = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap_err();
+
+            assert!(error
+                .to_string()
+                .contains(&format!("notebooks.app.{field} cannot be empty")));
+            assert!(!error.to_string().contains("could not inspect notebook"));
+        }
+
+        write(&temp.path().join("app.py"), "print(1)");
+        write(
+            &config_path,
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "app.py"
+description = ""
+"#,
+        );
+        let path = config_path.canonicalize().unwrap();
+        let config = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap();
+        assert_eq!(
+            config.notebooks["notebook"].description.as_deref(),
+            Some("")
+        );
+    }
+
+    #[test]
+    fn duplicate_notebook_ids_are_rejected_before_selection_and_file_reads() {
+        let temp = TempDir::new().unwrap();
+        write(
+            &temp.path().join(CONFIG_FILE),
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+[notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "missing-alpha.py"
+[notebooks.zebra]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "missing-zebra.py"
+"#,
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+
+        let error = resolve_selected(path.clone(), parse_raw(&path).unwrap(), &["zebra".into()])
+            .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains(
+            "notebooks.zebra.notebook_id duplicates notebooks.alpha.notebook_id (nb-7h2k9qm4xz7rp3w8)"
+        ));
+        assert!(!message.contains("could not inspect notebook"));
+    }
+
+    #[test]
     fn flat_and_named_notebook_forms_cannot_be_mixed() {
         let temp = TempDir::new().unwrap();
         let config_path = temp.path().join(CONFIG_FILE);
@@ -751,8 +936,58 @@ compute_profile = "large"
             Some(["one".into(), "two".into()].as_slice())
         );
         assert_eq!(notebook.readme.as_deref(), Some("Notebook docs"));
-        assert_eq!(notebook.base_image.as_deref(), Some("image"));
-        assert_eq!(notebook.compute_profile.as_deref(), Some("large"));
+        assert_eq!(
+            notebook.base_image,
+            Some(DeploymentOverride::Name("image".into()))
+        );
+        assert_eq!(
+            notebook.compute_profile,
+            Some(DeploymentOverride::Name("large".into()))
+        );
+    }
+
+    #[test]
+    fn false_clears_overrides_and_default_remains_a_literal_name() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("app.py"), "print(1)");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "app.py"
+base_image = "default"
+compute_profile = false
+"#,
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+
+        let config = resolve(path.clone(), parse_raw(&path).unwrap()).unwrap();
+        let notebook = &config.notebooks["notebook"];
+        assert_eq!(
+            notebook.base_image,
+            Some(DeploymentOverride::Name("default".into()))
+        );
+        assert_eq!(notebook.compute_profile, Some(DeploymentOverride::Clear));
+    }
+
+    #[test]
+    fn true_is_not_a_valid_override_value() {
+        let temp = TempDir::new().unwrap();
+        write(&temp.path().join("app.py"), "print(1)");
+        write(
+            &temp.path().join(CONFIG_FILE),
+            r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "app.py"
+base_image = true
+"#,
+        );
+        let path = temp.path().join(CONFIG_FILE).canonicalize().unwrap();
+
+        let error = parse_raw(&path).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("a name or false to clear the override"));
     }
 
     #[test]

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod cli;
 pub mod client;
 pub mod config;
+pub mod deploy;
+pub mod deploy_config;
 pub mod manifest;
 
 use std::io;
@@ -34,6 +36,9 @@ pub enum Error {
     #[error("operation cancelled")]
     #[diagnostic(code(mohub::cancelled))]
     Cancelled,
+    #[error("deployment failed: {0}")]
+    #[diagnostic(code(mohub::deployment))]
+    Deployment(String),
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use clap::ArgMatches;
-use mohub::{cli, client, config, manifest, Error};
+use mohub::{cli, client, config, deploy, manifest, Error};
 use secrecy::SecretString;
 use sha2::{Digest, Sha256};
 use update_informer::{registry, Check};
@@ -647,6 +647,34 @@ fn run_command(
     }
     if path.first().map(String::as_str) == Some("logout") {
         return handle_logout(matches);
+    }
+    if path == ["notebooks", "deploy"] {
+        let prepared = deploy::prepare(deploy::DeployOptions {
+            config: leaf
+                .get_one::<String>("deploy-config")
+                .map(std::path::PathBuf::from),
+            notebooks: leaf
+                .get_many::<String>("deploy-notebook")
+                .map(|values| values.cloned().collect())
+                .unwrap_or_default(),
+            dry_run: leaf.get_flag("deploy-dry-run"),
+            message: leaf.get_one::<String>("deploy-message").cloned(),
+        })?;
+        let (base_url, token) = resolve_runtime(matches)?;
+        let runtime = client::Runtime {
+            base_url: &base_url,
+            token: token.as_ref(),
+            timeout: Duration::from_secs(
+                *matches
+                    .get_one::<u64>("timeout")
+                    .expect("defaulted by clap"),
+            ),
+            output: matches
+                .get_one::<String>("output")
+                .expect("defaulted by clap"),
+            raw_envelope: matches.get_flag("raw-envelope"),
+        };
+        return deploy::execute(&runtime, prepared);
     }
     let operation = manifest
         .operations

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -649,6 +649,11 @@ fn run_command(
         return handle_logout(matches);
     }
     if path == ["notebooks", "deploy"] {
+        if matches.get_flag("raw-envelope") {
+            return Err(Error::Usage(
+                "--raw-envelope cannot be combined with notebooks deploy".into(),
+            ));
+        }
         let prepared = deploy::prepare(deploy::DeployOptions {
             config: leaf
                 .get_one::<String>("deploy-config")

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -222,6 +222,29 @@ fn notebooks_help_distinguishes_deploy_from_update() {
 }
 
 #[test]
+fn deploy_rejects_raw_envelope_before_reading_configuration() {
+    let temp = TempDir::new().unwrap();
+    let missing_config = temp.path().join("missing.toml");
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "notebooks",
+            "deploy",
+            "--raw-envelope",
+            "--config",
+            &missing_config.display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "--raw-envelope cannot be combined with notebooks deploy",
+        ))
+        .stderr(predicate::str::contains("could not resolve configuration").not())
+        .stderr(predicate::str::contains("no server URL").not());
+}
+
+#[test]
 fn deploy_updates_changed_code_with_the_preflight_etag() {
     let (_temp, config) = deploy_fixture(
         "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\ntitle = \"New\"\n",
@@ -553,11 +576,15 @@ fn malformed_content_stops_before_any_patch() {
 #[test]
 fn metadata_only_update_omits_code_and_message() {
     let (_temp, config) = deploy_fixture(
-        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\ntitle = \"New\"\n",
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\ntitle = \"New\"\nbase_image = false\n",
         &[("app.py", "print('same')")],
     );
     let (base_url, server) = serve_sequence(vec![
-        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-1\""),
+        StubResponse::json(
+            200,
+            r#"{"success":true,"data":{"meta":{"title":"Old","description":"D","tags":[],"base_image":"custom"},"readme":null,"source":{"type":"local"}}}"#,
+        )
+        .with_header("ETag", "\"etag-1\""),
         StubResponse::json(200, r#"{"success":true,"data":{"code":"print('same')"}}"#),
         StubResponse::json(200, r#"{"success":true,"data":{}}"#),
     ]);
@@ -579,12 +606,14 @@ fn metadata_only_update_omits_code_and_message() {
         .success()
         .stdout(predicate::str::contains(
             r#""changes": [
+        "base_image",
         "title"
       ]"#,
         ));
 
     let requests = server.join().unwrap();
     assert!(requests[2].starts_with("PATCH "));
+    assert!(requests[2].contains(r#""base_image":null"#));
     assert!(requests[2].contains(r#""title":"New""#));
     assert!(!requests[2].contains(r#""code""#));
     assert!(!requests[2].contains(r#""message""#));

--- a/apps/cli/tests/cli.rs
+++ b/apps/cli/tests/cli.rs
@@ -1,9 +1,111 @@
-use std::io::{Read, Write};
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::thread;
 
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
+use tempfile::TempDir;
+
+struct StubResponse {
+    status: u16,
+    body: &'static str,
+    headers: Vec<(&'static str, &'static str)>,
+}
+
+impl StubResponse {
+    fn json(status: u16, body: &'static str) -> Self {
+        Self {
+            status,
+            body,
+            headers: Vec::new(),
+        }
+    }
+
+    fn with_header(mut self, name: &'static str, value: &'static str) -> Self {
+        self.headers.push((name, value));
+        self
+    }
+}
+
+fn serve_sequence(responses: Vec<StubResponse>) -> (String, thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+    let address = listener.local_addr().expect("test server address");
+    let handle = thread::spawn(move || {
+        responses
+            .into_iter()
+            .map(|response| {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let mut reader = BufReader::new(stream.try_clone().expect("clone request stream"));
+                let mut request = String::new();
+                let mut content_length = 0;
+                loop {
+                    let mut line = String::new();
+                    reader.read_line(&mut line).expect("read request line");
+                    assert!(!line.is_empty(), "request ended before headers completed");
+                    if let Some((name, value)) = line.split_once(':') {
+                        if name.eq_ignore_ascii_case("content-length") {
+                            content_length = value.trim().parse().expect("valid content length");
+                        }
+                    }
+                    request.push_str(&line);
+                    if line == "\r\n" {
+                        break;
+                    }
+                }
+                let mut body = vec![0; content_length];
+                reader.read_exact(&mut body).expect("read request body");
+                request.push_str(&String::from_utf8(body).expect("UTF-8 request body"));
+
+                let extra_headers = response
+                    .headers
+                    .iter()
+                    .map(|(name, value)| format!("{name}: {value}\r\n"))
+                    .collect::<String>();
+                write!(
+                    stream,
+                    "HTTP/1.1 {} Test\r\nContent-Type: application/json\r\n{}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    response.status,
+                    extra_headers,
+                    response.body.len(),
+                    response.body,
+                )
+                .expect("write response");
+                request
+            })
+            .collect()
+    });
+    (format!("http://{address}"), handle)
+}
+
+fn deploy_fixture(notebooks: &str, files: &[(&str, &str)]) -> (TempDir, String) {
+    let temp = TempDir::new().expect("temporary deploy project");
+    for (path, contents) in files {
+        fs::write(temp.path().join(path), contents).expect("write deploy file");
+    }
+    let config = temp.path().join("marimohub.toml");
+    fs::write(
+        &config,
+        format!("project_id = \"proj-7h2k9qm4xz7rp3w8\"\n{notebooks}"),
+    )
+    .expect("write deploy config");
+    (temp, config.display().to_string())
+}
+
+fn local_detail(title: &'static str, source_type: &'static str) -> &'static str {
+    match (title, source_type) {
+        ("Old", "local") => {
+            r#"{"success":true,"data":{"meta":{"title":"Old","description":"D","tags":[]},"readme":null,"source":{"type":"local"}}}"#
+        }
+        ("Same", "local") => {
+            r#"{"success":true,"data":{"meta":{"title":"Same","description":"D","tags":[]},"readme":null,"source":{"type":"local"}}}"#
+        }
+        (_, "git") => {
+            r#"{"success":true,"data":{"meta":{"title":"Git","description":"D","tags":[]},"readme":null,"source":{"type":"git"}}}"#
+        }
+        _ => unreachable!(),
+    }
+}
 
 fn serve_once(status: u16, body: &str) -> (String, thread::JoinHandle<String>) {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
@@ -107,4 +209,677 @@ fn http_errors_are_diagnostic_and_do_not_echo_the_token() {
         .stderr(predicate::str::contains("mhub_pat_secret").not());
 
     server.join().expect("test server completed");
+}
+
+#[test]
+fn notebooks_help_distinguishes_deploy_from_update() {
+    cargo_bin_cmd!("mohub")
+        .args(["notebooks", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("deploy"))
+        .stdout(predicate::str::contains("update"));
+}
+
+#[test]
+fn deploy_updates_changed_code_with_the_preflight_etag() {
+    let (_temp, config) = deploy_fixture(
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\ntitle = \"New\"\n",
+        &[("app.py", "print('new')")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-1\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"print('old')"}}"#),
+        StubResponse::json(200, r#"{"success":true,"data":{"id":"nb"}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_secret",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action": "updated""#))
+        .stdout(predicate::str::contains(r#""code""#))
+        .stdout(predicate::str::contains("print('new')").not())
+        .stdout(predicate::str::contains("mhub_pat_secret").not());
+
+    let requests = server.join().expect("test server completed");
+    assert!(requests[0].starts_with(
+        "GET /api/v1/projects/proj-7h2k9qm4xz7rp3w8/notebooks/nb-7h2k9qm4xz7rp3w8 HTTP/1.1"
+    ));
+    assert!(requests[1].starts_with(
+        "GET /api/v1/projects/proj-7h2k9qm4xz7rp3w8/notebooks/nb-7h2k9qm4xz7rp3w8/content HTTP/1.1"
+    ));
+    assert!(requests[2].starts_with(
+        "PATCH /api/v1/projects/proj-7h2k9qm4xz7rp3w8/notebooks/nb-7h2k9qm4xz7rp3w8 HTTP/1.1"
+    ));
+    assert!(requests[2]
+        .to_ascii_lowercase()
+        .contains("if-match: \"etag-1\""));
+    assert!(requests[2].contains(r#""code":"print('new')""#));
+    assert!(requests[2].contains(r#""message":"Deploy app.py""#));
+    assert!(requests[2].contains(r#""title":"New""#));
+}
+
+#[test]
+fn dry_run_and_unchanged_deploys_do_not_patch() {
+    let (_temp, config) = deploy_fixture(
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\n",
+        &[("app.py", "print('new')")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-1\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"print('old')"}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action": "planned""#));
+    assert_eq!(server.join().unwrap().len(), 2);
+
+    fs::write(_temp.path().join("app.py"), "print('same')").unwrap();
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Same", "local")).with_header("ETag", "\"etag-2\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"print('same')"}}"#),
+    ]);
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action": "unchanged""#));
+    assert_eq!(server.join().unwrap().len(), 2);
+}
+
+#[test]
+fn multi_notebook_deploy_finishes_preflight_before_writing() {
+    let (_temp, config) = deploy_fixture(
+        r#"
+[notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "alpha.py"
+[notebooks.zebra]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "zebra.py"
+"#,
+        &[("alpha.py", "alpha = 2"), ("zebra.py", "zebra = 2")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-a\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"alpha = 1"}}"#),
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-z\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"zebra = 1"}}"#),
+        StubResponse::json(200, r#"{"success":true,"data":{}}"#),
+        StubResponse::json(200, r#"{"success":true,"data":{}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .success();
+
+    let requests = server.join().unwrap();
+    assert!(requests[0].contains("nb-7h2k9qm4xz7rp3w8"));
+    assert!(requests[2].contains("nb-8h2k9qm4xz7rp3w8"));
+    assert!(requests[..4]
+        .iter()
+        .all(|request| request.starts_with("GET ")));
+    assert!(requests[4].starts_with("PATCH "));
+    assert!(requests[5].starts_with("PATCH "));
+}
+
+#[test]
+fn failed_remote_preflight_prevents_all_writes() {
+    let (_temp, config) = deploy_fixture(
+        r#"
+[notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "alpha.py"
+[notebooks.zebra]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "zebra.py"
+"#,
+        &[("alpha.py", "alpha = 2"), ("zebra.py", "zebra = 2")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-a\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"alpha = 1"}}"#),
+        StubResponse::json(
+            404,
+            r#"{"success":false,"error":{"code":"NOT_FOUND","message":"Notebook not found"}}"#,
+        ),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains("HTTP 404 NOT_FOUND"));
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 3);
+    assert!(requests.iter().all(|request| request.starts_with("GET ")));
+}
+
+#[test]
+fn malformed_remote_preflight_prevents_all_writes() {
+    let (_temp, config) = deploy_fixture(
+        r#"
+[notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "alpha.py"
+[notebooks.zebra]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "zebra.py"
+"#,
+        &[("alpha.py", "alpha = 2"), ("zebra.py", "zebra = 2")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-a\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"alpha = 1"}}"#),
+        StubResponse::json(200, r#"{"success":true,"data":{"meta":{"title":"Old"}}}"#)
+            .with_header("ETag", "\"etag-z\""),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no valid tags"));
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 3);
+    assert!(requests.iter().all(|request| request.starts_with("GET ")));
+}
+
+#[test]
+fn missing_etag_stops_before_the_content_request() {
+    let (_temp, config) = deploy_fixture(
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\n",
+        &[("app.py", "print('new')")],
+    );
+    let (base_url, server) =
+        serve_sequence(vec![StubResponse::json(200, local_detail("Old", "local"))]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains("did not return an ETag"));
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert!(requests[0].starts_with("GET "));
+}
+
+#[test]
+fn transient_preflight_get_is_retried_before_planning() {
+    let (_temp, config) = deploy_fixture(
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\n",
+        &[("app.py", "print('same')")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(
+            503,
+            r#"{"success":false,"error":{"code":"SERVICE_UNAVAILABLE","message":"Try again"}}"#,
+        ),
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-1\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"print('same')"}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action": "unchanged""#));
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 3);
+    assert_eq!(
+        requests[0].lines().next(),
+        requests[1].lines().next(),
+        "the detail GET is retried"
+    );
+    assert!(requests.iter().all(|request| request.starts_with("GET ")));
+}
+
+#[test]
+fn malformed_content_stops_before_any_patch() {
+    let (_temp, config) = deploy_fixture(
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\n",
+        &[("app.py", "print('new')")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-1\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":42}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains("no valid code"));
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(requests.iter().all(|request| request.starts_with("GET ")));
+}
+
+#[test]
+fn metadata_only_update_omits_code_and_message() {
+    let (_temp, config) = deploy_fixture(
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\ntitle = \"New\"\n",
+        &[("app.py", "print('same')")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-1\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"print('same')"}}"#),
+        StubResponse::json(200, r#"{"success":true,"data":{}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+            "--message",
+            "Must not be sent",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#""changes": [
+        "title"
+      ]"#,
+        ));
+
+    let requests = server.join().unwrap();
+    assert!(requests[2].starts_with("PATCH "));
+    assert!(requests[2].contains(r#""title":"New""#));
+    assert!(!requests[2].contains(r#""code""#));
+    assert!(!requests[2].contains(r#""message""#));
+    assert!(!requests[2].contains("Must not be sent"));
+}
+
+#[test]
+fn pyproject_discovery_and_path_inference_work_together() {
+    let temp = TempDir::new().unwrap();
+    fs::write(temp.path().join("app.py"), "print('same')").unwrap();
+    fs::write(
+        temp.path().join("pyproject.toml"),
+        r#"[project]
+name = "demo"
+
+[tool.marimohub]
+project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+"#,
+    )
+    .unwrap();
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-1\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"print('same')"}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .current_dir(temp.path())
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""action": "unchanged""#))
+        .stdout(predicate::str::contains("pyproject.toml"));
+
+    assert_eq!(server.join().unwrap().len(), 2);
+}
+
+#[test]
+fn notebook_selector_reads_and_updates_only_the_selected_entry() {
+    let (_temp, config) = deploy_fixture(
+        r#"
+[notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "alpha.py"
+[notebooks.zebra]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "zebra.py"
+"#,
+        &[("zebra.py", "zebra = 2")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-z\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"zebra = 1"}}"#),
+        StubResponse::json(200, r#"{"success":true,"data":{}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+            "--notebook",
+            "zebra",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""name": "zebra""#))
+        .stdout(predicate::str::contains(r#""name": "alpha""#).not());
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 3);
+    assert!(requests
+        .iter()
+        .all(|request| request.contains("nb-8h2k9qm4xz7rp3w8")));
+}
+
+#[test]
+fn precondition_failure_is_not_retried() {
+    let (_temp, config) = deploy_fixture(
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\n",
+        &[("app.py", "print('new')")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-1\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"print('old')"}}"#),
+        StubResponse::json(
+            412,
+            r#"{"success":false,"error":{"code":"PRECONDITION_FAILED","message":"Notebook changed"}}"#,
+        ),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("HTTP 412"))
+        .stderr(predicate::str::contains("PRECONDITION_FAILED"));
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 3);
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.starts_with("PATCH "))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn rerun_after_partial_apply_skips_the_completed_notebook() {
+    let (_temp, config) = deploy_fixture(
+        r#"
+[notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "alpha.py"
+[notebooks.zebra]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "zebra.py"
+"#,
+        &[("alpha.py", "alpha = 2"), ("zebra.py", "zebra = 2")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-a\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"alpha = 1"}}"#),
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-z\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"zebra = 1"}}"#),
+        StubResponse::json(200, r#"{"success":true,"data":{}}"#),
+        StubResponse::json(
+            500,
+            r#"{"success":false,"error":{"code":"INTERNAL_ERROR","message":"Try again"}}"#,
+        ),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already updated: alpha"));
+    assert_eq!(
+        server
+            .join()
+            .unwrap()
+            .iter()
+            .filter(|request| request.starts_with("PATCH "))
+            .count(),
+        2
+    );
+
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-a2\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"alpha = 2"}}"#),
+        StubResponse::json(200, local_detail("Old", "local")).with_header("ETag", "\"etag-z2\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"zebra = 1"}}"#),
+        StubResponse::json(200, r#"{"success":true,"data":{}}"#),
+    ]);
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .success();
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 5);
+    assert!(requests[4].starts_with("PATCH "));
+    assert!(requests[4].contains("nb-8h2k9qm4xz7rp3w8"));
+}
+
+#[test]
+fn git_backed_notebook_is_rejected_without_a_patch() {
+    let (_temp, config) = deploy_fixture(
+        "notebook_id = \"nb-7h2k9qm4xz7rp3w8\"\npath = \"app.py\"\n",
+        &[("app.py", "print('new')")],
+    );
+    let (base_url, server) = serve_sequence(vec![
+        StubResponse::json(200, local_detail("Git", "git")).with_header("ETag", "\"etag-git\""),
+        StubResponse::json(200, r#"{"success":true,"data":{"code":"print('old')"}}"#),
+    ]);
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "--base-url",
+            &base_url,
+            "--token",
+            "mhub_pat_test",
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+        ])
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains("supports only local notebooks"));
+
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(requests.iter().all(|request| request.starts_with("GET ")));
+}
+
+#[test]
+fn invalid_local_configuration_fails_before_profile_resolution() {
+    let temp = TempDir::new().unwrap();
+    let config = temp.path().join("marimohub.toml");
+    fs::write(
+        &config,
+        r#"project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+"#,
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "notebooks",
+            "deploy",
+            "--config",
+            &config.display().to_string(),
+        ])
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains("set path for the notebook"))
+        .stderr(predicate::str::contains("no server URL").not());
+}
+
+#[test]
+fn unknown_selector_fails_before_profile_resolution() {
+    let (_temp, config) = deploy_fixture(
+        r#"
+[notebooks.alpha]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "alpha.py"
+[notebooks.zebra]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "zebra.py"
+"#,
+        &[("alpha.py", "alpha = 1"), ("zebra.py", "zebra = 1")],
+    );
+
+    cargo_bin_cmd!("mohub")
+        .args([
+            "notebooks",
+            "deploy",
+            "--config",
+            &config,
+            "--notebook",
+            "missing",
+        ])
+        .assert()
+        .failure()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "unknown notebook selection missing",
+        ))
+        .stderr(predicate::str::contains(
+            "available notebooks: alpha, zebra",
+        ))
+        .stderr(predicate::str::contains("no server URL").not());
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -163,6 +163,91 @@ terminal colors. Progress and update notices use standard error.
 The CLI skips its daily release check when standard error is not a terminal, including in CI. Use
 `--no-update-check` or `MARIMOHUB_NO_UPDATE_CHECK=true` to disable it explicitly.
 
+## Deploy notebooks from configuration
+
+`mohub notebooks deploy` updates existing local-source notebooks from repository files. Before it
+writes, the command compares each notebook, skips unchanged entries, and captures ETags to reject
+concurrent updates.
+
+For one `.py` file in the configuration directory, `marimohub.toml` needs two fields:
+
+```toml
+project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+```
+
+Alternatively, put these fields under `[tool.marimohub]` in `pyproject.toml`:
+
+```toml
+[tool.marimohub]
+project_id = "proj-7h2k9qm4xz7rp3w8"
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+```
+
+`path` and `readme_path` are relative to the configuration file. Without `path`, a single-notebook
+configuration uses the only immediate `.py` file. Zero or multiple matches produce an error.
+
+Use named tables for multiple notebooks:
+
+```toml
+project_id = "proj-7h2k9qm4xz7rp3w8"
+
+[notebooks.revenue]
+notebook_id = "nb-7h2k9qm4xz7rp3w8"
+path = "notebooks/revenue.py"
+
+[notebooks.inventory]
+notebook_id = "nb-8h2k9qm4xz7rp3w8"
+path = "notebooks/inventory.py"
+```
+
+Every named table in a multi-notebook configuration requires `path`. Optional fields are `title`,
+`description`, `tags`, `readme_path`, `base_image`, and `compute_profile`. Omitted fields preserve
+their remote values. The value `default` clears a `base_image` or `compute_profile` override.
+
+Preview or deploy notebooks:
+
+```bash
+mohub notebooks deploy --dry-run
+mohub notebooks deploy
+mohub notebooks deploy --notebook revenue
+mohub notebooks deploy --notebook revenue --notebook inventory
+```
+
+Use `--message` to set the immutable version message for code changes. Otherwise, the message is
+`Deploy <path>`.
+
+The CLI resolves configuration in this order:
+
+1. `--config PATH`.
+2. `MARIMOHUB_CONFIG`.
+3. The nearest ancestor with `marimohub.toml` or a `[tool.marimohub]` section.
+
+At the same directory level, `marimohub.toml` takes precedence over `pyproject.toml`.
+
+The command prints one aggregate result. Each entry includes its action and changed field names.
+Actions are `planned`, `updated`, or `unchanged`. Output excludes notebook and readme text.
+
+The configuration cannot contain server URLs or credentials. Each declaration must identify an
+existing local-source notebook. This command does not create or delete notebooks, upload
+dependencies, or update git-backed sources. For git-backed workspaces, use the
+[source sync workflow](./syncing.md).
+
+In CI, set the Hub URL and token through the environment. Replace `<CLI_VERSION>` with a CLI version
+that contains this command.
+
+```yaml
+- uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+- uses: marimo-team/setup-marimohub-cli@15f7152034cdf6728c02be77d39526360ce60ec2 # v1.0.1
+  with:
+    version: '<CLI_VERSION>'
+- name: Deploy notebooks
+  env:
+    MARIMOHUB_URL: ${{ vars.MARIMOHUB_URL }}
+    MARIMOHUB_TOKEN: ${{ secrets.MARIMOHUB_TOKEN }}
+  run: mohub notebooks deploy
+```
+
 ## Profiles
 
 Use profiles to connect to more than one marimohub deployment:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -187,7 +187,7 @@ notebook_id = "nb-7h2k9qm4xz7rp3w8"
 `path` and `readme_path` are relative to the configuration file. Without `path`, a single-notebook
 configuration uses the only immediate `.py` file. Zero or multiple matches produce an error.
 
-Use named tables for multiple notebooks:
+For multiple notebooks in `marimohub.toml`, use named tables:
 
 ```toml
 project_id = "proj-7h2k9qm4xz7rp3w8"
@@ -201,9 +201,13 @@ notebook_id = "nb-8h2k9qm4xz7rp3w8"
 path = "notebooks/inventory.py"
 ```
 
+In `pyproject.toml`, nest these tables under `[tool.marimohub]`. For example, use
+`[tool.marimohub.notebooks.revenue]` instead of `[notebooks.revenue]`.
+
 Every named table in a multi-notebook configuration requires `path`. Optional fields are `title`,
 `description`, `tags`, `readme_path`, `base_image`, and `compute_profile`. Omitted fields preserve
-their remote values. The value `default` clears a `base_image` or `compute_profile` override.
+their remote values. Set `base_image` or `compute_profile` to `false` to clear an override. String
+values are literal names, including `"default"`. Override names and `title` cannot be empty.
 
 Preview or deploy notebooks:
 


### PR DESCRIPTION
Adds `mohub notebooks deploy` to update existing local-source notebooks from repository files.

The command discovers config (`--config`, `MARIMOHUB_CONFIG`, or nearest `marimohub.toml` / `[tool.marimohub]`), diffs each notebook, skips unchanged entries, and uses ETags to reject concurrent updates. Supports single- and multi-notebook configs, `--dry-run`, repeatable `--notebook` filtering, and `--message`.

Config carries no server URLs or credentials; each declaration must identify an existing local-source notebook. The command does not create/delete notebooks, upload dependencies, or touch git-backed sources.

Part of #184