### PR TITLE
fix(cli): escape TOML paths in deploy config tests

### DIFF
--- a/apps/cli/src/deploy_config.rs
+++ b/apps/cli/src/deploy_config.rs
@@ -519,12 +519,21 @@ mod tests {
     }
 
     fn notebook_config(path: &str) -> String {
+        let path = toml::Value::String(path.to_owned());
         format!(
             r#"project_id = "proj-7h2k9qm4xz7rp3w8"
 notebook_id = "nb-7h2k9qm4xz7rp3w8"
-path = "{path}"
+path = {path}
 "#
         )
+    }
+
+    #[test]
+    fn notebook_config_escapes_toml_string_paths() {
+        let path = r#"C:\Users\runner\app.py"#;
+        let config: toml::Value = toml::from_str(&notebook_config(path)).unwrap();
+
+        assert_eq!(config.get("path").and_then(toml::Value::as_str), Some(path));
     }
 
     #[test]


### PR DESCRIPTION
Fixes the Windows CLI release failure in [v0.3.8 run 32880740469](https://github.com/marimo-team/marimohub/actions/runs/32880740469/job/97909335388).

The absolute-path rejection test interpolated a Windows path into a TOML basic string without escaping its backslashes, so parsing failed on `\U` before the intended assertion. Serialize the fixture path through `toml::Value` and cover Windows-style paths on every platform.
