### PR TITLE
feat(integrations): surface safe browse failure diagnostics

### DIFF
--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, it, expect, vi } from 'vitest';
 import { HTTPException } from 'hono/http-exception';
 import {
 	ConflictError,
+	createIntegrationId,
 	createNotebookId,
 	createProjectId,
 	createServices,
@@ -77,6 +78,41 @@ describe('createApi onError mapping', () => {
 		expect(log).toHaveBeenCalledOnce();
 		expect(log.mock.calls[0]?.[0]).toContain('request_error');
 		expect(log.mock.calls[0]?.[0]).not.toContain('do-not-return');
+	});
+
+	it('logs integration resource context and a safe transport cause for a browse failure', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const { app } = createTestApi();
+		const pid = createProjectId();
+		const iid = createIntegrationId();
+		app.get('/api/v1/projects/:pid/integrations/:iid/_unavailable', () => {
+			const cause = Object.assign(new Error('Integration transport failure'), {
+				name: 'IntegrationTransportError',
+				code: 'ECONNREFUSED',
+			});
+			throw new UnavailableError('The integration target refused the connection.', { cause });
+		});
+
+		const res = await app.request(`/api/v1/projects/${pid}/integrations/${iid}/_unavailable`, {
+			headers: { 'X-Request-Id': 'browse-request-1' },
+		});
+
+		expect(res.status).toBe(503);
+		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
+			event: 'request_error',
+			request_id: 'browse-request-1',
+			project_id: pid,
+			integration_id: iid,
+			error: {
+				name: 'UnavailableError',
+				message: 'The integration target refused the connection.',
+				cause: {
+					name: 'IntegrationTransportError',
+					message: 'Integration transport failure',
+					code: 'ECONNREFUSED',
+				},
+			},
+		});
 	});
 });
 

--- a/packages/api/src/createApi.test.ts
+++ b/packages/api/src/createApi.test.ts
@@ -80,7 +80,7 @@ describe('createApi onError mapping', () => {
 		expect(log.mock.calls[0]?.[0]).not.toContain('do-not-return');
 	});
 
-	it('logs integration resource context and a safe transport cause for a browse failure', async () => {
+	it('logs integration resource context and trusted transport metadata for a browse failure', async () => {
 		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 		const { app } = createTestApi();
 		const pid = createProjectId();

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -7,6 +7,7 @@ import { routePath } from 'hono/route';
 import {
 	DomainError,
 	ensureInitialized,
+	IntegrationId,
 	isPatRequest,
 	MAX_REQUEST_BYTES,
 	NotebookId,
@@ -95,13 +96,14 @@ async function rejectionDetails(response: Response): Promise<{ code: string; mes
 	};
 }
 
-function rejectionResourceContext(path: string) {
-	const match = /\/projects\/([^/]+)(?:\/notebooks\/([^/]+))?/.exec(path);
-	const projectId = match?.[1];
-	const notebookId = match?.[2];
+function requestResourceContext(path: string) {
+	const projectId = /\/projects\/([^/]+)/.exec(path)?.[1];
+	const notebookId = /\/projects\/[^/]+\/notebooks\/([^/]+)/.exec(path)?.[1];
+	const integrationId = /\/projects\/[^/]+\/integrations\/([^/]+)/.exec(path)?.[1];
 	return {
 		...(ProjectId.is(projectId) ? { project_id: projectId } : {}),
 		...(NotebookId.is(notebookId) ? { notebook_id: notebookId } : {}),
+		...(IntegrationId.is(integrationId) ? { integration_id: integrationId } : {}),
 	};
 }
 
@@ -187,6 +189,7 @@ export function createApi(rawDeps: ApiDeps) {
 					path: c.req.path,
 					user: c.get('user')?.id ?? null,
 					status: res.status,
+					...requestResourceContext(c.req.path),
 					error: errorMetadata(err),
 				});
 				return fail(c, code, internalErrorMessage(c.get('requestId')), res.status);
@@ -203,6 +206,7 @@ export function createApi(rawDeps: ApiDeps) {
 					path: c.req.path,
 					user: c.get('user')?.id ?? null,
 					status: err.status,
+					...requestResourceContext(c.req.path),
 					error: describeError(err),
 				});
 			}
@@ -216,6 +220,7 @@ export function createApi(rawDeps: ApiDeps) {
 			path: c.req.path,
 			user: c.get('user')?.id ?? null,
 			status: 500,
+			...requestResourceContext(c.req.path),
 			error: describeError(err),
 		});
 		return fail(c, 'INTERNAL_ERROR', internalErrorMessage(c.get('requestId')), 500);
@@ -252,7 +257,7 @@ export function createApi(rawDeps: ApiDeps) {
 			message: rejection.message,
 			request_id: c.get('requestId') ?? null,
 			user: c.get('user')?.id ?? null,
-			...rejectionResourceContext(c.req.path),
+			...requestResourceContext(c.req.path),
 		});
 	};
 	app.use(`${API_PREFIX}/*`, observeRejection);

--- a/packages/api/src/routes/integrationBrowse.ts
+++ b/packages/api/src/routes/integrationBrowse.ts
@@ -1208,8 +1208,11 @@ app.openapi(browseCapability, async (c) => {
 		logEvent({
 			level: 'warn',
 			event: 'integration_query_unavailable',
+			request_id: c.get('requestId') ?? null,
 			project_id: pid,
 			integration_id: iid,
+			integration_kind: capability.integration_kind,
+			surface: 'query',
 			reason: querySurface.reason ?? 'No reason provided.',
 		});
 	}
@@ -1247,6 +1250,7 @@ app.openapi(browseNamespaces, async (c) => {
 	const request = {
 		limit,
 		query_user: user.email,
+		signal: c.req.raw.signal,
 		...(cursor !== undefined ? { cursor } : {}),
 		...(parent !== undefined ? { parent: splitNamespace(parent) } : {}),
 	};
@@ -1276,6 +1280,7 @@ app.openapi(browseTables, async (c) => {
 	const request = {
 		limit,
 		query_user: user.email,
+		signal: c.req.raw.signal,
 		...(cursor !== undefined ? { cursor } : {}),
 	};
 	const data = await browseEndpoint({

--- a/packages/api/src/routes/integrationBrowse.ts
+++ b/packages/api/src/routes/integrationBrowse.ts
@@ -1250,7 +1250,6 @@ app.openapi(browseNamespaces, async (c) => {
 	const request = {
 		limit,
 		query_user: user.email,
-		signal: c.req.raw.signal,
 		...(cursor !== undefined ? { cursor } : {}),
 		...(parent !== undefined ? { parent: splitNamespace(parent) } : {}),
 	};
@@ -1280,7 +1279,6 @@ app.openapi(browseTables, async (c) => {
 	const request = {
 		limit,
 		query_user: user.email,
-		signal: c.req.raw.signal,
 		...(cursor !== undefined ? { cursor } : {}),
 	};
 	const data = await browseEndpoint({
@@ -1319,7 +1317,6 @@ app.openapi(browseTableSchema, async (c) => {
 		load: () =>
 			integrations.browseTableSchema(pid, iid, splitNamespace(namespace), table, {
 				query_user: user.email,
-				signal: c.req.raw.signal,
 			}),
 	});
 	return c.json({ success: true, data }, 200);

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -460,8 +460,11 @@ describe('Data browser routes', () => {
 		expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({
 			level: 'warn',
 			event: 'integration_query_unavailable',
+			request_id: expect.any(String),
 			project_id: pid,
 			integration_id: created.id,
+			integration_kind: 'browsy',
+			surface: 'query',
 			reason: 'guarded catalog and object-store HTTP brokering is not available in DuckDB-Wasm',
 		});
 	});

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -33,6 +33,10 @@ afterEach(() => vi.restoreAllMocks());
 /** U+001F, the separator multi-part namespaces use in query params. */
 const SEP = String.fromCharCode(0x1f);
 
+let namespaceSignal: AbortSignal | undefined;
+let tableSignal: AbortSignal | undefined;
+let schemaSignal: AbortSignal | undefined;
+
 /** Browsable test kind; ops are network-free, so no probe traffic in tests. */
 const browsyKind = defineIntegration({
 	kind: 'browsy',
@@ -62,6 +66,7 @@ const browsyKind = defineIntegration({
 			config.mode === 'open' ? { ok: true } : { ok: false, reason: 'sandbox only' },
 		// Echo the inputs so route tests can assert round-trips.
 		listNamespaces: async (config, _probe, request) => {
+			namespaceSignal = request.signal;
 			if (config.token === 'many-namespaces') {
 				return {
 					items: request.parent
@@ -90,6 +95,7 @@ const browsyKind = defineIntegration({
 			};
 		},
 		listTables: async (config, _probe, namespace, request) => {
+			tableSignal = request.signal;
 			// Simulated outage, so route tests can exercise the failure path.
 			if (namespace[0] === 'boom') throw new UnavailableError('The catalog answered HTTP 503.');
 			if (config.token === 'schema-work-limit' && namespace[0]?.startsWith('ns-')) {
@@ -110,9 +116,10 @@ const browsyKind = defineIntegration({
 			if (namespace[0]?.startsWith('ns-')) return { items: [], next_cursor: null };
 			return { items: [namespace.join('|')], next_cursor: null };
 		},
-		getTableSchema: async (_config, _probe, _namespace, table) => ({
-			columns: [{ name: `${table}_id`, type: 'long', nullable: false }],
-		}),
+		getTableSchema: async (_config, _probe, _namespace, table, request) => {
+			schemaSignal = request?.signal;
+			return { columns: [{ name: `${table}_id`, type: 'long', nullable: false }] };
+		},
 		previewRows: async (_config, _probe, namespace, table, request) => ({
 			columns: ['qualified', 'limit'],
 			rows: [[`${namespace.join('.')}.${table}`, request.limit]],
@@ -347,6 +354,9 @@ describe('Data browser routes', () => {
 	beforeEach(async () => {
 		clearObjectCredentialCacheForTests();
 		clearIntegrationBrowseStateForTests();
+		namespaceSignal = undefined;
+		tableSignal = undefined;
+		schemaSignal = undefined;
 		bucket = await createInitializedBucket();
 		deps = browserDeps(bucket);
 		request = createTestApi({ bucket, userId: ACTOR, deps }).request;
@@ -1595,6 +1605,20 @@ describe('Data browser routes', () => {
 			columns: [{ name: 'orders_id', type: 'long', nullable: false }],
 			snippet: 'load lake:sales.orders',
 		});
+	});
+
+	it('does not bind shared metadata loads to one caller signal', async () => {
+		const pid = await createProject();
+		const created = await createBrowsable(pid);
+		const base = `/projects/${pid}/integrations/${created.id}/browse`;
+
+		await expectOk(await request('GET', `${base}/namespaces`));
+		await expectOk(await request('GET', `${base}/tables?namespace=sales`));
+		await expectOk(await request('GET', `${base}/schema?namespace=sales&table=orders`));
+
+		expect(namespaceSignal).toBeUndefined();
+		expect(tableSignal).toBeUndefined();
+		expect(schemaSignal).toBeUndefined();
 	});
 
 	it('422s an instance whose kind cannot browse, with the reason on the capability', async () => {

--- a/packages/config/src/integrationProbe.test.ts
+++ b/packages/config/src/integrationProbe.test.ts
@@ -430,7 +430,7 @@ describe('createGuardedProbe policy', () => {
 		await expect(probe.fetch('http://10.0.0.5/')).resolves.toMatchObject({ ok: true });
 	});
 
-	it('classifies transport failures without retaining raw transport text', async () => {
+	it('classifies and sanitizes transport failures before logging', async () => {
 		const transport = vi.fn(() =>
 			Promise.reject(
 				Object.assign(new Error('connect ECONNREFUSED https://user:secret@example.test'), {
@@ -451,8 +451,13 @@ describe('createGuardedProbe policy', () => {
 				code: 'ECONNREFUSED',
 			},
 		});
-		expect(String(error)).not.toContain('secret');
-		expect(String((error as Error).cause)).not.toContain('secret');
+		const typedError = error as Error;
+		const cause = typedError.cause as Error;
+		const diagnostic = [typedError.message, typedError.stack, cause.message, cause.stack].join(
+			'\n',
+		);
+		expect(diagnostic).not.toContain('secret');
+		expect(diagnostic).not.toContain('user:');
 	});
 });
 

--- a/packages/config/src/integrationProbe.test.ts
+++ b/packages/config/src/integrationProbe.test.ts
@@ -4,6 +4,7 @@ import type { Server } from 'node:http';
 import { createServer as createTcpServer } from 'node:net';
 import type { Server as TcpServer, Socket } from 'node:net';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ResourceExhaustedError, UnavailableError, ValidationError } from '@marimo-hub/core';
 import { createGuardedHostResolver, createGuardedProbe } from './integrationProbe';
 import type { ProbeConnectionTransportRequest, ProbeTransportRequest } from './integrationProbe';
 
@@ -166,10 +167,12 @@ describe('createGuardedProbe policy', () => {
 
 	it('rejects non-http schemes, embedded credentials, and malformed URLs', async () => {
 		const probe = createGuardedProbe();
-		await expect(probe.fetch('ftp://example.com')).rejects.toThrow(/http\(s\)/);
-		await expect(probe.fetch('file:///etc/passwd')).rejects.toThrow(/http\(s\)/);
-		await expect(probe.fetch('https://user:pw@example.com')).rejects.toThrow(/credentials/);
-		await expect(probe.fetch('not a url')).rejects.toThrow(/Invalid URL/);
+		await expect(probe.fetch('ftp://example.com')).rejects.toBeInstanceOf(ValidationError);
+		await expect(probe.fetch('file:///etc/passwd')).rejects.toBeInstanceOf(ValidationError);
+		await expect(probe.fetch('https://user:pw@example.com')).rejects.toBeInstanceOf(
+			ValidationError,
+		);
+		await expect(probe.fetch('not a url')).rejects.toBeInstanceOf(ValidationError);
 	});
 
 	it('blocks loopback, private, link-local/metadata, CGNAT, and IPv6 special ranges', async () => {
@@ -259,6 +262,16 @@ describe('createGuardedProbe policy', () => {
 		expect(transport).not.toHaveBeenCalled();
 	});
 
+	it('explains how to allow a trusted private-network target', async () => {
+		const { transport } = stubTransport();
+		const probe = createGuardedProbe({ transport });
+
+		await expect(probe.fetch('http://10.0.0.5/')).rejects.toMatchObject({
+			name: 'UnavailableError',
+			message: expect.stringContaining('MARIMOHUB_INTEGRATIONS_PROBE=private'),
+		});
+	});
+
 	it('PINS the socket to the validated addresses (DNS cannot rebind mid-request)', async () => {
 		const { transport, calls } = stubTransport();
 		const probe = createGuardedProbe({ transport });
@@ -305,7 +318,7 @@ describe('createGuardedProbe policy', () => {
 		const probe = createGuardedProbe({ transport, allowPrivate: true, maxProbesPerMinute: 2 });
 		await probe.fetch('http://10.0.0.5/');
 		await probe.fetch('http://10.0.0.5/');
-		await expect(probe.fetch('http://10.0.0.5/')).rejects.toThrow(/Too many/);
+		await expect(probe.fetch('http://10.0.0.5/')).rejects.toBeInstanceOf(ResourceExhaustedError);
 
 		// The budget belongs to the instance, not the module: `createFromEnv` builds
 		// exactly one probe per process, which is what makes it the process cap.
@@ -346,7 +359,10 @@ describe('createGuardedProbe policy', () => {
 		dns.delayMs = 200;
 		const { transport } = stubTransport();
 		const probe = createGuardedProbe({ transport, allowPrivate: true, timeoutMs: 30 });
-		await expect(probe.fetch('http://localhost:9/')).rejects.toThrow(/timed out/);
+		await expect(probe.fetch('http://localhost:9/')).rejects.toMatchObject({
+			name: 'UnavailableError',
+			message: 'The integration request timed out.',
+		});
 		expect(transport).not.toHaveBeenCalled();
 	});
 
@@ -408,10 +424,35 @@ describe('createGuardedProbe policy', () => {
 		const { transport } = stubTransport();
 		const probe = createGuardedProbe({ transport, allowPrivate: true, maxProbesPerMinute: 1 });
 		await probe.fetch('http://10.0.0.5/');
-		await expect(probe.fetch('http://10.0.0.5/')).rejects.toThrow(/Too many/);
+		await expect(probe.fetch('http://10.0.0.5/')).rejects.toBeInstanceOf(ResourceExhaustedError);
 
 		vi.advanceTimersByTime(60_001);
 		await expect(probe.fetch('http://10.0.0.5/')).resolves.toMatchObject({ ok: true });
+	});
+
+	it('classifies transport failures without retaining raw transport text', async () => {
+		const transport = vi.fn(() =>
+			Promise.reject(
+				Object.assign(new Error('connect ECONNREFUSED https://user:secret@example.test'), {
+					code: 'ECONNREFUSED',
+				}),
+			),
+		);
+		const probe = createGuardedProbe({ transport });
+
+		const error = await probe.fetch('https://93.184.216.34/').catch((err: unknown) => err);
+
+		expect(error).toBeInstanceOf(UnavailableError);
+		expect(error).toMatchObject({
+			message: 'The integration target refused the connection.',
+			cause: {
+				name: 'IntegrationTransportError',
+				message: 'Integration transport failure',
+				code: 'ECONNREFUSED',
+			},
+		});
+		expect(String(error)).not.toContain('secret');
+		expect(String((error as Error).cause)).not.toContain('secret');
 	});
 });
 

--- a/packages/config/src/integrationProbe.ts
+++ b/packages/config/src/integrationProbe.ts
@@ -10,7 +10,15 @@ import { request as httpsRequest } from 'node:https';
 import { BlockList, connect as netConnect, isIP } from 'node:net';
 import type { TcpSocketConnectOpts } from 'node:net';
 import { connect as tlsConnect } from 'node:tls';
-import { createSlidingWindowBudget, parseHttpUrl, withDeadline } from '@marimo-hub/core';
+import {
+	createSlidingWindowBudget,
+	DomainError,
+	parseHttpUrl,
+	ResourceExhaustedError,
+	UnavailableError,
+	ValidationError,
+	withDeadline,
+} from '@marimo-hub/core';
 import type {
 	IntegrationProbe,
 	ProbeConnectRequest,
@@ -151,16 +159,23 @@ export function createGuardedProbe(options: GuardedProbeOptions = {}): Integrati
 			});
 			const remainingMs = deadline - Date.now();
 			if (remainingMs <= 0) throw timedOut();
-			const response = await transport({
-				url: target,
-				method: init.method ?? 'GET',
-				headers: init.headers ?? {},
-				body: init.body,
-				pinned,
-				timeoutMs: remainingMs,
-				maxResponseBytes,
-				signal: init.signal,
-			});
+			let response: Awaited<ReturnType<ProbeTransport>>;
+			try {
+				response = await transport({
+					url: target,
+					method: init.method ?? 'GET',
+					headers: init.headers ?? {},
+					body: init.body,
+					pinned,
+					timeoutMs: remainingMs,
+					maxResponseBytes,
+					signal: init.signal,
+				});
+			} catch (err) {
+				if (init.signal?.aborted) throw aborted();
+				if (err instanceof DomainError) throw err;
+				throw transportFailure(err);
+			}
 			return {
 				ok: response.status >= 200 && response.status < 300,
 				status: response.status,
@@ -179,7 +194,7 @@ export function createGuardedProbe(options: GuardedProbeOptions = {}): Integrati
 
 function consumeProbeBudget(budget: ReturnType<typeof createSlidingWindowBudget<'probe'>>): void {
 	if (!budget.consume('probe')) {
-		throw new Error('Too many connection tests — try again in a minute.');
+		throw new ResourceExhaustedError('Too many integration requests — try again in a minute.');
 	}
 }
 
@@ -282,11 +297,13 @@ const nodeConnectionTransport: ProbeConnectionTransport = (request) =>
 function parseTarget(url: string): URL {
 	const parsed = parseHttpUrl(url);
 	if (parsed.ok) return parsed.url;
-	if (parsed.issue === 'protocol') throw new Error('Only http(s) URLs can be tested.');
-	if (parsed.issue === 'credentials') {
-		throw new Error('URLs with embedded credentials cannot be tested.');
+	if (parsed.issue === 'protocol') {
+		throw new ValidationError('Integration request URLs must use http(s).');
 	}
-	throw new Error('Invalid URL.');
+	if (parsed.issue === 'credentials') {
+		throw new ValidationError('Integration request URLs cannot contain embedded credentials.');
+	}
+	throw new ValidationError('Invalid integration request URL.');
 }
 
 /** Resolves once and rejects the target if any returned address is forbidden. */
@@ -304,10 +321,14 @@ async function resolveAndValidate(
 	let addresses: { address: string; family: number }[];
 	try {
 		addresses = await lookup(bare, { all: true, verbatim: true });
-	} catch {
-		throw new Error(`Could not resolve "${hostname}".`);
+	} catch (err) {
+		throw new UnavailableError('The integration target could not be resolved.', {
+			cause: safeTransportCause(err),
+		});
 	}
-	if (addresses.length === 0) throw new Error(`Could not resolve "${hostname}".`);
+	if (addresses.length === 0) {
+		throw new UnavailableError('The integration target could not be resolved.');
+	}
 	if (!allowPrivate && addresses.some((a) => isForbiddenAddress(a.address))) {
 		throw forbidden(hostname);
 	}
@@ -315,18 +336,48 @@ async function resolveAndValidate(
 }
 
 function timedOut(): Error {
-	return new Error('Connection test timed out.');
+	return new UnavailableError('The integration request timed out.');
 }
 
 function aborted(): Error {
 	return Object.assign(new Error('Connection test aborted.'), { name: 'AbortError' });
 }
 
-function forbidden(hostname: string): Error {
-	return new Error(
-		`"${hostname}" resolves to a private or reserved address, which cannot be tested ` +
-			'from this deployment.',
+function forbidden(_hostname: string): Error {
+	return new UnavailableError(
+		'The integration target resolves to a private or reserved address. Set ' +
+			'MARIMOHUB_INTEGRATIONS_PROBE=private for trusted private-network services.',
 	);
+}
+
+function safeTransportCode(err: unknown, depth = 3): string | undefined {
+	if (!(err instanceof Error) || depth < 0) return undefined;
+	const code = (err as Error & { code?: unknown }).code;
+	if (typeof code === 'string' && /^[A-Z][A-Z0-9_]{0,63}$/.test(code)) return code;
+	const cause = (err as Error & { cause?: unknown }).cause;
+	return cause === undefined ? undefined : safeTransportCode(cause, depth - 1);
+}
+
+function safeTransportCause(err: unknown): Error {
+	const cause = new Error('Integration transport failure');
+	cause.name = 'IntegrationTransportError';
+	const code = safeTransportCode(err);
+	return code ? Object.assign(cause, { code }) : cause;
+}
+
+function transportFailure(err: unknown): UnavailableError {
+	const code = safeTransportCode(err);
+	const message =
+		code === 'ECONNREFUSED'
+			? 'The integration target refused the connection.'
+			: code === 'ECONNRESET'
+				? 'The integration target reset the connection.'
+				: code === 'ETIMEDOUT' || code === 'ABORT_ERR' || code === 'UND_ERR_CONNECT_TIMEOUT'
+					? 'The integration request timed out.'
+					: code && /(?:CERT|TLS|SSL|SELF_SIGNED|VERIFY)/.test(code)
+						? "The integration target's TLS certificate could not be verified."
+						: 'The integration request could not connect to its target.';
+	return new UnavailableError(message, { cause: safeTransportCause(err) });
 }
 
 function isForbiddenAddress(address: string): boolean {

--- a/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
+++ b/packages/core/src/services/integrations/ProjectIntegrationsStore.ts
@@ -1796,7 +1796,7 @@ export class ProjectIntegrationsStore implements ProjectIntegrationsService {
 		id: IntegrationId,
 		namespace: string[],
 		table: string,
-		request?: Pick<TablePreviewRequest, 'query_user'>,
+		request?: Pick<TablePreviewRequest, 'query_user' | 'signal'>,
 	): Promise<TableSchema> {
 		return this.withBrowseScope(projectId, id, (scope) =>
 			this.store.browseTableSchema(scope, id, namespace, table, request),

--- a/packages/core/src/services/integrations/kinds/icebergRest.browse.test.ts
+++ b/packages/core/src/services/integrations/kinds/icebergRest.browse.test.ts
@@ -294,6 +294,7 @@ describe('iceberg_rest browse operations', () => {
 	it('reports a non-JSON config response before requesting catalog routes', async () => {
 		const requested: string[] = [];
 		const probe: IntegrationProbe = {
+			connect: () => Promise.reject(new Error('unused')),
 			fetch: (url) => {
 				requested.push(url);
 				return Promise.resolve({

--- a/packages/core/src/services/integrations/kinds/icebergRest.browse.test.ts
+++ b/packages/core/src/services/integrations/kinds/icebergRest.browse.test.ts
@@ -291,6 +291,25 @@ describe('iceberg_rest browse operations', () => {
 		);
 	});
 
+	it('reports a non-JSON config response before requesting catalog routes', async () => {
+		const requested: string[] = [];
+		const probe: IntegrationProbe = {
+			fetch: (url) => {
+				requested.push(url);
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => Promise.resolve(undefined),
+				});
+			},
+		};
+
+		await expect(browse.listNamespaces(config(), probe, { limit: 10 })).rejects.toThrow(
+			'The catalog config response was not JSON or exceeded the size limit.',
+		);
+		expect(requested).toHaveLength(1);
+	});
+
 	it('replaces a transport throw with a generic failure', async () => {
 		const probe: IntegrationProbe = {
 			connect: () => Promise.reject(new Error('unused')),

--- a/packages/core/src/services/integrations/kinds/icebergRest.ts
+++ b/packages/core/src/services/integrations/kinds/icebergRest.ts
@@ -884,6 +884,11 @@ async function openCatalog(
 		throw new UnavailableError(`The catalog config endpoint answered HTTP ${res.status}.`);
 	}
 	const body = asRecord(await res.json());
+	if (!body) {
+		throw new UnavailableError(
+			'The catalog config response was not JSON or exceeded the size limit.',
+		);
+	}
 	const overrides = asRecord(body?.overrides);
 	const defaults = asRecord(body?.defaults);
 	const prefix = [overrides?.prefix, defaults?.prefix].find(

--- a/packages/core/src/services/integrations/kinds/trino.browse.test.ts
+++ b/packages/core/src/services/integrations/kinds/trino.browse.test.ts
@@ -41,6 +41,27 @@ describe('trino browse', () => {
 		expect(calls[0].init?.headers).toMatchObject({ 'X-Trino-User': 'alice@example.com' });
 	});
 
+	it('preserves explicitly configured protocol headers', async () => {
+		const { probe, calls } = queuedProbe([{ columns: [{ name: 'Catalog' }], data: [] }]);
+		await browse.listNamespaces(
+			config({
+				http_headers: [
+					{ name: 'accept', value: 'application/vnd.example+json' },
+					{ name: 'content-type', value: 'text/plain; charset=us-ascii' },
+				],
+			}),
+			probe,
+			{ limit: 10 },
+		);
+
+		expect(calls[0].init?.headers).toMatchObject({
+			accept: 'application/vnd.example+json',
+			'content-type': 'text/plain; charset=us-ascii',
+		});
+		expect(calls[0].init?.headers).not.toHaveProperty('Accept');
+		expect(calls[0].init?.headers).not.toHaveProperty('Content-Type');
+	});
+
 	it('lists catalogs and follows same-coordinator statement pages', async () => {
 		const { probe, calls } = queuedProbe([
 			{
@@ -61,7 +82,9 @@ describe('trino browse', () => {
 			init: { method: 'POST', body: 'SHOW CATALOGS' },
 		});
 		expect(calls[0].init?.headers).toMatchObject({
+			Accept: 'application/json',
 			Authorization: expect.stringMatching(/^Basic /),
+			'Content-Type': 'text/plain; charset=utf-8',
 			'X-Trino-User': 'alice',
 		});
 		expect(calls[1].url).toBe('https://trino.example.com/v1/statement/q1/1');

--- a/packages/core/src/services/integrations/kinds/trino.ts
+++ b/packages/core/src/services/integrations/kinds/trino.ts
@@ -589,6 +589,11 @@ function trinoHeaders(
 	queryUser: string | undefined,
 ): Record<string, string> {
 	const headers = Object.fromEntries(config.http_headers.map(({ name, value }) => [name, value]));
+	const customHeaderNames = new Set(Object.keys(headers).map((name) => name.toLowerCase()));
+	if (!customHeaderNames.has('accept')) headers.Accept = 'application/json';
+	if (!customHeaderNames.has('content-type')) {
+		headers['Content-Type'] = 'text/plain; charset=utf-8';
+	}
 	const user = config.user ?? (config.auth.method === 'basic' ? config.auth.username : queryUser);
 	if (!user) throw new ValidationError('Trino hub browsing requires a query user.');
 	headers['X-Trino-User'] = user;

--- a/packages/core/src/services/integrations/sdk.test.ts
+++ b/packages/core/src/services/integrations/sdk.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
-import { NotFoundError, ValidationError } from '../../errors';
+import { NotFoundError, UnavailableError, ValidationError } from '../../errors';
 import type { IntegrationProbe } from '../../ports/integrations';
 import { trino } from './kinds/trino';
 import {
@@ -299,6 +299,16 @@ describe('defineIntegration browse guard', () => {
 	it('passes a clean DomainError through untouched', async () => {
 		await expect(browsy.browse!.getTableSchema(config, unusedProbe(), [], 't')).rejects.toThrow(
 			'The catalog reports no such namespace or table.',
+		);
+	});
+
+	it('passes a safe probe availability error through untouched', async () => {
+		const probe: IntegrationProbe = {
+			fetch: () =>
+				Promise.reject(new UnavailableError('The integration target could not be resolved.')),
+		};
+		await expect(browsy.browse!.listNamespaces(config, probe, { limit: 10 })).rejects.toThrow(
+			'The integration target could not be resolved.',
 		);
 	});
 

--- a/packages/core/src/services/integrations/sdk.test.ts
+++ b/packages/core/src/services/integrations/sdk.test.ts
@@ -304,6 +304,7 @@ describe('defineIntegration browse guard', () => {
 
 	it('passes a safe probe availability error through untouched', async () => {
 		const probe: IntegrationProbe = {
+			connect: () => Promise.reject(new Error('unused')),
 			fetch: () =>
 				Promise.reject(new UnavailableError('The integration target could not be resolved.')),
 		};

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -229,7 +229,11 @@ function makeFetch({
 				return new Response(
 					JSON.stringify({
 						success: false,
-						error: { code: 'SERVICE_UNAVAILABLE', message: 'The catalog answered HTTP 503.' },
+						error: {
+							code: 'SERVICE_UNAVAILABLE',
+							message: 'The catalog answered HTTP 503.',
+							request_id: 'browse-req-123',
+						},
 					}),
 					{ status: 503, headers: { 'Content-Type': 'application/json' } },
 				);
@@ -1308,6 +1312,7 @@ describe('DataBrowserPage', () => {
 		setup(`/projects/${PID}/data/${IID}`, { namespacesDown: true });
 
 		expect(await screen.findByText('The catalog answered HTTP 503.')).toBeInTheDocument();
+		expect(screen.getByText('Reference: browse-req-123')).toBeInTheDocument();
 	});
 
 	it('an unknown integration id in the URL falls back to the empty detail pane', async () => {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -49,6 +49,7 @@ import {
 import { formatRelative } from '@/lib/time';
 import { errorMessage } from '@/lib/errors';
 import { cn } from '@/lib/utils';
+import { ApiRequestError } from '@/api/client';
 import type { IntegrationEntry, IntegrationKind } from '@/types';
 import { useSeededNotebook } from './notebookSeed';
 import { ObjectBrowser } from './ObjectBrowser';
@@ -505,7 +506,12 @@ function LoadState({ depth, error, hint }: { depth: number; error?: unknown; hin
 		>
 			{error ? (
 				<span className="text-destructive">
-					{error instanceof Error ? error.message : 'Request failed'}
+					<span className="block">{errorMessage(error)}</span>
+					{error instanceof ApiRequestError && error.requestId ? (
+						<span className="mt-0.5 block font-mono text-[0.6875rem] text-muted-foreground">
+							Reference: {error.requestId}
+						</span>
+					) : null}
 				</span>
 			) : hint ? (
 				<span>{hint}</span>


### PR DESCRIPTION
Improves observability and error handling for Trino/PySpark/Iceberg integration browsing without leaking secrets.

- Classify guarded-probe transport failures into typed `DomainError`s (`UnavailableError`/`ValidationError`/`ResourceExhaustedError`) with a sanitized `IntegrationTransportError` cause that keeps only an allowlisted error `code`; raw transport text that can embed credentials is dropped.
- Add `integration_id` and request resource context to `request_error` and rejection logs; enrich `integration_query_unavailable` with `request_id`, `integration_kind`, and `surface`.
- Keep coalesced namespace, table, and schema metadata loads independent of any single caller's abort signal, while retaining cancellation for non-shared preview and query work.
- Default Trino `Accept`/`Content-Type` headers, preserving any explicitly configured protocol headers.
- Guard Iceberg REST against a non-JSON config response before requesting catalog routes.
- Surface the request ID (`Reference: …`) on the data browser error pane.
- Cover cached cancellation ownership and guarded-probe credential redaction, including logged message and stack fields.
