### PR TITLE
feat(helm): add configurable ServiceAccount for chart pods

### DIFF
--- a/charts/marimohub/README.md
+++ b/charts/marimohub/README.md
@@ -61,6 +61,9 @@ Updater](https://argocd-image-updater.readthedocs.io/) or
 | `image.repository` | `ghcr.io/marimo-team/marimohub` | |
 | `image.tag` | `""` → chart `appVersion` | Override to decouple image from chart version |
 | `replicaCount` | `2` | Stateless API replicas |
+| `serviceAccount.create` / `.name` | `true` / `""` | Create a release-scoped account, or name an existing account |
+| `serviceAccount.annotations` | `{}` | Workload identity annotations, such as EKS IRSA or GKE Workload Identity |
+| `serviceAccount.automountServiceAccountToken` | `true` | Mount the Kubernetes API token in API and maintenance pods |
 | `compute.profiles` | `""` | Ordered sandbox CPU/memory profiles; first is the default |
 | `compute.profileOverride` | `none` | Set to `editors` to allow per-notebook profile selection |
 | `maintenance.enabled` | `true` | Singleton session reaper |
@@ -81,3 +84,34 @@ baked in, so the chart is portable across any Kubernetes.
 The chart sets `MARIMOHUB_RUN_MAINTENANCE` per deployment (`false` on API pods,
 `true` on the maintenance pod), overriding any value in `config`. The maintenance
 pod is pinned to one replica with the `Recreate` strategy — don't scale it.
+
+### ServiceAccount
+
+By default, the chart creates a ServiceAccount using the chart fullname and uses
+it for both the API and maintenance pods. Add cloud workload identity annotations
+to the generated account:
+
+```yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/marimohub
+```
+
+To use an account managed outside the chart:
+
+```yaml
+serviceAccount:
+  create: false
+  name: marimohub
+```
+
+Set `automountServiceAccountToken: false` when marimohub does not need a projected
+Kubernetes token. Keep it enabled for Kubernetes compute and workload identity
+providers that use that token. This account belongs to the marimohub control plane;
+`config.MARIMOHUB_COMPUTE_KUBERNETES_SERVICE_ACCOUNT` separately selects the
+ServiceAccount assigned to notebook kernel pods.
+
+The chart does not grant the control-plane account any RBAC permissions. Bind it
+to cluster-specific Roles separately, as shown in
+[`examples/kubernetes/rbac.yaml`](../../examples/kubernetes/rbac.yaml) for the
+native Kubernetes compute backend.

--- a/charts/marimohub/templates/_helpers.tpl
+++ b/charts/marimohub/templates/_helpers.tpl
@@ -31,6 +31,15 @@ app.kubernetes.io/name: {{ include "marimohub.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{/* Resolve the managed, existing, or namespace-default ServiceAccount name. */}}
+{{- define "marimohub.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "marimohub.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Resolved image ref: repository:(tag|appVersion). */}}
 {{- define "marimohub.image" -}}
 {{- printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) -}}
@@ -71,6 +80,8 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  serviceAccountName: {{ include "marimohub.serviceAccountName" $root }}
+  automountServiceAccountToken: {{ $v.serviceAccount.automountServiceAccountToken }}
   enableServiceLinks: false
   {{- with $v.imagePullSecrets }}
   imagePullSecrets:

--- a/charts/marimohub/templates/serviceaccount.yaml
+++ b/charts/marimohub/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "marimohub.serviceAccountName" . }}
+  labels:
+    {{- include "marimohub.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/marimohub/values.yaml
+++ b/charts/marimohub/values.yaml
@@ -14,6 +14,16 @@ imagePullSecrets: []
 nameOverride: ''
 fullnameOverride: ''
 
+# Kubernetes ServiceAccount used by both the API and maintenance pods.
+serviceAccount:
+  # Create a release-scoped ServiceAccount. Set to false to use an existing one.
+  create: true
+  # Annotations for workload identity integrations such as EKS IRSA or GKE.
+  annotations: {}
+  # Empty and create=true uses the chart fullname; empty and create=false uses "default".
+  name: ''
+  automountServiceAccountToken: true
+
 # The API tier is stateless, so it scales freely.
 replicaCount: 2
 

--- a/docs/deploying/helm.md
+++ b/docs/deploying/helm.md
@@ -61,6 +61,7 @@ at a semver range; the chart works with either.
 
 - **API Deployment** — `replicaCount` stateless replicas (`MARIMOHUB_RUN_MAINTENANCE=false`).
 - **Maintenance Deployment** — single replica, `Recreate`, runs the session reaper.
+- **ServiceAccount** — release-scoped by default, shared by the API and maintenance pods.
 - **ConfigMap** from `config`, **Secret** from `secrets` (or your `existingSecret`),
   both consumed via `envFrom`.
 - **Service** (ClusterIP) and an optional **Ingress** with TLS.
@@ -70,6 +71,24 @@ cluster-specific scheduling is baked in; set `nodeSelector` / `tolerations` /
 `podLabels` per cluster. The chart covers the marimohub tier only — install your
 ingress controller, cert-manager, and any kernel-namespace resources separately
 (see [Kubernetes](./kubernetes.md) and [CKS](./cks.md)).
+
+## ServiceAccount
+
+The chart creates a ServiceAccount using its fullname by default. Use annotations
+to connect it to a cloud workload identity:
+
+```yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/marimohub
+```
+
+To use an existing account, set `serviceAccount.create: false` and
+`serviceAccount.name`. The API and maintenance pods use the same account. The
+chart does not create cluster-specific RBAC bindings; install those separately if
+the server needs Kubernetes API access. The ServiceAccount configured for kernel
+pods is a separate setting:
+`config.MARIMOHUB_COMPUTE_KUBERNETES_SERVICE_ACCOUNT`.
 
 ## Validate
 


### PR DESCRIPTION
Adds a `serviceAccount` block to the Helm chart. By default the chart creates a release-scoped ServiceAccount (chart fullname) shared by the API and maintenance pods, with configurable `create`, `name`, `annotations` (for EKS IRSA / GKE Workload Identity), and `automountServiceAccountToken`. No RBAC is granted; bind separately. Docs and README updated.