### PR TITLE
feat(integrations): default data-source discovery on, warn on conflicts

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -302,10 +302,10 @@ the `ambient_env` switch. There are two reasons to do that:
   `AWS_ACCESS_KEY_ID`, `wandb` expects `WANDB_API_KEY`. These default **on**;
   Weights & Biases and Hugging Face have no other channel, so they always set
   them.
-- **Databases and engines** already hand notebook code an explicit URL, so they
-  default **off**. Turning `ambient_env` on publishes the names marimo's
-  data-source discovery scans for, which makes the integration show up as a
-  one-click connection in the notebook's data-source panel with no code to copy.
+- **Databases and engines** also hand notebook code an explicit URL or
+  descriptor, but their discovery variables default **on**. This makes a
+  compatible integration show up as a one-click connection in marimo's
+  data-source panel with no code to copy.
 
 | Kind             | What marimo looks for                                                                             |
 | ---------------- | ------------------------------------------------------------------------------------------------- |
@@ -317,16 +317,17 @@ the `ambient_env` switch. There are two reasons to do that:
 | Iceberg catalogs | the rendered `.pyiceberg.yaml`, found through `PYICEBERG_HOME`. Always set                        |
 
 Because these names are process-wide, only one integration per session can claim
-a given variable. Two that set the same name to different values fail the session
-with an error naming both — see the [failure model](#failure-model). That is also
-why the database kinds default off: a project with a prod and a staging
-PostgreSQL is ordinary, and only one of them can own `PGHOST`. When
+a discovery contract. When multiple integrations request the same names, the
+first by integration name is discovered. The others remain available through
+their namespaced variables and notebook snippets. The session manifest and
+provisioning log contain a warning naming the selected and skipped integrations.
+When
 [workload identity federation](./workload-identity-federation.md) is enabled it
 injects `AWS_*` for the session's own bucket, and hub-injected variables win over
 integrations.
 
-Two combinations are refused at save time rather than rendered, because the
-connection marimo would build is weaker than the one you configured:
+Two combinations fall back to the namespaced connection instead of advertising a
+connection that is weaker than the one you configured:
 
 - **MySQL with TLS on.** The discovered connection is a PyMySQL URL with no TLS
   arguments, and PyMySQL reads none from the environment, so it would be a
@@ -335,6 +336,7 @@ connection marimo would build is weaker than the one you configured:
   cannot express JWT, OAuth2, Kerberos, or certificate authentication, so the
   suggested connection could not authenticate.
 
+These fallbacks do not block session creation and emit a provisioning warning.
 PostgreSQL has no such caveat: libpq reads `PGSSLMODE` and `PGSSLROOTCERT` for
 any parameter the caller leaves unset, so a discovered connection verifies
 exactly like the rendered URL.
@@ -374,9 +376,10 @@ point it elsewhere:
 
 Set one or the other, not both.
 
-Turn on `ambient_env` to also export `PGHOST`, `PGUSER`, `PGDATABASE`,
-`PGPORT`, `PGPASSWORD`, and the TLS pair, which is what makes this connection
+By default, `ambient_env` also exports `PGHOST`, `PGUSER`, `PGDATABASE`,
+`PGPORT`, `PGPASSWORD`, and the TLS pair, which makes this connection
 [discoverable in the notebook](#vendor-standard-variables-and-one-click-connections).
+Turn it off to expose only the namespaced connection.
 
 <!--@include: ./partials/integrations/postgres.md-->
 
@@ -393,9 +396,10 @@ intermediate MySQL modes are deliberately absent — they are spelled with
 boolean-ish URL arguments whose meaning depends on how a driver version coerces
 the string `"false"`, so the choice here is verified TLS or none.
 
-`ambient_env` exports the `MYSQL_*` names for
-[discovery](#vendor-standard-variables-and-one-click-connections), and is
-available only on a connection with TLS disabled — see the caveat there.
+`ambient_env` requests the `MYSQL_*` names for
+[discovery](#vendor-standard-variables-and-one-click-connections). They are
+emitted only when TLS is disabled; otherwise the namespaced TLS connection stays
+available and the provisioning log explains the fallback.
 
 <!--@include: ./partials/integrations/mysql.md-->
 
@@ -579,9 +583,12 @@ JWT, OAuth2, client certificates, Kerberos, GSSAPI, TLS verification, headers,
 extra credentials, roles, session properties, spooling, retries, timeouts,
 isolation, and compatibility options.
 
-`ambient_env` exports `TRINO_HOST`, `TRINO_USER`, `TRINO_CATALOG`, and the rest
-for [discovery](#vendor-standard-variables-and-one-click-connections). It needs
-a default catalog, and an authentication mode discovery can express.
+By default, `ambient_env` exports `TRINO_HOST`, `TRINO_USER`, `TRINO_CATALOG`,
+and the rest for
+[discovery](#vendor-standard-variables-and-one-click-connections). It needs a
+default catalog, system TLS verification, and an authentication mode discovery
+can express. Other configurations keep the namespaced connection and emit a
+provisioning warning.
 
 <!--@include: ./partials/integrations/trino.md-->
 
@@ -596,7 +603,7 @@ settings from the JSON descriptor before calling `getOrCreate()`. This
 integration targets Spark Connect. Provisioning a classic Spark driver or
 cluster remains the compute backend's responsibility.
 
-`ambient_env` also exports the same string as `SPARK_REMOTE`, which
+By default, `ambient_env` also exports the same string as `SPARK_REMOTE`, which
 `SparkSession.builder` reads on its own and marimo
 [discovers](#vendor-standard-variables-and-one-click-connections) — so
 `getOrCreate()` needs no arguments at all.
@@ -786,6 +793,11 @@ never return a resolved value. See
 
 Integration rendering fails closed. A secret-source or configuration error
 stops session creation without disclosing secret values or locators.
+
+Automatic data-source discovery is best effort. An incompatible discovery
+contract or a second integration claiming the same standard variables falls
+back to namespaced variables and a notebook snippet instead of failing the
+session. The session manifest and provisioning log record the fallback.
 
 Saving a reference does not fetch its value. **Test connection** resolves the
 current draft for supported kinds. **Environment variables** has no connection

--- a/docs/partials/integrations/mysql.md
+++ b/docs/partials/integrations/mysql.md
@@ -16,7 +16,7 @@ Fields marked 🔒 use an encrypted value or an external reference. API response
 | `username` | string | Yes |  |  |
 | `password` 🔒 | string | Yes |  | Password for the database user |
 | `ssl.mode` | `verify_identity`, `disabled` |  | `verify_identity` | `verify_identity` checks the CA chain and the hostname; `disabled` is plaintext |
-| `ambient_env` | boolean |  | `false` | Also export MYSQL_HOST, MYSQL_TCP_PORT, MYSQL_DATABASE, MYSQL_USER, and MYSQL_PASSWORD so marimo's data-source discovery offers this connection. Only one integration per session can claim them. |
+| `ambient_env` | boolean |  | `true` | Automatically offer this connection in marimo's data-source discovery by exporting MYSQL_HOST, MYSQL_TCP_PORT, MYSQL_DATABASE, MYSQL_USER, and MYSQL_PASSWORD. If multiple integrations request the same variables, one is discovered and every connection remains available through its notebook snippet. |
 
 **`ssl.mode: verify_identity`**
 

--- a/docs/partials/integrations/postgres.md
+++ b/docs/partials/integrations/postgres.md
@@ -16,7 +16,7 @@ Fields marked 🔒 use an encrypted value or an external reference. API response
 | `username` | string | Yes |  |  |
 | `password` 🔒 | string | Yes |  | Password for the database user |
 | `ssl.mode` | `disable`, `prefer`, `require`, `verify-ca`, `verify-full` |  | `verify-full` | libpq sslmode; `verify-full` checks the CA chain and the hostname |
-| `ambient_env` | boolean |  | `false` | Also export PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD, and PGSSLMODE so marimo's data-source discovery offers this connection. Only one integration per session can claim them. |
+| `ambient_env` | boolean |  | `true` | Automatically offer this connection in marimo's data-source discovery by exporting PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD, and PGSSLMODE. If multiple integrations request the same variables, one is discovered and every connection remains available through its notebook snippet. |
 
 **`ssl.mode: verify-ca`**
 

--- a/docs/partials/integrations/pyspark.md
+++ b/docs/partials/integrations/pyspark.md
@@ -28,7 +28,7 @@ Fields marked 🔒 use an encrypted value or an external reference. API response
 | `secret_spark_config` | object[] |  |  |  |
 | `secret_spark_config[].name` | string | Yes |  |  |
 | `secret_spark_config[].value` 🔒 | string | Yes |  |  |
-| `ambient_env` | boolean |  | `false` | Also export SPARK_REMOTE so marimo's data-source discovery offers this connection. Only one integration per session can claim them. |
+| `ambient_env` | boolean |  | `true` | Automatically offer this connection in marimo's data-source discovery by exporting SPARK_REMOTE. If multiple integrations request the same variables, one is discovered and every connection remains available through its notebook snippet. |
 
 **`auth.method: token`**
 

--- a/docs/partials/integrations/trino.md
+++ b/docs/partials/integrations/trino.md
@@ -16,7 +16,7 @@ Fields marked 🔒 use an encrypted value or an external reference. API response
 | `user` | string |  |  | Query user; defaults to the signed-in user |
 | `auth.method` | `none`, `basic`, `jwt`, `oauth2`, `certificate`, `kerberos`, `gssapi` | Yes |  |  |
 | `tls.verification` | `system`, `disabled`, `custom_ca` |  | `system` |  |
-| `default_catalog` | string |  |  |  |
+| `default_catalog` | string |  |  | Default catalog; required for automatic marimo data-source discovery |
 | `default_schema` | string |  |  |  |
 | `source` | string |  |  |  |
 | `session_properties` | map&lt;string, string&gt; |  |  |  |
@@ -38,7 +38,7 @@ Fields marked 🔒 use an encrypted value or an external reference. API response
 | `isolation_level` | `AUTOCOMMIT`, `READ_UNCOMMITTED`, `READ_COMMITTED`, `REPEATABLE_READ`, `SERIALIZABLE` |  | `AUTOCOMMIT` |  |
 | `legacy_primitive_types` | boolean |  | `false` |  |
 | `legacy_prepared_statements` | boolean |  |  |  |
-| `ambient_env` | boolean |  | `false` | Also export TRINO_HOST, TRINO_PORT, TRINO_USER, TRINO_CATALOG, and TRINO_PASSWORD so marimo's data-source discovery offers this connection. Only one integration per session can claim them. |
+| `ambient_env` | boolean |  | `true` | Automatically offer this connection in marimo's data-source discovery by exporting TRINO_HOST, TRINO_PORT, TRINO_USER, TRINO_CATALOG, and TRINO_PASSWORD. If multiple integrations request the same variables, one is discovered and every connection remains available through its notebook snippet. |
 
 **`auth.method: basic`**
 

--- a/internal/schemas/integrations.yml
+++ b/internal/schemas/integrations.yml
@@ -754,7 +754,8 @@ paths:
           description: Accepted.
   /kinds/pyspark/config:
     summary: PySpark (Spark Connect)
-    description: Remote PySpark DataFrame sessions over Spark Connect.
+    description: Remote PySpark sessions that appear automatically in marimo
+      data-source discovery.
     x-kind-schema-version: 1
     x-category: engine
     x-brand-color: '#E25A1C'
@@ -943,8 +944,8 @@ paths:
           description: Accepted.
   /kinds/trino/config:
     summary: Trino
-    description: Trino DBAPI and SQLAlchemy connection with authentication and
-      session options.
+    description: Trino DBAPI and SQLAlchemy connections, with automatic marimo
+      discovery when compatible.
     x-kind-schema-version: 1
     x-category: engine
     x-brand-color: '#DD00A1'
@@ -3728,10 +3729,12 @@ components:
           discriminator:
             propertyName: mode
         ambient_env:
-          default: false
-          description: Also export MYSQL_HOST, MYSQL_TCP_PORT, MYSQL_DATABASE, MYSQL_USER,
-            and MYSQL_PASSWORD so marimo's data-source discovery offers this
-            connection. Only one integration per session can claim them.
+          default: true
+          description: Automatically offer this connection in marimo's data-source
+            discovery by exporting MYSQL_HOST, MYSQL_TCP_PORT, MYSQL_DATABASE,
+            MYSQL_USER, and MYSQL_PASSWORD. If multiple integrations request the
+            same variables, one is discovered and every connection remains
+            available through its notebook snippet.
           type: boolean
       required:
         - host
@@ -3797,10 +3800,12 @@ components:
           discriminator:
             propertyName: mode
         ambient_env:
-          default: false
-          description: Also export MYSQL_HOST, MYSQL_TCP_PORT, MYSQL_DATABASE, MYSQL_USER,
-            and MYSQL_PASSWORD so marimo's data-source discovery offers this
-            connection. Only one integration per session can claim them.
+          default: true
+          description: Automatically offer this connection in marimo's data-source
+            discovery by exporting MYSQL_HOST, MYSQL_TCP_PORT, MYSQL_DATABASE,
+            MYSQL_USER, and MYSQL_PASSWORD. If multiple integrations request the
+            same variables, one is discovered and every connection remains
+            available through its notebook snippet.
           type: boolean
       required:
         - host
@@ -3901,10 +3906,12 @@ components:
           discriminator:
             propertyName: mode
         ambient_env:
-          default: false
-          description: Also export PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD, and
-            PGSSLMODE so marimo's data-source discovery offers this connection.
-            Only one integration per session can claim them.
+          default: true
+          description: Automatically offer this connection in marimo's data-source
+            discovery by exporting PGHOST, PGPORT, PGDATABASE, PGUSER,
+            PGPASSWORD, and PGSSLMODE. If multiple integrations request the same
+            variables, one is discovered and every connection remains available
+            through its notebook snippet.
           type: boolean
       required:
         - host
@@ -4002,10 +4009,12 @@ components:
           discriminator:
             propertyName: mode
         ambient_env:
-          default: false
-          description: Also export PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD, and
-            PGSSLMODE so marimo's data-source discovery offers this connection.
-            Only one integration per session can claim them.
+          default: true
+          description: Automatically offer this connection in marimo's data-source
+            discovery by exporting PGHOST, PGPORT, PGDATABASE, PGUSER,
+            PGPASSWORD, and PGSSLMODE. If multiple integrations request the same
+            variables, one is discovered and every connection remains available
+            through its notebook snippet.
           type: boolean
       required:
         - host
@@ -4139,9 +4148,11 @@ components:
             additionalProperties: false
           x-unique-by: name
         ambient_env:
-          default: false
-          description: Also export SPARK_REMOTE so marimo's data-source discovery offers
-            this connection. Only one integration per session can claim them.
+          default: true
+          description: Automatically offer this connection in marimo's data-source
+            discovery by exporting SPARK_REMOTE. If multiple integrations
+            request the same variables, one is discovered and every connection
+            remains available through its notebook snippet.
           type: boolean
       required:
         - host
@@ -4274,9 +4285,11 @@ components:
             additionalProperties: false
           x-unique-by: name
         ambient_env:
-          default: false
-          description: Also export SPARK_REMOTE so marimo's data-source discovery offers
-            this connection. Only one integration per session can claim them.
+          default: true
+          description: Automatically offer this connection in marimo's data-source
+            discovery by exporting SPARK_REMOTE. If multiple integrations
+            request the same variables, one is discovered and every connection
+            remains available through its notebook snippet.
           type: boolean
       required:
         - host
@@ -5019,6 +5032,7 @@ components:
           discriminator:
             propertyName: verification
         default_catalog:
+          description: Default catalog; required for automatic marimo data-source discovery
           type: string
           pattern: ^[A-Za-z0-9_.-]+$
         default_schema:
@@ -5136,10 +5150,12 @@ components:
         legacy_prepared_statements:
           type: boolean
         ambient_env:
-          default: false
-          description: Also export TRINO_HOST, TRINO_PORT, TRINO_USER, TRINO_CATALOG, and
-            TRINO_PASSWORD so marimo's data-source discovery offers this
-            connection. Only one integration per session can claim them.
+          default: true
+          description: Automatically offer this connection in marimo's data-source
+            discovery by exporting TRINO_HOST, TRINO_PORT, TRINO_USER,
+            TRINO_CATALOG, and TRINO_PASSWORD. If multiple integrations request
+            the same variables, one is discovered and every connection remains
+            available through its notebook snippet.
           type: boolean
       required:
         - host
@@ -5352,6 +5368,7 @@ components:
           discriminator:
             propertyName: verification
         default_catalog:
+          description: Default catalog; required for automatic marimo data-source discovery
           type: string
           pattern: ^[A-Za-z0-9_.-]+$
         default_schema:
@@ -5469,10 +5486,12 @@ components:
         legacy_prepared_statements:
           type: boolean
         ambient_env:
-          default: false
-          description: Also export TRINO_HOST, TRINO_PORT, TRINO_USER, TRINO_CATALOG, and
-            TRINO_PASSWORD so marimo's data-source discovery offers this
-            connection. Only one integration per session can claim them.
+          default: true
+          description: Automatically offer this connection in marimo's data-source
+            discovery by exporting TRINO_HOST, TRINO_PORT, TRINO_USER,
+            TRINO_CATALOG, and TRINO_PASSWORD. If multiple integrations request
+            the same variables, one is discovered and every connection remains
+            available through its notebook snippet.
           type: boolean
       required:
         - host

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -107,6 +107,40 @@ describe('Session routes', () => {
 		return data.session_id as string;
 	}
 
+	it('logs best-effort integration warnings when provisioning a session', async () => {
+		const warning =
+			'Integration "staging" uses its notebook snippet because "prod" owns automatic discovery.';
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			const request = createTestApi({
+				bucket,
+				userId: ACTOR,
+				compute: makeFakeCompute(),
+				deps: {
+					integrations: {
+						resolveForSession: async () => ({
+							files: [],
+							vars: {},
+							attachments: [],
+							warnings: [warning],
+						}),
+					} as never,
+				},
+			}).request;
+
+			await expectOk<ApiSession>(await request('POST', sessionsPath()));
+			const line = log.mock.calls.find((call) =>
+				String(call[0]).includes('session_provision'),
+			)?.[0];
+			expect(JSON.parse(String(line))).toMatchObject({
+				integration_warning_count: 1,
+				integration_warnings: [warning],
+			});
+		} finally {
+			log.mockRestore();
+		}
+	});
+
 	it('POST /sessions with a non-existent notebook returns 404 and does not provision', async () => {
 		// Use a notebook id that was never created in this project.
 		const bogusNid = createNotebookId();

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1224,6 +1224,10 @@ app.openapi(createSession, async (c) => {
 							});
 							if (render) {
 								observer.tag('integrations_rendered_count', render.attachments.length);
+								if (render.warnings.length > 0) {
+									observer.tag('integration_warnings', render.warnings);
+									observer.tag('integration_warning_count', render.warnings.length);
+								}
 								integrationAttachments = render.attachments;
 							}
 							return render;

--- a/packages/core/src/ports/integrations.ts
+++ b/packages/core/src/ports/integrations.ts
@@ -313,4 +313,6 @@ export interface SessionRender {
 	vars: Record<string, string>;
 	/** Version pins persisted on the session record. */
 	attachments: IntegrationVersionPin[];
+	/** User-safe notices about best-effort integration features. */
+	warnings: string[];
 }

--- a/packages/core/src/services/integrations/bundle.test.ts
+++ b/packages/core/src/services/integrations/bundle.test.ts
@@ -196,3 +196,47 @@ describe('bundler-owned env', () => {
 		expect(result.vars[INTEGRATIONS_DIR_ENV]).toBe(INTEGRATIONS_DIR);
 	});
 });
+
+describe('data-source discovery env', () => {
+	it('selects one complete discovery contract and warns about later claimants', () => {
+		const result = bundle([
+			rendered('staging', {
+				discoveryEnv: {
+					TRINO_HOST: 'staging.internal',
+					TRINO_USER: 'staging-user',
+					TRINO_CATALOG: 'hive',
+				},
+			}),
+			rendered('prod', {
+				discoveryEnv: { TRINO_HOST: 'prod.internal', TRINO_USER: 'prod-user' },
+			}),
+		]);
+
+		expect(result.vars).toMatchObject({
+			TRINO_HOST: 'prod.internal',
+			TRINO_USER: 'prod-user',
+		});
+		expect(result.vars.TRINO_CATALOG).toBeUndefined();
+		expect(result.warnings).toEqual([
+			expect.stringMatching(/"staging".*"prod".*TRINO_HOST, TRINO_USER/),
+		]);
+	});
+
+	it('keeps ordinary env collisions strict and records discovery warnings in the manifest', () => {
+		expect(() =>
+			bundle([
+				rendered('first', { env: { SHARED: 'one' } }),
+				rendered('second', { env: { SHARED: 'two' } }),
+			]),
+		).toThrow(/same environment variable/);
+
+		const result = bundle([
+			rendered('fallback', {
+				warnings: ['Automatic discovery is unavailable.'],
+			}),
+		]);
+		const manifest = result.files.find(({ path }) => path.endsWith('/manifest.json'));
+		const parsed = JSON.parse(manifest?.content ?? '{}') as { warnings?: string[] };
+		expect(parsed.warnings).toEqual(['Automatic discovery is unavailable.']);
+	});
+});

--- a/packages/core/src/services/integrations/bundle.ts
+++ b/packages/core/src/services/integrations/bundle.ts
@@ -65,6 +65,7 @@ export function bundleIntegrations(
 	// collision error instead of having its value silently overwritten.
 	const vars: Record<string, string> = { [INTEGRATIONS_DIR_ENV]: INTEGRATIONS_DIR };
 	const varOwner = new Map<string, string>([[INTEGRATIONS_DIR_ENV, BUNDLER]]);
+	const warnings = rendered.flatMap((item) => item.output.warnings ?? []);
 
 	for (const item of rendered) {
 		for (const file of item.output.files ?? []) {
@@ -85,12 +86,7 @@ export function bundleIntegrations(
 			}
 		}
 		for (const [key, value] of Object.entries(item.output.env ?? {})) {
-			assertValidEnvName(key, item.name);
-			if (hasControlCharacter(value)) {
-				throw new ValidationError(
-					`Integration "${item.name}" emitted an environment value containing a control character.`,
-				);
-			}
+			assertValidEnvValue(key, value, item.name);
 			const owner = varOwner.get(key);
 			// An identical value from two instances is tolerated (e.g. a shared
 			// tool var like PYICEBERG_HOME); a differing one is ambiguous.
@@ -99,6 +95,29 @@ export function bundleIntegrations(
 					`Integrations "${owner}" and "${item.name}" set the same environment variable to different values.`,
 				);
 			}
+			varOwner.set(key, item.name);
+			vars[key] = value;
+		}
+	}
+
+	for (const item of [...rendered].sort((a, b) => a.name.localeCompare(b.name))) {
+		const discovery = Object.entries(item.output.discoveryEnv ?? {});
+		for (const [key, value] of discovery) assertValidEnvValue(key, value, item.name);
+		const conflicts = discovery.flatMap(([key]) => {
+			const owner = varOwner.get(key);
+			return owner ? [{ key, owner }] : [];
+		});
+		if (conflicts.length > 0) {
+			const owners = [...new Set(conflicts.map(({ owner }) => owner))];
+			const names = conflicts.map(({ key }) => key).join(', ');
+			warnings.push(
+				`Integration "${item.name}" is available through its notebook snippet, but not automatic ` +
+					`data-source discovery because ${owners.map((owner) => `"${owner}"`).join(', ')} already ` +
+					`claims ${names}.`,
+			);
+			continue;
+		}
+		for (const [key, value] of discovery) {
 			varOwner.set(key, item.name);
 			vars[key] = value;
 		}
@@ -112,6 +131,7 @@ export function bundleIntegrations(
 
 	const manifest = {
 		session_id: sessionId,
+		...(warnings.length > 0 ? { warnings } : {}),
 		integrations: rendered.map((item) => ({
 			name: item.name,
 			kind: item.kind,
@@ -131,7 +151,17 @@ export function bundleIntegrations(
 		files,
 		vars,
 		attachments: rendered.map(({ id, name, kind, version }) => ({ id, name, kind, version })),
+		warnings,
 	};
+}
+
+function assertValidEnvValue(key: string, value: string, instance: string): void {
+	assertValidEnvName(key, instance);
+	if (hasControlCharacter(value)) {
+		throw new ValidationError(
+			`Integration "${instance}" emitted an environment value containing a control character.`,
+		);
+	}
 }
 
 /**

--- a/packages/core/src/services/integrations/kinds/CONVENTIONS.md
+++ b/packages/core/src/services/integrations/kinds/CONVENTIONS.md
@@ -25,6 +25,8 @@ Use these rules for each new integration kind.
 
 - Validate protocol boundaries in the renderer. Do not depend only on the JSON Schema pattern.
 - List process-wide environment variables in `environmentVariables`.
+- Put best-effort marimo discovery variables in `RenderOutput.discoveryEnv`; keep required ambient
+  variables in `env` so conflicts still fail closed.
 - Use `resolveRequirements` when the selected configuration changes the package set.
 - Add one migration description for each increase of `schemaVersion`.
 - Keep secret values out of descriptors, errors, and manifest metadata.

--- a/packages/core/src/services/integrations/kinds/common.ts
+++ b/packages/core/src/services/integrations/kinds/common.ts
@@ -237,16 +237,17 @@ export const AMBIENT_ENV_DESCRIPTION =
  * The same switch for a kind whose client takes an explicit URL: the standard
  * names are what marimo's data-source discovery scans for, so setting them is
  * what turns an integration into a one-click connection in the notebook UI.
- * Off by default — the names are process-wide, and a project with a prod and a
- * staging instance of one kind is ordinary.
+ * The bundler chooses one connection when multiple instances request the same
+ * names; every instance remains available through its namespaced variables.
  */
 export const discoveryEnvField = (names: string) =>
 	z
 		.boolean()
-		.default(false)
+		.default(true)
 		.describe(
-			`Also export ${names} so marimo's data-source discovery offers this connection. ` +
-				'Only one integration per session can claim them.',
+			`Automatically offer this connection in marimo's data-source discovery by exporting ${names}. ` +
+				'If multiple integrations request the same variables, one is discovered and every connection ' +
+				'remains available through its notebook snippet.',
 		);
 
 type FieldValue = string | number | boolean | undefined;
@@ -266,6 +267,9 @@ export interface ConnectionRender {
 	files?: { path: string; content: string }[];
 	/** Vendor-standard names this instance claims in addition to its own. */
 	ambient?: Record<string, string | undefined>;
+	/** Vendor-standard names used only for marimo data-source discovery. */
+	discovery?: Record<string, string | undefined>;
+	warnings?: string[];
 	manifestExtra?: Record<string, unknown>;
 }
 
@@ -294,9 +298,16 @@ export function renderConnection(spec: ConnectionRender): RenderOutput {
 		(entry): entry is [string, string] => entry[1] !== undefined,
 	);
 	for (const [name, value] of ambient) env[name] = value;
+	const discovery = Object.fromEntries(
+		Object.entries(spec.discovery ?? {}).filter(
+			(entry): entry is [string, string] => entry[1] !== undefined,
+		),
+	);
 
 	return {
 		env,
+		...(Object.keys(discovery).length > 0 ? { discoveryEnv: discovery } : {}),
+		...(spec.warnings && spec.warnings.length > 0 ? { warnings: spec.warnings } : {}),
 		files: [
 			...(spec.files ?? []),
 			{
@@ -335,8 +346,9 @@ export function renderSqlConnection(options: {
 	};
 	/** Fields beyond the shared set, e.g. a TLS mode the driver reads separately. */
 	fields?: Record<string, FieldValue>;
-	/** Driver-standard names this instance claims, for marimo's discovery. */
-	ambient?: Record<string, string | undefined>;
+	/** Driver-standard names this instance claims for marimo's discovery. */
+	discovery?: Record<string, string | undefined>;
+	warnings?: string[];
 	descriptor?: Record<string, unknown>;
 	files?: { path: string; content: string }[];
 }): RenderOutput {
@@ -355,7 +367,8 @@ export function renderSqlConnection(options: {
 			...options.fields,
 		},
 		secretFields: ['URL', 'PASSWORD'],
-		ambient: options.ambient,
+		discovery: options.discovery,
+		warnings: options.warnings,
 		descriptor: options.descriptor,
 		files: options.files,
 		manifestExtra: { host: config.host, database: config.database },

--- a/packages/core/src/services/integrations/kinds/kinds.test.ts
+++ b/packages/core/src/services/integrations/kinds/kinds.test.ts
@@ -2067,7 +2067,7 @@ const DISCOVERY_CONTRACT = [
 		overrides: { ssl: { mode: 'disabled' } },
 	},
 	{ kind: 'trino', required: ['TRINO_HOST', 'TRINO_USER', 'TRINO_CATALOG'], overrides: {} },
-	{ kind: 'pyspark', required: ['SPARK_REMOTE'], overrides: {} },
+	{ kind: 'pyspark', required: ['SPARK_REMOTE'], overrides: { app_name: undefined } },
 	{ kind: 's3', required: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'], overrides: {} },
 ];
 
@@ -2078,7 +2078,8 @@ describe('marimo data-source discovery', () => {
 			const def = defaultRegistry().get(kind);
 			const config = def.configSchema.parse(fixtureFor(def, { ambient_env: true, ...overrides }));
 			expect(() => def.validate?.(config)).not.toThrow();
-			const env = renderDefinition(def, config).env ?? {};
+			const output = renderDefinition(def, config);
+			const env = kind === 's3' ? (output.env ?? {}) : (output.discoveryEnv ?? {});
 			for (const name of required) {
 				expect(env[name], `${kind} must set ${name}`).toBeTruthy();
 			}
@@ -2086,9 +2087,20 @@ describe('marimo data-source discovery', () => {
 	);
 
 	it.each(DISCOVERY_CONTRACT.filter(({ kind }) => kind !== 's3'))(
+		'$kind enables discovery by default',
+		({ kind, required, overrides }) => {
+			const def = defaultRegistry().get(kind);
+			const config = def.configSchema.parse(fixtureFor(def, overrides));
+			const output = renderDefinition(def, config);
+			for (const name of required) expect(output.discoveryEnv?.[name], name).toBeTruthy();
+		},
+	);
+
+	it.each(DISCOVERY_CONTRACT.filter(({ kind }) => kind !== 's3'))(
 		'$kind claims nothing outside its own prefix until asked',
 		({ kind, required }) => {
-			const env = renderFixture(defaultRegistry().get(kind), { ambient_env: false }).env ?? {};
+			const env =
+				renderFixture(defaultRegistry().get(kind), { ambient_env: false }).discoveryEnv ?? {};
 			for (const name of required) expect(env[name], name).toBeUndefined();
 		},
 	);
@@ -2097,46 +2109,87 @@ describe('marimo data-source discovery', () => {
 	// connection marimo builds sets none — so these are what stop a discovered
 	// connection from being a weaker one to the same server.
 	it('postgres: the discovered connection verifies exactly like the rendered URL', () => {
-		const env = renderFixture(postgres, { ambient_env: true }).env ?? {};
+		const env = renderFixture(postgres, { ambient_env: true }).discoveryEnv ?? {};
 		expect(env.PGSSLMODE).toBe('verify-full');
 		expect(env.PGSSLROOTCERT).toBe('/etc/ssl/certs/ca-certificates.crt');
 
 		const custom = renderFixture(postgres, {
 			ambient_env: true,
 			ssl: { mode: 'verify-ca', ca_bundle: 'CA' },
-		}).env;
+		}).discoveryEnv;
 		expect(custom?.PGSSLMODE).toBe('verify-ca');
 		expect(custom?.PGSSLROOTCERT).toBe(`${INTEGRATIONS_DIR}/postgres/prod-ca.pem`);
 	});
 
-	it('mysql: refuses to advertise a TLS connection PyMySQL would open in plaintext', () => {
+	it('mysql: falls back to its notebook snippet when discovery cannot preserve TLS', () => {
 		const config = mysql.configSchema.parse(fixtureFor(mysql, { ambient_env: true }));
-		expect(() => mysql.validate?.(config)).toThrow(/plaintext/);
+		expect(() => mysql.validate?.(config)).not.toThrow();
+		const output = renderDefinition(mysql, config);
+		expect(output.discoveryEnv).toBeUndefined();
+		expect(output.warnings).toEqual([expect.stringMatching(/cannot carry its MySQL TLS settings/)]);
 	});
 
 	it('trino: exports the password so the discovered connection authenticates over HTTPS', () => {
-		const env = renderFixture(trino, { ambient_env: true }).env ?? {};
+		const env = renderFixture(trino, { ambient_env: true }).discoveryEnv ?? {};
 		expect(env.TRINO_CATALOG).toBe('hive');
 		expect(env.TRINO_PASSWORD).toBe('pw');
 	});
 
 	it.each([
-		[{ default_catalog: undefined }, /requires default_catalog/],
-		[{ auth: { method: 'jwt', token: 'jwt-token' } }, /Basic auth over HTTPS/],
-		[{ auth: { method: 'none' } }, /Basic auth over HTTPS/],
+		[{ default_catalog: undefined }, /requires a default catalog/],
+		[{ auth: { method: 'jwt', token: 'jwt-token' } }, /Basic authentication over HTTPS/],
+		[{ auth: { method: 'none' } }, /Basic authentication over HTTPS/],
 		// Nothing carries a private CA or a disabled check into the discovered
 		// connection, so it would verify differently than the configured one.
-		[{ tls: { verification: 'custom_ca', ca_bundle: 'CA' } }, /custom CA or disabled/],
-		[{ tls: { verification: 'disabled' } }, /custom CA or disabled/],
+		[{ tls: { verification: 'custom_ca', ca_bundle: 'CA' } }, /custom Trino TLS/],
+		[{ tls: { verification: 'disabled' } }, /custom Trino TLS/],
 		// marimo authenticates as TRINO_USER, so a separate query user cannot be
 		// expressed — the discovered connection would use the wrong credential.
-		[{ user: 'analyst' }, /match/],
-	])('trino: refuses discovery it cannot express (%j)', (overrides, message) => {
+		[{ user: 'analyst' }, /same Trino query user/],
+		[{ source: 'marimohub' }, /configured Trino source/],
+		[{ session_properties: { join_distribution_type: 'BROADCAST' } }, /session properties/],
+		[{ roles: { hive: 'analyst' } }, /configured Trino roles/],
+		[{ client_tags: [{ value: 'interactive' }] }, /client tags/],
+		[{ http_headers: [{ name: 'X-Trace', value: 'trace' }] }, /HTTP headers/],
+		[{ extra_credentials: [{ name: 'tenant', value: 'acme' }] }, /extra credentials/],
+		[{ timezone: 'America/New_York' }, /configured Trino timezone/],
+		[{ encoding: [{ value: 'json+zstd' }] }, /configured Trino encoding/],
+		[{ max_attempts: 5 }, /maximum attempts/],
+		[{ request_timeout_seconds: 30 }, /request timeout/],
+		[{ heartbeat_interval_seconds: 10 }, /heartbeat interval/],
+		[{ isolation_level: 'READ_COMMITTED' }, /isolation level/],
+		[{ legacy_primitive_types: true }, /legacy primitive types/],
+		[{ legacy_prepared_statements: false }, /legacy prepared statements/],
+	])('trino: falls back when discovery cannot express the config (%j)', (overrides, message) => {
 		const config = trino.configSchema.parse(fixtureFor(trino, { ambient_env: true, ...overrides }));
-		expect(() => trino.validate?.(config)).toThrow(message);
+		expect(() => trino.validate?.(config)).not.toThrow();
+		const output = renderDefinition(trino, config);
+		expect(output.discoveryEnv).toBeUndefined();
+		expect(output.warnings?.join(' ')).toMatch(message);
 	});
 
-	it('two instances claiming the same variables fail the session, naming both', () => {
+	it.each([
+		[{ app_name: 'analytics' }, /Spark application name/],
+		[{ spark_config: { 'spark.sql.session.timeZone': 'UTC' } }, /Spark session properties/],
+		[
+			{
+				secret_spark_config: [{ name: 'spark.hadoop.fs.s3a.secret.key', value: 's3-secret' }],
+			},
+			/secret Spark session properties/,
+		],
+	])('pyspark: falls back when discovery cannot express the config (%j)', (overrides, message) => {
+		const config = pyspark.configSchema.parse(
+			fixtureFor(pyspark, { ambient_env: true, app_name: undefined, ...overrides }),
+		);
+		expect(() => pyspark.validate?.(config)).not.toThrow();
+		const output = renderDefinition(pyspark, config);
+		expect(output.discoveryEnv).toBeUndefined();
+		expect(output.env?.MARIMOHUB_PYSPARK_PROD_CONFIG).toBe(`${INTEGRATIONS_DIR}/pyspark/prod.json`);
+		expect(output.files?.some(({ path }) => path === 'pyspark/prod.json')).toBe(true);
+		expect(output.warnings?.join(' ')).toMatch(message);
+	});
+
+	it('two instances claiming the same variables discover one and warn about the fallback', () => {
 		const rendered = ['prod', 'staging'].map((name, index) => ({
 			id: `intg-00000000000000${index}0` as never,
 			name,
@@ -2144,9 +2197,11 @@ describe('marimo data-source discovery', () => {
 			version: 1,
 			output: renderFixture(postgres, { ambient_env: true, host: `${name}.internal` }, name),
 		}));
-		expect(() => bundleIntegrations(rendered, createSessionId())).toThrow(
-			/"prod" and "staging" set the same environment variable/,
-		);
+		const bundle = bundleIntegrations(rendered, createSessionId());
+		expect(bundle.vars.PGHOST).toBe('prod.internal');
+		expect(bundle.warnings).toEqual([
+			expect.stringMatching(/"staging".*not automatic data-source discovery.*"prod"/),
+		]);
 	});
 });
 

--- a/packages/core/src/services/integrations/kinds/mysql.ts
+++ b/packages/core/src/services/integrations/kinds/mysql.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { ValidationError } from '../../../errors';
 import { defineIntegration } from '../sdk';
 import {
 	caFields,
@@ -61,21 +60,11 @@ export const mysql = defineIntegration({
 		...SQL_CONNECTION_HINTS,
 		ssl: { group: 'Connection', order: 4 },
 		'ssl.ca_bundle': { widget: 'textarea' },
-		ambient_env: { group: 'Discovery', order: 60, widget: 'toggle', advanced: true },
+		ambient_env: { group: 'Discovery', order: 60, widget: 'toggle' },
 	},
 
 	validate(config) {
 		if (config.ssl.mode === 'verify_identity') validateCaFields(config.ssl, 'ssl');
-		// Unlike libpq, PyMySQL takes no TLS settings from the environment, and the
-		// connection marimo builds from MYSQL_* passes none — so exporting them for a
-		// TLS-required server would hand notebook code an unencrypted path to it.
-		if (config.ambient_env && config.ssl.mode !== 'disabled') {
-			throw new ValidationError(
-				'ambient_env would expose this connection to marimo as a plaintext one, because ' +
-					'the PyMySQL connection it builds carries no TLS settings. Connect through ' +
-					'MARIMOHUB_MYSQL_<NAME>_URL instead, which does.',
-			);
-		}
 	},
 
 	render({ config, instanceName }) {
@@ -99,15 +88,23 @@ export const mysql = defineIntegration({
 			instanceName,
 			url,
 			config,
-			ambient: config.ambient_env
-				? {
-						MYSQL_HOST: config.host,
-						MYSQL_TCP_PORT: String(config.port),
-						MYSQL_DATABASE: config.database,
-						MYSQL_USER: config.username,
-						MYSQL_PASSWORD: config.password,
-					}
-				: {},
+			discovery:
+				config.ambient_env && config.ssl.mode === 'disabled'
+					? {
+							MYSQL_HOST: config.host,
+							MYSQL_TCP_PORT: String(config.port),
+							MYSQL_DATABASE: config.database,
+							MYSQL_USER: config.username,
+							MYSQL_PASSWORD: config.password,
+						}
+					: {},
+			warnings:
+				config.ambient_env && config.ssl.mode !== 'disabled'
+					? [
+							`Integration "${instanceName}" is available through its notebook snippet, but not ` +
+								'automatic data-source discovery because marimo cannot carry its MySQL TLS settings.',
+						]
+					: [],
 			descriptor: {
 				ssl: { mode: config.ssl.mode, ...(caPath ? { ca_path: caPath } : {}) },
 			},

--- a/packages/core/src/services/integrations/kinds/postgres.ts
+++ b/packages/core/src/services/integrations/kinds/postgres.ts
@@ -130,7 +130,7 @@ export const postgres = defineIntegration({
 		...SQL_CONNECTION_HINTS,
 		ssl: { group: 'Connection', order: 4 },
 		'ssl.ca_bundle': { widget: 'textarea' },
-		ambient_env: { group: 'Discovery', order: 60, widget: 'toggle', advanced: true },
+		ambient_env: { group: 'Discovery', order: 60, widget: 'toggle' },
 	},
 
 	validate(config) {
@@ -194,22 +194,20 @@ export const postgres = defineIntegration({
 				[`MARIMOHUB_PG_${seg}_DATABASE`]: config.database,
 				[`MARIMOHUB_PG_${seg}_USER`]: config.username,
 				[`MARIMOHUB_PG_${seg}_PASSWORD`]: config.password,
-				// marimo's discovery builds its connection from PGHOST/PGUSER/PGDATABASE
-				// and never sets an sslmode, so PGSSLMODE and PGSSLROOTCERT are what
-				// keep that connection as verified as the URL above — libpq reads them
-				// for any parameter the caller left unspecified.
-				...(config.ambient_env
-					? {
-							PGHOST: config.host,
-							PGPORT: String(config.port),
-							PGDATABASE: config.database,
-							PGUSER: config.username,
-							PGPASSWORD: config.password,
-							PGSSLMODE: config.ssl.mode,
-							...(caPath ? { PGSSLROOTCERT: caPath } : {}),
-						}
-					: {}),
 			},
+			// libpq reads these TLS variables for parameters marimo's discovered
+			// connection leaves unspecified, preserving the configured verification.
+			discoveryEnv: config.ambient_env
+				? {
+						PGHOST: config.host,
+						PGPORT: String(config.port),
+						PGDATABASE: config.database,
+						PGUSER: config.username,
+						PGPASSWORD: config.password,
+						PGSSLMODE: config.ssl.mode,
+						...(caPath ? { PGSSLROOTCERT: caPath } : {}),
+					}
+				: {},
 			files,
 			manifestExtra: { host: config.host, database: config.database },
 		};

--- a/packages/core/src/services/integrations/kinds/pyspark.ts
+++ b/packages/core/src/services/integrations/kinds/pyspark.ts
@@ -67,10 +67,21 @@ const pysparkConfig = z.strictObject({
 	ambient_env: discoveryEnvField('SPARK_REMOTE'),
 });
 
+function pysparkDiscoveryReason(config: z.infer<typeof pysparkConfig>): string | undefined {
+	if (config.app_name) return 'marimo cannot carry the configured Spark application name';
+	if (Object.keys(config.spark_config).length > 0) {
+		return 'marimo cannot carry the configured Spark session properties';
+	}
+	if (config.secret_spark_config.length > 0) {
+		return 'marimo cannot carry the configured secret Spark session properties';
+	}
+	return undefined;
+}
+
 export const pyspark = defineIntegration({
 	kind: 'pyspark',
 	title: 'PySpark (Spark Connect)',
-	description: 'Remote PySpark DataFrame sessions over Spark Connect.',
+	description: 'Remote PySpark sessions that appear automatically in marimo data-source discovery.',
 	category: 'engine',
 	brand: { icon: 'apachespark', color: '#E25A1C' },
 	schemaVersion: 1,
@@ -92,7 +103,7 @@ export const pyspark = defineIntegration({
 		spark_config: { group: 'Spark config', order: 60, advanced: true, widget: 'kv-pairs' },
 		secret_spark_config: { group: 'Spark config', order: 61, advanced: true },
 		'secret_spark_config.*.value': { widget: 'password' },
-		ambient_env: { group: 'Discovery', order: 70, widget: 'toggle', advanced: true },
+		ambient_env: { group: 'Discovery', order: 70, widget: 'toggle' },
 	},
 
 	validate(config) {
@@ -144,16 +155,23 @@ export const pyspark = defineIntegration({
 			...config.spark_config,
 			...Object.fromEntries(config.secret_spark_config.map(({ name, value }) => [name, value])),
 		};
+		const discoveryReason = config.ambient_env ? pysparkDiscoveryReason(config) : undefined;
 
 		return {
 			env: {
 				[`${prefix}_REMOTE`]: remote,
 				[`${prefix}_CONFIG`]: configPath,
 				...(config.auth.method === 'token' ? { [`${prefix}_TOKEN`]: config.auth.token } : {}),
-				// The same string: SPARK_REMOTE is what `SparkSession.builder` reads on
-				// its own, so this needs no separate contract.
-				...(config.ambient_env ? { SPARK_REMOTE: remote } : {}),
 			},
+			...(config.ambient_env && discoveryReason === undefined
+				? { discoveryEnv: { SPARK_REMOTE: remote } }
+				: {}),
+			warnings: discoveryReason
+				? [
+						`Integration "${instanceName}" is available through its notebook snippet, but not ` +
+							`automatic data-source discovery because ${discoveryReason}.`,
+					]
+				: [],
 			files: [
 				{
 					path: `pyspark/${instanceName}.json`,

--- a/packages/core/src/services/integrations/kinds/trino.ts
+++ b/packages/core/src/services/integrations/kinds/trino.ts
@@ -77,7 +77,11 @@ const trinoConfig = z.strictObject({
 	user: z.string().min(1).optional().describe('Query user; defaults to the signed-in user'),
 	auth: authSchema,
 	tls: tlsSchema,
-	default_catalog: z.string().regex(IDENTIFIER_REGEX).optional(),
+	default_catalog: z
+		.string()
+		.regex(IDENTIFIER_REGEX)
+		.optional()
+		.describe('Default catalog; required for automatic marimo data-source discovery'),
 	default_schema: z.string().regex(IDENTIFIER_REGEX).optional(),
 	source: z.string().min(1).optional(),
 	session_properties: z.record(z.string(), z.string()).default({}),
@@ -121,10 +125,54 @@ const trinoConfig = z.strictObject({
 	),
 });
 
+function trinoDiscoveryReason(config: z.infer<typeof trinoConfig>): string | undefined {
+	if (!config.default_catalog) return 'marimo requires a default catalog';
+	if (
+		config.auth.method !== 'basic' &&
+		!(config.auth.method === 'none' && config.http_scheme === 'http')
+	) {
+		return 'marimo supports only Basic authentication over HTTPS or no authentication over HTTP';
+	}
+	if (config.tls.verification !== 'system') {
+		return 'marimo cannot carry custom Trino TLS verification settings';
+	}
+	if (
+		config.auth.method === 'basic' &&
+		config.user !== undefined &&
+		config.user !== config.auth.username
+	) {
+		return 'marimo must use the same Trino query user and Basic-auth username';
+	}
+	const unsupportedOptions = [
+		[config.source !== undefined, 'source'],
+		[Object.keys(config.session_properties).length > 0, 'session properties'],
+		[Object.keys(config.roles).length > 0, 'roles'],
+		[config.client_tags.length > 0, 'client tags'],
+		[config.http_headers.length > 0, 'HTTP headers'],
+		[config.extra_credentials.length > 0, 'extra credentials'],
+		[config.timezone !== undefined, 'timezone'],
+		[config.encoding !== undefined, 'encoding'],
+		[config.max_attempts !== undefined, 'maximum attempts'],
+		[config.request_timeout_seconds !== undefined, 'request timeout'],
+		[config.heartbeat_interval_seconds !== undefined, 'heartbeat interval'],
+		[config.isolation_level !== 'AUTOCOMMIT', 'isolation level'],
+		[config.legacy_primitive_types, 'legacy primitive types'],
+		[config.legacy_prepared_statements !== undefined, 'legacy prepared statements'],
+	] as const;
+	const unsupported = unsupportedOptions
+		.filter(([configured]) => configured)
+		.map(([, name]) => name);
+	if (unsupported.length > 0) {
+		return `marimo cannot carry the configured Trino ${unsupported.join(', ')}`;
+	}
+	return undefined;
+}
+
 export const trino = defineIntegration({
 	kind: 'trino',
 	title: 'Trino',
-	description: 'Trino DBAPI and SQLAlchemy connection with authentication and session options.',
+	description:
+		'Trino DBAPI and SQLAlchemy connections, with automatic marimo discovery when compatible.',
 	category: 'engine',
 	brand: { icon: 'trino', color: '#DD00A1' },
 	schemaVersion: 1,
@@ -151,7 +199,7 @@ export const trino = defineIntegration({
 		'auth.krb5_config': { widget: 'textarea' },
 		tls: { group: 'TLS', order: 15, advanced: true },
 		'tls.ca_bundle': { widget: 'textarea' },
-		default_catalog: { group: 'Defaults', order: 20, advanced: true },
+		default_catalog: { group: 'Defaults', order: 20 },
 		default_schema: { group: 'Defaults', order: 21, advanced: true },
 		source: { group: 'Session', order: 30, advanced: true },
 		session_properties: { group: 'Session', order: 31, advanced: true, widget: 'kv-pairs' },
@@ -179,7 +227,7 @@ export const trino = defineIntegration({
 			advanced: true,
 			widget: 'toggle',
 		},
-		ambient_env: { group: 'Discovery', order: 60, widget: 'toggle', advanced: true },
+		ambient_env: { group: 'Discovery', order: 60, widget: 'toggle' },
 	},
 
 	validate(config) {
@@ -225,51 +273,6 @@ export const trino = defineIntegration({
 				'spooling encoding',
 			);
 		}
-		if (config.ambient_env) {
-			if (!config.default_catalog) {
-				throw new ValidationError(
-					'marimo discovers a Trino connection only when a catalog is set, so ambient_env ' +
-						'requires default_catalog.',
-				);
-			}
-			// The connection marimo builds from TRINO_* uses Basic auth over HTTPS when
-			// it sees a password and plain HTTP otherwise. Any other combination here
-			// would advertise a connection that cannot authenticate or cannot reach the
-			// coordinator, so it is refused rather than rendered.
-			const discoverable =
-				config.auth.method === 'basic' ||
-				(config.auth.method === 'none' && config.http_scheme === 'http');
-			if (!discoverable) {
-				throw new ValidationError(
-					'marimo discovers Trino as Basic auth over HTTPS, or no auth over HTTP. This ' +
-						'authentication mode cannot be expressed that way — leave ambient_env off and ' +
-						'connect through MARIMOHUB_TRINO_<NAME>_URL.',
-				);
-			}
-			// Nothing carries this deployment's trust material into the discovered
-			// connection: a private CA would fail to verify there, and a disabled
-			// check would silently become an enabled one.
-			if (config.tls.verification !== 'system') {
-				throw new ValidationError(
-					'marimo discovers Trino with the runtime default TLS verification, so a custom ' +
-						'CA or disabled verification cannot be carried over. Leave ambient_env off ' +
-						'and connect through MARIMOHUB_TRINO_<NAME>_URL.',
-				);
-			}
-			// marimo uses TRINO_USER for both the query user and the Basic credential,
-			// so the two have to be the same name for the discovered connection to
-			// authenticate at all.
-			if (
-				config.auth.method === 'basic' &&
-				config.user !== undefined &&
-				config.user !== config.auth.username
-			) {
-				throw new ValidationError(
-					'marimo authenticates the discovered connection as TRINO_USER, so ambient_env ' +
-						'needs the query user and the Basic username to match (or no query user).',
-				);
-			}
-		}
 	},
 
 	render({ config, instanceName, principal }) {
@@ -301,6 +304,7 @@ export const trino = defineIntegration({
 			extraCredentials,
 		});
 		const configPath = `${INTEGRATIONS_DIR}/trino/${instanceName}.json`;
+		const discoveryReason = config.ambient_env ? trinoDiscoveryReason(config) : undefined;
 		Object.assign(env, {
 			[`${prefix}_URL`]: url,
 			[`${prefix}_CONFIG`]: configPath,
@@ -312,16 +316,6 @@ export const trino = defineIntegration({
 				? {
 						[`${prefix}_AUTH_USER`]: config.auth.username,
 						[`${prefix}_PASSWORD`]: config.auth.password,
-					}
-				: {}),
-			...(config.ambient_env
-				? {
-						TRINO_HOST: config.host,
-						TRINO_PORT: String(config.port),
-						TRINO_USER: user,
-						TRINO_CATALOG: config.default_catalog ?? '',
-						...(config.default_schema ? { TRINO_SCHEMA: config.default_schema } : {}),
-						...(config.auth.method === 'basic' ? { TRINO_PASSWORD: config.auth.password } : {}),
 					}
 				: {}),
 		});
@@ -370,6 +364,24 @@ export const trino = defineIntegration({
 
 		return {
 			env,
+			...(config.ambient_env && discoveryReason === undefined
+				? {
+						discoveryEnv: {
+							TRINO_HOST: config.host,
+							TRINO_PORT: String(config.port),
+							TRINO_USER: user,
+							TRINO_CATALOG: config.default_catalog!,
+							...(config.default_schema ? { TRINO_SCHEMA: config.default_schema } : {}),
+							...(config.auth.method === 'basic' ? { TRINO_PASSWORD: config.auth.password } : {}),
+						},
+					}
+				: {}),
+			warnings: discoveryReason
+				? [
+						`Integration "${instanceName}" is available through its notebook snippet, but not ` +
+							`automatic data-source discovery because ${discoveryReason}.`,
+					]
+				: [],
 			files,
 			manifestExtra: { host: config.host, auth_method: config.auth.method },
 		};

--- a/packages/core/src/services/integrations/sdk.ts
+++ b/packages/core/src/services/integrations/sdk.ts
@@ -55,6 +55,14 @@ export interface RenderOutput {
 	 * emitting the same key with different values is a hard error.
 	 */
 	env?: Record<string, string>;
+	/**
+	 * Vendor-standard variables that enable marimo's data-source discovery.
+	 * The bundler applies this object atomically and skips it when another
+	 * integration already claims any key.
+	 */
+	discoveryEnv?: Record<string, string>;
+	/** User-safe notices produced while rendering this instance. */
+	warnings?: string[];
 	/** User-safe metadata copied into this instance's manifest entry. */
 	manifestExtra?: Record<string, unknown>;
 }

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -51,6 +51,26 @@ const azureObjectKind: IntegrationKind = {
 	title: 'Azure Blob',
 };
 
+const pysparkKind: IntegrationKind = {
+	...icebergKind,
+	kind: 'pyspark',
+	title: 'PySpark (Spark Connect)',
+	description: 'Remote PySpark DataFrame sessions over Spark Connect.',
+	category: 'engine',
+	brand: { icon: 'apachespark', color: '#E25A1C' },
+	supports_test: false,
+	supports_browse: false,
+	browse_surfaces: [],
+	requirements: ['pyspark[connect]>=4.2'],
+};
+
+const sparkEntry: IntegrationEntry = {
+	...lakeEntry,
+	id: 'intg_spark',
+	kind: 'pyspark',
+	name: 'analytics-prod',
+};
+
 const SNIPPET = 'from pyiceberg.catalog import load_catalog\n\ncatalog = load_catalog("lake")';
 
 function ok(data: unknown) {
@@ -262,7 +282,7 @@ function makeFetch({
 				},
 			});
 		}
-		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse`)) {
+		if (url.includes(`/api/v1/projects/${PID}/integrations/${entry.id}/browse`)) {
 			if (objectFailures.capability) return failed(objectFailures.capability);
 			if (kind.browse_surfaces.includes('objects')) {
 				return ok({
@@ -356,6 +376,34 @@ afterEach(() => {
 });
 
 describe('DataBrowserPage', () => {
+	it('shows PySpark connection info and opens its session snippet in a notebook', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = setup(`/projects/${PID}/data/${sparkEntry.id}`, {
+			kind: pysparkKind,
+			entry: sparkEntry,
+		});
+
+		expect(await screen.findByTestId('browse-integration')).toHaveTextContent('analytics-prod');
+		expect(
+			screen.getByText(/cannot inspect its catalogs without opening a Spark session/),
+		).toBeInTheDocument();
+		expect(screen.getByText('pyspark[connect]>=4.2')).toBeInTheDocument();
+		expect(screen.getByText(/SparkSession\.builder\.remote/)).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: 'Create PySpark Notebook' }));
+
+		await waitFor(() => {
+			expect(screen.getByTestId('location').textContent).toContain(
+				`/projects/${PID}/notebooks/nb_1`,
+			);
+		});
+		const post = fetchImpl.mock.calls.find(([, init]) => init?.method === 'POST');
+		const body = JSON.parse(String(post?.[1]?.body)) as { title: string; code: string };
+		expect(body.title).toBe('connect_analytics_prod');
+		expect(body.code).toContain('.joinpath("pyspark", "analytics-prod.json")');
+		expect(body.code).toContain('builder.getOrCreate()');
+	});
+
 	it('shows a disabled Query control with the server blocker reason', async () => {
 		setup(`/projects/${PID}/data/${IID}`, {
 			role: 'manager',
@@ -484,7 +532,7 @@ describe('DataBrowserPage', () => {
 		const user = userEvent.setup();
 		const fetchImpl = setup(`/projects/${PID}/data/${IID}?ns=sales&table=orders`);
 
-		await user.click(await screen.findByRole('button', { name: /Open in notebook/ }));
+		await user.click(await screen.findByRole('button', { name: /Open in Notebook/ }));
 
 		await waitFor(() => {
 			expect(screen.getByTestId('location').textContent).toContain(
@@ -1164,7 +1212,7 @@ describe('DataBrowserPage', () => {
 			`/projects/${PID}/data/${IID}?surface=objects&bucket=lake&key=events.jsonl`,
 			{ kind: objectKind, entry: { ...lakeEntry, kind: 's3' } },
 		);
-		await user.click(await screen.findByRole('button', { name: 'Open in notebook' }));
+		await user.click(await screen.findByRole('button', { name: 'Open in Notebook' }));
 		await waitFor(() =>
 			expect(screen.getByTestId('location')).toHaveTextContent(`/projects/${PID}/notebooks/nb_1`),
 		);
@@ -1191,8 +1239,8 @@ describe('DataBrowserPage', () => {
 			},
 		);
 
-		await user.click(await screen.findByRole('button', { name: 'Open in notebook' }));
-		const pending = await screen.findByRole('button', { name: 'Creating notebook…' });
+		await user.click(await screen.findByRole('button', { name: 'Open in Notebook' }));
+		const pending = await screen.findByRole('button', { name: 'Creating Notebook…' });
 		expect(pending).toBeDisabled();
 		await user.click(pending);
 		expect(
@@ -1213,9 +1261,9 @@ describe('DataBrowserPage', () => {
 			entry: { ...lakeEntry, kind: 's3' },
 			notebookFailure: 'Notebook creation failed.',
 		});
-		await user.click(await screen.findByRole('button', { name: 'Open in notebook' }));
+		await user.click(await screen.findByRole('button', { name: 'Open in Notebook' }));
 		await waitFor(() =>
-			expect(screen.getByRole('button', { name: 'Open in notebook' })).toBeEnabled(),
+			expect(screen.getByRole('button', { name: 'Open in Notebook' })).toBeEnabled(),
 		);
 		expect(screen.getByTestId('location')).toHaveTextContent('key=events.jsonl');
 		expect(screen.getByText('s3://lake/events.jsonl')).toBeInTheDocument();
@@ -1314,6 +1362,6 @@ describe('DataBrowserPage', () => {
 		setup(`/projects/${PID}/data/intg_ghost?ns=sales&table=orders`);
 
 		expect(await screen.findByTestId('browse-integration')).toBeInTheDocument();
-		expect(await screen.findByText('Select a table')).toBeInTheDocument();
+		expect(await screen.findByText('Select an Integration')).toBeInTheDocument();
 	});
 });

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -6,13 +6,10 @@ import { useQueryClient } from '@tanstack/react-query';
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 import {
 	ArrowLeft,
-	Check,
 	ChevronDown,
 	ChevronRight,
-	Copy,
 	Database,
 	Folder,
-	NotebookPen,
 	RefreshCw,
 	Table2,
 } from 'lucide-react';
@@ -20,7 +17,6 @@ import {
 	Button,
 	Chip,
 	EmptyState,
-	IconButton,
 	IconLink,
 	SearchField,
 	Skeleton,
@@ -38,7 +34,6 @@ import {
 	useIntegrationsQuery,
 	useProjectQuery,
 } from '@/api/hooks';
-import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { BRAND_ICONS } from '@/components/Project/brandIcons';
 import {
 	objectBrowseCapability,
@@ -46,11 +41,12 @@ import {
 	supportsTableBrowse,
 	tableBrowseCapability,
 } from '@/lib/integrationBrowse';
+import { integrationNotebookInfo, supportsIntegrationDataPage } from '@/lib/integrationNotebook';
 import { formatRelative } from '@/lib/time';
 import { errorMessage } from '@/lib/errors';
 import { cn } from '@/lib/utils';
 import type { IntegrationEntry, IntegrationKind } from '@/types';
-import { useSeededNotebook } from './notebookSeed';
+import { NotebookSnippet, OpenInNotebookButton } from './NotebookActions';
 import { ObjectBrowser } from './ObjectBrowser';
 import { TabularPreviewGrid } from './TabularPreviewGrid';
 
@@ -115,14 +111,13 @@ export default function DataBrowserPage() {
 	const { data: entries } = useIntegrationsQuery({ pid: pid! }, available);
 
 	const kindsByName = useMemo(() => new Map((kinds ?? []).map((k) => [k.kind, k])), [kinds]);
-	const browsable = useMemo(
+	const dataIntegrations = useMemo(
 		() =>
 			(entries ?? []).filter(
 				(entry) =>
 					entry.enabled &&
 					!entry.shadowed &&
-					(supportsTableBrowse(kindsByName.get(entry.kind)) ||
-						supportsObjectBrowse(kindsByName.get(entry.kind))),
+					supportsIntegrationDataPage(kindsByName.get(entry.kind)),
 			),
 		[entries, kindsByName],
 	);
@@ -183,8 +178,14 @@ export default function DataBrowserPage() {
 	const selectIntegration = (entry: IntegrationEntry) => {
 		// A different integration means a different tree; selection does not carry.
 		const kind = kindsByName.get(entry.kind);
-		const surface = supportsTableBrowse(kind) ? 'tables' : 'objects';
-		void navigate(`/projects/${pid}/data/${entry.id}?surface=${surface}`);
+		const surface = supportsTableBrowse(kind)
+			? 'tables'
+			: supportsObjectBrowse(kind)
+				? 'objects'
+				: undefined;
+		void navigate(
+			`/projects/${pid}/data/${entry.id}${surface === undefined ? '' : `?surface=${surface}`}`,
+		);
 	};
 
 	const refresh = async () => {
@@ -196,8 +197,11 @@ export default function DataBrowserPage() {
 		}
 	};
 
-	const selected = browsable.find((entry) => entry.id === iid);
+	const selected = dataIntegrations.find((entry) => entry.id === iid);
 	const selectedKind = selected ? kindsByName.get(selected.kind) : undefined;
+	const selectedNotebookInfo = selected
+		? integrationNotebookInfo(selected, selectedKind)
+		: undefined;
 	const requestedSurface = searchParams.get('surface');
 	const selectedCapability = useBrowseCapabilityQuery(pid!, iid ?? '', selected !== undefined);
 	const querySurface = selectedCapability.data?.surfaces.query;
@@ -322,11 +326,11 @@ export default function DataBrowserPage() {
 					message="Data browsing is not available"
 					description="It may be disabled on this deployment, or your role in this project cannot browse data."
 				/>
-			) : browsable.length === 0 ? (
+			) : dataIntegrations.length === 0 ? (
 				<EmptyState
 					icon={<Database />}
-					message="Nothing to browse"
-					description="No enabled integration in this project supports browsing."
+					message="No data integrations"
+					description="No enabled integration in this project can be explored here."
 				/>
 			) : (
 				<div className="grid min-h-0 flex-1 grid-cols-[minmax(18rem,1fr)_minmax(0,2fr)] gap-4 text-sm max-lg:grid-cols-1 max-lg:overflow-y-auto">
@@ -340,7 +344,7 @@ export default function DataBrowserPage() {
 							/>
 						)}
 						<div className="min-h-0 flex-1 overflow-y-auto">
-							{browsable.map((entry) => (
+							{dataIntegrations.map((entry) => (
 								<IntegrationSection
 									key={entry.id}
 									projectId={pid!}
@@ -400,6 +404,13 @@ export default function DataBrowserPage() {
 									}
 								/>
 							)
+						) : selected && selectedKind && selectedNotebookInfo ? (
+							<NotebookIntegrationDetail
+								projectId={pid!}
+								integration={selected}
+								kind={selectedKind}
+								info={selectedNotebookInfo}
+							/>
 						) : selected && selection ? (
 							<TableDetail
 								// Remount per table so per-table state (the column filter)
@@ -410,17 +421,97 @@ export default function DataBrowserPage() {
 								selection={selection}
 								previewAvailable={selectedTableCapability?.preview ?? false}
 							/>
-						) : (
+						) : selected ? (
 							<EmptyState
 								icon={<Table2 />}
-								message="Select a table"
-								description="Pick an integration on the left, then drill into a namespace and choose a table to see its schema, stats, and a ready-to-paste load snippet."
+								message="Select a Table"
+								description="Drill into a namespace and choose a table to see its schema, stats, and a ready-to-paste load snippet."
+							/>
+						) : (
+							<EmptyState
+								icon={<Database />}
+								message="Select an Integration"
+								description="Choose an integration to browse its data or connect from a notebook."
 							/>
 						)}
 					</div>
 				</div>
 			)}
 		</div>
+	);
+}
+
+function NotebookIntegrationDetail({
+	projectId,
+	integration,
+	kind,
+	info,
+}: {
+	projectId: string;
+	integration: IntegrationEntry;
+	kind: IntegrationKind;
+	info: NonNullable<ReturnType<typeof integrationNotebookInfo>>;
+}) {
+	const iconSlug = kind.brand.icon;
+	const BrandIcon = iconSlug ? BRAND_ICONS[iconSlug] : undefined;
+	const notebook = {
+		title: `connect_${integration.name.replaceAll('-', '_')}`,
+		heading: `${kind.title}: ${integration.name}`,
+		description: `Connect to the ${integration.name} ${kind.title} integration.`,
+		snippet: info.snippet,
+	};
+
+	return (
+		<article className="flex h-full flex-col gap-6 overflow-y-auto rounded-xl border bg-card p-5 sm:p-6">
+			<header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+				<div className="flex min-w-0 items-center gap-3">
+					<div
+						className="flex size-11 shrink-0 items-center justify-center rounded-xl border bg-background"
+						style={{ color: kind.brand.color }}
+					>
+						{BrandIcon ? (
+							<BrandIcon className="size-6" aria-hidden />
+						) : (
+							<Database className="size-5" aria-hidden />
+						)}
+					</div>
+					<div className="min-w-0">
+						<p className="text-sm text-muted-foreground" translate="no">
+							{kind.title}
+						</p>
+						<h2 className="break-words text-xl font-semibold text-balance" translate="no">
+							{integration.name}
+						</h2>
+					</div>
+				</div>
+				<OpenInNotebookButton
+					projectId={projectId}
+					notebook={notebook}
+					label="Create PySpark Notebook"
+					className="w-full sm:w-auto"
+				/>
+			</header>
+
+			<section className="max-w-3xl rounded-lg border border-primary/20 bg-primary/5 p-4">
+				<h3 className="font-medium">Connect from a Notebook</h3>
+				<p className="mt-1 text-sm text-pretty text-muted-foreground">{info.description}</p>
+			</section>
+
+			{kind.requirements.length > 0 && (
+				<section className="flex flex-col gap-2">
+					<h3 className="text-sm font-medium">Required Package</h3>
+					<div className="flex flex-wrap gap-1.5">
+						{kind.requirements.map((requirement) => (
+							<Chip key={requirement}>
+								<code translate="no">{requirement}</code>
+							</Chip>
+						))}
+					</div>
+				</section>
+			)}
+
+			<NotebookSnippet snippet={info.snippet} title="PySpark Connection Code" />
+		</article>
 	);
 }
 
@@ -712,22 +803,8 @@ function TableDetail({
 		selection.namespace,
 		selection.table,
 	);
-	const { copied, copy } = useCopyToClipboard();
 	const [columnFilter, setColumnFilter] = useState('');
-	const seededNotebook = useSeededNotebook(projectId);
 	const qualifiedName = [...selection.namespace, selection.table].join('.');
-
-	const openInNotebook = async () => {
-		const snippet = schema.data?.snippet;
-		if (!snippet) return;
-		const title = `explore_${selection.table}`;
-		await seededNotebook.create({
-			title,
-			heading: qualifiedName,
-			description: `Explore ${qualifiedName} via the ${integration.name} integration`,
-			snippet,
-		});
-	};
 
 	if (schema.data === undefined) {
 		return schema.error ? (
@@ -806,14 +883,15 @@ function TableDetail({
 					</span>
 				</div>
 				{schema.data.snippet && (
-					<Button
-						variant="primary"
-						onPress={() => void openInNotebook()}
-						isDisabled={seededNotebook.isPending}
-					>
-						<NotebookPen className="size-4" />
-						{seededNotebook.isPending ? 'Creating…' : 'Open in notebook'}
-					</Button>
+					<OpenInNotebookButton
+						projectId={projectId}
+						notebook={{
+							title: `explore_${selection.table}`,
+							heading: qualifiedName,
+							description: `Explore ${qualifiedName} via the ${integration.name} integration`,
+							snippet: schema.data.snippet,
+						}}
+					/>
 				)}
 			</div>
 
@@ -868,21 +946,7 @@ function TableDetail({
 			)}
 
 			{schema.data.snippet && (
-				<div className="flex flex-col gap-1.5">
-					<div className="flex items-center justify-between">
-						<span className="text-xs font-medium text-muted-foreground">Load in a notebook</span>
-						<IconButton
-							label={copied ? 'Copied' : 'Copy snippet'}
-							tooltip={copied ? 'Copied' : 'Copy snippet'}
-							onPress={() => void copy(schema.data.snippet ?? '')}
-						>
-							{copied ? <Check className="size-4 text-primary" /> : <Copy className="size-4" />}
-						</IconButton>
-					</div>
-					<pre className="overflow-x-auto rounded-md border border-input bg-muted/40 p-3 font-mono text-xs">
-						{schema.data.snippet}
-					</pre>
-				</div>
+				<NotebookSnippet snippet={schema.data.snippet} title="Load in a Notebook" />
 			)}
 		</div>
 	);

--- a/packages/web/src/components/DataBrowser/NotebookActions.tsx
+++ b/packages/web/src/components/DataBrowser/NotebookActions.tsx
@@ -1,0 +1,70 @@
+import { Check, Copy, NotebookPen } from 'lucide-react';
+import { Button } from '@/components/ui';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { cn } from '@/lib/utils';
+import { useSeededNotebook } from './notebookSeed';
+
+export interface SeededNotebook {
+	title: string;
+	heading: string;
+	description: string;
+	snippet: string;
+}
+
+export function OpenInNotebookButton({
+	projectId,
+	notebook,
+	label = 'Open in Notebook',
+	className,
+}: {
+	projectId: string;
+	notebook: SeededNotebook;
+	label?: string;
+	className?: string;
+}) {
+	const seededNotebook = useSeededNotebook(projectId);
+	return (
+		<Button
+			variant="primary"
+			className={className}
+			onPress={() => void seededNotebook.create(notebook)}
+			isDisabled={seededNotebook.isPending}
+		>
+			<NotebookPen className="size-4" aria-hidden />
+			<span aria-live="polite">{seededNotebook.isPending ? 'Creating Notebook…' : label}</span>
+		</Button>
+	);
+}
+
+export function NotebookSnippet({
+	snippet,
+	title = 'Notebook Code',
+	className,
+}: {
+	snippet: string;
+	title?: string;
+	className?: string;
+}) {
+	const { copied, copy } = useCopyToClipboard();
+	return (
+		<section className={cn('flex min-w-0 flex-col gap-2', className)}>
+			<div className="flex min-h-9 items-center justify-between gap-3">
+				<h3 className="text-sm font-medium text-foreground">{title}</h3>
+				<Button variant="ghost" size="sm" onPress={() => void copy(snippet)}>
+					{copied ? (
+						<Check className="size-4 text-primary" aria-hidden />
+					) : (
+						<Copy className="size-4" aria-hidden />
+					)}
+					<span aria-live="polite">{copied ? 'Copied' : 'Copy Snippet'}</span>
+				</Button>
+			</div>
+			<pre
+				translate="no"
+				className="max-h-96 overflow-auto rounded-lg border border-input bg-muted/40 p-4 font-mono text-xs leading-5"
+			>
+				<code>{snippet}</code>
+			</pre>
+		</section>
+	);
+}

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -13,7 +13,6 @@ import {
 	Folder,
 	HardDrive,
 	Link2,
-	NotebookPen,
 	Search,
 	X,
 } from 'lucide-react';
@@ -45,7 +44,7 @@ import type {
 	IntegrationObjectEntry,
 	IntegrationObjectPreview,
 } from '@/types';
-import { useSeededNotebook } from './notebookSeed';
+import { OpenInNotebookButton } from './NotebookActions';
 import { TabularPreviewGrid } from './TabularPreviewGrid';
 
 type ObjectCapability = NonNullable<IntegrationBrowseCapability['surfaces']['objects']>;
@@ -729,7 +728,6 @@ function ObjectDetail({
 		versionsAvailable,
 	);
 	const preview = useObjectPreview(projectId, integration.id);
-	const seededNotebook = useSeededNotebook(projectId);
 	if (!detail.data) {
 		return detail.error ? (
 			<p className="text-destructive">
@@ -752,16 +750,6 @@ function ObjectDetail({
 		versionId,
 		etag: detail.data.etag,
 	});
-	const openInNotebook = async () => {
-		if (!detail.data.snippet) return;
-		const title = `explore_${safeNotebookTitle(objectKey)}`;
-		await seededNotebook.create({
-			title,
-			heading: displayLocation,
-			description: `Explore ${displayLocation} via the ${integration.name} integration`,
-			snippet: detail.data.snippet,
-		});
-	};
 	return (
 		<div className="flex flex-col gap-4">
 			<div className="flex flex-col gap-2.5">
@@ -775,14 +763,15 @@ function ObjectDetail({
 				</div>
 				<div className="flex flex-wrap items-center gap-2">
 					{detail.data.snippet && (
-						<Button
-							variant="primary"
-							isDisabled={seededNotebook.isPending}
-							onPress={() => void openInNotebook()}
-						>
-							<NotebookPen className="size-4" aria-hidden />
-							{seededNotebook.isPending ? 'Creating notebook…' : 'Open in notebook'}
-						</Button>
+						<OpenInNotebookButton
+							projectId={projectId}
+							notebook={{
+								title: `explore_${safeNotebookTitle(objectKey)}`,
+								heading: displayLocation,
+								description: `Explore ${displayLocation} via the ${integration.name} integration`,
+								snippet: detail.data.snippet,
+							}}
+						/>
 					)}
 					{downloadAvailable && (
 						<a

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -77,7 +77,7 @@ import {
 	useIntegrationKindsQuery,
 	useIntegrationsQuery,
 } from '@/api/hooks';
-import { supportsTableBrowse } from '@/lib/integrationBrowse';
+import { supportsIntegrationDataPage } from '@/lib/integrationNotebook';
 import { AppSessionIndicator } from './AppSessionIndicator';
 import { ProjectMembersDialog } from './ProjectMembersDialog';
 import { ProjectEnvironmentDialog } from './ProjectEnvironmentDialog';
@@ -201,12 +201,15 @@ export function Project() {
 	const projectAlertsAvailable = (capabilities?.project_alerts?.available ?? false) && canManage;
 	const { data: integrationKinds } = useIntegrationKindsQuery(dataBrowserAvailable);
 	const { data: projectIntegrations } = useIntegrationsQuery({ pid: pid! }, dataBrowserAvailable);
-	const browsableKinds = new Set(
-		(integrationKinds ?? []).filter(supportsTableBrowse).map((kind) => kind.kind),
-	);
-	const browsableIntegrations = (projectIntegrations ?? []).filter(
-		(entry) => entry.enabled && !entry.shadowed && browsableKinds.has(entry.kind),
-	);
+	const dataIntegrations = useMemo(() => {
+		const kindsByName = new Map((integrationKinds ?? []).map((kind) => [kind.kind, kind]));
+		return (projectIntegrations ?? []).filter(
+			(entry) =>
+				entry.enabled &&
+				!entry.shadowed &&
+				supportsIntegrationDataPage(kindsByName.get(entry.kind)),
+		);
+	}, [integrationKinds, projectIntegrations]);
 
 	const editProjectForm = useAppForm({
 		defaultValues: { name: project.name, description: project.description },
@@ -598,7 +601,7 @@ export function Project() {
 								<Bell className="size-4" />
 							</IconButton>
 						)}
-						{dataBrowserAvailable && browsableIntegrations.length > 0 && (
+						{dataBrowserAvailable && dataIntegrations.length > 0 && (
 							<IconLink to={`/projects/${pid}/data`} label="Browse data" tooltip="Browse data">
 								<Database className="size-4" />
 							</IconLink>

--- a/packages/web/src/lib/integrationNotebook.test.ts
+++ b/packages/web/src/lib/integrationNotebook.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { IntegrationEntry, IntegrationKind } from '@/types';
+import { integrationNotebookInfo, supportsIntegrationDataPage } from './integrationNotebook';
+
+const entry = {
+	id: 'intg_spark',
+	kind: 'pyspark',
+	name: 'analytics-prod',
+	enabled: true,
+	current_version: 1,
+	created_by: 'u_1',
+	created_at: '2026-01-01T00:00:00Z',
+	updated_at: '2026-01-01T00:00:00Z',
+	scope: 'project',
+} satisfies IntegrationEntry;
+
+const kind = {
+	kind: 'pyspark',
+	title: 'PySpark (Spark Connect)',
+	description: 'Remote PySpark DataFrame sessions over Spark Connect.',
+	category: 'engine',
+	brand: { icon: 'apachespark', color: '#E25A1C' },
+	schema_version: 1,
+	json_schema: { type: 'object' },
+	ui_hints: {},
+	supports_test: false,
+	supports_browse: false,
+	browse_surfaces: [],
+	secret_sources: { inline: false, references: [] },
+	requirements: ['pyspark[connect]>=4.2'],
+} satisfies IntegrationKind;
+
+describe('integrationNotebookInfo', () => {
+	it('builds a PySpark session from the rendered instance descriptor', () => {
+		const info = integrationNotebookInfo(entry, kind);
+
+		expect(info?.snippet).toContain('.joinpath("pyspark", "analytics-prod.json")');
+		expect(info?.snippet).toContain('SparkSession.builder.remote');
+		expect(info?.snippet).toContain('descriptor["spark_config"]');
+	});
+
+	it('does not claim notebook guidance for unrelated integrations', () => {
+		expect(integrationNotebookInfo({ ...entry, kind: 'custom_env' }, undefined)).toBeUndefined();
+	});
+
+	it('includes PySpark and browsable kinds on the project Data page', () => {
+		expect(supportsIntegrationDataPage(kind)).toBe(true);
+		expect(supportsIntegrationDataPage({ ...kind, kind: 's3', browse_surfaces: ['objects'] })).toBe(
+			true,
+		);
+		expect(supportsIntegrationDataPage(undefined)).toBe(false);
+	});
+});

--- a/packages/web/src/lib/integrationNotebook.test.ts
+++ b/packages/web/src/lib/integrationNotebook.test.ts
@@ -40,7 +40,9 @@ describe('integrationNotebookInfo', () => {
 	});
 
 	it('does not claim notebook guidance for unrelated integrations', () => {
-		expect(integrationNotebookInfo({ ...entry, kind: 'custom_env' }, undefined)).toBeUndefined();
+		expect(
+			integrationNotebookInfo({ ...entry, kind: 'custom_env' }, { ...kind, kind: 'custom_env' }),
+		).toBeUndefined();
 	});
 
 	it('includes PySpark and browsable kinds on the project Data page', () => {

--- a/packages/web/src/lib/integrationNotebook.ts
+++ b/packages/web/src/lib/integrationNotebook.ts
@@ -1,0 +1,49 @@
+import type { IntegrationEntry, IntegrationKind } from '@/types';
+import { supportsObjectBrowse, supportsTableBrowse } from './integrationBrowse';
+
+export interface IntegrationNotebookInfo {
+	description: string;
+	snippet: string;
+}
+
+const NOTEBOOK_INFO_BUILDERS: Record<string, (entry: IntegrationEntry) => IntegrationNotebookInfo> =
+	{
+		pyspark(entry) {
+			return {
+				description:
+					'PySpark connects from the notebook process over Spark Connect. The hub cannot inspect its catalogs without opening a Spark session, so tables are available through PySpark rather than the server-side browser.',
+				snippet: [
+					'import json',
+					'import os',
+					'from pathlib import Path',
+					'from pyspark.sql import SparkSession',
+					'',
+					`descriptor_path = Path(os.environ["MARIMOHUB_INTEGRATIONS_DIR"]).joinpath("pyspark", ${JSON.stringify(`${entry.name}.json`)})`,
+					'descriptor = json.loads(descriptor_path.read_text())',
+					'builder = SparkSession.builder.remote(os.environ[descriptor["remote_env"]])',
+					'if app_name := descriptor.get("app_name"):',
+					'    builder = builder.appName(app_name)',
+					'for key, value in descriptor["spark_config"].items():',
+					'    builder = builder.config(key, value)',
+					'spark = builder.getOrCreate()',
+					'spark',
+				].join('\n'),
+			};
+		},
+	};
+
+export function integrationNotebookInfo(
+	entry: IntegrationEntry,
+	kind: IntegrationKind | undefined,
+): IntegrationNotebookInfo | undefined {
+	if (kind === undefined) return undefined;
+	return NOTEBOOK_INFO_BUILDERS[kind.kind]?.(entry);
+}
+
+export function supportsIntegrationDataPage(kind: IntegrationKind | undefined): boolean {
+	return (
+		supportsTableBrowse(kind) ||
+		supportsObjectBrowse(kind) ||
+		(kind !== undefined && NOTEBOOK_INFO_BUILDERS[kind.kind] !== undefined)
+	);
+}


### PR DESCRIPTION
Discovery env vars now default on. When multiple instances claim the same vendor-standard names, the bundler picks one connection and surfaces a user-safe warning instead of erroring — every instance stays available through its namespaced variables and notebook snippet. Warnings propagate through the session render and are tagged on the session span. Docs and integration schema updated accordingly.