### PR TITLE
feat(web): promote data browser entry to a labeled header button

### DIFF
--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -38,6 +38,7 @@ import {
 	DropdownMenu,
 	IconButton,
 	IconLink,
+	LinkButton,
 	RowLink,
 	SearchField,
 	ConfirmDialog,
@@ -543,6 +544,12 @@ export function Project() {
 			<PageHeader
 				actions={
 					<div className="flex items-center gap-1.5">
+						{dataBrowserAvailable && dataIntegrations.length > 0 && (
+							<LinkButton to={`/projects/${pid}/data`} aria-label="Browse data">
+								<Database className="size-4" />
+								<span className="max-sm:hidden">Browse data</span>
+							</LinkButton>
+						)}
 						<Button variant="primary" onPress={uploadModal.open}>
 							<Plus className="size-4" />
 							New Notebook
@@ -600,11 +607,6 @@ export function Project() {
 							>
 								<Bell className="size-4" />
 							</IconButton>
-						)}
-						{dataBrowserAvailable && dataIntegrations.length > 0 && (
-							<IconLink to={`/projects/${pid}/data`} label="Browse data" tooltip="Browse data">
-								<Database className="size-4" />
-							</IconLink>
 						)}
 						<IconButton label="Edit project" tooltip="Edit project" onPress={editProjectModal.open}>
 							<Pencil className="size-4" />

--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -1,5 +1,7 @@
 import { Button as AriaButton } from 'react-aria-components';
 import type { ButtonProps as AriaButtonProps } from 'react-aria-components';
+import { Link } from 'react-router-dom';
+import type { LinkProps } from 'react-router-dom';
 import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
@@ -55,5 +57,29 @@ export function Button({
 		<AriaButton className={cn(buttonVariants({ variant, size }), className)} {...props}>
 			{children}
 		</AriaButton>
+	);
+}
+
+export interface LinkButtonProps extends Omit<LinkProps, 'className'> {
+	variant?: 'default' | 'primary' | 'ghost' | 'danger';
+	size?: 'sm' | 'md';
+	className?: string;
+}
+
+/**
+ * Like `Button`, but renders a react-router `<Link>` so cmd/ctrl/middle-click
+ * open the target in a new tab. Use for labeled navigation styled as a button.
+ */
+export function LinkButton({
+	variant = 'default',
+	size = 'md',
+	className = '',
+	children,
+	...props
+}: LinkButtonProps) {
+	return (
+		<Link className={cn(buttonVariants({ variant, size }), className)} {...props}>
+			{children}
+		</Link>
 	);
 }

--- a/packages/web/src/components/ui/index.ts
+++ b/packages/web/src/components/ui/index.ts
@@ -1,8 +1,8 @@
 export { Brand } from './Brand';
 export type { BrandProps } from './Brand';
 
-export { Button } from './Button';
-export type { ButtonProps } from './Button';
+export { Button, LinkButton } from './Button';
+export type { ButtonProps, LinkButtonProps } from './Button';
 
 export { Chip } from './Chip';
 


### PR DESCRIPTION
The only way into the project data browser was an unlabeled 16px `Database` icon in the low-emphasis admin icon strip next to the project title — grouped with access/environment/alerts/edit/delete and parked beside the delete button, so a day-to-day work action read as obscure project settings.

This moves the entry into the page-header actions as a labeled **Browse data** button next to **New Notebook**, where users actually scan for what they can do on the page. It's backed by a new `LinkButton` ui primitive (a react-router `Link` sharing the existing `buttonVariants`, so cmd/ctrl/middle-click open in a new tab). The label collapses to just the icon on small screens, and visibility rules are unchanged (browsable integrations exist, role ≠ viewer).

`pnpm check`, `pnpm typecheck` (web), and the web test suite (824 tests) pass.