### PR TITLE
feat(compute-coreweave): trace CoreWeave sandbox gateway requests

### DIFF
--- a/packages/compute-coreweave/package.json
+++ b/packages/compute-coreweave/package.json
@@ -21,10 +21,13 @@
 	"dependencies": {
 		"@coreweave/cwsandbox": "file:../../vendor/cwsandbox",
 		"@marimo-hub/compute-commons": "workspace:*",
-		"@marimo-hub/core": "workspace:*"
+		"@marimo-hub/core": "workspace:*",
+		"@opentelemetry/api": "catalog:"
 	},
 	"devDependencies": {
 		"@marimo-hub/tsconfig": "workspace:*",
+		"@opentelemetry/context-async-hooks": "catalog:",
+		"@opentelemetry/sdk-trace-base": "catalog:",
 		"@types/node": "catalog:",
 		"typescript": "catalog:",
 		"vite-plus": "catalog:",

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -36,7 +36,11 @@
  * hostname template (the SDK exposes no ingress-URL accessor); and the
  * `waitForPort` probe assumes `python3` is on the image PATH.
  */
-import { CWSandboxNotFoundError } from '@coreweave/cwsandbox';
+import {
+	CWSandboxConfigurationError,
+	CWSandboxNotFoundError,
+	SandboxClient,
+} from '@coreweave/cwsandbox';
 import type {
 	CommandProcess,
 	CommandProcessStatus,
@@ -47,7 +51,11 @@ import type {
 	SandboxInfo,
 	SandboxRunOptions,
 } from '@coreweave/cwsandbox';
-import { createSandboxClient, DEFAULT_CONTAINER_IMAGE } from '@coreweave/cwsandbox/node';
+import {
+	DEFAULT_BASE_URL,
+	DEFAULT_CONTAINER_IMAGE,
+	GrpcSandboxTransport,
+} from '@coreweave/cwsandbox/node';
 import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
@@ -87,6 +95,7 @@ import type {
 	WaitForPortOptions,
 } from '@marimo-hub/core/ports';
 import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
+import { instrumentCoreWeaveTransport } from './tracing';
 
 /** marimo's hardcoded kernel port (see `SandboxProvisioner`'s `MARIMO_PORT`). */
 const DEFAULT_KERNEL_PORT = 2718;
@@ -684,14 +693,18 @@ export class CoreWeaveCompute implements SandboxProvider {
 					'CoreWeaveCompute requires either an apiKey in its config or an injected client',
 				);
 			}
+			const apiKey = this.config.apiKey.trim();
+			if (!apiKey) throw new CWSandboxConfigurationError('CWSandbox API key is required.');
+			const baseUrl = this.config.baseUrl?.trim().replace(/\/+$/, '') || DEFAULT_BASE_URL;
+			const transport = instrumentCoreWeaveTransport(
+				new GrpcSandboxTransport({ apiKey, baseUrl }),
+				baseUrl,
+			);
 			// The real SDK client exposes the CoreWeaveClient surface at runtime; one
 			// controlled cast at the construction boundary avoids overload-variance
 			// friction between the SDK's broad signatures and our narrow seam.
 			// oxlint-disable-next-line anti-slop/no-chained-type-assertions
-			this.client = createSandboxClient({
-				apiKey: this.config.apiKey,
-				...(this.config.baseUrl ? { baseUrl: this.config.baseUrl } : {}),
-			}) as unknown as CoreWeaveClient;
+			this.client = new SandboxClient({ transport }) as unknown as CoreWeaveClient;
 		}
 		return this.client;
 	}

--- a/packages/compute-coreweave/src/tracing.test.ts
+++ b/packages/compute-coreweave/src/tracing.test.ts
@@ -1,5 +1,11 @@
 import { SandboxClient } from '@coreweave/cwsandbox';
-import type { LogStream, SandboxStatus, SandboxTransport } from '@coreweave/cwsandbox';
+import type {
+	CommandProcess,
+	LogStream,
+	ProcessResult,
+	SandboxStatus,
+	SandboxTransport,
+} from '@coreweave/cwsandbox';
 import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
@@ -67,7 +73,8 @@ describe('instrumentCoreWeaveTransport', () => {
 		await transport.delete({ sandboxId: SANDBOX_ID });
 		await transport.exec({ sandboxId: SANDBOX_ID, command: ['true'] });
 		await transport.startCommand({ sandboxId: SANDBOX_ID, command: ['marimo'] });
-		await transport.streamLogs({ sandboxId: SANDBOX_ID, mode: 'lines' });
+		const logStream = await transport.streamLogs({ sandboxId: SANDBOX_ID, mode: 'lines' });
+		await logStream[Symbol.asyncIterator]().next();
 		await transport.stop({ sandboxId: SANDBOX_ID });
 		await transport.writeFile({
 			sandboxId: SANDBOX_ID,
@@ -146,5 +153,57 @@ describe('instrumentCoreWeaveTransport', () => {
 		expect(requestSpan?.status.code).toBe(SpanStatusCode.ERROR);
 		expect(requestSpan?.attributes['error.type']).toBe('Error');
 		expect(requestSpan?.events.some((event) => event.name === 'exception')).toBe(true);
+	});
+
+	it('keeps a command span open and records a failure after the handshake', async () => {
+		let rejectWait!: (error: Error) => void;
+		const wait = new Promise<ProcessResult>((_resolve, reject) => {
+			rejectWait = reject;
+		});
+		const process: CommandProcess = { ...fakeProcess(), wait: () => wait };
+		const raw = fakeTransport();
+		raw.startCommand.mockResolvedValueOnce(process);
+		const transport = instrumentCoreWeaveTransport(raw, 'https://gateway.example');
+
+		await expect(
+			transport.startCommand({ sandboxId: SANDBOX_ID, command: ['marimo'] }),
+		).resolves.toBe(process);
+		expect(exporter.getFinishedSpans()).toHaveLength(0);
+
+		rejectWait(new Error('stream reset'));
+		await vi.waitFor(() => expect(exporter.getFinishedSpans()).toHaveLength(1));
+
+		const span = exporter.getFinishedSpans()[0];
+		expect(span?.name).toBe(`${STREAMING}/StreamExec`);
+		expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+		expect(span?.attributes['error.type']).toBe('Error');
+		expect(span?.events.some((event) => event.name === 'exception')).toBe(true);
+	});
+
+	it('keeps a log span open and records an iterator failure after the handshake', async () => {
+		const failure = new Error('log stream reset');
+		const stream: LogStream = {
+			...emptyLogStream(),
+			async *[Symbol.asyncIterator]() {
+				yield 'ready';
+				throw failure;
+			},
+		};
+		const raw = fakeTransport();
+		raw.streamLogs.mockResolvedValueOnce(stream);
+		const transport = instrumentCoreWeaveTransport(raw, 'https://gateway.example');
+
+		const observed = await transport.streamLogs({ sandboxId: SANDBOX_ID, mode: 'lines' });
+		expect(exporter.getFinishedSpans()).toHaveLength(0);
+		const iterator = observed[Symbol.asyncIterator]();
+		await expect(iterator.next()).resolves.toEqual({ done: false, value: 'ready' });
+		expect(exporter.getFinishedSpans()).toHaveLength(0);
+		await expect(iterator.next()).rejects.toBe(failure);
+
+		const span = exporter.getFinishedSpans()[0];
+		expect(span?.name).toBe(`${STREAMING}/StreamLogs`);
+		expect(span?.status.code).toBe(SpanStatusCode.ERROR);
+		expect(span?.attributes['error.type']).toBe('Error');
+		expect(span?.events.some((event) => event.name === 'exception')).toBe(true);
 	});
 });

--- a/packages/compute-coreweave/src/tracing.test.ts
+++ b/packages/compute-coreweave/src/tracing.test.ts
@@ -1,0 +1,150 @@
+import { SandboxClient } from '@coreweave/cwsandbox';
+import type { LogStream, SandboxStatus, SandboxTransport } from '@coreweave/cwsandbox';
+import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import {
+	BasicTracerProvider,
+	InMemorySpanExporter,
+	SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { fakeProcess, procResult } from './testWorld';
+import { instrumentCoreWeaveTransport } from './tracing';
+
+const exporter = new InMemorySpanExporter();
+const provider = new BasicTracerProvider({
+	spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
+trace.setGlobalTracerProvider(provider);
+context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+
+afterEach(() => exporter.reset());
+afterAll(() => {
+	trace.disable();
+	context.disable();
+});
+
+function emptyLogStream(): LogStream {
+	return {
+		closed: false,
+		offset: undefined,
+		sessionId: undefined,
+		cancel: async () => {},
+		close: async () => {},
+		async *[Symbol.asyncIterator]() {},
+	};
+}
+
+function fakeTransport() {
+	return {
+		start: vi.fn(async () => ({ sandboxId: 'cw-1', status: 'creating' as const })),
+		get: vi.fn(async ({ sandboxId }) => ({ sandboxId, status: 'running' as SandboxStatus })),
+		list: vi.fn(async () => ({ sandboxes: [] })),
+		delete: vi.fn(async () => {}),
+		exec: vi.fn(async () => procResult()),
+		startCommand: vi.fn(async () => fakeProcess()),
+		streamLogs: vi.fn(async () => emptyLogStream()),
+		stop: vi.fn(async () => {}),
+		writeFile: vi.fn(async () => {}),
+		readFile: vi.fn(async () => ({ content: new Uint8Array() })),
+	} satisfies SandboxTransport;
+}
+
+const SANDBOX_ID = 'cw-1';
+const GATEWAY = 'coreweave.sandbox.v1beta2.GatewayService';
+const STREAMING = 'coreweave.sandbox.v1beta2.GatewayStreamingService';
+
+describe('instrumentCoreWeaveTransport', () => {
+	it('spans every transport request with RPC and endpoint attributes', async () => {
+		const transport = instrumentCoreWeaveTransport(
+			fakeTransport(),
+			'https://gateway.example:8443/api',
+		);
+
+		await transport.start({ command: ['sleep', 'infinity'] });
+		await transport.get({ sandboxId: SANDBOX_ID });
+		await transport.list({});
+		await transport.delete({ sandboxId: SANDBOX_ID });
+		await transport.exec({ sandboxId: SANDBOX_ID, command: ['true'] });
+		await transport.startCommand({ sandboxId: SANDBOX_ID, command: ['marimo'] });
+		await transport.streamLogs({ sandboxId: SANDBOX_ID, mode: 'lines' });
+		await transport.stop({ sandboxId: SANDBOX_ID });
+		await transport.writeFile({
+			sandboxId: SANDBOX_ID,
+			path: '/workspace/private.txt',
+			content: new Uint8Array([1]),
+		});
+		await transport.readFile({ sandboxId: SANDBOX_ID, path: '/workspace/private.txt' });
+
+		const spans = exporter.getFinishedSpans();
+		expect(spans.map((span) => span.name)).toEqual([
+			`${GATEWAY}/Start`,
+			`${GATEWAY}/Get`,
+			`${GATEWAY}/List`,
+			`${GATEWAY}/Delete`,
+			`${GATEWAY}/Exec`,
+			`${STREAMING}/StreamExec`,
+			`${STREAMING}/StreamLogs`,
+			`${GATEWAY}/Stop`,
+			`${GATEWAY}/AddFile`,
+			`${GATEWAY}/RetrieveFile`,
+		]);
+		for (const span of spans) {
+			expect(span.kind).toBe(SpanKind.CLIENT);
+			expect(span.attributes).toMatchObject({
+				'rpc.system.name': 'grpc',
+				'rpc.method': span.name,
+				'server.address': 'gateway.example',
+				'server.port': 8443,
+			});
+		}
+		expect(spans[0]?.attributes['coreweave.sandbox_id']).toBe(SANDBOX_ID);
+		expect(spans[2]?.attributes).not.toHaveProperty('coreweave.sandbox_id');
+		expect(JSON.stringify(spans.map((span) => span.attributes))).not.toContain('private.txt');
+		expect(JSON.stringify(spans.map((span) => span.attributes))).not.toContain('marimo');
+	});
+
+	it('captures the SDK request fan-out from boot polling and multi-file writes', async () => {
+		const raw = fakeTransport();
+		raw.get
+			.mockResolvedValueOnce({ sandboxId: SANDBOX_ID, status: 'creating' })
+			.mockResolvedValueOnce({ sandboxId: SANDBOX_ID, status: 'running' });
+		const client = new SandboxClient({
+			transport: instrumentCoreWeaveTransport(raw, 'https://gateway.example'),
+		});
+		const sandbox = await client.create({ waitUntilRunning: false });
+
+		await sandbox.wait({ intervalMs: 1 });
+		await sandbox.files.write([
+			{ path: '/workspace/a.txt', content: 'a' },
+			{ path: '/workspace/b.txt', content: 'b' },
+		]);
+
+		expect(exporter.getFinishedSpans().map((span) => span.name)).toEqual([
+			`${GATEWAY}/Start`,
+			`${GATEWAY}/Get`,
+			`${GATEWAY}/Get`,
+			`${GATEWAY}/AddFile`,
+			`${GATEWAY}/AddFile`,
+		]);
+	});
+
+	it('inherits the active compute span and records request failures', async () => {
+		const raw = fakeTransport();
+		raw.get.mockRejectedValueOnce(new Error('gateway unavailable'));
+		const transport = instrumentCoreWeaveTransport(raw, 'https://gateway.example');
+		let parentSpanId = '';
+
+		await provider.getTracer('test').startActiveSpan('SandboxInstance.ready', async (parent) => {
+			parentSpanId = parent.spanContext().spanId;
+			await expect(transport.get({ sandboxId: SANDBOX_ID })).rejects.toThrow('gateway unavailable');
+			parent.end();
+		});
+
+		const requestSpan = exporter.getFinishedSpans().find((span) => span.name === `${GATEWAY}/Get`);
+		expect(requestSpan?.parentSpanContext?.spanId).toBe(parentSpanId);
+		expect(requestSpan?.status.code).toBe(SpanStatusCode.ERROR);
+		expect(requestSpan?.attributes['error.type']).toBe('Error');
+		expect(requestSpan?.events.some((event) => event.name === 'exception')).toBe(true);
+	});
+});

--- a/packages/compute-coreweave/src/tracing.test.ts
+++ b/packages/compute-coreweave/src/tracing.test.ts
@@ -206,4 +206,33 @@ describe('instrumentCoreWeaveTransport', () => {
 		expect(span?.attributes['error.type']).toBe('Error');
 		expect(span?.events.some((event) => event.name === 'exception')).toBe(true);
 	});
+
+	it('ends a log span and closes the iterator when consumption stops early', async () => {
+		let iteratorClosed = false;
+		const stream: LogStream = {
+			...emptyLogStream(),
+			async *[Symbol.asyncIterator]() {
+				try {
+					yield 'first';
+					yield 'second';
+				} finally {
+					iteratorClosed = true;
+				}
+			},
+		};
+		const raw = fakeTransport();
+		raw.streamLogs.mockResolvedValueOnce(stream);
+		const transport = instrumentCoreWeaveTransport(raw, 'https://gateway.example');
+
+		const observed = await transport.streamLogs({ sandboxId: SANDBOX_ID, mode: 'lines' });
+		for await (const line of observed) {
+			expect(line).toBe('first');
+			break;
+		}
+
+		expect(iteratorClosed).toBe(true);
+		const span = exporter.getFinishedSpans()[0];
+		expect(span?.name).toBe(`${STREAMING}/StreamLogs`);
+		expect(span?.status.code).toBe(SpanStatusCode.UNSET);
+	});
 });

--- a/packages/compute-coreweave/src/tracing.ts
+++ b/packages/compute-coreweave/src/tracing.ts
@@ -149,6 +149,19 @@ function observeIterator(
 				throw error;
 			}
 		},
+		async return(value) {
+			try {
+				const result =
+					iterator.return === undefined
+						? { done: true as const, value }
+						: await iterator.return(value);
+				lifecycle.end();
+				return result;
+			} catch (error) {
+				lifecycle.fail(error);
+				throw error;
+			}
+		},
 		[Symbol.asyncIterator]() {
 			return this;
 		},

--- a/packages/compute-coreweave/src/tracing.ts
+++ b/packages/compute-coreweave/src/tracing.ts
@@ -1,0 +1,170 @@
+import type {
+	CommandProcess,
+	DeleteSandboxRequest,
+	ExecRequest,
+	GetSandboxRequest,
+	ListSandboxesResult,
+	LogEntryStream,
+	LogRawStream,
+	LogStream,
+	ProcessResult,
+	ReadFileRequest,
+	ReadFileResult,
+	SandboxTransport,
+	StartCommandRequest,
+	StartSandboxRequest,
+	StartSandboxResult,
+	StopSandboxRequest,
+	StreamLogsRequest,
+	WriteFileRequest,
+} from '@coreweave/cwsandbox';
+import type { Attributes, Span } from '@opentelemetry/api';
+import { SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+
+const GATEWAY_SERVICE = 'coreweave.sandbox.v1beta2.GatewayService';
+const STREAMING_SERVICE = 'coreweave.sandbox.v1beta2.GatewayStreamingService';
+
+function endpointAttributes(baseUrl: string): Attributes {
+	try {
+		const url = new URL(baseUrl);
+		return {
+			'server.address': url.hostname,
+			...(url.port ? { 'server.port': Number(url.port) } : {}),
+		};
+	} catch {
+		return {};
+	}
+}
+
+function errorType(error: unknown): string {
+	if (error instanceof Error) return error.name;
+	return typeof error;
+}
+
+async function rpcRequest<T>(
+	method: string,
+	endpoint: Attributes,
+	request: () => Promise<T>,
+	attributes: Attributes = {},
+	onResult?: (span: Span, result: T) => void,
+): Promise<T> {
+	const tracer = trace.getTracer('@marimo-hub/compute-coreweave');
+	return tracer.startActiveSpan(
+		method,
+		{
+			kind: SpanKind.CLIENT,
+			attributes: {
+				'rpc.system.name': 'grpc',
+				'rpc.method': method,
+				...endpoint,
+				...attributes,
+			},
+		},
+		async (span) => {
+			try {
+				const result = await request();
+				onResult?.(span, result);
+				return result;
+			} catch (error) {
+				span.recordException(error instanceof Error ? error : String(error));
+				span.setAttribute('error.type', errorType(error));
+				span.setStatus({ code: SpanStatusCode.ERROR });
+				throw error;
+			} finally {
+				span.end();
+			}
+		},
+	);
+}
+
+function sandboxAttributes(sandboxId: string): Attributes {
+	return { 'coreweave.sandbox_id': sandboxId };
+}
+
+export function instrumentCoreWeaveTransport(
+	transport: SandboxTransport,
+	baseUrl: string,
+): SandboxTransport {
+	const endpoint = endpointAttributes(baseUrl);
+	const gateway = (method: string) => `${GATEWAY_SERVICE}/${method}`;
+	const streaming = (method: string) => `${STREAMING_SERVICE}/${method}`;
+
+	return {
+		start(request: StartSandboxRequest): Promise<StartSandboxResult> {
+			return rpcRequest(
+				gateway('Start'),
+				endpoint,
+				() => transport.start(request),
+				{},
+				(span, result) => span.setAttribute('coreweave.sandbox_id', result.sandboxId),
+			);
+		},
+		get(request: GetSandboxRequest) {
+			return rpcRequest(
+				gateway('Get'),
+				endpoint,
+				() => transport.get(request),
+				sandboxAttributes(request.sandboxId),
+			);
+		},
+		list(options): Promise<ListSandboxesResult> {
+			return rpcRequest(gateway('List'), endpoint, () => transport.list(options));
+		},
+		delete(request: DeleteSandboxRequest): Promise<void> {
+			return rpcRequest(
+				gateway('Delete'),
+				endpoint,
+				() => transport.delete(request),
+				sandboxAttributes(request.sandboxId),
+			);
+		},
+		exec(request: ExecRequest): Promise<ProcessResult> {
+			return rpcRequest(
+				gateway('Exec'),
+				endpoint,
+				() => transport.exec(request),
+				sandboxAttributes(request.sandboxId),
+			);
+		},
+		startCommand(request: StartCommandRequest): Promise<CommandProcess> {
+			return rpcRequest(
+				streaming('StreamExec'),
+				endpoint,
+				() => transport.startCommand(request),
+				sandboxAttributes(request.sandboxId),
+			);
+		},
+		streamLogs(request: StreamLogsRequest): Promise<LogEntryStream | LogRawStream | LogStream> {
+			return rpcRequest(
+				streaming('StreamLogs'),
+				endpoint,
+				() => transport.streamLogs(request),
+				sandboxAttributes(request.sandboxId),
+			);
+		},
+		stop(request: StopSandboxRequest): Promise<void> {
+			return rpcRequest(
+				gateway('Stop'),
+				endpoint,
+				() => transport.stop(request),
+				sandboxAttributes(request.sandboxId),
+			);
+		},
+		writeFile(request: WriteFileRequest): Promise<void> {
+			return rpcRequest(
+				gateway('AddFile'),
+				endpoint,
+				() => transport.writeFile(request),
+				sandboxAttributes(request.sandboxId),
+			);
+		},
+		readFile(request: ReadFileRequest): Promise<ReadFileResult> {
+			return rpcRequest(
+				gateway('RetrieveFile'),
+				endpoint,
+				() => transport.readFile(request),
+				sandboxAttributes(request.sandboxId),
+			);
+		},
+	};
+}

--- a/packages/compute-coreweave/src/tracing.ts
+++ b/packages/compute-coreweave/src/tracing.ts
@@ -41,12 +41,34 @@ function errorType(error: unknown): string {
 	return typeof error;
 }
 
-async function rpcRequest<T>(
+interface SpanLifecycle {
+	end(): void;
+	fail(error: unknown): void;
+}
+
+function spanLifecycle(span: Span): SpanLifecycle {
+	let ended = false;
+	return {
+		end() {
+			if (ended) return;
+			ended = true;
+			span.end();
+		},
+		fail(error) {
+			if (ended) return;
+			span.recordException(error instanceof Error ? error : String(error));
+			span.setAttribute('error.type', errorType(error));
+			span.setStatus({ code: SpanStatusCode.ERROR });
+			this.end();
+		},
+	};
+}
+
+function startRpcSpan<T>(
 	method: string,
 	endpoint: Attributes,
-	request: () => Promise<T>,
-	attributes: Attributes = {},
-	onResult?: (span: Span, result: T) => void,
+	attributes: Attributes,
+	request: (span: Span) => Promise<T>,
 ): Promise<T> {
 	const tracer = trace.getTracer('@marimo-hub/compute-coreweave');
 	return tracer.startActiveSpan(
@@ -60,21 +82,112 @@ async function rpcRequest<T>(
 				...attributes,
 			},
 		},
-		async (span) => {
+		request,
+	);
+}
+
+async function rpcRequest<T>(
+	method: string,
+	endpoint: Attributes,
+	request: () => Promise<T>,
+	attributes: Attributes = {},
+	onResult?: (span: Span, result: T) => void,
+): Promise<T> {
+	return startRpcSpan(method, endpoint, attributes, async (span) => {
+		const lifecycle = spanLifecycle(span);
+		try {
+			const result = await request();
+			onResult?.(span, result);
+			return result;
+		} catch (error) {
+			lifecycle.fail(error);
+			throw error;
+		} finally {
+			lifecycle.end();
+		}
+	});
+}
+
+function streamingRpcRequest<T>(
+	method: string,
+	endpoint: Attributes,
+	request: () => Promise<T>,
+	attributes: Attributes,
+	observe: (result: T, lifecycle: SpanLifecycle) => T,
+): Promise<T> {
+	return startRpcSpan(method, endpoint, attributes, async (span) => {
+		const lifecycle = spanLifecycle(span);
+		try {
+			return observe(await request(), lifecycle);
+		} catch (error) {
+			lifecycle.fail(error);
+			throw error;
+		}
+	});
+}
+
+function observeCommandProcess(process: CommandProcess, lifecycle: SpanLifecycle): CommandProcess {
+	void process.wait().then(
+		() => lifecycle.end(),
+		(error: unknown) => lifecycle.fail(error),
+	);
+	return process;
+}
+
+function observeIterator(
+	iterator: AsyncIterator<unknown>,
+	lifecycle: SpanLifecycle,
+): AsyncIterator<unknown> & AsyncIterable<unknown> {
+	return {
+		async next() {
 			try {
-				const result = await request();
-				onResult?.(span, result);
+				const result = await iterator.next();
+				if (result.done) lifecycle.end();
 				return result;
 			} catch (error) {
-				span.recordException(error instanceof Error ? error : String(error));
-				span.setAttribute('error.type', errorType(error));
-				span.setStatus({ code: SpanStatusCode.ERROR });
+				lifecycle.fail(error);
 				throw error;
-			} finally {
-				span.end();
 			}
 		},
-	);
+		[Symbol.asyncIterator]() {
+			return this;
+		},
+	};
+}
+
+type CoreWeaveLogStream = LogEntryStream | LogRawStream | LogStream;
+
+function observeLogStream<T extends CoreWeaveLogStream>(stream: T, lifecycle: SpanLifecycle): T {
+	return new Proxy(stream, {
+		get(target, property) {
+			if (property === Symbol.asyncIterator) {
+				return () => observeIterator(target[Symbol.asyncIterator](), lifecycle);
+			}
+			const value: unknown = Reflect.get(target, property, target);
+			if ((property === 'cancel' || property === 'close') && typeof value === 'function') {
+				return (...args: unknown[]) => {
+					let pending: Promise<unknown>;
+					try {
+						pending = Reflect.apply(value, target, args);
+					} catch (error) {
+						lifecycle.fail(error);
+						throw error;
+					}
+					return pending.then(
+						(result) => {
+							lifecycle.end();
+							return result;
+						},
+						(error: unknown) => {
+							lifecycle.fail(error);
+							throw error;
+						},
+					);
+				};
+			}
+			return typeof value === 'function' ? value.bind(target) : value;
+		},
+	});
 }
 
 function sandboxAttributes(sandboxId: string): Attributes {
@@ -127,19 +240,21 @@ export function instrumentCoreWeaveTransport(
 			);
 		},
 		startCommand(request: StartCommandRequest): Promise<CommandProcess> {
-			return rpcRequest(
+			return streamingRpcRequest(
 				streaming('StreamExec'),
 				endpoint,
 				() => transport.startCommand(request),
 				sandboxAttributes(request.sandboxId),
+				observeCommandProcess,
 			);
 		},
 		streamLogs(request: StreamLogsRequest): Promise<LogEntryStream | LogRawStream | LogStream> {
-			return rpcRequest(
+			return streamingRpcRequest(
 				streaming('StreamLogs'),
 				endpoint,
 				() => transport.streamLogs(request),
 				sandboxAttributes(request.sandboxId),
+				observeLogStream,
 			);
 		},
 		stop(request: StopSandboxRequest): Promise<void> {

--- a/packages/compute-coreweave/src/wandb.ts
+++ b/packages/compute-coreweave/src/wandb.ts
@@ -26,6 +26,7 @@ import { SandboxClient } from '@coreweave/cwsandbox';
 import { DEFAULT_BASE_URL, GrpcSandboxTransport } from '@coreweave/cwsandbox/node';
 import { CoreWeaveCompute } from './index';
 import type { CoreWeaveClient, CoreWeaveConfig } from './index';
+import { instrumentCoreWeaveTransport } from './tracing';
 
 /**
  * Version reported in the gateway telemetry headers. The vendored SDK build's
@@ -112,11 +113,15 @@ export function createWandbCompute(
 	const { apiKey, entity, project, baseUrl, ...coreweave } = config;
 	if (client) return new CoreWeaveCompute(coreweave, client);
 
-	const transport = new GrpcSandboxTransport({
-		// `||` (not `??`): a set-but-empty env var must also fall back.
-		baseUrl: baseUrl?.trim() || DEFAULT_BASE_URL,
-		metadata: buildWandbMetadata({ apiKey, entity, project }),
-	});
+	// `||` (not `??`): a set-but-empty env var must also fall back.
+	const gatewayUrl = baseUrl?.trim() || DEFAULT_BASE_URL;
+	const transport = instrumentCoreWeaveTransport(
+		new GrpcSandboxTransport({
+			baseUrl: gatewayUrl,
+			metadata: buildWandbMetadata({ apiKey, entity, project }),
+		}),
+		gatewayUrl,
+	);
 	return new CoreWeaveCompute(
 		{
 			...coreweave,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,10 +729,19 @@ importers:
       '@marimo-hub/core':
         specifier: workspace:*
         version: link:../core
+      '@opentelemetry/api':
+        specifier: 'catalog:'
+        version: 1.9.1
     devDependencies:
       '@marimo-hub/tsconfig':
         specifier: workspace:*
         version: link:../ts-config
+      '@opentelemetry/context-async-hooks':
+        specifier: 'catalog:'
+        version: 2.9.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: 'catalog:'
+        version: 2.9.0(@opentelemetry/api@1.9.1)
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.3


### PR DESCRIPTION
Wraps the CoreWeave `SandboxTransport` in an OTEL-instrumenting decorator (`instrumentCoreWeaveTransport`) so every gateway/streaming RPC emits a CLIENT span with `rpc.*` and `server.*` attributes plus the sandbox id, with exceptions recorded on failure.

- Direct and W&B client construction now build the transport explicitly and wrap it.
- No request payloads (file contents, paths, args) are added to spans.
- New `tracing.test.ts` verifies span fan-out and attribute redaction.