### PR TITLE
feat(integrations): broaden trino/pyspark auto-discovery

### DIFF
--- a/packages/core/src/services/integrations/kinds/kinds.test.ts
+++ b/packages/core/src/services/integrations/kinds/kinds.test.ts
@@ -2072,7 +2072,7 @@ const DISCOVERY_CONTRACT = [
 		overrides: { ssl: { mode: 'disabled' } },
 	},
 	{ kind: 'trino', required: ['TRINO_HOST', 'TRINO_USER', 'TRINO_CATALOG'], overrides: {} },
-	{ kind: 'pyspark', required: ['SPARK_REMOTE'], overrides: { app_name: undefined } },
+	{ kind: 'pyspark', required: ['SPARK_REMOTE'], overrides: {} },
 	{ kind: 's3', required: ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'], overrides: {} },
 ];
 
@@ -2140,6 +2140,29 @@ describe('marimo data-source discovery', () => {
 		expect(env.TRINO_PASSWORD).toBe('pw');
 	});
 
+	it('keeps discovery enabled when marimo omits optional connection settings', () => {
+		const trinoOutput = renderFixture(trino, {
+			ambient_env: true,
+			legacy_prepared_statements: false,
+		});
+		expect(trinoOutput.discoveryEnv?.TRINO_HOST).toBe('trino.internal');
+		expect(trinoOutput.warnings).toEqual([]);
+		expect(
+			new URL(trinoOutput.env?.MARIMOHUB_TRINO_PROD_URL ?? '').searchParams.get(
+				'legacy_prepared_statements',
+			),
+		).toBe('false');
+
+		const pysparkOutput = renderFixture(pyspark, { ambient_env: true, app_name: 'analytics' });
+		expect(pysparkOutput.discoveryEnv?.SPARK_REMOTE).toContain('spark.internal');
+		expect(pysparkOutput.warnings).toEqual([]);
+		const descriptor = JSON.parse(pysparkOutput.files?.[0]?.content ?? '') as Record<
+			string,
+			unknown
+		>;
+		expect(descriptor.app_name).toBe('analytics');
+	});
+
 	it.each([
 		[{ default_catalog: undefined }, /requires a default catalog/],
 		[{ auth: { method: 'jwt', token: 'jwt-token' } }, /Basic authentication over HTTPS/],
@@ -2164,7 +2187,6 @@ describe('marimo data-source discovery', () => {
 		[{ heartbeat_interval_seconds: 10 }, /heartbeat interval/],
 		[{ isolation_level: 'READ_COMMITTED' }, /isolation level/],
 		[{ legacy_primitive_types: true }, /legacy primitive types/],
-		[{ legacy_prepared_statements: false }, /legacy prepared statements/],
 	])('trino: falls back when discovery cannot express the config (%j)', (overrides, message) => {
 		const config = trino.configSchema.parse(fixtureFor(trino, { ambient_env: true, ...overrides }));
 		expect(() => trino.validate?.(config)).not.toThrow();
@@ -2174,7 +2196,6 @@ describe('marimo data-source discovery', () => {
 	});
 
 	it.each([
-		[{ app_name: 'analytics' }, /Spark application name/],
 		[{ spark_config: { 'spark.sql.session.timeZone': 'UTC' } }, /Spark session properties/],
 		[
 			{
@@ -2184,7 +2205,7 @@ describe('marimo data-source discovery', () => {
 		],
 	])('pyspark: falls back when discovery cannot express the config (%j)', (overrides, message) => {
 		const config = pyspark.configSchema.parse(
-			fixtureFor(pyspark, { ambient_env: true, app_name: undefined, ...overrides }),
+			fixtureFor(pyspark, { ambient_env: true, ...overrides }),
 		);
 		expect(() => pyspark.validate?.(config)).not.toThrow();
 		const output = renderDefinition(pyspark, config);

--- a/packages/core/src/services/integrations/kinds/pyspark.ts
+++ b/packages/core/src/services/integrations/kinds/pyspark.ts
@@ -68,7 +68,6 @@ const pysparkConfig = z.strictObject({
 });
 
 function pysparkDiscoveryReason(config: z.infer<typeof pysparkConfig>): string | undefined {
-	if (config.app_name) return 'marimo cannot carry the configured Spark application name';
 	if (Object.keys(config.spark_config).length > 0) {
 		return 'marimo cannot carry the configured Spark session properties';
 	}

--- a/packages/core/src/services/integrations/kinds/trino.ts
+++ b/packages/core/src/services/integrations/kinds/trino.ts
@@ -157,7 +157,6 @@ function trinoDiscoveryReason(config: z.infer<typeof trinoConfig>): string | und
 		[config.heartbeat_interval_seconds !== undefined, 'heartbeat interval'],
 		[config.isolation_level !== 'AUTOCOMMIT', 'isolation level'],
 		[config.legacy_primitive_types, 'legacy primitive types'],
-		[config.legacy_prepared_statements !== undefined, 'legacy prepared statements'],
 	] as const;
 	const unsupported = unsupportedOptions
 		.filter(([configured]) => configured)

--- a/packages/web/src/lib/integrationNotebook.test.ts
+++ b/packages/web/src/lib/integrationNotebook.test.ts
@@ -37,6 +37,7 @@ describe('integrationNotebookInfo', () => {
 		expect(info?.snippet).toContain('.joinpath("pyspark", "analytics-prod.json")');
 		expect(info?.snippet).toContain('SparkSession.builder.remote');
 		expect(info?.snippet).toContain('descriptor["spark_config"]');
+		expect(info?.snippet).toContain('builder.appName(app_name)');
 	});
 
 	it('does not claim notebook guidance for unrelated integrations', () => {


### PR DESCRIPTION
Keep marimo data-source discovery enabled when a Trino integration sets `legacy_prepared_statements` or a PySpark integration sets `app_name`. Both are now carried through the discovery env / descriptor (PySpark's `builder.appName`) instead of forcing a fallback to the full config path.