### PR TITLE
Remove compute startup request waterfalls

### DIFF
--- a/examples/cloudflare-worker/src/tieredCompute.test.ts
+++ b/examples/cloudflare-worker/src/tieredCompute.test.ts
@@ -5,16 +5,24 @@ import { TieredComputeProvider } from './tieredCompute';
 
 const SANDBOX_ID = 'sb-test' as SandboxId;
 
-function fakeInstance(supportsBucketMount: boolean): SandboxInstance {
+function fakeInstance(
+	supportsBucketMount: boolean,
+	launchProcess?: SandboxInstance['launchProcess'],
+): SandboxInstance {
 	return {
 		supportsBucketMount,
 		exec: async () => ({ success: true as const, stdout: '', stderr: '' }),
+		...(launchProcess ? { launchProcess } : {}),
 	} as unknown as SandboxInstance;
 }
 
-function fakeProvider(opts: { flag: boolean; reachable?: boolean }): SandboxProvider {
+function fakeProvider(opts: {
+	flag: boolean;
+	reachable?: boolean;
+	launchProcess?: SandboxInstance['launchProcess'];
+}): SandboxProvider {
 	return {
-		create: () => fakeInstance(opts.flag),
+		create: () => fakeInstance(opts.flag, opts.launchProcess),
 		proxy: async () => null,
 		listActive: async (): Promise<ActiveSandbox[]> => {
 			if (opts.reachable === false) throw new Error('unreachable');
@@ -56,5 +64,43 @@ describe('TieredSandboxInstance supportsBucketMount', () => {
 		await instance.exec('true');
 		expect(instance.supportsBucketMount).toBe(true);
 		vi.restoreAllMocks();
+	});
+});
+
+describe('TieredSandboxInstance launchProcess', () => {
+	it('leaves the capability absent when the pinned backend does not implement it', async () => {
+		const tiered = new TieredComputeProvider(
+			fakeProvider({ flag: false }),
+			fakeProvider({ flag: true }),
+		);
+		const instance = tiered.create(SANDBOX_ID);
+
+		await instance.exec('true');
+
+		expect(instance.launchProcess).toBeUndefined();
+	});
+
+	it('forwards the capability of the pinned backend', async () => {
+		const launchProcess = vi.fn<NonNullable<SandboxInstance['launchProcess']>>(async () => ({
+			success: false,
+			reason: 'readiness_timeout',
+			stdout: '',
+			stderr: '',
+			timings: { setup: 0, start: 1, waitport: 2 },
+		}));
+		const tiered = new TieredComputeProvider(
+			fakeProvider({ flag: false, launchProcess }),
+			fakeProvider({ flag: true }),
+		);
+		const instance = tiered.create(SANDBOX_ID);
+		await instance.exec('true');
+		const launch = instance.launchProcess;
+
+		expect(launch).toBeTypeOf('function');
+		await launch?.('kernel', { port: 2718, startupTimeout: 1_000 });
+		expect(launchProcess).toHaveBeenCalledWith('kernel', {
+			port: 2718,
+			startupTimeout: 1_000,
+		});
 	});
 });

--- a/examples/cloudflare-worker/src/tieredCompute.ts
+++ b/examples/cloudflare-worker/src/tieredCompute.ts
@@ -149,10 +149,13 @@ class TieredSandboxInstance implements SandboxInstance {
 		return (await this.resolve()).startProcess(cmd, options);
 	}
 
-	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
-		const backend = await this.resolve();
-		if (backend.launchProcess) return backend.launchProcess(cmd, options);
-		throw new Error('selected compute backend does not support combined process launch');
+	get launchProcess():
+		| ((cmd: string, options: LaunchProcessOptions) => Promise<SandboxLaunchResult>)
+		| undefined {
+		// A prototype method would make capability checks truthy for legacy backends.
+		const launchProcess = this.resolved?.launchProcess;
+		if (!launchProcess) return undefined;
+		return launchProcess.bind(this.resolved);
 	}
 
 	async exposePort(port: number, options: ExposePortOptions): Promise<ExposePortResult> {

--- a/examples/cloudflare-worker/src/tieredCompute.ts
+++ b/examples/cloudflare-worker/src/tieredCompute.ts
@@ -27,11 +27,13 @@ import type {
 	ExposePortOptions,
 	ExposePortResult,
 	GitCheckoutOptions,
+	LaunchProcessOptions,
 	ListFilesOptions,
 	ListFilesResult,
 	MountBucketOptions,
 	ReadFileResult,
 	SandboxFileWrite,
+	SandboxLaunchResult,
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
@@ -145,6 +147,12 @@ class TieredSandboxInstance implements SandboxInstance {
 
 	async startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess> {
 		return (await this.resolve()).startProcess(cmd, options);
+	}
+
+	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
+		const backend = await this.resolve();
+		if (backend.launchProcess) return backend.launchProcess(cmd, options);
+		throw new Error('selected compute backend does not support combined process launch');
 	}
 
 	async exposePort(port: number, options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-cloudflare/src/index.ts
+++ b/packages/compute-cloudflare/src/index.ts
@@ -5,6 +5,7 @@ import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
 	classifyListFilesFailure,
+	launchWithProcess,
 	mapWithConcurrency,
 	parseFindFilesOutput,
 	withEnvPrefix,
@@ -18,11 +19,13 @@ import type {
 	ExposePortOptions,
 	ExposePortResult,
 	GitCheckoutOptions,
+	LaunchProcessOptions,
 	ListFilesOptions,
 	ListFilesResult,
 	MountBucketOptions,
 	ReadFileResult,
 	SandboxFileWrite,
+	SandboxLaunchResult,
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
@@ -179,6 +182,22 @@ class CloudflareSandboxInstance implements SandboxInstance {
 			waitForPort: (port, opts) => proc.waitForPort(port, opts),
 			getLogs: () => proc.getLogs(),
 		};
+	}
+
+	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
+		return launchWithProcess({
+			setup: options.setup,
+			command: cmd,
+			port: options.port,
+			startupTimeout: options.startupTimeout,
+			waitForPort: options.waitForPort,
+			start: (command) =>
+				this.startProcess(command, {
+					cwd: options.cwd,
+					env: options.env,
+					processId: options.processId,
+				}),
+		});
 	}
 
 	async exposePort(port: number, options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -502,6 +502,9 @@ describe('launch protocol', () => {
 		expect(built.command).toContain('python3 -c');
 		expect(built.command).toContain("'abc123'");
 		expect(built.command).toContain("'2718'");
+		expect(built.command.indexOf("'printf '\\''%s'\\'' kernel'")).toBeLessThan(
+			built.command.indexOf("'printf '\\''%s'\\'' setup'"),
+		);
 	});
 
 	it('removes protocol records and returns the terminal outcome', () => {
@@ -572,6 +575,23 @@ describe('launch protocol', () => {
 			}),
 		});
 		expect(result).toMatchObject({ success: false, reason: 'readiness_timeout' });
+	});
+
+	it('passes an explicit unbounded readiness timeout when startupTimeout is zero', async () => {
+		let timeout: number | undefined;
+		await launchWithProcess({
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 0,
+			start: async () => ({
+				waitForPort: async (_port, options) => {
+					timeout = options?.timeout;
+					throw new Error('test stop');
+				},
+				getLogs: async () => ({ stdout: '', stderr: '' }),
+			}),
+		});
+		expect(timeout).toBe(Number.POSITIVE_INFINITY);
 	});
 
 	it('preserves a setup failure and its output through the compatibility launcher', async () => {

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -7,6 +7,7 @@ import type { AddressInfo } from 'node:net';
 import { describe, it, expect } from 'vitest';
 import {
 	base64Encode,
+	buildLaunchCommand,
 	buildDirectoryProbeCommand,
 	buildFindFilesCommand,
 	buildGitCloneCommand,
@@ -16,11 +17,13 @@ import {
 	NOT_A_DIRECTORY_EXIT_CODE,
 	NOT_A_DIRECTORY_MARKER,
 	parseFindFilesOutput,
+	parseLaunchOutput,
 	pollUntilReady,
 	portWaitCommand,
 	removeUndefined,
 	shellQuote,
 	withEnvPrefix,
+	launchWithProcess,
 } from './index';
 
 describe('shellQuote', () => {
@@ -483,6 +486,124 @@ describe('mapWithConcurrency', () => {
 		});
 		expect(seen.sort((a, b) => a - b)).toEqual([1, 2, 3]);
 		expect(results).toEqual([2, 4, 6]);
+	});
+});
+
+describe('launch protocol', () => {
+	it('quotes setup and kernel commands as supervisor arguments', () => {
+		const built = buildLaunchCommand({
+			setup: "printf '%s' setup",
+			command: "printf '%s' kernel",
+			port: 2718,
+			startupTimeout: 120_000,
+			nonce: 'abc123',
+		});
+		expect(built.nonce).toBe('abc123');
+		expect(built.command).toContain('python3 -c');
+		expect(built.command).toContain("'abc123'");
+		expect(built.command).toContain("'2718'");
+	});
+
+	it('removes protocol records and returns the terminal outcome', () => {
+		const marker = '__MARIMOHUB_LAUNCH_n1__';
+		const parsed = parseLaunchOutput(
+			{
+				stdout: 'setup output\nkernel output\n',
+				stderr:
+					`${marker}{"event":"setup_complete","setupMs":12,"waitportMs":0}\n` +
+					`${marker}{"event":"ready","setupMs":12,"waitportMs":34}\n`,
+			},
+			'n1',
+		);
+		expect(parsed).toEqual({
+			stdout: 'setup output\nkernel output\n',
+			stderr: '',
+			outcome: { kind: 'ready', setupMs: 12, waitportMs: 34 },
+		});
+	});
+
+	it('preserves output before a protocol record in the same fragmented line', () => {
+		const marker = '__MARIMOHUB_LAUNCH_n1__';
+		const parsed = parseLaunchOutput(
+			{
+				stdout: '',
+				stderr: `setup output${marker}{"event":"ready","setupMs":3,"waitportMs":4}\n`,
+			},
+			'n1',
+		);
+		expect(parsed).toEqual({
+			stdout: '',
+			stderr: 'setup output',
+			outcome: { kind: 'ready', setupMs: 3, waitportMs: 4 },
+		});
+	});
+
+	it('returns a structured transport failure when process start rejects', async () => {
+		const result = await launchWithProcess({
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 1000,
+			start: async () => {
+				throw new Error('stream unavailable');
+			},
+		});
+		expect(result).toEqual({
+			success: false,
+			reason: 'transport_failure',
+			stdout: '',
+			stderr: 'stream unavailable',
+			timings: { setup: 0, start: expect.any(Number), waitport: 0 },
+		});
+	});
+
+	it('classifies an expired no-setup launch as a readiness timeout', async () => {
+		let now = 0;
+		const result = await launchWithProcess({
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 10,
+			now: () => now,
+			start: async () => ({
+				waitForPort: async () => {
+					now = 20;
+					throw new Error('timed out waiting for port 2718');
+				},
+				getLogs: async () => ({ stdout: '', stderr: '' }),
+			}),
+		});
+		expect(result).toMatchObject({ success: false, reason: 'readiness_timeout' });
+	});
+
+	it('preserves a setup failure and its output through the compatibility launcher', async () => {
+		const result = await launchWithProcess({
+			setup: 'uv sync',
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 1000,
+			start: async (command) => {
+				const nonce = command.match(/'([a-f0-9]{32})'/)?.[1];
+				if (!nonce) throw new Error('missing launch nonce');
+				return {
+					waitForPort: async () => {
+						throw new Error('process exited before port 2718 opened');
+					},
+					getLogs: async () => ({
+						stdout: '',
+						stderr:
+							'permission denied\n' +
+							`__MARIMOHUB_LAUNCH_${nonce}__{"event":"setup_exit","setupMs":19,"waitportMs":0,"exitCode":2}\n`,
+					}),
+				};
+			},
+		});
+		expect(result).toEqual({
+			success: false,
+			reason: 'setup_exit',
+			exitCode: 2,
+			stdout: '',
+			stderr: 'permission denied\n',
+			timings: { setup: 19, start: expect.any(Number), waitport: 0 },
+		});
 	});
 });
 

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -224,6 +224,318 @@ export function portWaitCommand(port: number, seconds: number): string {
 	return `python3 -c ${shellQuote(script)}`;
 }
 
+export type LaunchProtocolFailure =
+	| 'setup_exit'
+	| 'setup_timeout'
+	| 'kernel_exit'
+	| 'readiness_timeout';
+
+export interface LaunchProtocolOutcome {
+	kind: 'ready' | LaunchProtocolFailure;
+	setupMs: number;
+	waitportMs: number;
+	exitCode?: number;
+}
+
+export interface LaunchCommand {
+	command: string;
+	nonce: string;
+}
+
+const LAUNCH_SUPERVISOR = `import json, os, signal, socket, subprocess, sys, time
+nonce, timeout_arg, setup, command, port_arg = sys.argv[1:]
+timeout = float(timeout_arg) / 1000
+port = int(port_arg)
+started = time.monotonic()
+deadline = None if timeout == 0 else started + timeout
+prefix = "__MARIMOHUB_LAUNCH_" + nonce + "__"
+current = None
+
+def elapsed(since):
+    return max(0, round((time.monotonic() - since) * 1000))
+
+def emit(event, **values):
+    print(prefix + json.dumps({"event": event, **values}, separators=(",", ":")), file=sys.stderr, flush=True)
+
+def remaining():
+    return None if deadline is None else max(0, deadline - time.monotonic())
+
+def stop_process(process, sig=signal.SIGTERM):
+    if process is None or process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, sig)
+    except ProcessLookupError:
+        return
+
+def forward(sig, _frame):
+    stop_process(current, sig)
+
+for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    signal.signal(sig, forward)
+
+setup_started = time.monotonic()
+if setup:
+    current = subprocess.Popen(["sh", "-lc", setup], start_new_session=True)
+    try:
+        setup_code = current.wait(timeout=remaining())
+    except subprocess.TimeoutExpired:
+        stop_process(current, signal.SIGKILL)
+        current.wait()
+        emit("setup_timeout", setupMs=elapsed(setup_started), waitportMs=0)
+        sys.exit(124)
+    if setup_code != 0:
+        emit("setup_exit", setupMs=elapsed(setup_started), waitportMs=0, exitCode=setup_code)
+        sys.exit(setup_code)
+setup_ms = elapsed(setup_started)
+emit("setup_complete", setupMs=setup_ms, waitportMs=0)
+
+kernel_started = time.monotonic()
+current = subprocess.Popen(["sh", "-lc", command], start_new_session=True)
+while True:
+    kernel_code = current.poll()
+    if kernel_code is not None:
+        emit("kernel_exit", setupMs=setup_ms, waitportMs=elapsed(kernel_started), exitCode=kernel_code)
+        sys.exit(kernel_code or 1)
+    probe = socket.socket()
+    probe.settimeout(0.2)
+    try:
+        ready = probe.connect_ex(("127.0.0.1", port)) == 0
+    finally:
+        probe.close()
+    if ready:
+        emit("ready", setupMs=setup_ms, waitportMs=elapsed(kernel_started))
+        sys.exit(current.wait())
+    if deadline is not None and time.monotonic() >= deadline:
+        emit("readiness_timeout", setupMs=setup_ms, waitportMs=elapsed(kernel_started))
+        stop_process(current, signal.SIGTERM)
+        try:
+            current.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            stop_process(current, signal.SIGKILL)
+            current.wait()
+        sys.exit(124)
+    time.sleep(0.05)`;
+
+export function buildLaunchCommand(options: {
+	setup?: string;
+	command: string;
+	port: number;
+	startupTimeout: number;
+	nonce?: string;
+}): LaunchCommand {
+	const nonce = options.nonce ?? crypto.randomUUID().replaceAll('-', '');
+	const args = [
+		nonce,
+		String(options.startupTimeout),
+		options.setup ?? '',
+		options.command,
+		String(options.port),
+	].map(shellQuote);
+	return {
+		nonce,
+		command: `exec python3 -c ${shellQuote(LAUNCH_SUPERVISOR)} ${args.join(' ')}`,
+	};
+}
+
+function parseProtocolText(
+	text: string,
+	nonce: string,
+): {
+	text: string;
+	events: LaunchProtocolOutcome[];
+} {
+	const marker = `__MARIMOHUB_LAUNCH_${nonce}__`;
+	const events: LaunchProtocolOutcome[] = [];
+	const kept: string[] = [];
+	for (const line of text.split(/(?<=\n)/)) {
+		const normalized = line.replace(/\r?\n$/, '');
+		const index = normalized.indexOf(marker);
+		if (index === -1) {
+			kept.push(line);
+			continue;
+		}
+		const json = normalized.slice(index + marker.length);
+		try {
+			const value = JSON.parse(json) as {
+				event?: string;
+				setupMs?: number;
+				waitportMs?: number;
+				exitCode?: number;
+			};
+			if (
+				value.event === 'ready' ||
+				value.event === 'setup_exit' ||
+				value.event === 'setup_timeout' ||
+				value.event === 'kernel_exit' ||
+				value.event === 'readiness_timeout'
+			) {
+				events.push({
+					kind: value.event,
+					setupMs: Math.max(0, value.setupMs ?? 0),
+					waitportMs: Math.max(0, value.waitportMs ?? 0),
+					...(value.exitCode === undefined ? {} : { exitCode: value.exitCode }),
+				});
+			}
+			const beforeMarker = normalized.slice(0, index);
+			if (beforeMarker) kept.push(beforeMarker);
+		} catch {
+			kept.push(line);
+		}
+	}
+	return { text: kept.join(''), events };
+}
+
+export function parseLaunchOutput(
+	logs: { stdout: string; stderr: string },
+	nonce: string,
+): { stdout: string; stderr: string; outcome?: LaunchProtocolOutcome } {
+	const stdout = parseProtocolText(logs.stdout, nonce);
+	const stderr = parseProtocolText(logs.stderr, nonce);
+	return {
+		stdout: stdout.text,
+		stderr: stderr.text,
+		outcome: [...stdout.events, ...stderr.events].at(-1),
+	};
+}
+
+export interface LaunchableProcess {
+	waitForPort(
+		port: number,
+		options?: { timeout?: number; mode?: 'http' | 'tcp'; path?: string },
+	): Promise<void>;
+	getLogs(): Promise<{ stdout: string; stderr: string }>;
+}
+
+export type ProcessLaunchResult<P extends LaunchableProcess> =
+	| {
+			success: true;
+			process: P;
+			timings: { setup: number; start: number; waitport: number };
+	  }
+	| {
+			success: false;
+			reason: LaunchProtocolFailure | 'transport_failure';
+			exitCode?: number;
+			stdout: string;
+			stderr: string;
+			timings: { setup: number; start: number; waitport: number };
+	  };
+
+/**
+ * Compatibility implementation for process APIs that expose readiness and logs
+ * but not their live output stream. The setup and kernel still share one remote
+ * command; the native waiter observes the same port as the supervisor.
+ */
+export async function launchWithProcess<P extends LaunchableProcess>(options: {
+	setup?: string;
+	command: string;
+	port: number;
+	startupTimeout: number;
+	waitForPort?: { mode?: 'http' | 'tcp'; path?: string };
+	start(command: string): Promise<P>;
+	now?: () => number;
+}): Promise<ProcessLaunchResult<P>> {
+	const now = options.now ?? Date.now;
+	const built = buildLaunchCommand(options);
+	const launchStarted = now();
+	let process: P;
+	try {
+		process = await options.start(built.command);
+	} catch (error) {
+		return {
+			success: false,
+			reason: 'transport_failure',
+			stdout: '',
+			stderr: error instanceof Error ? error.message : String(error),
+			timings: { setup: 0, start: Math.max(0, now() - launchStarted), waitport: 0 },
+		};
+	}
+	const start = now() - launchStarted;
+	const waitStarted = now();
+	const remaining =
+		options.startupTimeout === 0
+			? 2_147_483_647
+			: Math.max(0, options.startupTimeout - (now() - launchStarted));
+	try {
+		await process.waitForPort(options.port, {
+			...options.waitForPort,
+			timeout: remaining,
+		});
+	} catch (error) {
+		if (options.startupTimeout !== 0 && now() - launchStarted >= options.startupTimeout) {
+			await sleep(75);
+		}
+		let parsed: ReturnType<typeof parseLaunchOutput>;
+		let setupCompleted = false;
+		try {
+			const logs = await process.getLogs();
+			setupCompleted = `${logs.stdout}\n${logs.stderr}`.includes(
+				`__MARIMOHUB_LAUNCH_${built.nonce}__{"event":"setup_complete"`,
+			);
+			parsed = parseLaunchOutput(logs, built.nonce);
+		} catch (logError) {
+			return {
+				success: false,
+				reason: 'transport_failure',
+				stdout: '',
+				stderr: logError instanceof Error ? logError.message : String(logError),
+				timings: {
+					setup: 0,
+					start,
+					waitport: Math.max(0, now() - waitStarted),
+				},
+			};
+		}
+		const outcome = parsed.outcome;
+		const deadlineExpired =
+			options.startupTimeout !== 0 && now() - launchStarted >= options.startupTimeout;
+		const reason =
+			outcome?.kind && outcome.kind !== 'ready'
+				? outcome.kind
+				: options.setup && deadlineExpired && !setupCompleted
+					? 'setup_timeout'
+					: /before port \d+/.test(error instanceof Error ? error.message.split('\n', 1)[0] : '')
+						? 'kernel_exit'
+						: 'readiness_timeout';
+		return {
+			success: false,
+			reason,
+			...(outcome?.exitCode === undefined ? {} : { exitCode: outcome.exitCode }),
+			stdout: parsed.stdout,
+			stderr: parsed.stderr,
+			timings: {
+				setup:
+					outcome?.setupMs ??
+					(reason === 'setup_timeout' ? Math.max(0, options.startupTimeout - start) : 0),
+				start,
+				waitport: outcome?.waitportMs ?? now() - waitStarted,
+			},
+		};
+	}
+	let parsed: ReturnType<typeof parseLaunchOutput>;
+	try {
+		parsed = parseLaunchOutput(await process.getLogs(), built.nonce);
+	} catch (error) {
+		return {
+			success: false,
+			reason: 'transport_failure',
+			stdout: '',
+			stderr: error instanceof Error ? error.message : String(error),
+			timings: { setup: 0, start, waitport: Math.max(0, now() - waitStarted) },
+		};
+	}
+	return {
+		success: true,
+		process,
+		timings: {
+			setup: parsed.outcome?.setupMs ?? 0,
+			start,
+			waitport: parsed.outcome?.waitportMs ?? now() - waitStarted,
+		},
+	};
+}
+
 export interface PollOptions {
 	/** Give up after this many ms. Default 30000. */
 	timeoutMs?: number;

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -243,7 +243,7 @@ export interface LaunchCommand {
 }
 
 const LAUNCH_SUPERVISOR = `import json, os, signal, socket, subprocess, sys, time
-nonce, timeout_arg, setup, command, port_arg = sys.argv[1:]
+nonce, timeout_arg, command, setup, port_arg = sys.argv[1:]
 timeout = float(timeout_arg) / 1000
 port = int(port_arg)
 started = time.monotonic()
@@ -328,8 +328,8 @@ export function buildLaunchCommand(options: {
 	const args = [
 		nonce,
 		String(options.startupTimeout),
-		options.setup ?? '',
 		options.command,
+		options.setup ?? '',
 		String(options.port),
 	].map(shellQuote);
 	return {
@@ -455,7 +455,7 @@ export async function launchWithProcess<P extends LaunchableProcess>(options: {
 	const waitStarted = now();
 	const remaining =
 		options.startupTimeout === 0
-			? 2_147_483_647
+			? Number.POSITIVE_INFINITY
 			: Math.max(0, options.startupTimeout - (now() - launchStarted));
 	try {
 		await process.waitForPort(options.port, {

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -388,14 +388,22 @@ describe('DockerCompute', () => {
 		});
 		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
 
-		const proc = await sb.startProcess('uv run marimo edit app.py', { cwd: '/workspace' });
+		const proc = await sb.startProcess('uv run marimo edit app.py', {
+			cwd: '/workspace',
+			env: { SESSION_TOKEN: 'a b', OMITTED: undefined },
+			processId: 'kernel-process',
+		});
 		const logs = await proc.getLogs();
 		await proc.kill();
 
+		expect(proc.id).toBe('kernel-process');
 		expect(proc.command).toBe('uv run marimo edit app.py');
 		expect(logs).toEqual({ stdout: 'kernel log', stderr: '' });
 		const launch = calls.find((c) => c.args[0] === 'exec' && c.args.includes('-d'))!;
-		expect(launch.args.at(-1)).toContain("cd '/workspace' && uv run marimo edit app.py >");
+		expect(launch.args.at(-1)).toContain(
+			"cd '/workspace' && export SESSION_TOKEN='a b'; uv run marimo edit app.py >",
+		);
+		expect(launch.args.at(-1)).not.toContain('OMITTED');
 		expect(calls.some((c) => c.args[0] === 'exec' && c.args.includes('pkill'))).toBe(true);
 	});
 

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -407,6 +407,50 @@ describe('DockerCompute', () => {
 		expect(calls.some((c) => c.args[0] === 'exec' && c.args.includes('pkill'))).toBe(true);
 	});
 
+	it('returns a launch failure from one log wait without probing the port', async () => {
+		const { runner, calls } = fakeRunner((args) => {
+			const base = defaultHandler(args);
+			if (base) return base;
+			const command = args.at(-1) ?? '';
+			if (!command.includes('terminal_events')) return;
+			const marker = command.match(/__MARIMOHUB_LAUNCH_[a-f0-9]{32}__/)?.[0];
+			if (!marker) throw new Error('missing launch marker');
+			return {
+				stdout:
+					`setup output\n${marker}` +
+					'{"event":"setup_exit","setupMs":12,"waitportMs":0,"exitCode":7}\n',
+				stderr: '',
+				exitCode: 0,
+			};
+		});
+		const sb = new DockerCompute({}, runner).create(SANDBOX_ID);
+
+		const result = await sb.launchProcess!('run kernel', {
+			setup: 'run setup',
+			port: 2718,
+			startupTimeout: 60_000,
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			reason: 'setup_exit',
+			exitCode: 7,
+			stdout: 'setup output\n',
+			timings: { setup: 12, start: expect.any(Number), waitport: 0 },
+		});
+		const execCalls = calls.filter((call) => call.args[0] === 'exec');
+		expect(execCalls).toHaveLength(2);
+		expect(execCalls.filter((call) => call.args.includes('-d'))).toHaveLength(1);
+		expect(execCalls.filter((call) => call.args.at(-1)?.includes('terminal_events'))).toHaveLength(
+			1,
+		);
+		expect(
+			execCalls.some(
+				(call) => !call.args.includes('-d') && call.args.at(-1)?.includes('connect_ex'),
+			),
+		).toBe(false);
+	});
+
 	describe('listFiles()', () => {
 		const findOutput = (lines: string[]) => `${lines.join('\0')}\0`;
 		const onlyFind =

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -7,9 +7,10 @@ import { spawn } from 'node:child_process';
 import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
+	buildLaunchCommand,
 	classifyListFilesFailure,
-	launchWithProcess,
 	mapWithConcurrency,
+	parseLaunchOutput,
 	parseFindFilesOutput,
 	pollUntilReady,
 	removeUndefined,
@@ -50,6 +51,7 @@ const NAME_PREFIX = 'marimohub-sbx-';
 const DEFAULT_LABEL_KEY = 'marimohub.sandbox';
 const DEFAULT_IMAGE = 'ghcr.io/marimo-team/marimo:latest';
 const EXEC_TIMEOUT_GRACE_MS = 100;
+const LAUNCH_MARKER_GRACE_MS = 100;
 const EXEC_TIMEOUT_SUPERVISOR = `import os, signal, subprocess, sys
 process = subprocess.Popen(['sh', '-lc', sys.argv[2]], start_new_session=True)
 try:
@@ -59,11 +61,33 @@ except subprocess.TimeoutExpired:
 	process.wait()
 	code = 124
 sys.exit(code)`;
+const LAUNCH_LOG_WAITER = `import sys, time
+path, prefix, timeout_arg = sys.argv[1:]
+timeout = float(timeout_arg) / 1000
+deadline = None if timeout == 0 else time.monotonic() + timeout
+terminal_events = ("ready", "setup_exit", "setup_timeout", "kernel_exit", "readiness_timeout")
+while True:
+    try:
+        with open(path, errors="replace") as launch_log:
+            data = launch_log.read()
+    except FileNotFoundError:
+        data = ""
+    if any(prefix + '{"event":"' + event + '"' in data for event in terminal_events):
+        sys.stdout.write(data)
+        sys.exit(0)
+    if deadline is not None and time.monotonic() >= deadline:
+        sys.stdout.write(data)
+        sys.exit(124)
+    time.sleep(0.05)`;
 
 export interface ContainerRunResult {
 	stdout: string;
 	stderr: string;
 	exitCode: number;
+}
+
+interface ContainerSandboxProcess extends SandboxProcess {
+	waitForLaunch(nonce: string, timeoutMs: number): Promise<ContainerRunResult>;
 }
 
 /**
@@ -323,7 +347,7 @@ class ContainerSandboxInstance implements SandboxInstance {
 		return (await this.dexec(probe)).exitCode === 0;
 	}
 
-	async startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess> {
+	async startProcess(cmd: string, options?: StartProcessOptions): Promise<ContainerSandboxProcess> {
 		await this.ensure();
 		const logPath = `/tmp/marimohub-proc-${++procSeq}.log`;
 		// Run detached inside the container; redirect to a log file we can tail.
@@ -336,6 +360,19 @@ class ContainerSandboxInstance implements SandboxInstance {
 		}
 		const probeInside = (port: number) => this.probePort(port);
 		const readLogs = () => this.dexec(`cat ${logPath} 2>/dev/null || true`);
+		const waitForLaunch = (nonce: string, timeoutMs: number) =>
+			this.dexec(
+				[
+					'python3',
+					'-c',
+					LAUNCH_LOG_WAITER,
+					logPath,
+					`__MARIMOHUB_LAUNCH_${nonce}__`,
+					String(timeoutMs),
+				]
+					.map(shellQuote)
+					.join(' '),
+			);
 		const id = options?.processId ?? `${this.config.engine}-proc-${procSeq}`;
 		const containerName = this.name;
 		const runner = this.runner;
@@ -362,23 +399,113 @@ class ContainerSandboxInstance implements SandboxInstance {
 				const logs = await readLogs();
 				return { stdout: logs.stdout, stderr: '' };
 			},
+			waitForLaunch,
 		};
 	}
 
 	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
-		return launchWithProcess({
+		const built = buildLaunchCommand({
 			setup: options.setup,
 			command: cmd,
 			port: options.port,
 			startupTimeout: options.startupTimeout,
-			waitForPort: options.waitForPort,
-			start: (command) =>
-				this.startProcess(command, {
-					cwd: options.cwd,
-					env: options.env,
-					processId: options.processId,
-				}),
 		});
+		const launchStarted = Date.now();
+		let process: ContainerSandboxProcess;
+		try {
+			process = await this.startProcess(built.command, {
+				cwd: options.cwd,
+				env: options.env,
+				processId: options.processId,
+			});
+		} catch (error) {
+			return {
+				success: false,
+				reason: 'transport_failure',
+				stdout: '',
+				stderr: error instanceof Error ? error.message : String(error),
+				timings: { setup: 0, start: Math.max(0, Date.now() - launchStarted), waitport: 0 },
+			};
+		}
+
+		const start = Math.max(0, Date.now() - launchStarted);
+		const waitStarted = Date.now();
+		const waitTimeout =
+			options.startupTimeout === 0
+				? 0
+				: Math.max(0, options.startupTimeout - start) + LAUNCH_MARKER_GRACE_MS;
+		let waited: ContainerRunResult;
+		try {
+			waited = await process.waitForLaunch(built.nonce, waitTimeout);
+		} catch (error) {
+			await process.kill().catch(() => {});
+			return {
+				success: false,
+				reason: 'transport_failure',
+				stdout: '',
+				stderr: error instanceof Error ? error.message : String(error),
+				timings: { setup: 0, start, waitport: Math.max(0, Date.now() - waitStarted) },
+			};
+		}
+
+		const parsed = parseLaunchOutput({ stdout: waited.stdout, stderr: '' }, built.nonce);
+		const terminal = parsed.outcome;
+		if (terminal?.kind === 'ready') {
+			return {
+				success: true,
+				timings: { setup: terminal.setupMs, start, waitport: terminal.waitportMs },
+				process: {
+					id: process.id,
+					command: cmd,
+					kill: (signal) => process.kill(signal),
+					waitForPort: (port, waitOptions) =>
+						port === options.port ? Promise.resolve() : process.waitForPort(port, waitOptions),
+					async getLogs() {
+						const logs = parseLaunchOutput(await process.getLogs(), built.nonce);
+						return { stdout: logs.stdout, stderr: logs.stderr };
+					},
+				},
+			};
+		}
+		if (terminal) {
+			return {
+				success: false,
+				reason: terminal.kind,
+				...(terminal.exitCode === undefined ? {} : { exitCode: terminal.exitCode }),
+				stdout: parsed.stdout,
+				stderr: parsed.stderr,
+				timings: { setup: terminal.setupMs, start, waitport: terminal.waitportMs },
+			};
+		}
+
+		await process.kill().catch(() => {});
+		if (waited.exitCode !== 124) {
+			return {
+				success: false,
+				reason: 'transport_failure',
+				stdout: parsed.stdout,
+				stderr: [parsed.stderr, waited.stderr || 'launch monitor exited without a terminal marker']
+					.filter(Boolean)
+					.join('\n'),
+				timings: { setup: 0, start, waitport: Math.max(0, Date.now() - waitStarted) },
+			};
+		}
+
+		const setupCompleted = waited.stdout.includes(
+			`__MARIMOHUB_LAUNCH_${built.nonce}__{"event":"setup_complete"`,
+		);
+		const reason = options.setup && !setupCompleted ? 'setup_timeout' : 'readiness_timeout';
+		return {
+			success: false,
+			reason,
+			stdout: parsed.stdout,
+			stderr: parsed.stderr,
+			timings: {
+				setup: reason === 'setup_timeout' ? Math.max(0, options.startupTimeout - start) : 0,
+				start,
+				waitport: Math.max(0, Date.now() - waitStarted),
+			},
+		};
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -12,6 +12,7 @@ import {
 	mapWithConcurrency,
 	parseFindFilesOutput,
 	pollUntilReady,
+	removeUndefined,
 	shellQuote,
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
@@ -328,13 +329,14 @@ class ContainerSandboxInstance implements SandboxInstance {
 		// Run detached inside the container; redirect to a log file we can tail.
 		// `sh -lc` has no cwd flag, so cd into the working dir first when requested.
 		const prefix = options?.cwd ? `cd ${shellQuote(options.cwd)} && ` : '';
-		const res = await this.dexec(`${prefix}${cmd} > ${logPath} 2>&1 &`, ['-d']);
+		const processCommand = withEnvPrefix(cmd, removeUndefined(options?.env ?? {}));
+		const res = await this.dexec(`${prefix}${processCommand} > ${logPath} 2>&1 &`, ['-d']);
 		if (res.exitCode !== 0) {
 			throw new Error(`startProcess failed: ${res.stderr || res.stdout}`);
 		}
 		const probeInside = (port: number) => this.probePort(port);
 		const readLogs = () => this.dexec(`cat ${logPath} 2>/dev/null || true`);
-		const id = `${this.config.engine}-proc-${procSeq}`;
+		const id = options?.processId ?? `${this.config.engine}-proc-${procSeq}`;
 		const containerName = this.name;
 		const runner = this.runner;
 

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -8,6 +8,7 @@ import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
 	classifyListFilesFailure,
+	launchWithProcess,
 	mapWithConcurrency,
 	parseFindFilesOutput,
 	pollUntilReady,
@@ -26,11 +27,13 @@ import type {
 	ExposePortOptions,
 	ExposePortResult,
 	GitCheckoutOptions,
+	LaunchProcessOptions,
 	ListFilesOptions,
 	ListFilesResult,
 	MountBucketOptions,
 	ReadFileResult,
 	SandboxFileWrite,
+	SandboxLaunchResult,
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
@@ -358,6 +361,22 @@ class ContainerSandboxInstance implements SandboxInstance {
 				return { stdout: logs.stdout, stderr: '' };
 			},
 		};
+	}
+
+	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
+		return launchWithProcess({
+			setup: options.setup,
+			command: cmd,
+			port: options.port,
+			startupTimeout: options.startupTimeout,
+			waitForPort: options.waitForPort,
+			start: (command) =>
+				this.startProcess(command, {
+					cwd: options.cwd,
+					env: options.env,
+					processId: options.processId,
+				}),
+		});
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -487,6 +487,61 @@ describe('CoreWeaveCompute', () => {
 		});
 	});
 
+	describe('launchProcess()', () => {
+		function streamedOutcome(event: 'ready' | 'setup_exit') {
+			return async (command: readonly string[]) => {
+				const nonce = command.join(' ').match(/'([a-f0-9]{32})'/)?.[1];
+				if (!nonce) throw new Error('launch nonce missing from supervisor command');
+				async function* stderr() {
+					yield `kernel diagnostics\n__MARIMOHUB_LAUNCH_${nonce}__${JSON.stringify({
+						event,
+						setupMs: 17,
+						waitportMs: event === 'ready' ? 23 : 0,
+						...(event === 'setup_exit' ? { exitCode: 2 } : {}),
+					})}\n`;
+				}
+				return { ...fakeProcess(), stderr: stderr() };
+			};
+		}
+
+		it('uses one stream for setup, kernel launch, and readiness', async () => {
+			const world = makeWorld({ startImpl: streamedOutcome('ready') });
+			const inst = makeCompute(world).create(SANDBOX_ID, { reuse: false });
+			const result = await inst.launchProcess!('uv run marimo edit', {
+				setup: 'uv sync',
+				cwd: '/workspace',
+				port: 2718,
+				startupTimeout: 120_000,
+			});
+
+			expect(result).toMatchObject({
+				success: true,
+				timings: { setup: 17, start: expect.any(Number), waitport: 23 },
+			});
+			const fake = world.registry.get('cw-1')!.fake;
+			expect(fake.startCalls).toHaveLength(1);
+			expect(fake.startCalls[0].join(' ')).toContain('uv sync');
+			expect(fake.runCalls).toHaveLength(0);
+		});
+
+		it('returns a structured setup failure without a readiness Exec', async () => {
+			const world = makeWorld({ startImpl: streamedOutcome('setup_exit') });
+			const inst = makeCompute(world).create(SANDBOX_ID, { reuse: false });
+			const result = await inst.launchProcess!('marimo edit', {
+				setup: 'uv sync',
+				port: 2718,
+				startupTimeout: 120_000,
+			});
+			expect(result).toMatchObject({
+				success: false,
+				reason: 'setup_exit',
+				exitCode: 2,
+				stderr: 'kernel diagnostics\n',
+			});
+			expect(world.registry.get('cw-1')!.fake.runCalls).toHaveLength(0);
+		});
+	});
+
 	describe('startProcess().waitForPort()', () => {
 		it('waits in ONE in-sandbox command rather than one round-trip per probe', async () => {
 			const world = makeWorld();

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -19,7 +19,8 @@
  *    ingress at create so the later `exposePort` is reachable.
  *  - The sandbox MAIN process is the SDK keep-alive; marimo runs as a streamed
  *    COMMAND (`commands.start`), not the main process.
- *  - The SDK has no `waitForPort`, so we poll an in-sandbox TCP probe via `exec`.
+ *  - The SDK has no `waitForPort`. Combined launch detects readiness inside its
+ *    command stream; the compatibility `startProcess` path probes via `exec`.
  *
  * `listActive()` is intentionally NOT implemented. The SDK list response
  * (`SandboxInfo`) returns only CoreWeave's `sandboxId` + status — it does NOT echo
@@ -59,14 +60,17 @@ import {
 import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
+	buildLaunchCommand,
 	classifyListFilesFailure,
 	iterableToStream,
+	parseLaunchOutput,
 	parseFindFilesOutput,
 	portWaitCommand,
 	removeUndefined,
 	shellQuote,
 	withEnvPrefix,
 } from '@marimo-hub/compute-commons';
+import type { LaunchProtocolOutcome } from '@marimo-hub/compute-commons';
 import type {
 	ComputeResources,
 	SandboxId,
@@ -82,11 +86,13 @@ import type {
 	ExposePortOptions,
 	ExposePortResult,
 	GitCheckoutOptions,
+	LaunchProcessOptions,
 	ListFilesOptions,
 	ListFilesResult,
 	MountBucketOptions,
 	ReadFileResult,
 	SandboxFileWrite,
+	SandboxLaunchResult,
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
@@ -563,6 +569,128 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 
 	async unmountBucket(_mountPath: string): Promise<void> {
 		// no-op: nothing was mounted.
+	}
+
+	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
+		const built = buildLaunchCommand({
+			setup: options.setup,
+			command: cmd,
+			port: options.port,
+			startupTimeout: options.startupTimeout,
+		});
+		const startedAt = Date.now();
+		let proc: CommandProcess;
+		try {
+			const sandbox = await this.ensure();
+			proc = await sandbox.commands.start(['sh', '-lc', this.withEnv(built.command)], {
+				cwd: options.cwd,
+			});
+		} catch (error) {
+			return {
+				success: false,
+				reason: 'transport_failure',
+				stdout: '',
+				stderr: error instanceof Error ? error.message : String(error),
+				timings: { setup: 0, start: Math.max(0, Date.now() - startedAt), waitport: 0 },
+			};
+		}
+		const start = Date.now() - startedAt;
+		const waitStartedAt = Date.now();
+		let stdout = '';
+		let stderr = '';
+		let settled = false;
+		let resolveOutcome!: (outcome: LaunchProtocolOutcome) => void;
+		let rejectOutcome!: (error: unknown) => void;
+		const outcome = new Promise<LaunchProtocolOutcome>((resolve, reject) => {
+			resolveOutcome = resolve;
+			rejectOutcome = reject;
+		});
+		const inspect = () => {
+			if (settled) return;
+			const parsed = parseLaunchOutput({ stdout, stderr }, built.nonce).outcome;
+			if (parsed) {
+				settled = true;
+				resolveOutcome(parsed);
+			}
+		};
+		const pump = async (stream: AsyncIterable<string>, sink: (chunk: string) => void) => {
+			try {
+				for await (const chunk of stream) {
+					sink(chunk);
+					inspect();
+				}
+			} catch (error) {
+				if (!settled) {
+					settled = true;
+					rejectOutcome(error);
+				}
+			}
+		};
+		const stdoutDone = pump(proc.stdout, (chunk) => (stdout += chunk));
+		const stderrDone = pump(proc.stderr, (chunk) => (stderr += chunk));
+		void Promise.allSettled([stdoutDone, stderrDone]).then(() => {
+			inspect();
+			if (!settled) {
+				settled = true;
+				rejectOutcome(new Error('CoreWeave launch stream ended before reporting readiness'));
+			}
+		});
+
+		const logs = () => parseLaunchOutput({ stdout, stderr }, built.nonce);
+		let terminal: LaunchProtocolOutcome;
+		try {
+			terminal = await outcome;
+		} catch (error) {
+			await proc.cancel().catch(() => {});
+			const parsed = logs();
+			const transportMessage = error instanceof Error ? error.message : String(error);
+			return {
+				success: false,
+				reason: 'transport_failure',
+				stdout: parsed.stdout,
+				stderr: [parsed.stderr, transportMessage].filter(Boolean).join('\n'),
+				timings: {
+					setup: 0,
+					start,
+					waitport: Math.max(0, Date.now() - waitStartedAt),
+				},
+			};
+		}
+		const timings = { setup: terminal.setupMs, start, waitport: terminal.waitportMs };
+		if (terminal.kind !== 'ready') {
+			const parsed = logs();
+			return {
+				success: false,
+				reason: terminal.kind,
+				...(terminal.exitCode === undefined ? {} : { exitCode: terminal.exitCode }),
+				stdout: parsed.stdout,
+				stderr: parsed.stderr,
+				timings,
+			};
+		}
+
+		const exec = this.exec.bind(this);
+		return {
+			success: true,
+			timings,
+			process: {
+				id: `cw-proc-${++PROC_SEQ}`,
+				command: cmd,
+				async kill(): Promise<void> {
+					await proc.cancel().catch(() => {});
+				},
+				async waitForPort(port: number, waitOptions?: WaitForPortOptions): Promise<void> {
+					if (port === options.port) return;
+					const timeout = waitOptions?.timeout ?? 30_000;
+					const result = await exec(portWaitCommand(port, Math.max(0.001, timeout / 1000)));
+					if (!result.success) throw new Error(`timed out waiting for port ${port}`);
+				},
+				async getLogs(): Promise<{ stdout: string; stderr: string }> {
+					const parsed = logs();
+					return { stdout: parsed.stdout, stderr: parsed.stderr };
+				},
+			},
+		};
 	}
 
 	async startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess> {

--- a/packages/compute-coreweave/src/testWorld.ts
+++ b/packages/compute-coreweave/src/testWorld.ts
@@ -86,6 +86,7 @@ function recordWrite(fake: FakeSandbox) {
 
 export function makeWorld(opts?: {
 	runImpl?: (cmd: readonly string[]) => Promise<ProcessResult>;
+	startImpl?: (cmd: readonly string[]) => Promise<CommandProcess>;
 	/** State for started processes; omit to leave them running. */
 	proc?: FakeProcessState;
 }) {
@@ -118,7 +119,7 @@ export function makeWorld(opts?: {
 				},
 				start: async (command: readonly string[]) => {
 					fake.startCalls.push([...command]);
-					return fakeProcess(opts?.proc);
+					return opts?.startImpl?.(command) ?? fakeProcess(opts?.proc);
 				},
 			},
 			files: {
@@ -181,7 +182,7 @@ export function makeWorld(opts?: {
 				},
 				start: async (command: readonly string[]) => {
 					entry.fake.startCalls.push([...command]);
-					return fakeProcess();
+					return opts?.startImpl?.(command) ?? fakeProcess();
 				},
 			},
 			files: {

--- a/packages/compute-coreweave/src/wandb.test.ts
+++ b/packages/compute-coreweave/src/wandb.test.ts
@@ -124,6 +124,8 @@ describe('withServiceAddressCache', () => {
 		}));
 		await cache.get('cw-1', afterDelete);
 		expect(afterDelete).toHaveBeenCalledOnce();
+		await cache.get('cw-1', afterDelete);
+		expect(afterDelete).toHaveBeenCalledOnce();
 	});
 
 	it('falls back when the poll response has no address', async () => {

--- a/packages/compute-coreweave/src/wandb.test.ts
+++ b/packages/compute-coreweave/src/wandb.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import type { GetSandboxResult, SandboxTransport } from '@coreweave/cwsandbox';
+import { describe, it, expect, vi } from 'vitest';
 import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
 import { Seconds } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
@@ -8,7 +9,12 @@ import {
 } from '@marimo-hub/core/testing/compute-contract';
 import { expectExecResult } from '@marimo-hub/core/testing';
 import { CoreWeaveCompute } from './index';
-import { buildWandbMetadata, createWandbCompute, serviceAddressResolver } from './wandb';
+import {
+	buildWandbMetadata,
+	createWandbCompute,
+	serviceAddressResolver,
+	withServiceAddressCache,
+} from './wandb';
 import type { WandbConfig } from './wandb';
 import { makeWorld, procResult } from './testWorld';
 
@@ -67,6 +73,75 @@ describe('serviceAddressResolver', () => {
 	it('throws when no serviceAddress is assigned', async () => {
 		const resolve = serviceAddressResolver(async () => ({}));
 		await expect(resolve('cw-1', 2718)).rejects.toThrow(/no serviceAddress/);
+	});
+});
+
+describe('withServiceAddressCache', () => {
+	function transport(
+		get: SandboxTransport['get'] = vi.fn(
+			async ({ sandboxId }: { sandboxId: string }): Promise<GetSandboxResult> => ({
+				sandboxId,
+				status: 'running',
+				serviceAddress: '166.19.118.62',
+			}),
+		),
+	) {
+		return {
+			start: async () => ({ sandboxId: 'cw-1', status: 'creating' as const }),
+			get,
+			list: async () => ({ sandboxes: [] }),
+			delete: async () => {},
+			exec: async () => {
+				throw new Error('unused');
+			},
+			startCommand: async () => {
+				throw new Error('unused');
+			},
+			streamLogs: async () => {
+				throw new Error('unused');
+			},
+			stop: async () => {},
+			writeFile: async () => {},
+			readFile: async () => ({ content: new Uint8Array() }),
+		} satisfies SandboxTransport;
+	}
+
+	it('reuses the latest boot Get result for URL resolution', async () => {
+		const raw = transport();
+		const cache = withServiceAddressCache(raw);
+		await cache.transport.get({ sandboxId: 'cw-1' });
+		const fallback = vi.fn();
+		expect(await cache.get('cw-1', fallback)).toMatchObject({
+			serviceAddress: '166.19.118.62',
+		});
+		expect(vi.mocked(raw.get)).toHaveBeenCalledTimes(1);
+		expect(fallback).not.toHaveBeenCalled();
+		await cache.transport.delete({ sandboxId: 'cw-1' });
+		const afterDelete = vi.fn(async () => ({
+			sandboxId: 'cw-1',
+			status: 'running' as const,
+			serviceAddress: '10.0.0.3',
+		}));
+		await cache.get('cw-1', afterDelete);
+		expect(afterDelete).toHaveBeenCalledOnce();
+	});
+
+	it('falls back when the poll response has no address', async () => {
+		const raw = transport(
+			vi.fn(async ({ sandboxId }: { sandboxId: string }) => ({
+				sandboxId,
+				status: 'running' as const,
+			})),
+		);
+		const cache = withServiceAddressCache(raw);
+		await cache.transport.get({ sandboxId: 'cw-1' });
+		const fallback = vi.fn(async () => ({
+			sandboxId: 'cw-1',
+			status: 'running' as const,
+			serviceAddress: '10.0.0.2',
+		}));
+		expect(await cache.get('cw-1', fallback)).toMatchObject({ serviceAddress: '10.0.0.2' });
+		expect(fallback).toHaveBeenCalledOnce();
 	});
 });
 

--- a/packages/compute-coreweave/src/wandb.ts
+++ b/packages/compute-coreweave/src/wandb.ts
@@ -142,7 +142,9 @@ export function withServiceAddressCache(transport: SandboxTransport): {
 		async get(sandboxId, fallback) {
 			const result = results.get(sandboxId);
 			if (result?.serviceAddress) return result;
-			return fallback ? fallback() : cached.get({ sandboxId });
+			const fetched = await (fallback ? fallback() : cached.get({ sandboxId }));
+			results.set(fetched.sandboxId, fetched);
+			return fetched;
 		},
 	};
 }

--- a/packages/compute-coreweave/src/wandb.ts
+++ b/packages/compute-coreweave/src/wandb.ts
@@ -25,6 +25,7 @@
 import { SandboxClient } from '@coreweave/cwsandbox';
 import { DEFAULT_BASE_URL, GrpcSandboxTransport } from '@coreweave/cwsandbox/node';
 import { CoreWeaveCompute } from './index';
+import type { GetSandboxResult, SandboxTransport } from '@coreweave/cwsandbox';
 import type { CoreWeaveClient, CoreWeaveConfig } from './index';
 import { instrumentCoreWeaveTransport } from './tracing';
 
@@ -100,6 +101,52 @@ export function serviceAddressResolver(
 	};
 }
 
+export function withServiceAddressCache(transport: SandboxTransport): {
+	transport: SandboxTransport;
+	get(sandboxId: string, fallback?: () => Promise<GetSandboxResult>): Promise<GetSandboxResult>;
+} {
+	const results = new Map<string, GetSandboxResult>();
+	const cached = new Proxy(transport, {
+		get(target, property, receiver) {
+			if (property === 'get') {
+				return async (request: Parameters<SandboxTransport['get']>[0]) => {
+					const result = await target.get(request);
+					results.set(result.sandboxId, result);
+					return result;
+				};
+			}
+			if (property === 'delete') {
+				return async (request: Parameters<SandboxTransport['delete']>[0]) => {
+					try {
+						return await target.delete(request);
+					} finally {
+						results.delete(request.sandboxId);
+					}
+				};
+			}
+			if (property === 'stop') {
+				return async (request: Parameters<SandboxTransport['stop']>[0]) => {
+					try {
+						return await target.stop(request);
+					} finally {
+						results.delete(request.sandboxId);
+					}
+				};
+			}
+			const value = Reflect.get(target, property, receiver) as unknown;
+			return typeof value === 'function' ? value.bind(target) : value;
+		},
+	});
+	return {
+		transport: cached,
+		async get(sandboxId, fallback) {
+			const result = results.get(sandboxId);
+			if (result?.serviceAddress) return result;
+			return fallback ? fallback() : cached.get({ sandboxId });
+		},
+	};
+}
+
 /**
  * A `SandboxProvider` for W&B sandboxes: `CoreWeaveCompute` composed with a
  * W&B-gateway-authenticated client and per-sandbox URL resolution. The optional
@@ -115,17 +162,19 @@ export function createWandbCompute(
 
 	// `||` (not `??`): a set-but-empty env var must also fall back.
 	const gatewayUrl = baseUrl?.trim() || DEFAULT_BASE_URL;
-	const transport = instrumentCoreWeaveTransport(
+	const addressCache = withServiceAddressCache(
 		new GrpcSandboxTransport({
 			baseUrl: gatewayUrl,
 			metadata: buildWandbMetadata({ apiKey, entity, project }),
 		}),
-		gatewayUrl,
 	);
+	const transport = instrumentCoreWeaveTransport(addressCache.transport, gatewayUrl);
 	return new CoreWeaveCompute(
 		{
 			...coreweave,
-			resolveExposedUrl: serviceAddressResolver((sandboxId) => transport.get({ sandboxId })),
+			resolveExposedUrl: serviceAddressResolver((sandboxId) =>
+				addressCache.get(sandboxId, () => transport.get({ sandboxId })),
+			),
 		},
 		// Same controlled cast as `CoreWeaveCompute.getClient()`: the SDK client
 		// exposes the CoreWeaveClient surface at runtime. Eager construction is

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -493,6 +493,74 @@ describe('E2bCompute', () => {
 		await expect(proc.waitForPort(2718, { timeout: 2000 })).resolves.toBeUndefined();
 	});
 
+	it('launchProcess returns a supervisor failure without waiting for the startup deadline', async () => {
+		const state: { fake?: FakeE2b } = {};
+		const fake = new FakeE2b({
+			runResult: (cmd) => {
+				if (!cmd.startsWith('cat /tmp/marimohub-kernel.log')) return;
+				const launch = state.fake?.backgroundCalls[0]?.cmd ?? '';
+				const nonce = launch.match(/ '([0-9a-f]{32})' '\d+' /)?.[1];
+				if (!nonce) throw new Error('launch nonce not found');
+				return {
+					stdout:
+						`setup output\n__MARIMOHUB_LAUNCH_${nonce}__` +
+						'{"event":"setup_exit","setupMs":12,"waitportMs":0,"exitCode":7}\n',
+					stderr: '',
+					exitCode: 0,
+				};
+			},
+		});
+		state.fake = fake;
+
+		const result = await new E2bCompute(baseConfig, fake).create(SANDBOX_ID).launchProcess!(
+			'run kernel',
+			{ setup: 'run setup', port: 2718, startupTimeout: 60_000 },
+		);
+
+		expect(result).toEqual({
+			success: false,
+			reason: 'setup_exit',
+			exitCode: 7,
+			stdout: 'setup output\n',
+			stderr: '',
+			timings: { setup: 12, start: expect.any(Number), waitport: 0 },
+		});
+		expect(fake.runCalls.some((cmd) => cmd.includes('connect_ex'))).toBe(false);
+	});
+
+	it('merges defined launch environment variables into the background command', async () => {
+		const state: { fake?: FakeE2b } = {};
+		const fake = new FakeE2b({
+			runResult: (cmd) => {
+				if (!cmd.startsWith('cat /tmp/marimohub-kernel.log')) return;
+				const launch = state.fake?.backgroundCalls[0]?.cmd ?? '';
+				const nonce = launch.match(/ '([0-9a-f]{32})' '\d+' /)?.[1];
+				if (!nonce) throw new Error('launch nonce not found');
+				return {
+					stdout: `__MARIMOHUB_LAUNCH_${nonce}__{"event":"ready","setupMs":2,"waitportMs":3}\n`,
+					stderr: '',
+					exitCode: 0,
+				};
+			},
+		});
+		state.fake = fake;
+		const sb = new E2bCompute(baseConfig, fake).create(SANDBOX_ID);
+		await sb.setEnvVars({ TOKEN: 'sandbox', MODE: 'prod' });
+
+		const result = await sb.launchProcess!('run kernel', {
+			port: 2718,
+			startupTimeout: 60_000,
+			env: { TOKEN: 'launch', REQUEST_ID: 'request', OMITTED: undefined },
+		});
+
+		expect(result.success).toBe(true);
+		expect(fake.backgroundCalls[0]?.options?.envs).toEqual({
+			TOKEN: 'launch',
+			MODE: 'prod',
+			REQUEST_ID: 'request',
+		});
+	});
+
 	describe('listFiles()', () => {
 		const findOutput = (lines: string[]) => `${lines.join('\0')}\0`;
 

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -21,6 +21,7 @@ import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
 	classifyListFilesFailure,
+	launchWithProcess,
 	parseFindFilesOutput,
 	pollUntilReady,
 	withEnvPrefix,
@@ -35,6 +36,7 @@ import type {
 	ExposePortOptions,
 	ExposePortResult,
 	GitCheckoutOptions,
+	LaunchProcessOptions,
 	ListFilesOptions,
 	ListFilesResult,
 	MountBucketOptions,
@@ -42,6 +44,7 @@ import type {
 	SandboxFileWrite,
 	SandboxInstance,
 	SandboxProcess,
+	SandboxLaunchResult,
 	SandboxProvider,
 	SetEnvVarsOptions,
 	StartProcessOptions,
@@ -306,6 +309,22 @@ class E2bSandboxInstance implements SandboxInstance {
 				return { stdout: logs.stdout, stderr: '' };
 			},
 		};
+	}
+
+	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
+		return launchWithProcess({
+			setup: options.setup,
+			command: cmd,
+			port: options.port,
+			startupTimeout: options.startupTimeout,
+			waitForPort: options.waitForPort,
+			start: (command) =>
+				this.startProcess(command, {
+					cwd: options.cwd,
+					env: options.env,
+					processId: options.processId,
+				}),
+		});
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -20,8 +20,9 @@
 import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
+	buildLaunchCommand,
 	classifyListFilesFailure,
-	launchWithProcess,
+	parseLaunchOutput,
 	parseFindFilesOutput,
 	pollUntilReady,
 	withEnvPrefix,
@@ -57,6 +58,21 @@ const ID_META_KEY = 'mh-sandbox-id';
 /** Metadata key marking sandboxes this deployment owns (for discovery/cleanup). */
 const OWNER_META_KEY = 'mh-owner';
 const DEFAULT_OWNER_TAG = 'marimohub';
+const KERNEL_LOG_PATH = '/tmp/marimohub-kernel.log';
+const LAUNCH_POLL_INTERVAL_MS = 50;
+const LAUNCH_MARKER_GRACE_MS = 250;
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
+function definedEnv(env?: Record<string, string | undefined>): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(env ?? {}).filter((entry): entry is [string, string] => entry[1] !== undefined),
+	);
+}
 
 // --- Injection seam: the slice of the E2B SDK this adapter uses --------------
 
@@ -276,11 +292,13 @@ class E2bSandboxInstance implements SandboxInstance {
 
 	async startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess> {
 		const sb = await this.ensure();
-		const logPath = '/tmp/marimohub-kernel.log';
-		const handle = await sb.commands.runBackground(this.withDefaults(`${cmd} > ${logPath} 2>&1`), {
-			envs: this.env,
-			cwd: options?.cwd,
-		});
+		const handle = await sb.commands.runBackground(
+			this.withDefaults(`${cmd} > ${KERNEL_LOG_PATH} 2>&1`),
+			{
+				envs: { ...this.env, ...definedEnv(options?.env) },
+				cwd: options?.cwd,
+			},
+		);
 		const exec = (c: string) => this.exec(c);
 		const id = `e2b-proc-${sb.sandboxId}`;
 
@@ -301,30 +319,108 @@ class E2bSandboxInstance implements SandboxInstance {
 					timeoutMs: timeout,
 					intervalMs: 500,
 					timeoutMessage: async () =>
-						`timed out waiting for port ${port} after ${timeout}ms.\n${(await exec(`cat ${logPath} 2>/dev/null || true`)).stdout}`,
+						`timed out waiting for port ${port} after ${timeout}ms.\n${(await exec(`cat ${KERNEL_LOG_PATH} 2>/dev/null || true`)).stdout}`,
 				});
 			},
 			async getLogs(): Promise<{ stdout: string; stderr: string }> {
-				const logs = await exec(`cat ${logPath} 2>/dev/null || true`);
+				const logs = await exec(`cat ${KERNEL_LOG_PATH} 2>/dev/null || true`);
 				return { stdout: logs.stdout, stderr: '' };
 			},
 		};
 	}
 
 	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
-		return launchWithProcess({
+		const built = buildLaunchCommand({
 			setup: options.setup,
 			command: cmd,
 			port: options.port,
 			startupTimeout: options.startupTimeout,
-			waitForPort: options.waitForPort,
-			start: (command) =>
-				this.startProcess(command, {
-					cwd: options.cwd,
-					env: options.env,
-					processId: options.processId,
-				}),
 		});
+		const launchStarted = Date.now();
+		let process: SandboxProcess;
+		try {
+			process = await this.startProcess(built.command, {
+				cwd: options.cwd,
+				env: options.env,
+				processId: options.processId,
+			});
+		} catch (error) {
+			return {
+				success: false,
+				reason: 'transport_failure',
+				stdout: '',
+				stderr: error instanceof Error ? error.message : String(error),
+				timings: { setup: 0, start: Math.max(0, Date.now() - launchStarted), waitport: 0 },
+			};
+		}
+
+		const start = Math.max(0, Date.now() - launchStarted);
+		const waitStarted = Date.now();
+		const deadline =
+			options.startupTimeout === 0 ? undefined : launchStarted + options.startupTimeout;
+		let setupCompleted = false;
+
+		while (true) {
+			let logs: { stdout: string; stderr: string };
+			try {
+				logs = await process.getLogs();
+			} catch (error) {
+				await process.kill().catch(() => {});
+				return {
+					success: false,
+					reason: 'transport_failure',
+					stdout: '',
+					stderr: error instanceof Error ? error.message : String(error),
+					timings: { setup: 0, start, waitport: Math.max(0, Date.now() - waitStarted) },
+				};
+			}
+
+			setupCompleted ||= `${logs.stdout}\n${logs.stderr}`.includes(
+				`__MARIMOHUB_LAUNCH_${built.nonce}__{"event":"setup_complete"`,
+			);
+			const parsed = parseLaunchOutput(logs, built.nonce);
+			const outcome = parsed.outcome;
+			if (outcome?.kind === 'ready') {
+				return {
+					success: true,
+					process,
+					timings: { setup: outcome.setupMs, start, waitport: outcome.waitportMs },
+				};
+			}
+			if (outcome) {
+				return {
+					success: false,
+					reason: outcome.kind,
+					...(outcome.exitCode === undefined ? {} : { exitCode: outcome.exitCode }),
+					stdout: parsed.stdout,
+					stderr: parsed.stderr,
+					timings: { setup: outcome.setupMs, start, waitport: outcome.waitportMs },
+				};
+			}
+
+			const now = Date.now();
+			if (deadline !== undefined && now >= deadline + LAUNCH_MARKER_GRACE_MS) {
+				await process.kill().catch(() => {});
+				const reason = options.setup && !setupCompleted ? 'setup_timeout' : 'readiness_timeout';
+				return {
+					success: false,
+					reason,
+					stdout: parsed.stdout,
+					stderr: parsed.stderr,
+					timings: {
+						setup: reason === 'setup_timeout' ? Math.max(0, options.startupTimeout - start) : 0,
+						start,
+						waitport: Math.max(0, now - waitStarted),
+					},
+				};
+			}
+
+			const sleepFor =
+				deadline === undefined
+					? LAUNCH_POLL_INTERVAL_MS
+					: Math.min(LAUNCH_POLL_INTERVAL_MS, Math.max(1, deadline + LAUNCH_MARKER_GRACE_MS - now));
+			await delay(sleepFor);
+		}
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -555,7 +555,11 @@ describe('KubernetesCompute', () => {
 				},
 			});
 			const inst = makeCompute(world).create(SANDBOX_ID);
-			const proc = await inst.startProcess('uv run marimo edit --port 2718', { cwd: '/workspace' });
+			const proc = await inst.startProcess('uv run marimo edit --port 2718', {
+				cwd: '/workspace',
+				env: { SESSION_TOKEN: 'a b', OMITTED: undefined },
+				processId: 'kernel-process',
+			});
 			await proc.waitForPort(2718, { timeout: 5000 });
 			expect(chunks).toBe(2);
 
@@ -566,12 +570,15 @@ describe('KubernetesCompute', () => {
 
 			const launch = world.execCalls.find((c) => shCmd(c).includes('setsid'))!;
 			expect(shCmd(launch)).toContain("cd '/workspace'");
+			expect(shCmd(launch)).toContain('export SESSION_TOKEN=');
+			expect(shCmd(launch)).toContain('a b');
+			expect(shCmd(launch)).not.toContain('OMITTED');
 			expect(shCmd(launch)).toContain('uv run marimo edit --port 2718');
 			// Outer shell non-login (its stdout is the parsed PID); the detached
 			// inner shell is a login shell so profile env reaches the kernel.
 			expect(launch.command[1]).toBe('-c');
 			expect(shCmd(launch)).toContain('setsid sh -lc');
-			expect(proc.id).toContain('4242');
+			expect(proc.id).toBe('kernel-process');
 		});
 
 		it('honors a sub-second timeout in the chunk it hands to the pod', async () => {

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -48,6 +48,7 @@ import {
 	parseFindFilesOutput,
 	pollUntilReady,
 	portWaitCommand,
+	removeUndefined,
 	shellQuote,
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
@@ -495,12 +496,13 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		await this.ensure();
 		const logFile = `/tmp/mh-proc-${++PROC_SEQ}.log`;
 		const cwd = options?.cwd ? `cd ${shellQuote(options.cwd)}; ` : '';
+		const processCommand = withEnvPrefix(cmd, removeUndefined(options?.env ?? {}));
 		// Launch marimo detached so it outlives this exec session (the kernel must keep
 		// serving after startProcess returns). setsid + redirect + background; echo PID.
 		// The OUTER shell is non-login (its stdout is the PID we parse); the inner
 		// detached shell is a login shell so profile-provided env reaches the kernel
 		// (its output goes to the log file, where profile noise is harmless).
-		const launch = `${cwd}setsid sh -lc ${shellQuote(this.withEnv(cmd))} >${logFile} 2>&1 </dev/null & echo $!`;
+		const launch = `${cwd}setsid sh -lc ${shellQuote(this.withEnv(processCommand))} >${logFile} 2>&1 </dev/null & echo $!`;
 		const started = await this.execInPod(launch);
 		const pid = started.stdout.trim();
 
@@ -509,7 +511,7 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		const readLog = async () => (await execIn(`cat ${logFile} 2>/dev/null || true`)).stdout;
 		const name = this.name;
 		return {
-			id: `k8s-proc-${pid || PROC_SEQ}`,
+			id: options?.processId ?? `k8s-proc-${pid || PROC_SEQ}`,
 			command: cmd,
 			async kill(signal?: string): Promise<void> {
 				if (!pid) return;

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -43,6 +43,7 @@ import {
 	buildFindFilesCommand,
 	buildGitCloneCommand,
 	classifyListFilesFailure,
+	launchWithProcess,
 	mapWithConcurrency,
 	parseFindFilesOutput,
 	pollUntilReady,
@@ -68,11 +69,13 @@ import type {
 	ExposePortOptions,
 	ExposePortResult,
 	GitCheckoutOptions,
+	LaunchProcessOptions,
 	ListFilesOptions,
 	ListFilesResult,
 	MountBucketOptions,
 	ReadFileResult,
 	SandboxFileWrite,
+	SandboxLaunchResult,
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
@@ -555,6 +558,22 @@ class KubernetesSandboxInstance implements SandboxInstance {
 				return { stdout: await readLog(), stderr: '' };
 			},
 		};
+	}
+
+	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
+		return launchWithProcess({
+			setup: options.setup,
+			command: cmd,
+			port: options.port,
+			startupTimeout: options.startupTimeout,
+			waitForPort: options.waitForPort,
+			start: (command) =>
+				this.startProcess(command, {
+					cwd: options.cwd,
+					env: options.env,
+					processId: options.processId,
+				}),
+		});
 	}
 
 	async exposePort(_port: number, options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -422,6 +422,133 @@ describe('LocalCompute env propagation', () => {
 });
 
 describe('LocalCompute process lifecycle', () => {
+	it('runs checked setup and readiness through the combined launcher', async () => {
+		const sb = newSandbox();
+		const result = await sb.launchProcess!(`test -f setup.flag && ${SERVER_CMD}`, {
+			setup: 'printf setup-ok > setup.flag',
+			cwd: '/workspace',
+			port: 2718,
+			startupTimeout: 15_000,
+		});
+		if (!result.success) throw new Error(JSON.stringify(result));
+		expect(result).toMatchObject({
+			success: true,
+			timings: {
+				setup: expect.any(Number),
+				start: expect.any(Number),
+				waitport: expect.any(Number),
+			},
+		});
+		const { url } = await sb.exposePort(2718, { hostname: 'ignored' });
+		expect(await (await fetch(url)).text()).toBe('ok');
+		const pid = Number(result.process.id);
+		await result.process.kill();
+		await expect.poll(() => processIsAlive(pid), { timeout: 5000, interval: 20 }).toBe(false);
+	}, 15_000);
+
+	it('prepares a marimo launch before wrapping it in the supervisor', async () => {
+		const stubDir = await mkdtemp(path.join(os.tmpdir(), 'marimohub-launch-'));
+		const uvLog = path.join(stubDir, 'uv.log');
+		await writeFile(
+			path.join(stubDir, 'uv'),
+			`#!/bin/sh
+printf '%s\n' "$*" > "$UV_LOG"
+with_marimo=0
+port=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --with) [ "\${2:-}" = marimo ] && with_marimo=1; shift 2 ;;
+    --port) port="\${2:-}"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[ "$with_marimo" -eq 1 ] || exit 64
+[ -n "$port" ] || exit 65
+exec "$NODE_BIN" -e 'const p=Number(process.argv[1]);require("http").createServer((_,r)=>r.end("ok")).listen(p,"127.0.0.1")' "$port"
+`,
+			{ mode: 0o755 },
+		);
+		const sb = newSandbox();
+		try {
+			const command = buildMarimoLaunch({
+				notebookFile: 'notebook.py',
+				port: 2718,
+				host: '127.0.0.1',
+			}).start;
+			const result = await sb.launchProcess!(command, {
+				cwd: '/workspace',
+				env: {
+					PATH: `${stubDir}:${process.env.PATH}`,
+					UV_LOG: uvLog,
+					NODE_BIN: process.execPath,
+				},
+				port: 2718,
+				startupTimeout: 15_000,
+			});
+			if (!result.success) throw new Error(JSON.stringify(result));
+			expect(await readFile(uvLog, 'utf8')).toContain('run --with marimo');
+			const { url } = await sb.exposePort(2718, { hostname: 'ignored' });
+			expect(await (await fetch(url)).text()).toBe('ok');
+			await result.process.kill();
+		} finally {
+			await rm(stubDir, { recursive: true, force: true });
+		}
+	}, 15_000);
+
+	it.each([
+		{
+			name: 'setup exit',
+			setup: 'printf setup-failed >&2; exit 7',
+			command: SERVER_CMD,
+			timeout: 5000,
+			reason: 'setup_exit',
+			output: 'setup-failed',
+		},
+		{
+			name: 'setup timeout',
+			setup: 'sleep 10',
+			command: SERVER_CMD,
+			timeout: 20,
+			reason: 'setup_timeout',
+			output: '',
+		},
+		{
+			name: 'early kernel exit',
+			command: 'printf kernel-failed >&2; exit 9',
+			timeout: 5000,
+			reason: 'kernel_exit',
+			output: 'kernel-failed',
+		},
+		{
+			name: 'readiness timeout',
+			command: 'sleep 10',
+			timeout: 20,
+			reason: 'readiness_timeout',
+			output: '',
+		},
+	] as const)('reports $name with filtered logs and timings', async (testCase) => {
+		const sb = newSandbox();
+		const result = await sb.launchProcess!(testCase.command, {
+			...(testCase.setup ? { setup: testCase.setup } : {}),
+			cwd: '/workspace',
+			port: 2718,
+			startupTimeout: testCase.timeout,
+		});
+		expect(result).toMatchObject({
+			success: false,
+			reason: testCase.reason,
+			timings: {
+				setup: expect.any(Number),
+				start: expect.any(Number),
+				waitport: expect.any(Number),
+			},
+		});
+		if (result.success) throw new Error('expected launch failure');
+		expect(result.stdout + result.stderr).toContain(testCase.output);
+		expect(result.stderr).not.toContain('__MARIMOHUB_LAUNCH_');
+		for (const timing of Object.values(result.timings)) expect(timing).toBeGreaterThanOrEqual(0);
+	});
+
 	it('maps the logical port to a real free port and serves there', async () => {
 		const sb = newSandbox();
 		const proc = await sb.startProcess(SERVER_CMD, { cwd: '/workspace' });

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -425,7 +425,7 @@ describe('LocalCompute process lifecycle', () => {
 	it('runs checked setup and readiness through the combined launcher', async () => {
 		const sb = newSandbox();
 		const result = await sb.launchProcess!(`test -f setup.flag && ${SERVER_CMD}`, {
-			setup: 'printf setup-ok > setup.flag',
+			setup: `printf '%s' '--port 9999' > setup-port.txt && printf setup-ok > setup.flag`,
 			cwd: '/workspace',
 			port: 2718,
 			startupTimeout: 15_000,
@@ -441,6 +441,10 @@ describe('LocalCompute process lifecycle', () => {
 		});
 		const { url } = await sb.exposePort(2718, { hostname: 'ignored' });
 		expect(await (await fetch(url)).text()).toBe('ok');
+		expect(await sb.readFile('/workspace/setup-port.txt')).toMatchObject({
+			success: true,
+			content: '--port 9999',
+		});
 		const pid = Number(result.process.id);
 		await result.process.kill();
 		await expect.poll(() => processIsAlive(pid), { timeout: 5000, interval: 20 }).toBe(false);
@@ -677,6 +681,22 @@ describe('LocalCompute registry & teardown', () => {
 		// Port no longer served.
 		await expect(fetch(url)).rejects.toThrow();
 	});
+
+	it('destroy terminates a kernel started by the combined supervisor', async () => {
+		const id = `sb-launch-destroy-${Math.random().toString(36).slice(2, 10)}` as SandboxId;
+		const sb = compute.create(id);
+		const result = await sb.launchProcess!(SERVER_CMD, {
+			cwd: '/workspace',
+			port: 2718,
+			startupTimeout: 15_000,
+		});
+		if (!result.success) throw new Error(JSON.stringify(result));
+		const { url } = await sb.exposePort(2718, { hostname: '' });
+
+		await sb.destroy();
+
+		await expect(fetch(url)).rejects.toThrow();
+	}, 15_000);
 
 	it('proxy is a no-op', async () => {
 		expect(await compute.proxy()).toBeNull();

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -82,6 +82,39 @@ function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
 	}
 }
 
+function childIsRunning(child: ChildProcess): boolean {
+	return child.exitCode === null && child.signalCode === null;
+}
+
+async function waitForChildren(
+	children: readonly ChildProcess[],
+	timeoutMs: number,
+): Promise<void> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			Promise.all(
+				children.map(
+					(child) =>
+						new Promise<void>((resolve) => {
+							if (!childIsRunning(child)) {
+								resolve();
+								return;
+							}
+							child.once('exit', () => resolve());
+							child.once('error', () => resolve());
+						}),
+				),
+			),
+			new Promise<void>((resolve) => {
+				timer = setTimeout(resolve, timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
 const WORKSPACE = '/workspace';
 
 export interface PortRange {
@@ -546,14 +579,20 @@ class LocalSandboxInstance implements SandboxInstance {
 
 	async destroy(): Promise<void> {
 		if (this.destroyPromise) return this.destroyPromise;
-		for (const child of this.children) killProcessGroup(child, 'SIGKILL');
-		this.children.clear();
-		this.portMap.clear();
-		this.destroyPromise = Promise.allSettled(this.pendingWrites)
-			.then(() => rm(this.root, { recursive: true, force: true }))
-			.then(() => {
-				this.onDestroyed?.();
-			});
+		const children = [...this.children];
+		this.destroyPromise = (async () => {
+			for (const child of children) killProcessGroup(child, 'SIGTERM');
+			await waitForChildren(children, 2_000);
+			for (const child of children) {
+				if (childIsRunning(child)) killProcessGroup(child, 'SIGKILL');
+			}
+			await waitForChildren(children, 500);
+			this.children.clear();
+			this.portMap.clear();
+			await Promise.allSettled(this.pendingWrites);
+			await rm(this.root, { recursive: true, force: true });
+			this.onDestroyed?.();
+		})();
 		return this.destroyPromise;
 	}
 }

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -26,6 +26,7 @@ import path from 'node:path';
 import { Readable } from 'node:stream';
 import {
 	buildGitCloneCommand,
+	launchWithProcess,
 	mapWithConcurrency,
 	pollUntilReady,
 	withEnvPrefix,
@@ -42,11 +43,13 @@ import type {
 	ExposePortResult,
 	FileInfo,
 	GitCheckoutOptions,
+	LaunchProcessOptions,
 	ListFilesOptions,
 	ListFilesResult,
 	MountBucketOptions,
 	ReadFileResult,
 	SandboxFileWrite,
+	SandboxLaunchResult,
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
@@ -458,6 +461,9 @@ class LocalSandboxInstance implements SandboxInstance {
 			const real = await allocatePort(this.bindHost, this.ports);
 			this.portMap.set(logical, real);
 			command = command.replace(/--port\s+\d+/, `--port ${real}`);
+			if (command.includes('__MARIMOHUB_LAUNCH_')) {
+				command = command.replace(new RegExp(`'${logical}'$`), `'${real}'`);
+			}
 		}
 
 		const cwd = options?.cwd ? this.mapPath(options.cwd) : this.root;
@@ -515,6 +521,22 @@ class LocalSandboxInstance implements SandboxInstance {
 			},
 		};
 		return proc;
+	}
+
+	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
+		return launchWithProcess({
+			setup: options.setup,
+			command: this.prepareMarimoCmd(cmd),
+			port: options.port,
+			startupTimeout: options.startupTimeout,
+			waitForPort: options.waitForPort,
+			start: (command) =>
+				this.startProcess(command, {
+					cwd: options.cwd,
+					env: options.env,
+					processId: options.processId,
+				}),
+		});
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -437,6 +437,40 @@ describe('ModalCompute', () => {
 		expect(sandbox.execCalls).toHaveLength(2);
 	});
 
+	it('uses the launch stream for readiness without polling through exec', async () => {
+		const world = makeWorld();
+		const sandbox = new FakeSandbox();
+		const pending = pendingProcessResult();
+		sandbox.execImpl = (command) => {
+			const nonce = command[2]?.match(/[a-f0-9]{32}/)?.[0];
+			if (!nonce) return processResult();
+			return {
+				stdout: textStream('kernel output\n'),
+				stderr: textStream(
+					`__MARIMOHUB_LAUNCH_${nonce}__{"event":"ready","setupMs":8,"waitportMs":13}\n`,
+				),
+				wait: pending.process.wait,
+			};
+		};
+		world.existing.set(SANDBOX_ID, sandbox);
+
+		const result = await makeCompute(world).create(SANDBOX_ID).launchProcess!('run kernel', {
+			setup: 'run setup',
+			port: 2718,
+			startupTimeout: 60_000,
+		});
+
+		expect(result).toMatchObject({
+			success: true,
+			timings: { setup: 8, start: expect.any(Number), waitport: 13 },
+		});
+		expect(sandbox.execCalls).toHaveLength(1);
+		expect(sandbox.execCalls[0].command[2]).not.toContain('socket.create_connection');
+		if (!result.success) throw new Error(JSON.stringify(result));
+		expect(await result.process.getLogs()).toEqual({ stdout: 'kernel output\n', stderr: '' });
+		pending.resolve(0);
+	});
+
 	it('treats destroy of an absent sandbox as idempotent', async () => {
 		const world = makeWorld();
 		await expect(makeCompute(world).create(SANDBOX_ID).destroy()).resolves.toBeUndefined();

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -6,13 +6,15 @@ import {
 	SandboxFilesystemNotADirectoryError,
 } from 'modal';
 import {
+	buildLaunchCommand,
 	buildGitCloneCommand,
-	launchWithProcess,
 	mapWithConcurrency,
+	parseLaunchOutput,
 	shellQuote,
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
+import type { LaunchProtocolOutcome } from '@marimo-hub/compute-commons';
 import { NotFoundError, SandboxId } from '@marimo-hub/core';
 import type {
 	ActiveSandbox,
@@ -201,6 +203,11 @@ function delay(ms: number): Promise<void> {
 }
 
 let processSequence = 0;
+const LAUNCH_MARKER_GRACE_MS = 100;
+
+class ModalLaunchTimeoutError extends Error {
+	override readonly name = 'ModalLaunchTimeoutError';
+}
 
 class ModalSandboxInstance implements SandboxInstance {
 	readonly supportsBucketMount = false;
@@ -362,7 +369,11 @@ class ModalSandboxInstance implements SandboxInstance {
 
 	async unmountBucket(_mountPath: string): Promise<void> {}
 
-	async startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess> {
+	private async startProcessWithOutput(
+		cmd: string,
+		options?: StartProcessOptions,
+		onOutput?: (logs: { stdout: string; stderr: string }) => void,
+	): Promise<{ process: SandboxProcess; completed: Promise<void> }> {
 		const pidPath = `/tmp/marimohub-process-${randomUUID()}.pid`;
 		const trackedCommand = [
 			'stat=$(cat /proc/$$/stat)',
@@ -371,7 +382,7 @@ class ModalSandboxInstance implements SandboxInstance {
 			`printf '%s %s\\n' "$$" "\${20}" > ${shellQuote(pidPath)}`,
 			`exec sh -lc ${shellQuote(cmd)}`,
 		].join('; ');
-		const process = await this.spawn(['sh', '-lc', this.withDefaults(trackedCommand)], {
+		const modalProcess = await this.spawn(['sh', '-lc', this.withDefaults(trackedCommand)], {
 			cwd: options?.cwd,
 			env: options?.env,
 			timeout: options?.timeout,
@@ -381,13 +392,15 @@ class ModalSandboxInstance implements SandboxInstance {
 		let exitCode: number | undefined;
 		let settled = false;
 		const execInSandbox = (command: string) => this.exec(command);
-		const stdoutDone = consumeStream(process.stdout, (chunk) => {
+		const stdoutDone = consumeStream(modalProcess.stdout, (chunk) => {
 			stdout += chunk;
+			onOutput?.({ stdout, stderr });
 		});
-		const stderrDone = consumeStream(process.stderr, (chunk) => {
+		const stderrDone = consumeStream(modalProcess.stderr, (chunk) => {
 			stderr += chunk;
+			onOutput?.({ stdout, stderr });
 		});
-		const exited = process
+		const exited = modalProcess
 			.wait()
 			.then((code) => {
 				exitCode = code;
@@ -397,8 +410,9 @@ class ModalSandboxInstance implements SandboxInstance {
 				settled = true;
 				void execInSandbox(`rm -f ${shellQuote(pidPath)}`).catch(() => {});
 			});
+		const completed = Promise.all([stdoutDone, stderrDone, exited]).then(() => {});
 
-		return {
+		const sandboxProcess: SandboxProcess = {
 			id: options?.processId ?? `modal-process-${++processSequence}`,
 			command: cmd,
 			async kill(signal?: string): Promise<void> {
@@ -438,26 +452,163 @@ class ModalSandboxInstance implements SandboxInstance {
 				);
 			},
 			async getLogs(): Promise<{ stdout: string; stderr: string }> {
-				if (exitCode !== undefined) await Promise.allSettled([stdoutDone, stderrDone, exited]);
+				if (exitCode !== undefined) await completed.catch(() => {});
 				return { stdout, stderr };
 			},
 		};
+		return { process: sandboxProcess, completed };
+	}
+
+	async startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess> {
+		return (await this.startProcessWithOutput(cmd, options)).process;
 	}
 
 	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
-		return launchWithProcess({
+		const built = buildLaunchCommand({
 			setup: options.setup,
 			command: cmd,
 			port: options.port,
 			startupTimeout: options.startupTimeout,
-			waitForPort: options.waitForPort,
-			start: (command) =>
-				this.startProcess(command, {
+		});
+		const launchStarted = Date.now();
+		let settled = false;
+		let resolveOutcome!: (outcome: LaunchProtocolOutcome) => void;
+		let rejectOutcome!: (error: unknown) => void;
+		const outcome = new Promise<LaunchProtocolOutcome>((resolve, reject) => {
+			resolveOutcome = resolve;
+			rejectOutcome = reject;
+		});
+		const inspect = (logs: { stdout: string; stderr: string }) => {
+			if (settled) return;
+			const terminal = parseLaunchOutput(logs, built.nonce).outcome;
+			if (terminal) {
+				settled = true;
+				resolveOutcome(terminal);
+			}
+		};
+
+		let started: Awaited<ReturnType<ModalSandboxInstance['startProcessWithOutput']>>;
+		try {
+			started = await this.startProcessWithOutput(
+				built.command,
+				{
 					cwd: options.cwd,
 					env: options.env,
 					processId: options.processId,
-				}),
-		});
+				},
+				inspect,
+			);
+		} catch (error) {
+			return {
+				success: false,
+				reason: 'transport_failure',
+				stdout: '',
+				stderr: error instanceof Error ? error.message : String(error),
+				timings: { setup: 0, start: Math.max(0, Date.now() - launchStarted), waitport: 0 },
+			};
+		}
+
+		const start = Math.max(0, Date.now() - launchStarted);
+		const waitStarted = Date.now();
+		void started.completed.then(
+			() => {
+				if (!settled) {
+					settled = true;
+					rejectOutcome(new Error('Modal launch stream ended before reporting readiness'));
+				}
+			},
+			(error) => {
+				if (!settled) {
+					settled = true;
+					rejectOutcome(error);
+				}
+			},
+		);
+
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timedOutcome =
+			options.startupTimeout === 0
+				? outcome
+				: Promise.race([
+						outcome,
+						new Promise<LaunchProtocolOutcome>((_resolve, reject) => {
+							timer = setTimeout(
+								() => reject(new ModalLaunchTimeoutError()),
+								Math.max(0, options.startupTimeout - start) + LAUNCH_MARKER_GRACE_MS,
+							);
+						}),
+					]);
+
+		let terminal: LaunchProtocolOutcome;
+		try {
+			terminal = await timedOutcome;
+		} catch (error) {
+			settled = true;
+			const logs = await started.process.getLogs();
+			const parsed = parseLaunchOutput(logs, built.nonce);
+			if (!(error instanceof ModalLaunchTimeoutError)) {
+				await started.process.kill().catch(() => {});
+				return {
+					success: false,
+					reason: 'transport_failure',
+					stdout: parsed.stdout,
+					stderr: [parsed.stderr, error instanceof Error ? error.message : String(error)]
+						.filter(Boolean)
+						.join('\n'),
+					timings: { setup: 0, start, waitport: Math.max(0, Date.now() - waitStarted) },
+				};
+			}
+
+			await started.process.kill().catch(() => {});
+			const setupCompleted = `${logs.stdout}\n${logs.stderr}`.includes(
+				`__MARIMOHUB_LAUNCH_${built.nonce}__{"event":"setup_complete"`,
+			);
+			const reason = options.setup && !setupCompleted ? 'setup_timeout' : 'readiness_timeout';
+			return {
+				success: false,
+				reason,
+				stdout: parsed.stdout,
+				stderr: parsed.stderr,
+				timings: {
+					setup: reason === 'setup_timeout' ? Math.max(0, options.startupTimeout - start) : 0,
+					start,
+					waitport: Math.max(0, Date.now() - waitStarted),
+				},
+			};
+		} finally {
+			if (timer) clearTimeout(timer);
+		}
+
+		const timings = { setup: terminal.setupMs, start, waitport: terminal.waitportMs };
+		if (terminal.kind === 'ready') {
+			const process = started.process;
+			return {
+				success: true,
+				timings,
+				process: {
+					id: process.id,
+					command: cmd,
+					kill: (signal) => process.kill(signal),
+					waitForPort: (port, waitOptions) =>
+						port === options.port ? Promise.resolve() : process.waitForPort(port, waitOptions),
+					async getLogs() {
+						const parsed = parseLaunchOutput(await process.getLogs(), built.nonce);
+						return { stdout: parsed.stdout, stderr: parsed.stderr };
+					},
+				},
+			};
+		}
+
+		await started.completed.catch(() => {});
+		const parsed = parseLaunchOutput(await started.process.getLogs(), built.nonce);
+		return {
+			success: false,
+			reason: terminal.kind,
+			...(terminal.exitCode === undefined ? {} : { exitCode: terminal.exitCode }),
+			stdout: parsed.stdout,
+			stderr: parsed.stderr,
+			timings,
+		};
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -7,6 +7,7 @@ import {
 } from 'modal';
 import {
 	buildGitCloneCommand,
+	launchWithProcess,
 	mapWithConcurrency,
 	shellQuote,
 	withEnvPrefix,
@@ -24,11 +25,13 @@ import type {
 	ExposePortResult,
 	FileInfo,
 	GitCheckoutOptions,
+	LaunchProcessOptions,
 	ListFilesOptions,
 	ListFilesResult,
 	MountBucketOptions,
 	ReadFileResult,
 	SandboxFileWrite,
+	SandboxLaunchResult,
 	SandboxInstance,
 	SandboxProcess,
 	SandboxProvider,
@@ -439,6 +442,22 @@ class ModalSandboxInstance implements SandboxInstance {
 				return { stdout, stderr };
 			},
 		};
+	}
+
+	async launchProcess(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult> {
+		return launchWithProcess({
+			setup: options.setup,
+			command: cmd,
+			port: options.port,
+			startupTimeout: options.startupTimeout,
+			waitForPort: options.waitForPort,
+			start: (command) =>
+				this.startProcess(command, {
+					cwd: options.cwd,
+					env: options.env,
+					processId: options.processId,
+				}),
+		});
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -52,7 +52,7 @@ export interface StartProcessOptions {
 	timeout?: number;
 }
 
-export interface LaunchProcessOptions extends StartProcessOptions {
+export interface LaunchProcessOptions extends Omit<StartProcessOptions, 'timeout'> {
 	setup?: string;
 	port: number;
 	/** Readiness mode; the shared launch supervisor currently uses TCP. */

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -52,6 +52,15 @@ export interface StartProcessOptions {
 	timeout?: number;
 }
 
+export interface LaunchProcessOptions extends StartProcessOptions {
+	setup?: string;
+	port: number;
+	/** Readiness mode; the shared launch supervisor currently uses TCP. */
+	waitForPort?: Omit<WaitForPortOptions, 'timeout'>;
+	/** One deadline shared by setup and readiness. Zero disables the deadline. */
+	startupTimeout: number;
+}
+
 export interface WaitForPortOptions {
 	mode?: 'http' | 'tcp';
 	path?: string;
@@ -65,6 +74,34 @@ export interface SandboxProcess {
 	waitForPort(port: number, options?: WaitForPortOptions): Promise<void>;
 	getLogs(): Promise<{ stdout: string; stderr: string }>;
 }
+
+export interface SandboxLaunchTimings {
+	setup: number;
+	start: number;
+	waitport: number;
+}
+
+export type SandboxLaunchFailureReason =
+	| 'setup_exit'
+	| 'setup_timeout'
+	| 'kernel_exit'
+	| 'readiness_timeout'
+	| 'transport_failure';
+
+export type SandboxLaunchResult =
+	| {
+			success: true;
+			process: SandboxProcess;
+			timings: SandboxLaunchTimings;
+	  }
+	| {
+			success: false;
+			reason: SandboxLaunchFailureReason;
+			exitCode?: number;
+			stdout: string;
+			stderr: string;
+			timings: SandboxLaunchTimings;
+	  };
 
 export type ReadFileResult =
 	| { success: true; content: string; encoding?: 'utf-8' | 'base64' }
@@ -175,6 +212,11 @@ export interface SandboxInstance {
 	mountBucket(options: MountBucketOptions): Promise<void>;
 	unmountBucket(mountPath: string): Promise<void>;
 	startProcess(cmd: string, options?: StartProcessOptions): Promise<SandboxProcess>;
+	/**
+	 * Start a checked setup + long-running process and wait for readiness as one
+	 * adapter-owned operation. Optional for compatibility with external adapters.
+	 */
+	launchProcess?(cmd: string, options: LaunchProcessOptions): Promise<SandboxLaunchResult>;
 	exposePort(port: number, options: ExposePortOptions): Promise<ExposePortResult>;
 	destroy(): Promise<void>;
 	/**

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -547,6 +547,28 @@ describe('SandboxProvisioner', () => {
 		// A command round-trip is the dominant unit of startup cost on a remote
 		// backend (~220ms each on CoreWeave), so these lock in the count.
 		describe('command round-trips', () => {
+			it('prefers combined launch and keeps its phase timings', async () => {
+				const { instance, calls } = makeFakeSandbox();
+				instance.ready = async () => {};
+				instance.launchProcess = async (command, options) => ({
+					success: true,
+					process: await instance.startProcess(command, { cwd: options.cwd }),
+					timings: { setup: 41, start: 3, waitport: 17 },
+				});
+
+				const result = await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				});
+
+				expect(calls.exec).toHaveLength(0);
+				expect(calls.startProcess).toHaveLength(1);
+				expect(result.timings).toMatchObject({ setup: 41, start: 3, waitport: 17 });
+			});
+
 			it('a copy-path provision spends one checked setup exec', async () => {
 				const { instance, calls } = makeFakeSandbox({ failMount: true });
 				const bucketHandle = new MemoryBucket();
@@ -660,6 +682,7 @@ describe('SandboxProvisioner', () => {
 				code: 'PYTHON_ENV_SETUP_FAILED',
 				status: 503,
 			});
+
 			expect((failure as Error).message).toContain('does not allow replacing');
 			expect(calls.startProcess).toHaveLength(0);
 			expect(calls.destroy).toBe(1);
@@ -750,6 +773,32 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess[0].cmd).toContain("marimo edit 'apps/my_app.py'");
 		});
 
+		it('classifies a combined-launch setup failure the same way', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			instance.launchProcess = async () => ({
+				success: false,
+				reason: 'setup_exit',
+				exitCode: 2,
+				stdout: '',
+				stderr: 'TOMLDecodeError: Invalid value',
+				timings: { setup: 7, start: 2, waitport: 0 },
+			});
+
+			const failure = await new SandboxProvisioner(fakeComputeFrom(instance))
+				.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				})
+				.catch((error: unknown) => error);
+
+			expect(failure).toMatchObject({ code: 'PYTHON_ENV_SETUP_FAILED', status: 503 });
+			expect((failure as Error).message).toContain('pyproject.toml could not be parsed');
+			expect(calls.destroy).toBe(1);
+		});
+
 		it('restores pull-source Git metadata into the workspace .git directory', async () => {
 			const { instance, calls } = makeFakeSandbox();
 			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
@@ -777,6 +826,71 @@ describe('SandboxProvisioner', () => {
 			expect(restored).toContain(`${MOUNT_PATH}/.git/HEAD`);
 			expect(restored).toContain(`${MOUNT_PATH}/.git/objects/pack/pack-a.pack`);
 			expect(result.counters).toMatchObject({ files_objects: 3 });
+		});
+
+		it('preserves Git metadata stored in an ordinary copied workspace', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceFile('app.py'), 'import marimo as mo');
+			await bucketHandle.put(version.workspaceFile('.git/HEAD'), 'ref: refs/heads/main\n');
+
+			await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				bucketHandle,
+				workspaceLoadMode: 'copy-only',
+				workspacePrefix: version.workspacePrefix,
+			});
+
+			expect(calls.writeFiles.flat().map((file) => file.path)).toEqual(
+				expect.arrayContaining([`${MOUNT_PATH}/app.py`, `${MOUNT_PATH}/.git/HEAD`]),
+			);
+		});
+
+		it('restores copied workspace and Git metadata concurrently', async () => {
+			const { instance: base, calls } = makeFakeSandbox();
+			const writeFiles = base.writeFiles.bind(base);
+			let inFlight = 0;
+			let maxInFlight = 0;
+			const instance: SandboxInstance = {
+				...base,
+				supportsBucketMount: false,
+				async writeFiles(files) {
+					inFlight++;
+					maxInFlight = Math.max(maxInFlight, inFlight);
+					await new Promise((resolve) => setTimeout(resolve, 20));
+					await writeFiles(files);
+					inFlight--;
+				},
+			};
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceFile('app.py'), 'import marimo as mo');
+			await bucketHandle.put(version.workspaceFile('.git/config'), 'stale');
+			await bucketHandle.put(version.gitFile('HEAD'), 'ref: refs/heads/main\n');
+
+			await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				bucketHandle,
+				workspacePrefix: version.workspacePrefix,
+				gitPrefix: version.gitPrefix,
+			});
+
+			expect(maxInFlight).toBe(2);
+			expect(calls.writeFiles.flat().map((file) => file.path)).toEqual(
+				expect.arrayContaining([`${MOUNT_PATH}/app.py`, `${MOUNT_PATH}/.git/HEAD`]),
+			);
+			expect(calls.writeFiles.flat().map((file) => file.path)).not.toContain(
+				`${MOUNT_PATH}/.git/config`,
+			);
 		});
 
 		it('restores Git metadata after a successful workspace mount', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -225,6 +225,7 @@ export interface WorkspaceLoadContext {
 	bucketHandle?: Bucket;
 	mountPath: string;
 	workspacePrefix: string;
+	excludeRelativeRoots?: readonly string[];
 }
 
 export interface WorkspaceLoadResult {
@@ -249,6 +250,7 @@ class CopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 		bucketHandle,
 		workspacePrefix,
 		mountPath,
+		excludeRelativeRoots,
 	}: WorkspaceLoadContext): Promise<WorkspaceLoadResult> {
 		if (!bucketHandle) {
 			throw provisionFailure(
@@ -257,7 +259,13 @@ class CopyWorkspaceLoadStrategy implements WorkspaceLoadStrategy {
 			);
 		}
 		try {
-			const stats = await restoreWorkspace(sandbox, bucketHandle, workspacePrefix, mountPath);
+			const stats = await restoreWorkspace(
+				sandbox,
+				bucketHandle,
+				workspacePrefix,
+				mountPath,
+				excludeRelativeRoots ? { excludeRelativeRoots } : undefined,
+			);
 			return { usedFallback: true, stats };
 		} catch (err) {
 			throw provisionFailure('restoring the notebook workspace into the sandbox', err);
@@ -421,7 +429,7 @@ export class SandboxProvisioner {
 			options.workspaceLoadMode === 'copy-only'
 				? this.workspaceLoadStrategies.copyOnly
 				: this.workspaceLoadStrategies.mountOrCopy;
-		const loaded = await strategy.load({
+		const load = strategy.load({
 			sandbox,
 			projectId: options.projectId,
 			notebookId: options.notebookId,
@@ -429,43 +437,51 @@ export class SandboxProvisioner {
 			bucketHandle: options.bucketHandle,
 			mountPath,
 			workspacePrefix,
+			...(options.gitPrefix ? { excludeRelativeRoots: ['.git'] } : {}),
 		});
-		if (!options.gitPrefix) return loaded;
-		try {
-			if (!options.bucketHandle) {
-				throw new Error('bucket handle is required for Git metadata restoration');
+		if (!options.gitPrefix) return await load;
+		const gitPrefix = options.gitPrefix;
+		const restoreGit = async (): Promise<WorkspaceRestoreStats> => {
+			try {
+				if (!options.bucketHandle) {
+					throw new Error('bucket handle is required for Git metadata restoration');
+				}
+				const stats = await restoreWorkspace(
+					sandbox,
+					options.bucketHandle,
+					gitPrefix,
+					`${mountPath}/.git`,
+					{ requireComplete: true },
+				);
+				if (stats.objectCount === 0) throw new Error('the stored Git directory is empty');
+				return stats;
+			} catch (error) {
+				logOperationalError(
+					'git_workspace_restore_failed',
+					{
+						operation: 'session.git.restore',
+						object: gitPrefix,
+						project_id: options.projectId,
+						notebook_id: options.notebookId,
+					},
+					error,
+				);
+				throw provisionFailure('restoring Git metadata into the sandbox', error);
 			}
-			const gitStats = await restoreWorkspace(
-				sandbox,
-				options.bucketHandle,
-				options.gitPrefix,
-				`${mountPath}/.git`,
-				{ requireComplete: true },
-			);
-			if (gitStats.objectCount === 0) {
-				throw new Error('the stored Git directory is empty');
-			}
-			if (!loaded.stats) return { ...loaded, stats: gitStats };
-			return {
-				...loaded,
-				stats: {
-					objectCount: loaded.stats.objectCount + gitStats.objectCount,
-					bytes: loaded.stats.bytes + gitStats.bytes,
-				},
-			};
-		} catch (error) {
-			logOperationalError(
-				'git_workspace_restore_failed',
-				{
-					operation: 'session.git.restore',
-					object: options.gitPrefix,
-					project_id: options.projectId,
-					notebook_id: options.notebookId,
-				},
-				error,
-			);
-			throw provisionFailure('restoring Git metadata into the sandbox', error);
-		}
+		};
+		const copyPath =
+			options.workspaceLoadMode === 'copy-only' || sandbox.supportsBucketMount === false;
+		const [loaded, gitStats] = copyPath
+			? await Promise.all([load, restoreGit()])
+			: [await load, await restoreGit()];
+		if (!loaded.stats) return { ...loaded, stats: gitStats };
+		return {
+			...loaded,
+			stats: {
+				objectCount: loaded.stats.objectCount + gitStats.objectCount,
+				bytes: loaded.stats.bytes + gitStats.bytes,
+			},
+		};
 	}
 
 	private async injectSessionEnv(
@@ -513,6 +529,47 @@ export class SandboxProvisioner {
 		);
 		const startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS;
 		const startupStart = Date.now();
+		if (sandbox.launchProcess) {
+			let launched: Awaited<ReturnType<NonNullable<SandboxInstance['launchProcess']>>>;
+			try {
+				launched = await sandbox.launchProcess(launch.start, {
+					...(launch.setup.length > 0 ? { setup: launch.setup.join(' && ') } : {}),
+					cwd: mountPath,
+					port: MARIMO_PORT,
+					waitForPort: { mode: 'tcp' },
+					startupTimeout: startupTimeoutMs,
+				});
+			} catch (error) {
+				throw provisionFailure('starting the marimo kernel', error);
+			}
+			Object.assign(sw.timings, launched.timings);
+			if (launched.success) return;
+			if (launched.reason === 'setup_timeout') {
+				throw new PythonEnvironmentSetupError(
+					`Failed to prepare the notebook Python environment within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`,
+				);
+			}
+			if (launched.reason === 'setup_exit') {
+				throw pythonEnvironmentSetupFailure({
+					success: false,
+					stdout: launched.stdout,
+					stderr: launched.stderr,
+					error: { code: 'COMMAND_FAILED' },
+				});
+			}
+			const step =
+				launched.reason === 'readiness_timeout'
+					? `starting the marimo kernel: not ready within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`
+					: 'starting the marimo kernel';
+			const kernelLogs = [launched.stdout, launched.stderr]
+				.filter((value) => value.trim())
+				.join('\n')
+				.trim();
+			throw provisionFailure(
+				kernelLogs ? `${step}; kernel output:\n${kernelLogs}` : step,
+				new Error(launched.reason),
+			);
+		}
 		if (launch.setup.length > 0) {
 			const command = `cd ${shellQuote(mountPath)} && ${launch.setup.join(' && ')}`;
 			const setupTimeoutMs =

--- a/packages/core/src/services/runtime/sandboxFiles.test.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.test.ts
@@ -56,6 +56,22 @@ describe('restoreWorkspace', () => {
 		expect(stats.bytes).toBe(('import marimo' + '[project]\nname = "nb"' + 'a,b\n1,2\n').length);
 	});
 
+	it('can exclude a destination root owned by a separate restore', async () => {
+		const { nb } = nbCtx();
+		const bucket = new MemoryBucket();
+		await bucket.put(nb.workspaceFile('app.py'), 'print(1)');
+		await bucket.put(nb.workspaceFile('.git/HEAD'), 'poisoned');
+		const { instance, fs } = makeFsSandbox();
+
+		const stats = await restoreWorkspace(instance, bucket, nb.workspacePrefix, MOUNT, {
+			excludeRelativeRoots: ['.git'],
+		});
+
+		expect(stats.objectCount).toBe(1);
+		expect(fs.has('app.py')).toBe(true);
+		expect(fs.has('.git/HEAD')).toBe(false);
+	});
+
 	it('empty workspace: still creates the working dir marimo runs in', async () => {
 		const { nb } = nbCtx();
 		const { instance, calls } = makeFsSandbox();

--- a/packages/core/src/services/runtime/sandboxFiles.ts
+++ b/packages/core/src/services/runtime/sandboxFiles.ts
@@ -111,6 +111,8 @@ export interface WorkspaceRestoreStats {
 
 export interface WorkspaceRestoreOptions {
 	requireComplete?: boolean;
+	/** Relative path roots owned by another restore and therefore skipped. */
+	excludeRelativeRoots?: readonly string[];
 }
 
 /**
@@ -139,6 +141,9 @@ export async function restoreWorkspace(
 	for (const obj of objects) {
 		const rel = obj.key.slice(sourcePrefix.length);
 		if (!rel) continue;
+		if (options.excludeRelativeRoots?.some((root) => rel === root || rel.startsWith(`${root}/`))) {
+			continue;
+		}
 		// A poisoned key (e.g. from a compromised/synced source) whose relative path
 		// carries `..`/absolute/backslash segments would escape workingDir once
 		// concatenated. Reject or skip it — the sandbox working dir is a hard boundary.


### PR DESCRIPTION
- Adds a combined setup, launch, and readiness capability across built-in compute backends while preserving compatibility fallbacks and error classification.
- Reuses W&B boot responses for URL resolution and removes CoreWeave setup/readiness RPCs.
- Restores workspace and separate Git data concurrently on safe copy paths.