### PR TITLE
Support runtime path-prefixed deployments

### DIFF
--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -131,8 +131,11 @@ export async function bootstrap(
 	// so they take precedence; everything else falls through to static assets, with
 	// a single-page-app fallback to index.html.
 	const staticRoot = validatedEnv.MARIMOHUB_STATIC_ROOT ?? './public';
+	const spaFallback = serveSpaFallback(staticRoot, validatedEnv.MARIMOHUB_APP_BASE_URL);
+	app.get('/', spaFallback);
+	app.get('/index.html', spaFallback);
 	app.use('/*', serveStaticWithCache({ root: staticRoot }));
-	app.get('*', serveSpaFallback(staticRoot));
+	app.get('*', spaFallback);
 
 	// Maintenance + session-lifecycle loops — run on a single replica (the
 	// marimohub-maintenance Deployment). The bucket-CAS leases inside are

--- a/apps/server/src/env.test.ts
+++ b/apps/server/src/env.test.ts
@@ -16,6 +16,7 @@ describe('validateServerEnv', () => {
 	it('preserves known and unknown variables unchanged', () => {
 		const env = {
 			PORT: '4321',
+			MARIMOHUB_APP_BASE_URL: 'https://hub.example.com/marimohub',
 			MARIMOHUB_STATIC_ROOT: './public',
 			MARIMOHUB_RUN_MAINTENANCE: 'false',
 			MARIMOHUB_STORAGE_BACKEND: 'memory',
@@ -29,6 +30,8 @@ describe('validateServerEnv', () => {
 		['PORT', 'abc', 'expected an integer from 1 to 65535'],
 		['PORT', '0', 'expected an integer from 1 to 65535'],
 		['PORT', '65536', 'expected an integer from 1 to 65535'],
+		['MARIMOHUB_APP_BASE_URL', 'hub.example.com/marimohub', 'expected an HTTP(S) URL'],
+		['MARIMOHUB_APP_BASE_URL', 'ftp://hub.example.com', 'expected an HTTP(S) URL'],
 		['MARIMOHUB_STATIC_ROOT', '   ', 'expected a non-empty path'],
 		['MARIMOHUB_RUN_MAINTENANCE', 'yes', 'expected true or false'],
 	] as const)('rejects invalid %s=%s', (variable, value, message) => {

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { ConfigError } from '@marimo-hub/config';
+import { parseHttpUrl } from '@marimo-hub/core';
 
 export type ServerEnv = Record<string, string | undefined>;
 
@@ -10,8 +11,13 @@ const port = z
 		'expected an integer from 1 to 65535',
 	);
 
+const appBaseUrl = z
+	.string()
+	.refine((value) => !value.trim() || parseHttpUrl(value).ok, 'expected an HTTP(S) URL');
+
 export const ServerEnvSchema = z.looseObject({
 	PORT: port.optional(),
+	MARIMOHUB_APP_BASE_URL: appBaseUrl.optional(),
 	MARIMOHUB_STATIC_ROOT: z
 		.string()
 		.refine((value) => value.trim().length > 0, 'expected a non-empty path')

--- a/apps/server/src/staticCache.test.ts
+++ b/apps/server/src/staticCache.test.ts
@@ -6,6 +6,7 @@ import { Hono } from 'hono';
 import {
 	cacheControlForStaticPath,
 	IMMUTABLE_ASSET_CACHE_CONTROL,
+	injectAppBaseHref,
 	REVALIDATE_STATIC_CACHE_CONTROL,
 	serveSpaFallback,
 	serveStaticWithCache,
@@ -16,6 +17,15 @@ const temporaryRoots: string[] = [];
 afterEach(() => {
 	for (const root of temporaryRoots.splice(0)) rmSync(root, { force: true, recursive: true });
 });
+
+function staticApp(appBaseUrl?: string, indexHtml = '<!doctype html><base href="/" />'): Hono {
+	const root = mkdtempSync(join(tmpdir(), 'marimohub-static-'));
+	temporaryRoots.push(root);
+	writeFileSync(join(root, 'index.html'), indexHtml);
+	const app = new Hono();
+	app.get('*', serveSpaFallback(root, appBaseUrl));
+	return app;
+}
 
 describe('cacheControlForStaticPath', () => {
 	it('revalidates the HTML shell', () => {
@@ -46,12 +56,15 @@ describe('cacheControlForStaticPath', () => {
 		const root = mkdtempSync(join(tmpdir(), 'marimohub-static-'));
 		temporaryRoots.push(root);
 		mkdirSync(join(root, 'assets'));
-		writeFileSync(join(root, 'index.html'), '<!doctype html>');
+		writeFileSync(join(root, 'index.html'), '<!doctype html><base href="/" />');
 		writeFileSync(join(root, 'assets', 'index-C8a1b2.js'), 'console.log(1);');
 
 		const app = new Hono();
+		const spaFallback = serveSpaFallback(root, 'https://hub.example.com/marimohub');
+		app.get('/', spaFallback);
+		app.get('/index.html', spaFallback);
 		app.use('/*', serveStaticWithCache({ root }));
-		app.get('*', serveSpaFallback(root));
+		app.get('*', spaFallback);
 
 		expect((await app.request('/')).headers.get('Cache-Control')).toBe(
 			REVALIDATE_STATIC_CACHE_CONTROL,
@@ -59,6 +72,13 @@ describe('cacheControlForStaticPath', () => {
 		expect((await app.request('/projects/acme')).headers.get('Cache-Control')).toBe(
 			REVALIDATE_STATIC_CACHE_CONTROL,
 		);
+		expect(await (await app.request('/')).text()).toContain('<base href="/marimohub/" />');
+		expect(await (await app.request('/projects/acme')).text()).toContain(
+			'<base href="/marimohub/" />',
+		);
+		const head = await app.request('/', { method: 'HEAD' });
+		expect(head.headers.get('Content-Length')).toBeNull();
+		expect(await head.text()).toBe('');
 		expect((await app.request('/assets/index-C8a1b2.js')).headers.get('Cache-Control')).toBe(
 			IMMUTABLE_ASSET_CACHE_CONTROL,
 		);
@@ -72,5 +92,62 @@ describe('cacheControlForStaticPath', () => {
 		});
 		expect(invalidRange.status).toBe(416);
 		expect(invalidRange.headers.get('Cache-Control')).toBe(REVALIDATE_STATIC_CACHE_CONTROL);
+	});
+});
+
+describe('serveSpaFallback', () => {
+	it.each([
+		[undefined, '/'],
+		['', '/'],
+		['   ', '/'],
+		['https://hub.example.com', '/'],
+		['https://hub.example.com/marimohub', '/marimohub/'],
+		['https://hub.example.com/marimohub/', '/marimohub/'],
+		['https://hub.example.com/marimohub///?ignored=1#ignored', '/marimohub/'],
+	] as const)('injects exactly one trailing slash for %j', async (appBaseUrl, expected) => {
+		const response = await staticApp(appBaseUrl).request('/projects/project-1');
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toContain(`<base href="${expected}" />`);
+	});
+
+	it('returns 404 when the SPA shell is missing', async () => {
+		const root = mkdtempSync(join(tmpdir(), 'marimohub-static-'));
+		temporaryRoots.push(root);
+		const app = new Hono();
+		app.get('*', serveSpaFallback(root, 'https://hub.example.com/marimohub/'));
+
+		expect((await app.request('/projects/project-1')).status).toBe(404);
+	});
+
+	it('rejects an invalid configured URL before serving requests', () => {
+		expect(() => serveSpaFallback('/tmp/static', '/relative')).toThrow(TypeError);
+	});
+});
+
+describe('injectAppBaseHref', () => {
+	it('replaces the build-time root marker', () => {
+		expect(injectAppBaseHref('<head><base href="/" /></head>', '/marimohub/')).toBe(
+			'<head><base href="/marimohub/" /></head>',
+		);
+		expect(injectAppBaseHref("<BASE href='/'></BASE>", '/marimohub/')).toBe(
+			'<base href="/marimohub/" /></BASE>',
+		);
+	});
+
+	it('escapes the injected attribute value', () => {
+		expect(injectAppBaseHref('<base href="/">', '/team&"<>/')).toBe(
+			'<base href="/team&amp;&quot;&lt;&gt;/" />',
+		);
+	});
+
+	it.each([
+		['a shell without a marker', '<head></head>'],
+		['a shell with an already rewritten marker', '<base href="/marimohub/" />'],
+		['a shell with duplicate markers', '<base href="/" /><base href="/" />'],
+	])('rejects %s', (_case, html) => {
+		expect(() => injectAppBaseHref(html, '/marimohub/')).toThrow(
+			'exactly one <base href="/" /> marker',
+		);
 	});
 });

--- a/apps/server/src/staticCache.test.ts
+++ b/apps/server/src/staticCache.test.ts
@@ -111,6 +111,30 @@ describe('serveSpaFallback', () => {
 		expect(await response.text()).toContain(`<base href="${expected}" />`);
 	});
 
+	it.each([undefined, '', '   ', 'https://hub.example.com'] as const)(
+		'does not require a build-time marker without a path prefix for %j',
+		async (appBaseUrl) => {
+			const html = '<!doctype html><main>custom shell</main>';
+			const response = await staticApp(appBaseUrl, html).request('/projects/project-1');
+
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe(html);
+		},
+	);
+
+	it('still requires the build-time marker for a path prefix', async () => {
+		const app = staticApp(
+			'https://hub.example.com/marimohub',
+			'<!doctype html><main>custom shell</main>',
+		);
+		app.onError((error, context) => context.text(error.message, 500));
+
+		const response = await app.request('/projects/project-1');
+
+		expect(response.status).toBe(500);
+		expect(await response.text()).toContain('exactly one <base href="/" /> marker');
+	});
+
 	it('returns 404 when the SPA shell is missing', async () => {
 		const root = mkdtempSync(join(tmpdir(), 'marimohub-static-'));
 		temporaryRoots.push(root);

--- a/apps/server/src/staticCache.ts
+++ b/apps/server/src/staticCache.ts
@@ -1,5 +1,6 @@
 import { serveStatic } from '@hono/node-server/serve-static';
 import type { ServeStaticOptions } from '@hono/node-server/serve-static';
+import { baseHrefFromUrl } from '@marimo-hub/core/url';
 import type { MiddlewareHandler } from 'hono';
 
 export const REVALIDATE_STATIC_CACHE_CONTROL = 'public, max-age=0, must-revalidate';
@@ -7,6 +8,22 @@ export const IMMUTABLE_ASSET_CACHE_CONTROL = 'public, max-age=31536000, immutabl
 
 function isAssetPath(requestPath: string): boolean {
 	return requestPath === '/assets' || requestPath.startsWith('/assets/');
+}
+
+function escapeHtmlAttribute(value: string): string {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('"', '&quot;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;');
+}
+
+export function injectAppBaseHref(html: string, baseHref: string): string {
+	const marker = /<base\s+href=["']\/["']\s*\/?>/gi;
+	if ([...html.matchAll(marker)].length !== 1) {
+		throw new Error('SPA index.html must contain exactly one <base href="/" /> marker');
+	}
+	return html.replace(marker, `<base href="${escapeHtmlAttribute(baseHref)}" />`);
 }
 
 /**
@@ -42,10 +59,28 @@ export function serveStaticWithCache(options: ServeStaticOptions): MiddlewareHan
 	};
 }
 
-export function serveSpaFallback(staticRoot: string): MiddlewareHandler {
+export function serveSpaFallback(staticRoot: string, appBaseUrl?: string): MiddlewareHandler {
 	const handler = serveStaticWithCache({ path: `${staticRoot}/index.html` });
+	const baseHref = appBaseUrl?.trim() ? baseHrefFromUrl(appBaseUrl) : '/';
 	return async (context, next) => {
 		if (isAssetPath(context.req.path)) return next();
-		return handler(context, next);
+		const response = await handler(context, next);
+		if (!(response instanceof Response) || response.status !== 200) {
+			return response;
+		}
+		const headers = new Headers(response.headers);
+		headers.delete('Content-Length');
+		if (context.req.method === 'HEAD') {
+			return new Response(null, {
+				status: response.status,
+				statusText: response.statusText,
+				headers,
+			});
+		}
+		return new Response(injectAppBaseHref(await response.text(), baseHref), {
+			status: response.status,
+			statusText: response.statusText,
+			headers,
+		});
 	};
 }

--- a/apps/server/src/staticCache.ts
+++ b/apps/server/src/staticCache.ts
@@ -68,6 +68,7 @@ export function serveSpaFallback(staticRoot: string, appBaseUrl?: string): Middl
 		if (!(response instanceof Response) || response.status !== 200) {
 			return response;
 		}
+		if (baseHref === '/') return response;
 		const headers = new Headers(response.headers);
 		headers.delete('Content-Length');
 		if (context.req.method === 'HEAD') {

--- a/charts/marimohub/values.yaml
+++ b/charts/marimohub/values.yaml
@@ -54,7 +54,7 @@ maintenance:
 #   # `proxy` forwards kernel traffic through the app (authenticated, per-session
 #   # authorized) but serves untrusted code same-origin — trusted clusters only:
 #   MARIMOHUB_SANDBOX_PROXY_ACK_UNTRUSTED: "true"   # required to enable proxy mode
-#   MARIMOHUB_APP_BASE_URL: https://hub.example.com # optional; else derived per-request
+#   MARIMOHUB_APP_BASE_URL: https://hub.example.com/marimohub # required for a path prefix
 config: {}
 #  MARIMOHUB_EDITOR_SANDBOX_SHARING: shared # shared | exclusive
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,5 +62,5 @@ Persistent edit sandboxes use a per-notebook editor claim. See
   replica).
 - Your **storage**, **compute**, and **identity** providers.
 
-See [Deploying](/deploying/) for platform-specific topologies, and
+See [Deploying](/deploying/README) for platform-specific topologies, and
 [Security](/security) for the isolation and trust model.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,5 +62,5 @@ Persistent edit sandboxes use a per-notebook editor claim. See
   replica).
 - Your **storage**, **compute**, and **identity** providers.
 
-See [Deploying](/deploying/README) for platform-specific topologies, and
+See [Deploying](/deploying/) for platform-specific topologies, and
 [Security](/security) for the isolation and trust model.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -263,7 +263,6 @@ All kernel traffic is forwarded through the app, authenticated like `/api/v1/*` 
 | Variable | Description | Required | Default | Example |
 | --- | --- | --- | --- | --- |
 | `MARIMOHUB_SANDBOX_PROXY_ACK_UNTRUSTED` | Safety gate: must be `true` to boot in proxy mode, acknowledging that kernels then run untrusted code same-origin with the app (XSS-capable). Fails closed. | Yes | `false` | `true` |
-| `MARIMOHUB_APP_BASE_URL` | Public origin used to build `…/proxy/<token>` client URLs, e.g. when the app sits behind a proxy that rewrites the host. Omit to derive it from the inbound request origin. | — | — | `https://hub.example.com` |
 
 ## Auth
 
@@ -328,6 +327,7 @@ Server-wide settings; no backend selector.
 | --- | --- | --- | --- | --- |
 | `MARIMOHUB_EXPERIMENTS` | Comma-separated experimental feature IDs. Unknown IDs are ignored with a startup warning. Current value: `duckdb-wasm-preview`. | — | — | `duckdb-wasm-preview` |
 | `PORT` | Port the HTTP server listens on. | — | `3000` | — |
+| `MARIMOHUB_APP_BASE_URL` | Public URL for browser links and the Node SPA base path. When the app uses a path prefix, set this variable. If unset, links use the request origin and the SPA uses `/`. | — | — | `https://hub.example.com/marimohub` |
 | `MARIMOHUB_STATIC_ROOT` | Directory containing the web UI's static files. | — | `./public` | — |
 | `MARIMOHUB_RUN_MAINTENANCE` | Run background maintenance (expiring old sessions, cleaning up sandboxes) on this replica only. | — | `false` | `true` |
 | `MARIMOHUB_MAX_SESSIONS_PER_USER` | Per-user concurrent session cap (`0` = unlimited). Counts `edit` sessions, and separately bounds the apps a single user may have started — the cost ceiling a user cannot escape by fanning apps out across projects (apps are also capped per project via `MARIMOHUB_MAX_APPS_PER_PROJECT`). | — | `10` | — |

--- a/docs/deploying/README.md
+++ b/docs/deploying/README.md
@@ -32,19 +32,28 @@ MARIMOHUB_AUTH_OIDC_REDIRECT_URI=https://hub.example.com/marimohub/api/auth/call
 Configure nginx to strip the prefix and forward WebSocket connections:
 
 ```nginx
+location = /marimohub {
+    return 308 /marimohub/;
+}
+
 location /marimohub/ {
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+    proxy_buffering off;
     proxy_pass http://marimohub:3000/;
 }
 ```
 
-The trailing slash on `proxy_pass` strips the prefix. `X-Forwarded-Proto`
-preserves HTTPS in public links. The path prefix is runtime configuration, so one
-image can serve different prefixes.
+The redirect adds the trailing slash to the public URL. The trailing slash on
+`proxy_pass` strips the prefix. `X-Forwarded-Proto` preserves HTTPS in public
+links. The timeouts permit one hour between WebSocket I/O operations. nginx
+passes streamed responses without buffering. The path prefix is runtime
+configuration, so one image can serve different prefixes.
 
 After deploy, validate the same core flow on every platform:
 

--- a/docs/deploying/README.md
+++ b/docs/deploying/README.md
@@ -20,6 +20,32 @@ background maintenance.
 - [AWS](./aws.md) — EKS or ECS/Fargate + native S3.
 - [Cloudflare](./cloudflare.md) — Workers + R2 + Containers + Access (serverless).
 
+## Path prefix
+
+To publish the Node deployment at `https://hub.example.com/marimohub/`, set:
+
+```bash
+MARIMOHUB_APP_BASE_URL=https://hub.example.com/marimohub
+MARIMOHUB_AUTH_OIDC_REDIRECT_URI=https://hub.example.com/marimohub/api/auth/callback
+```
+
+Configure nginx to strip the prefix and forward WebSocket connections:
+
+```nginx
+location /marimohub/ {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_pass http://marimohub:3000/;
+}
+```
+
+The trailing slash on `proxy_pass` strips the prefix. `X-Forwarded-Proto`
+preserves HTTPS in public links. The path prefix is runtime configuration, so one
+image can serve different prefixes.
+
 After deploy, validate the same core flow on every platform:
 
 1. Check `/api/health`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -57,7 +57,7 @@ and **refuses to start** without an explicit acknowledgement:
 ```bash
 MARIMOHUB_SANDBOX_EXPOSURE=proxy
 MARIMOHUB_SANDBOX_PROXY_ACK_UNTRUSTED=true   # required — acknowledges same-origin/XSS
-# optional: build proxy URLs from this origin instead of the request host
+# optional public URL for browser links
 MARIMOHUB_APP_BASE_URL=https://hub.example.com
 ```
 

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -109,9 +109,8 @@ export interface SandboxConfig {
 	 */
 	exposure?: SandboxExposure;
 	/**
-	 * The app's public origin used to build `proxy`-mode client URLs
-	 * (config: MARIMOHUB_APP_BASE_URL). Falls back to the inbound request origin at
-	 * provision time when unset.
+	 * Public URL for browser links (MARIMOHUB_APP_BASE_URL). Can include a path prefix.
+	 * Falls back to the request origin when unset.
 	 */
 	appBaseUrl?: string;
 	/**

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -35,7 +35,7 @@ import cliAuthorizationsApp, { cliTokenApp } from './routes/cliAuthorizations';
 import usersApp from './routes/users';
 import { createOidcDiscovery } from './oidcDiscovery';
 import { sandboxProxyMiddleware } from './sandboxProxy';
-import { createApp, ErrorResponseSchema, fail } from './shared';
+import { createApp, ErrorResponseSchema, fail, resolvePublicBaseUrl } from './shared';
 import type { ErrorCode } from './shared';
 
 function internalErrorMessage(requestId: string | undefined): string {
@@ -406,15 +406,9 @@ export function createApi(rawDeps: ApiDeps) {
 			} catch {
 				sourceOrigin = null;
 			}
-			const requestUrl = new URL(c.req.url);
-			const destinationHost = c.req.header('host') ?? requestUrl.host;
-			const forwardedProtocol = c.req.header('x-forwarded-proto')?.split(',')[0]?.trim();
-			const protocol = forwardedProtocol || requestUrl.protocol.slice(0, -1);
 			let destinationOrigin: string | null = null;
 			try {
-				destinationOrigin = deps.sandbox.appBaseUrl
-					? new URL(deps.sandbox.appBaseUrl).origin
-					: new URL(`${protocol}://${destinationHost}`).origin;
+				destinationOrigin = new URL(resolvePublicBaseUrl(c, deps.sandbox.appBaseUrl)).origin;
 			} catch {
 				destinationOrigin = null;
 			}

--- a/packages/api/src/routes/cliAuthorizations.test.ts
+++ b/packages/api/src/routes/cliAuthorizations.test.ts
@@ -152,7 +152,7 @@ describe('CLI authorization routes', () => {
 
 	it('uses the configured public app URL for device verification links', async () => {
 		const deps = makeTestDeps(bucket);
-		deps.sandbox.appBaseUrl = 'https://hub.example.com';
+		deps.sandbox.appBaseUrl = 'https://hub.example.com/marimohub';
 		const publicApp = createApi(deps);
 
 		const device = await expectOk<{
@@ -167,9 +167,9 @@ describe('CLI authorization routes', () => {
 			}),
 		);
 
-		expect(device.verification_uri).toBe('https://hub.example.com/cli/device');
+		expect(device.verification_uri).toBe('https://hub.example.com/marimohub/cli/device');
 		expect(device.verification_uri_complete).toBe(
-			`https://hub.example.com/cli/device?user_code=${device.user_code}`,
+			`https://hub.example.com/marimohub/cli/device?user_code=${device.user_code}`,
 		);
 	});
 

--- a/packages/api/src/routes/cliAuthorizations.ts
+++ b/packages/api/src/routes/cliAuthorizations.ts
@@ -3,6 +3,7 @@ import type { Context } from 'hono';
 import {
 	BadRequestError,
 	createSlidingWindowBudget,
+	joinUrlPath,
 	parseCliAuthorizationCode,
 	ResourceExhaustedError,
 } from '@marimo-hub/core';
@@ -15,6 +16,7 @@ import {
 	errorResponses,
 	jsonBody,
 	jsonContent,
+	resolvePublicBaseUrl,
 	SESSION_ONLY_SECURITY,
 } from '../shared';
 import type { HonoEnv } from '../shared';
@@ -387,8 +389,8 @@ cliTokenApp.openapi(requestDeviceAuthorization, async (c) => {
 	const requested = await c
 		.get('deps')
 		.services.cliAuthorizations.requestDevice(c.req.valid('json').code_challenge);
-	const publicBaseUrl = c.get('deps').sandbox.appBaseUrl ?? new URL(c.req.url).origin;
-	const verification = new URL('/cli/device', publicBaseUrl);
+	const publicBaseUrl = resolvePublicBaseUrl(c, c.get('deps').sandbox.appBaseUrl);
+	const verification = new URL(joinUrlPath(publicBaseUrl, '/cli/device'));
 	const complete = new URL(verification);
 	complete.searchParams.set('user_code', requested.userCode);
 	preventCaching(c);

--- a/packages/api/src/routes/notebooks.ts
+++ b/packages/api/src/routes/notebooks.ts
@@ -8,6 +8,7 @@ import {
 	createGitSource,
 	DomainError,
 	ForbiddenError,
+	joinUrlPath,
 	NotebookId,
 	NotFoundError,
 	notificationRouter,
@@ -37,6 +38,7 @@ import {
 	NotebookIdParam,
 	NotebookMetaResponseSchema,
 	ProjectIdParam,
+	resolvePublicBaseUrl,
 	RuntimeResponseSchema,
 	NotebookVersionResponseSchema,
 	retireLiveApps,
@@ -561,7 +563,10 @@ const duplicateNotebook = createRoute({
 const app = createApp();
 
 function syncUrl(c: Context<HonoEnv>, pid: string, nid: string) {
-	return `${new URL(c.req.url).origin}/api/sync/git/v1/projects/${pid}/notebooks/${nid}`;
+	return joinUrlPath(
+		resolvePublicBaseUrl(c, c.get('deps').sandbox.appBaseUrl),
+		`/api/sync/git/v1/projects/${pid}/notebooks/${nid}`,
+	);
 }
 
 app.openapi(listNotebooks, async (c) => {

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -50,6 +50,7 @@ import {
 	TakeoverInProgressError,
 	TakeoverRetirementError,
 	kernelActiveConnections,
+	joinUrlPath,
 	ValidationError,
 	workspaceSourcePolicy,
 } from '@marimo-hub/core';
@@ -72,6 +73,7 @@ import {
 	loadVisibleProject,
 	NotebookIdParam,
 	ProjectIdParam,
+	resolvePublicBaseUrl,
 	SessionIdParam,
 	sessionGrantsFor,
 	SessionResponseSchema,
@@ -1050,8 +1052,7 @@ app.openapi(createSession, async (c) => {
 			};
 
 	const hostname = sandbox.hostname || new URL(c.req.url).hostname;
-	// App origin for building proxy-mode client URLs; falls back to this request.
-	const appBaseUrl = sandbox.appBaseUrl ?? new URL(c.req.url).origin;
+	const appBaseUrl = resolvePublicBaseUrl(c, sandbox.appBaseUrl);
 
 	// Provision as a saga: if a later step fails, completed steps compensate in
 	// reverse — the session record is terminated (so it does not linger in
@@ -1192,7 +1193,7 @@ app.openapi(createSession, async (c) => {
 								);
 								contributors.push(
 									marimoAiContributor({
-										baseUrl: `${appBaseUrl}/api/ai/v1`,
+										baseUrl: joinUrlPath(appBaseUrl, '/api/ai/v1'),
 										apiKey: token,
 										model: deps.ai.model,
 										enabled: true,

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -562,7 +562,7 @@ describe('create-session in proxy mode', () => {
 				workdir: '/workspace',
 				persistWorkspace: 'source',
 				exposure: new ProxyExposure(SECRET),
-				appBaseUrl: 'https://hub.example.com',
+				appBaseUrl: 'https://hub.example.com/marimohub',
 			},
 		});
 		const app = createApi(deps);
@@ -574,7 +574,7 @@ describe('create-session in proxy mode', () => {
 		const { data } = (await res.json()) as { data: { session_id: string; sandbox_url: string } };
 
 		const token = await signProxyToken(pid, data.session_id as never, SECRET);
-		expect(data.sandbox_url).toBe(`https://hub.example.com/proxy/${token}/`);
+		expect(data.sandbox_url).toBe(`https://hub.example.com/marimohub/proxy/${token}/`);
 		// The server-reachable origin is persisted on the record but never in the response.
 		expect(data).not.toHaveProperty('sandbox_origin_url');
 		const stored = await services.sessions.getSession(pid, data.session_id as never);

--- a/packages/api/src/shared.test.ts
+++ b/packages/api/src/shared.test.ts
@@ -35,6 +35,17 @@ describe('resolvePublicBaseUrl', () => {
 		expect(await response.text()).toBe('https://hub.example.com');
 	});
 
+	it('treats a whitespace-only configured URL as unset', async () => {
+		const app = createApp();
+		app.get('/base', (c) => c.text(resolvePublicBaseUrl(c, '   ')));
+
+		const response = await app.request('http://api.internal/base', {
+			headers: { host: 'hub.example.com', 'x-forwarded-proto': 'https' },
+		});
+
+		expect(await response.text()).toBe('https://hub.example.com');
+	});
+
 	it.each([
 		['https://hub.example.com', 'https://hub.example.com'],
 		['https://hub.example.com/', 'https://hub.example.com'],

--- a/packages/api/src/shared.test.ts
+++ b/packages/api/src/shared.test.ts
@@ -19,8 +19,35 @@ import {
 	jsonContent,
 	NotebookIdParam,
 	ProjectIdParam,
+	resolvePublicBaseUrl,
 	SessionIdParam,
 } from './shared';
+
+describe('resolvePublicBaseUrl', () => {
+	it('uses the public host and forwarded protocol behind a reverse proxy', async () => {
+		const app = createApp();
+		app.get('/base', (c) => c.text(resolvePublicBaseUrl(c)));
+
+		const response = await app.request('http://api.internal/base', {
+			headers: { host: 'hub.example.com', 'x-forwarded-proto': 'https, http' },
+		});
+
+		expect(await response.text()).toBe('https://hub.example.com');
+	});
+
+	it.each([
+		['https://hub.example.com', 'https://hub.example.com'],
+		['https://hub.example.com/', 'https://hub.example.com'],
+		['https://hub.example.com/base', 'https://hub.example.com/base'],
+		['https://hub.example.com/base/', 'https://hub.example.com/base'],
+		['https://hub.example.com/base///?ignored=1#ignored', 'https://hub.example.com/base'],
+	] as const)('normalizes configured public URL %s', async (configured, expected) => {
+		const app = createApp();
+		app.get('/base', (c) => c.text(resolvePublicBaseUrl(c, configured)));
+
+		expect(await (await app.request('http://api.internal/base')).text()).toBe(expected);
+	});
+});
 
 describe('extensibleResponseEnum', () => {
 	const schema = z.object({

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -11,6 +11,7 @@ import {
 	NotebookId,
 	NotFoundError,
 	NOTEBOOK_STATUSES,
+	normalizeBaseUrl,
 	PROJECT_ALERT_KINDS,
 	PROJECT_STATUSES,
 	ProjectId,
@@ -46,6 +47,18 @@ import { describeError, logEvent } from './log';
 
 // Re-export the injected-context types for route modules that import from './shared'.
 export type { ApiDeps, HonoEnv } from './context';
+
+export function resolvePublicBaseUrl(c: Context<HonoEnv>, configured?: string): string {
+	if (configured) return normalizeBaseUrl(configured);
+	const requestUrl = new URL(c.req.url);
+	const forwardedProtocol = c.req.header('x-forwarded-proto')?.split(',')[0]?.trim().toLowerCase();
+	const protocol =
+		forwardedProtocol === 'http' || forwardedProtocol === 'https'
+			? forwardedProtocol
+			: requestUrl.protocol.slice(0, -1);
+	const host = c.req.header('host') ?? requestUrl.host;
+	return new URL(`${protocol}://${host}`).origin;
+}
 
 export function extensibleResponseEnum<const Values extends readonly [string, ...string[]]>(
 	knownValues: Values,

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -49,7 +49,8 @@ import { describeError, logEvent } from './log';
 export type { ApiDeps, HonoEnv } from './context';
 
 export function resolvePublicBaseUrl(c: Context<HonoEnv>, configured?: string): string {
-	if (configured) return normalizeBaseUrl(configured);
+	const publicBaseUrl = configured?.trim();
+	if (publicBaseUrl) return normalizeBaseUrl(publicBaseUrl);
 	const requestUrl = new URL(c.req.url);
 	const forwardedProtocol = c.req.header('x-forwarded-proto')?.split(',')[0]?.trim().toLowerCase();
 	const protocol =

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -225,10 +225,17 @@ describe('createOidcAuth configuration validation', () => {
 		expect(() => makeOidc(overrides)).toThrow(expected);
 	});
 
-	it.each(['https://evil.example.com', '//evil.example.com', '/api/auth/login', 'relative'])(
+	it.each(['https://evil.example.com', '//evil.example.com', 'relative'])(
 		'rejects an unsafe post-login redirect: %s',
 		(postLoginRedirect) => {
 			expect(() => makeOidc({ postLoginRedirect })).toThrow(/same-origin application path/);
+		},
+	);
+
+	it.each(['/api', '/api/marimohub'])(
+		'allows a configured post-login redirect under /api: %s',
+		(postLoginRedirect) => {
+			expect(() => makeOidc({ postLoginRedirect })).not.toThrow();
 		},
 	);
 
@@ -671,6 +678,21 @@ describe('OIDC routes', () => {
 		expect(res.status).toBe(302);
 		expect(res.headers.get('location')).toBe(deepLink);
 		expect(res.headers.get('set-cookie') ?? '').toMatch(/mh_session=[^;,]+/);
+	});
+
+	it('rejects a client redirect_url under /api and uses the configured redirect', async () => {
+		const { routes } = makeOidc({ postLoginRedirect: '/api/marimohub' });
+		const txn = await beginOidcTransaction(
+			routes,
+			`/api/auth/login?redirect_url=${encodeURIComponent('/api/auth/login')}`,
+		);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+
+		expect(res.status).toBe(302);
+		expect(res.headers.get('location')).toBe('/api/marimohub');
 	});
 
 	it.each(['https://evil.com/phish', '//evil.com', '/\\evil.com', '/..//evil.com'])(

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -254,25 +254,7 @@ function mappedEntitlements(groups: readonly string[], policy: OidcGroupPolicy):
 	return [...entitlements];
 }
 
-/**
- * Validate a client-supplied post-login destination (`?redirect_url=` on the
- * login route) down to a same-origin absolute path, or null if it is anything
- * else. This is the open-redirect guard: the value is attacker-controllable (a
- * phisher can send a victim a crafted /api/auth/login link), so it must never
- * be able to leave this origin. Rejected here:
- *
- * - absolute URLs and scheme-relative `//evil.com` (and `/\evil.com` — browsers
- *   normalize `\` to `/` in URLs, so a backslash anywhere is rejected outright)
- * - schemes like `javascript:`/`data:` (no leading `/`)
- * - control characters (header/URL smuggling)
- * - paths that URL-normalize back OUT to another origin (`/..//evil.com`
- *   dot-segment-normalizes to `//evil.com`)
- * - `/api/…` paths (would loop straight back into the auth routes, and there is
- *   no UI there)
- *
- * Exported for direct unit testing.
- */
-export function sanitizeReturnTo(value: string | null | undefined): string | null {
+function sanitizeApplicationPath(value: string | null | undefined): string | null {
 	if (!value || value.length > MAX_RETURN_TO_LENGTH) return null;
 	if (!value.startsWith('/') || value.startsWith('//')) return null;
 	// eslint-disable-next-line no-control-regex
@@ -288,6 +270,16 @@ export function sanitizeReturnTo(value: string | null | undefined): string | nul
 	// Dot-segment normalization can surface a scheme-relative `//` prefix that the
 	// prefix check above did not see (e.g. `/..//evil.com`).
 	if (!path.startsWith('/') || path.startsWith('//')) return null;
+	return path;
+}
+
+/**
+ * Validate an attacker-controlled `?redirect_url=`. API paths are excluded to
+ * avoid redirecting the browser back into an auth or data endpoint.
+ */
+export function sanitizeReturnTo(value: string | null | undefined): string | null {
+	const path = sanitizeApplicationPath(value);
+	if (!path) return null;
 	if (path === '/api' || path.startsWith('/api/')) return null;
 	return path;
 }
@@ -319,7 +311,7 @@ export function createOidcAuth(config: OidcConfig): { authenticator: Authenticat
 	const secret = secretBytes;
 	const scopes = config.scopes ?? 'openid email profile';
 	const configuredPostLoginRedirect = config.postLoginRedirect ?? '/';
-	const sanitizedPostLoginRedirect = sanitizeReturnTo(configuredPostLoginRedirect);
+	const sanitizedPostLoginRedirect = sanitizeApplicationPath(configuredPostLoginRedirect);
 	if (!sanitizedPostLoginRedirect) {
 		throw new Error('OIDC post-login redirect must be a same-origin application path');
 	}

--- a/packages/client/src/index.test.ts
+++ b/packages/client/src/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
-import { apiClient, apiData, ApiRequestError } from './index';
+import { apiClient, apiData, ApiRequestError, createApiClient } from './index';
 import type { components } from './schema';
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -51,6 +51,15 @@ describe('apiData', () => {
 		expect(init?.method).toBe('POST');
 		expect(new Headers(init?.headers).get('content-type')).toBe('application/json');
 		expect(init?.body).toBe(JSON.stringify({ name: 'Example', description: 'Typed request' }));
+	});
+
+	it('preserves a path prefix in a same-origin custom base URL', async () => {
+		const fn = stubFetch(async () => jsonResponse({ success: true, data: null }));
+		const client = createApiClient({ baseUrl: 'http://localhost/marimohub' });
+
+		await apiData(client.GET('/api/v1/me'));
+
+		expect(fn.mock.calls[0]?.[0]).toBe('/marimohub/api/v1/me');
 	});
 
 	it('forwards the body even when the Request.body getter is missing (Firefox)', async () => {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -141,13 +141,13 @@ const timeoutMiddleware: Middleware = {
 	},
 };
 
-const defaultBaseUrl =
+const defaultOrigin =
 	typeof globalThis.location === 'object' ? globalThis.location.origin : 'http://localhost';
+const defaultBaseUrl = defaultOrigin;
 
 async function dispatchRequest(request: Request): Promise<Response> {
 	const url = new URL(request.url);
-	const input =
-		url.origin === defaultBaseUrl ? `${url.pathname}${url.search}${url.hash}` : url.href;
+	const input = url.origin === defaultOrigin ? `${url.pathname}${url.search}${url.hash}` : url.href;
 	// Firefox has no Request.body getter (Bugzilla #1387483), so detect a
 	// payload by reading it; '' maps to undefined so a bodyless POST does not
 	// pick up a spurious text/plain content-type.

--- a/packages/config/src/auth.test.ts
+++ b/packages/config/src/auth.test.ts
@@ -70,6 +70,28 @@ describe('makeAuth selector errors', () => {
 });
 
 describe('makeAuth oidc required vars', () => {
+	it.each([
+		['https://hub.example.com/marimohub', '/marimohub?auth_error=session_expired'],
+		['https://hub.example.com/marimohub/', '/marimohub?auth_error=session_expired'],
+		[
+			'https://hub.example.com/marimohub///?ignored=1#ignored',
+			'/marimohub?auth_error=session_expired',
+		],
+		['https://hub.example.com', '/?auth_error=session_expired'],
+	] as const)(
+		'uses the path from app base URL %s for fallback redirects',
+		async (url, expected) => {
+			const { authRoutes } = makeAuth({
+				...oidcEnv,
+				MARIMOHUB_APP_BASE_URL: url,
+			});
+
+			const response = await authRoutes!.request('/api/auth/callback');
+
+			expect(response.headers.get('location')).toBe(expected);
+		},
+	);
+
 	it('throws when MARIMOHUB_AUTH_SESSION_SECRET is missing', () => {
 		const { MARIMOHUB_AUTH_SESSION_SECRET: _omit, ...env } = oidcEnv;
 		expect(() => makeAuth(env)).toThrow(/MARIMOHUB_AUTH_SESSION_SECRET/);

--- a/packages/config/src/auth.test.ts
+++ b/packages/config/src/auth.test.ts
@@ -73,6 +73,8 @@ describe('makeAuth oidc required vars', () => {
 	it.each([
 		['https://hub.example.com/marimohub', '/marimohub?auth_error=session_expired'],
 		['https://hub.example.com/marimohub/', '/marimohub?auth_error=session_expired'],
+		['https://hub.example.com/api', '/api?auth_error=session_expired'],
+		['https://hub.example.com/api/marimohub/', '/api/marimohub?auth_error=session_expired'],
 		[
 			'https://hub.example.com/marimohub///?ignored=1#ignored',
 			'/marimohub?auth_error=session_expired',

--- a/packages/config/src/auth.ts
+++ b/packages/config/src/auth.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from '@marimo-hub/core';
+import { basePathFromUrl } from '@marimo-hub/core/url';
 import { createOidcAuth } from '@marimo-hub/auth-oidc';
 import type { EmailVerificationPolicy, OidcGroupPolicy } from '@marimo-hub/auth-oidc';
 import { DevAuthenticator } from '@marimo-hub/auth-dev';
@@ -102,6 +103,15 @@ function parseScopes(raw: string | undefined): string {
 		});
 	}
 	return scopes.join(' ');
+}
+
+function appRedirectPath(value: string | undefined): string | undefined {
+	if (!value?.trim()) return undefined;
+	try {
+		return basePathFromUrl(value);
+	} catch {
+		return undefined;
+	}
 }
 
 function checkedGroups(env: Env, key: string): string[] | undefined {
@@ -222,6 +232,7 @@ export function makeAuth(env: Env): { authenticator: Authenticator; authRoutes?:
 				sessionTtlSeconds: Math.min(sessionTtlSeconds, groupSessionTtlSeconds),
 				allowedEmailDomains: parseEmailDomains(env.MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS),
 				prompt: env.MARIMOHUB_AUTH_OIDC_PROMPT?.trim() || undefined,
+				postLoginRedirect: appRedirectPath(env.MARIMOHUB_APP_BASE_URL),
 				...(groups ? { groups } : {}),
 			});
 			return { authenticator, authRoutes: routes };

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -737,13 +737,6 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						default: 'false',
 						required: true,
 					},
-					{
-						id: 'MARIMOHUB_APP_BASE_URL',
-						name: 'App base URL',
-						description:
-							'Public origin used to build `…/proxy/<token>` client URLs, e.g. when the app sits behind a proxy that rewrites the host. Omit to derive it from the inbound request origin.',
-						example: 'https://hub.example.com',
-					},
 				],
 			},
 		],
@@ -941,6 +934,13 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						name: 'HTTP port',
 						description: 'Port the HTTP server listens on.',
 						default: '3000',
+					},
+					{
+						id: 'MARIMOHUB_APP_BASE_URL',
+						name: 'App base URL',
+						description:
+							'Public URL for browser links and the Node SPA base path. When the app uses a path prefix, set this variable. If unset, links use the request origin and the SPA uses `/`.',
+						example: 'https://hub.example.com/marimohub',
 					},
 					{
 						id: 'MARIMOHUB_STATIC_ROOT',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
 		".": "./src/index.ts",
 		"./data-query-sql": "./src/services/integrations/data-query/sql.ts",
 		"./ports": "./src/ports/index.ts",
+		"./url": "./src/url.ts",
 		"./testing": "./src/testing/index.ts",
 		"./testing/memory-bucket": "./src/testing/MemoryBucket.ts",
 		"./testing/contract": "./src/testing/bucketContract.ts",

--- a/packages/core/src/notifications.test.ts
+++ b/packages/core/src/notifications.test.ts
@@ -55,7 +55,7 @@ describe('NotificationRouter', () => {
 			audience: 'personal',
 			title: 'You were invited to Forecasts',
 			body: 'Owner invited you to Forecasts as editor.',
-			link: `https://hub.example.com/projects/${project.id}`,
+			link: `https://hub.example.com/base/projects/${project.id}`,
 			recipients: [{ email: 'member@example.com' }],
 			context: { pid: project.id, role: 'editor' },
 			data: {

--- a/packages/core/src/notifications.ts
+++ b/packages/core/src/notifications.ts
@@ -11,6 +11,7 @@ import {
 	UserIdSchema,
 } from './schema';
 import type { Identity, Project, ProjectMember } from './schema';
+import { joinUrlPath } from './url';
 
 export const NotificationRecipientSchema = z.object({
 	userId: UserIdSchema.optional(),
@@ -191,7 +192,7 @@ export interface AlertTestNotificationInput {
 
 function hubLink(baseUrl: string | undefined, path: string): string | undefined {
 	if (!baseUrl) return undefined;
-	return new URL(path, baseUrl).toString();
+	return joinUrlPath(baseUrl, path);
 }
 
 function optionalLink(link: string | undefined): { link?: string } {

--- a/packages/core/src/ports/sandboxExposure.ts
+++ b/packages/core/src/ports/sandboxExposure.ts
@@ -22,7 +22,7 @@ export interface ExposureContext {
 	projectId: ProjectId;
 	notebookId: NotebookId;
 	sandboxId: SandboxId;
-	/** The app's public origin (e.g. `https://hub.example.com`), no trailing slash. */
+	/** The app's public base URL, which may include a path prefix. */
 	appBaseUrl: string;
 }
 

--- a/packages/core/src/services/runtime/sandboxExposure.test.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.test.ts
@@ -58,12 +58,17 @@ describe('ProxyExposure', () => {
 		expect(result.clientUrl).toBe(`https://hub.example.com/proxy/${token}/`);
 	});
 
-	it('preserves a path prefix in the app base url', async () => {
-		const result = await exposure.finalize('http://kernel:2718', {
-			...ctx,
-			appBaseUrl: 'https://hub.example.com/marimohub',
-		});
-		const token = await signProxyToken(ctx.projectId, ctx.sessionId, SECRET);
-		expect(result.clientUrl).toBe(`https://hub.example.com/marimohub/proxy/${token}/`);
-	});
+	it.each(['https://hub.example.com/marimohub', 'https://hub.example.com/marimohub/'])(
+		'preserves a path prefix in marimo and client URLs: %s',
+		async (appBaseUrl) => {
+			const prefixedCtx = { ...ctx, appBaseUrl };
+			const token = await signProxyToken(ctx.projectId, ctx.sessionId, SECRET);
+
+			expect(await exposure.prepare(prefixedCtx)).toEqual({
+				baseUrl: `/marimohub/proxy/${token}`,
+			});
+			const result = await exposure.finalize('http://kernel:2718', prefixedCtx);
+			expect(result.clientUrl).toBe(`https://hub.example.com/marimohub/proxy/${token}/`);
+		},
+	);
 });

--- a/packages/core/src/services/runtime/sandboxExposure.test.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.test.ts
@@ -57,4 +57,13 @@ describe('ProxyExposure', () => {
 		const token = await signProxyToken(ctx.projectId, ctx.sessionId, SECRET);
 		expect(result.clientUrl).toBe(`https://hub.example.com/proxy/${token}/`);
 	});
+
+	it('preserves a path prefix in the app base url', async () => {
+		const result = await exposure.finalize('http://kernel:2718', {
+			...ctx,
+			appBaseUrl: 'https://hub.example.com/marimohub',
+		});
+		const token = await signProxyToken(ctx.projectId, ctx.sessionId, SECRET);
+		expect(result.clientUrl).toBe(`https://hub.example.com/marimohub/proxy/${token}/`);
+	});
 });

--- a/packages/core/src/services/runtime/sandboxExposure.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.ts
@@ -8,12 +8,8 @@ import type {
 	ExposureResult,
 	SandboxExposure,
 } from '../../ports/sandboxExposure';
+import { joinUrlPath } from '../../url';
 import { signProxyToken } from './proxyToken';
-
-/** Strip any trailing slashes so we can join path segments cleanly (no `//proxy`). */
-function trimTrailingSlash(s: string): string {
-	return s.replace(/\/+$/, '');
-}
 
 /**
  * `subdomain` (default) — the compute adapter's `exposePort()` URL is used as-is;
@@ -58,7 +54,7 @@ export class ProxyExposure implements SandboxExposure {
 	async finalize(exposedUrl: string, ctx: ExposureContext): Promise<ExposureResult> {
 		const path = await this.pathFor(ctx);
 		return {
-			clientUrl: `${trimTrailingSlash(ctx.appBaseUrl)}${path}/`,
+			clientUrl: `${joinUrlPath(ctx.appBaseUrl, path)}/`,
 			originUrl: exposedUrl,
 		};
 	}

--- a/packages/core/src/services/runtime/sandboxExposure.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.ts
@@ -47,14 +47,17 @@ export class ProxyExposure implements SandboxExposure {
 		return `/proxy/${token}`;
 	}
 
+	private async publicUrlFor(ctx: ExposureContext): Promise<string> {
+		return joinUrlPath(ctx.appBaseUrl, await this.pathFor(ctx));
+	}
+
 	async prepare(ctx: ExposureContext): Promise<ExposurePreparation> {
-		return { baseUrl: await this.pathFor(ctx) };
+		return { baseUrl: new URL(await this.publicUrlFor(ctx)).pathname };
 	}
 
 	async finalize(exposedUrl: string, ctx: ExposureContext): Promise<ExposureResult> {
-		const path = await this.pathFor(ctx);
 		return {
-			clientUrl: `${joinUrlPath(ctx.appBaseUrl, path)}/`,
+			clientUrl: `${await this.publicUrlFor(ctx)}/`,
 			originUrl: exposedUrl,
 		};
 	}

--- a/packages/core/src/url.test.ts
+++ b/packages/core/src/url.test.ts
@@ -1,5 +1,111 @@
 import { describe, expect, it } from 'vitest';
-import { parseHttpUrl } from './url';
+import {
+	baseHrefFromUrl,
+	basePathFromUrl,
+	joinUrlPath,
+	normalizeBasePath,
+	normalizeBaseUrl,
+	parseHttpUrl,
+} from './url';
+
+describe('normalizeBasePath', () => {
+	it.each([
+		['', '/'],
+		['/', '/'],
+		['///', '/'],
+		['/marimohub', '/marimohub'],
+		['/marimohub/', '/marimohub'],
+		['/team/marimohub///', '/team/marimohub'],
+	] as const)('maps %j to %j', (pathname, expected) => {
+		expect(normalizeBasePath(pathname)).toBe(expected);
+	});
+});
+
+describe('basePathFromUrl', () => {
+	it.each([
+		['https://hub.example.com', '/'],
+		['https://hub.example.com/', '/'],
+		['https://hub.example.com/marimohub', '/marimohub'],
+		['https://hub.example.com/marimohub/', '/marimohub'],
+		['https://hub.example.com/marimohub///?ignored=1#ignored', '/marimohub'],
+		['https://hub.example.com/team%20one/hub/', '/team%20one/hub'],
+	] as const)('reads %s as %s', (value, expected) => {
+		expect(basePathFromUrl(value)).toBe(expected);
+	});
+
+	it('accepts URL objects', () => {
+		expect(basePathFromUrl(new URL('https://hub.example.com/nested/'))).toBe('/nested');
+	});
+
+	it.each(['not a URL', '/relative'])('rejects %j', (value) => {
+		expect(() => basePathFromUrl(value)).toThrow(TypeError);
+	});
+});
+
+describe('baseHrefFromUrl', () => {
+	it.each([
+		['https://hub.example.com', '/'],
+		['https://hub.example.com/', '/'],
+		['https://hub.example.com/marimohub', '/marimohub/'],
+		['https://hub.example.com/marimohub/', '/marimohub/'],
+		['https://hub.example.com/marimohub///', '/marimohub/'],
+	] as const)('maps %s to %s', (value, expected) => {
+		expect(baseHrefFromUrl(value)).toBe(expected);
+	});
+});
+
+describe('normalizeBaseUrl', () => {
+	it.each([
+		['https://hub.example.com', 'https://hub.example.com'],
+		['https://hub.example.com/', 'https://hub.example.com'],
+		['https://hub.example.com///', 'https://hub.example.com'],
+		['https://hub.example.com/marimohub', 'https://hub.example.com/marimohub'],
+		['https://hub.example.com/marimohub/', 'https://hub.example.com/marimohub'],
+		['https://hub.example.com/marimohub///?ignored=1#ignored', 'https://hub.example.com/marimohub'],
+		['https://hub.example.com/team%20one/hub/', 'https://hub.example.com/team%20one/hub'],
+	] as const)('maps %s to %s', (value, expected) => {
+		expect(normalizeBaseUrl(value)).toBe(expected);
+	});
+
+	it('rejects an invalid URL', () => {
+		expect(() => normalizeBaseUrl('/relative')).toThrow(TypeError);
+	});
+});
+
+describe('joinUrlPath', () => {
+	it.each([
+		['https://hub.example.com', 'api/v1/me', 'https://hub.example.com/api/v1/me'],
+		['https://hub.example.com/', '/api/v1/me', 'https://hub.example.com/api/v1/me'],
+		[
+			'https://hub.example.com/marimohub',
+			'/projects/proj-1',
+			'https://hub.example.com/marimohub/projects/proj-1',
+		],
+		[
+			'https://hub.example.com/marimohub///',
+			'///projects/proj-1',
+			'https://hub.example.com/marimohub/projects/proj-1',
+		],
+	] as const)('joins %s and %s', (baseUrl, path, expected) => {
+		expect(joinUrlPath(baseUrl, path)).toBe(expected);
+	});
+
+	it('drops query and fragment data from the base URL', () => {
+		expect(joinUrlPath('https://hub.example.com/base/?stale=1#old', 'api/v1/me')).toBe(
+			'https://hub.example.com/base/api/v1/me',
+		);
+	});
+
+	it('preserves encoded path segments', () => {
+		expect(joinUrlPath('https://hub.example.com/team%20one/', '/projects/project%201')).toBe(
+			'https://hub.example.com/team%20one/projects/project%201',
+		);
+	});
+
+	it('rejects an invalid base URL', () => {
+		expect(() => joinUrlPath('/relative', '/api/v1/me')).toThrow(TypeError);
+	});
+});
 
 describe('parseHttpUrl', () => {
 	it.each([

--- a/packages/core/src/url.test.ts
+++ b/packages/core/src/url.test.ts
@@ -13,8 +13,10 @@ describe('normalizeBasePath', () => {
 		['', '/'],
 		['/', '/'],
 		['///', '/'],
+		['marimohub/', '/marimohub'],
 		['/marimohub', '/marimohub'],
 		['/marimohub/', '/marimohub'],
+		['//marimohub/', '/marimohub'],
 		['/team/marimohub///', '/team/marimohub'],
 	] as const)('maps %j to %j', (pathname, expected) => {
 		expect(normalizeBasePath(pathname)).toBe(expected);
@@ -28,6 +30,7 @@ describe('basePathFromUrl', () => {
 		['https://hub.example.com/marimohub', '/marimohub'],
 		['https://hub.example.com/marimohub/', '/marimohub'],
 		['https://hub.example.com/marimohub///?ignored=1#ignored', '/marimohub'],
+		['https://hub.example.com//cdn.example/app/', '/cdn.example/app'],
 		['https://hub.example.com/team%20one/hub/', '/team%20one/hub'],
 	] as const)('reads %s as %s', (value, expected) => {
 		expect(basePathFromUrl(value)).toBe(expected);
@@ -49,6 +52,7 @@ describe('baseHrefFromUrl', () => {
 		['https://hub.example.com/marimohub', '/marimohub/'],
 		['https://hub.example.com/marimohub/', '/marimohub/'],
 		['https://hub.example.com/marimohub///', '/marimohub/'],
+		['https://hub.example.com//cdn.example/app/', '/cdn.example/app/'],
 	] as const)('maps %s to %s', (value, expected) => {
 		expect(baseHrefFromUrl(value)).toBe(expected);
 	});
@@ -62,6 +66,7 @@ describe('normalizeBaseUrl', () => {
 		['https://hub.example.com/marimohub', 'https://hub.example.com/marimohub'],
 		['https://hub.example.com/marimohub/', 'https://hub.example.com/marimohub'],
 		['https://hub.example.com/marimohub///?ignored=1#ignored', 'https://hub.example.com/marimohub'],
+		['https://hub.example.com//cdn.example/app/', 'https://hub.example.com/cdn.example/app'],
 		['https://hub.example.com/team%20one/hub/', 'https://hub.example.com/team%20one/hub'],
 	] as const)('maps %s to %s', (value, expected) => {
 		expect(normalizeBaseUrl(value)).toBe(expected);
@@ -85,6 +90,11 @@ describe('joinUrlPath', () => {
 			'https://hub.example.com/marimohub///',
 			'///projects/proj-1',
 			'https://hub.example.com/marimohub/projects/proj-1',
+		],
+		[
+			'https://hub.example.com//cdn.example/app/',
+			'/api/v1/me',
+			'https://hub.example.com/cdn.example/app/api/v1/me',
 		],
 	] as const)('joins %s and %s', (baseUrl, path, expected) => {
 		expect(joinUrlPath(baseUrl, path)).toBe(expected);

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -9,6 +9,36 @@ export interface ParseHttpUrlOptions {
 	allowCredentials?: boolean;
 }
 
+export function normalizeBasePath(pathname: string): string {
+	return pathname.replace(/\/+$/, '') || '/';
+}
+
+export function basePathFromUrl(value: string | URL): string {
+	return normalizeBasePath(new URL(value).pathname);
+}
+
+export function baseHrefFromUrl(value: string | URL): string {
+	const pathname = basePathFromUrl(value);
+	return pathname === '/' ? '/' : `${pathname}/`;
+}
+
+export function normalizeBaseUrl(value: string | URL): string {
+	const url = new URL(value);
+	url.pathname = normalizeBasePath(url.pathname);
+	url.search = '';
+	url.hash = '';
+	return url.pathname === '/' ? url.href.slice(0, -1) : url.href;
+}
+
+export function joinUrlPath(baseUrl: string, path: string): string {
+	const url = new URL(baseUrl);
+	const basePath = normalizeBasePath(url.pathname);
+	url.pathname = `${basePath === '/' ? '' : basePath}/${path.replace(/^\/+/, '')}`;
+	url.search = '';
+	url.hash = '';
+	return url.toString();
+}
+
 export function parseHttpUrl(value: string, options: ParseHttpUrlOptions = {}): HttpUrlParseResult {
 	let url: URL;
 	try {

--- a/packages/core/src/url.ts
+++ b/packages/core/src/url.ts
@@ -10,7 +10,8 @@ export interface ParseHttpUrlOptions {
 }
 
 export function normalizeBasePath(pathname: string): string {
-	return pathname.replace(/\/+$/, '') || '/';
+	const normalized = pathname.replaceAll(/^\/+|\/+$/g, '');
+	return normalized ? `/${normalized}` : '/';
 }
 
 export function basePathFromUrl(value: string | URL): string {

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<base href="/" />
+		<link rel="icon" type="image/svg+xml" href="./favicon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<!-- Private/internal deployment: keep it out of search indexes (belt-and-suspenders to robots.txt). -->
 		<meta name="robots" content="noindex, nofollow" />
@@ -16,6 +17,6 @@
 	</head>
 	<body>
 		<div id="root"></div>
-		<script type="module" src="/src/main.tsx"></script>
+		<script type="module" src="./src/main.tsx"></script>
 	</body>
 </html>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -19,6 +19,7 @@
 		"@codemirror/state": "catalog:",
 		"@codemirror/view": "catalog:",
 		"@marimo-hub/client": "workspace:*",
+		"@marimo-hub/core": "workspace:*",
 		"@marimo-team/codemirror-sql": "catalog:",
 		"@pierre/diffs": "^1.2.11",
 		"@tailwindcss/vite": "catalog:",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -14,6 +14,7 @@ import { ErrorBoundary, Button } from '@/components/ui';
 import { Toaster } from '@/components/ui/sonner';
 import { ApiRequestError } from '@/api/client';
 import { AdminLayout } from '@/components/Admin/AdminLayout';
+import { appBasePath, withBasePath } from '@/lib/basePath';
 
 const AuditLogPage = lazy(() => import('@/components/AuditLog/AuditLogPage'));
 const DataBrowserPage = lazy(() => import('@/components/DataBrowser/DataBrowserPage'));
@@ -43,7 +44,7 @@ function NotFoundPage() {
 			<p className="text-sm text-muted-foreground">
 				The page may have moved, or you may not have access to it.
 			</p>
-			<Button variant="default" onPress={() => window.location.assign('/')}>
+			<Button variant="default" onPress={() => window.location.assign(withBasePath('/'))}>
 				Back to projects
 			</Button>
 		</div>
@@ -93,7 +94,7 @@ function AuthGate({ children }: { children: React.ReactNode }) {
 					variant="unstyled"
 					className="rounded text-sm text-muted-foreground underline-offset-4 outline-none hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
 					onPress={() => {
-						window.location.href = '/api/auth/logout';
+						window.location.href = withBasePath('/api/auth/logout');
 					}}
 				>
 					Sign out
@@ -172,7 +173,7 @@ function AppContent() {
 function App() {
 	return (
 		<AppErrorBoundary>
-			<BrowserRouter>
+			<BrowserRouter basename={appBasePath()}>
 				<ThemeProvider>
 					<AuthProvider>
 						<AuthGate>

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -1,10 +1,16 @@
-export {
-	apiClient,
+import {
+	createApiClient,
 	apiData,
 	apiDataWithResponse,
 	apiErrorFromResponse,
 	ApiRequestError,
 } from '@marimo-hub/client';
+import { appBasePath } from '@/lib/basePath';
+
+const basePath = appBasePath().replace(/\/+$/, '');
+export const apiClient = createApiClient({ baseUrl: `${window.location.origin}${basePath}` });
+
+export { apiData, apiDataWithResponse, apiErrorFromResponse, ApiRequestError };
 export type {
 	ApiError,
 	ApiResponse,

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -11,6 +11,7 @@ import { apiClient, apiData, apiDataWithResponse, apiErrorFromResponse } from '.
 import { useApiMutation, useInvalidate } from './mutation';
 import { isApiErrorCode, isNotFoundError, notebookPath } from './request';
 import { sanitizeFilename, triggerDownload } from '../lib/download';
+import { withBasePath } from '../lib/basePath';
 import {
 	userKeys,
 	projectKeys,
@@ -1207,7 +1208,9 @@ export function objectContentUrl(input: {
 	if (input.versionId) params.set('version_id', input.versionId);
 	if (input.etag) params.set('etag', input.etag);
 	if (input.inline) params.set('inline', 'true');
-	return `/api/v1/projects/${encodeURIComponent(input.projectId)}/integrations/${encodeURIComponent(input.integrationId)}/browse/objects/content?${params}`;
+	return withBasePath(
+		`/api/v1/projects/${encodeURIComponent(input.projectId)}/integrations/${encodeURIComponent(input.integrationId)}/browse/objects/content?${params}`,
+	);
 }
 
 // Notebooks

--- a/packages/web/src/api/request.ts
+++ b/packages/web/src/api/request.ts
@@ -1,7 +1,8 @@
 import { ApiRequestError } from './client';
 import type { ApiRequestErrorCode } from './client';
+import { withBasePath } from '../lib/basePath';
 
-export const projectPath = (projectId: string) => `/api/v1/projects/${projectId}`;
+export const projectPath = (projectId: string) => withBasePath(`/api/v1/projects/${projectId}`);
 export const notebookPath = (projectId: string, notebookId: string) =>
 	`${projectPath(projectId)}/notebooks/${notebookId}`;
 

--- a/packages/web/src/components/Account/CliDeviceLoginPage.test.tsx
+++ b/packages/web/src/components/Account/CliDeviceLoginPage.test.tsx
@@ -139,4 +139,21 @@ describe('CliDeviceLoginPage', () => {
 		expect(navigate).toHaveBeenCalledWith('/');
 		expect(calls.filter((call) => call.url.includes('cli-device'))).toEqual([]);
 	});
+
+	it('includes the deployment prefix in the hard-navigation cancel URL', async () => {
+		const base = document.createElement('base');
+		base.href = '/marimohub/';
+		document.head.append(base);
+		try {
+			const user = userEvent.setup();
+			const { navigate } = setup();
+			await screen.findByText(/dev@example.com/);
+
+			await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+			expect(navigate).toHaveBeenCalledWith('/marimohub/');
+		} finally {
+			base.remove();
+		}
+	});
 });

--- a/packages/web/src/components/Account/CliDeviceLoginPage.tsx
+++ b/packages/web/src/components/Account/CliDeviceLoginPage.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 import { useApproveCliDeviceAuthorization } from '@/api/hooks';
 import { useAuth } from '@/context/AuthContext';
 import { Brand, Button, TextField } from '@/components/ui';
+import { withBasePath } from '@/lib/basePath';
 
 const USER_CODE_RE = /^[BCDFGHJKLMNPQRSTVWXZ]{8}$/;
 const TOKEN_LIFETIME_PRESETS = ['7', '30', '90'] as const;
@@ -141,7 +142,11 @@ export function CliDeviceLoginPage({
 						</div>
 
 						<div className="flex justify-end gap-2 border-t pt-5">
-							<Button type="button" isDisabled={approve.isPending} onPress={() => navigate('/')}>
+							<Button
+								type="button"
+								isDisabled={approve.isPending}
+								onPress={() => navigate(withBasePath('/'))}
+							>
 								Cancel
 							</Button>
 							<Button type="submit" variant="primary" isDisabled={approve.isPending}>

--- a/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
+++ b/packages/web/src/components/DataBrowser/ObjectBrowser.tsx
@@ -16,6 +16,7 @@ import {
 	Search,
 	X,
 } from 'lucide-react';
+import { withBasePath } from '@/lib/basePath';
 import {
 	objectContentUrl,
 	useObjectBucketsQuery,
@@ -951,7 +952,7 @@ function PreviewResult({ value }: { value: IntegrationObjectPreview }) {
 	if (value.kind === 'image')
 		return (
 			<img
-				src={value.content_url}
+				src={withBasePath(value.content_url)}
 				alt="Object preview"
 				width={value.width ?? 1024}
 				height={value.height ?? 768}

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useUserQuery } from '../api/hooks';
 import { userKeys } from '../api/queryKeys';
 import type { User } from '../types';
+import { withBasePath } from '../lib/basePath';
 
 interface AuthContextValue {
 	user: User | null;
@@ -32,13 +33,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 		const returnTo = window.location.pathname + (search ? `?${search}` : '') + window.location.hash;
 		window.location.href =
 			returnTo === '/'
-				? '/api/auth/login'
-				: `/api/auth/login?redirect_url=${encodeURIComponent(returnTo)}`;
+				? withBasePath('/api/auth/login')
+				: withBasePath(`/api/auth/login?redirect_url=${encodeURIComponent(returnTo)}`);
 	}, []);
 
 	const signOut = useCallback(() => {
 		if (user?.logout_url) {
-			window.location.href = user.logout_url;
+			window.location.href = withBasePath(user.logout_url);
 		} else {
 			queryClient.setQueryData(userKeys.me(), null);
 		}

--- a/packages/web/src/lib/basePath.test.ts
+++ b/packages/web/src/lib/basePath.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { appBasePath, withBasePath } from './basePath';
+
+describe('appBasePath', () => {
+	it.each([
+		['https://hub.example.com', '/'],
+		['https://hub.example.com/', '/'],
+		['https://hub.example.com/marimohub', '/marimohub'],
+		['https://hub.example.com/marimohub/', '/marimohub'],
+		['https://hub.example.com/marimohub///?ignored=1#ignored', '/marimohub'],
+		['https://hub.example.com/team%20one/hub/', '/team%20one/hub'],
+	] as const)('reads %s as %s', (baseUri, expected) => {
+		expect(appBasePath(baseUri)).toBe(expected);
+	});
+
+	it.each(['/marimohub', '/marimohub/', '/marimohub///'])('reads base element %s', (href) => {
+		const base = document.createElement('base');
+		base.href = href;
+		document.head.append(base);
+		try {
+			expect(appBasePath()).toBe('/marimohub');
+		} finally {
+			base.remove();
+		}
+	});
+
+	it('does not infer a prefix from the current route without a base element', () => {
+		const previousPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+		window.history.replaceState(null, '', '/projects/project-1?tab=data#cell');
+		try {
+			expect(appBasePath()).toBe('/');
+		} finally {
+			window.history.replaceState(null, '', previousPath);
+		}
+	});
+
+	it.each(['not a URL', '/relative'])('rejects invalid explicit base URI %j', (baseUri) => {
+		expect(() => appBasePath(baseUri)).toThrow(TypeError);
+	});
+});
+
+describe('withBasePath', () => {
+	it.each([
+		['/', '/marimohub/', '/marimohub/'],
+		['/', '/marimohub', '/marimohub/'],
+		['/', '/marimohub///', '/marimohub/'],
+		['/api/v1/me', '/marimohub/', '/marimohub/api/v1/me'],
+		['/api/v1/me', '/', '/api/v1/me'],
+		['/api/v1/me', '', '/api/v1/me'],
+		['/marimohub', '/marimohub/', '/marimohub'],
+		['/marimohub/projects', '/marimohub/', '/marimohub/projects'],
+		['/marimohub-other', '/marimohub/', '/marimohub/marimohub-other'],
+		['https://idp.example/logout', '/marimohub/', 'https://idp.example/logout'],
+		['//cdn.example/app.js', '/marimohub/', '//cdn.example/app.js'],
+		['projects/project-1', '/marimohub/', 'projects/project-1'],
+		['?tab=data', '/marimohub/', '?tab=data'],
+		['#cell', '/marimohub/', '#cell'],
+		['', '/marimohub/', ''],
+	] as const)('maps %s under %s to %s', (path, basePath, expected) => {
+		expect(withBasePath(path, basePath)).toBe(expected);
+	});
+});

--- a/packages/web/src/lib/basePath.test.ts
+++ b/packages/web/src/lib/basePath.test.ts
@@ -8,6 +8,7 @@ describe('appBasePath', () => {
 		['https://hub.example.com/marimohub', '/marimohub'],
 		['https://hub.example.com/marimohub/', '/marimohub'],
 		['https://hub.example.com/marimohub///?ignored=1#ignored', '/marimohub'],
+		['https://hub.example.com//cdn.example/app/', '/cdn.example/app'],
 		['https://hub.example.com/team%20one/hub/', '/team%20one/hub'],
 	] as const)('reads %s as %s', (baseUri, expected) => {
 		expect(appBasePath(baseUri)).toBe(expected);
@@ -45,6 +46,7 @@ describe('withBasePath', () => {
 		['/', '/marimohub', '/marimohub/'],
 		['/', '/marimohub///', '/marimohub/'],
 		['/api/v1/me', '/marimohub/', '/marimohub/api/v1/me'],
+		['/api/v1/me', '//cdn.example/app/', '/cdn.example/app/api/v1/me'],
 		['/api/v1/me', '/', '/api/v1/me'],
 		['/api/v1/me', '', '/api/v1/me'],
 		['/marimohub', '/marimohub/', '/marimohub'],

--- a/packages/web/src/lib/basePath.ts
+++ b/packages/web/src/lib/basePath.ts
@@ -1,0 +1,14 @@
+import { basePathFromUrl, normalizeBasePath } from '@marimo-hub/core/url';
+
+export function appBasePath(
+	baseUri = document.querySelector<HTMLBaseElement>('base[href]')?.href ?? window.location.origin,
+): string {
+	return basePathFromUrl(baseUri);
+}
+
+export function withBasePath(path: string, basePath = appBasePath()): string {
+	if (!path.startsWith('/') || path.startsWith('//')) return path;
+	const prefix = normalizeBasePath(basePath);
+	if (prefix === '/' || path === prefix || path.startsWith(`${prefix}/`)) return path;
+	return `${prefix}${path}`;
+}

--- a/packages/web/src/lib/links.ts
+++ b/packages/web/src/lib/links.ts
@@ -1,4 +1,6 @@
 // External docs links surfaced in the UI. GitHub for now; swap for hosted docs later.
+import { withBasePath } from './basePath';
+
 const DOCS_BASE = 'https://github.com/marimo-team/marimo-hub/blob/main/docs';
 
 export const DOCS_FEDERATION_URL = `${DOCS_BASE}/workload-identity-federation.md`;
@@ -10,5 +12,5 @@ export const DOCS_SYNCING_URL = `${DOCS_BASE}/syncing.md`;
  * URL the create/rotate API returns.
  */
 export function syncUrl(projectId: string, notebookId: string): string {
-	return `${window.location.origin}/api/sync/git/v1/projects/${projectId}/notebooks/${notebookId}`;
+	return `${window.location.origin}${withBasePath(`/api/sync/git/v1/projects/${projectId}/notebooks/${notebookId}`)}`;
 }

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -11,6 +11,7 @@ const webPort = envPort(process.env.WEB_PORT, 5175);
 // pure consumer of the /api/* surface and is served as static assets by whatever
 // fronts the deployment (apps/server in Node, or Cloudflare in the reference).
 export default defineConfig({
+	base: './',
 	// lazyPlugins: only loaded for dev/build/preview, not for `vp lint`/`vp fmt`.
 	plugins: lazyPlugins(() => [react(), tailwindcss()]),
 	resolve: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1508,6 +1508,9 @@ importers:
       '@marimo-hub/client':
         specifier: workspace:*
         version: link:../client
+      '@marimo-hub/core':
+        specifier: workspace:*
+        version: link:../core
       '@marimo-team/codemirror-sql':
         specifier: 'catalog:'
         version: 0.3.0(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.7)


### PR DESCRIPTION
Fixes #223

- Honor forwarded protocols when building public URLs.
- Support path-prefixed deployments at runtime through `MARIMOHUB_APP_BASE_URL`.
- Share base-path normalization and cover slash and failure edge cases.