### PR TITLE
Prune marimo from uv-script-pins export

### DIFF
--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -70,14 +70,13 @@ inline dependencies into the base environment:
 
 ```sh
 [ -d "${UV_PROJECT_ENVIRONMENT:-.venv}" ] || uv venv "${UV_PROJECT_ENVIRONMENT:-.venv}"
-uv export --script notebook.py --format requirements-txt --no-hashes -o "${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"
+uv export --script notebook.py --format requirements-txt --no-hashes --prune marimo -o "${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"
 uv pip install --python "${UV_PROJECT_ENVIRONMENT:-.venv}" --no-build -r "${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"
 ```
 
 A setup failure stops the session with `PYTHON_ENV_SETUP_FAILED` before the kernel
-starts. A `marimo` pin in the metadata replaces the image version for that
-sandbox. This version can be incompatible with a frontend served through
-`--asset-url`.
+starts. The export keeps the image's bytecode-compiled `marimo` version and removes
+packages used only by marimo. Direct notebook dependencies remain in the export.
 
 So your image must provide:
 

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -412,9 +412,9 @@ then applies dependency sources from the synced workspace in this order:
   marimohub installs these dependencies with `uv export --script` and
   `uv pip install`. If uv cannot resolve them, the session fails.
 
-If both sources declare the same package, the inline metadata takes precedence.
-No configuration is necessary. marimohub selects the dependency strategy when
-the session starts.
+If both sources declare the same package, inline metadata takes precedence.
+`marimo` is the exception: marimohub keeps the image version and prunes dependencies
+used only by marimo. No configuration is necessary.
 
 ## Read-only sessions
 

--- a/examples/sandbox-image/acceptance-test.sh
+++ b/examples/sandbox-image/acceptance-test.sh
@@ -95,11 +95,12 @@ dependencies = ["polars", "narwhals"]
 TOML
 }
 
-provision_python314_notebook() { # $1 = container id
-	docker exec -i "$1" sh -lc 'cd /workspace && cat > notebook.py' <<'PY'
+provision_python314_notebook() { # $1 = container id; $2 = image marimo version
+	local marimo_version="$2"
+	docker exec -i "$1" sh -lc 'cd /workspace && cat > notebook.py' <<PY
 # /// script
 # requires-python = ">=3.14"
-# dependencies = ["click", "marimo==0.23.11"]
+# dependencies = ["click", "marimo!=${marimo_version}"]
 # ///
 
 import marimo
@@ -176,7 +177,7 @@ ok "marimo pinned to $mv (pre-installed; launch never upgrades it)"
 # --- 2c. a notebook may replace the warm env with a newer Python ------------
 echo "==> 2c. Python-version replacement"
 cid="$(run_detached "$IMAGE" sleep infinity)"
-provision_python314_notebook "$cid"
+provision_python314_notebook "$cid" "$mv"
 docker exec "$cid" sh -lc '
 	set -e
 	cd /workspace

--- a/examples/sandbox-image/acceptance-test.sh
+++ b/examples/sandbox-image/acceptance-test.sh
@@ -99,7 +99,7 @@ provision_python314_notebook() { # $1 = container id
 	docker exec -i "$1" sh -lc 'cd /workspace && cat > notebook.py' <<'PY'
 # /// script
 # requires-python = ">=3.14"
-# dependencies = ["click"]
+# dependencies = ["click", "marimo==0.23.11"]
 # ///
 
 import marimo
@@ -186,7 +186,7 @@ docker exec "$cid" sh -lc '
 	[ "$installed_marimo" = "$marimohub_marimo_version" ] || \
 		uv pip install --python "$UV_PROJECT_ENVIRONMENT" --no-build \
 			"marimo==$marimohub_marimo_version"
-	uv export --script notebook.py --format requirements-txt --no-hashes \
+	uv export --script notebook.py --format requirements-txt --no-hashes --prune marimo \
 		-o "$UV_PROJECT_ENVIRONMENT/marimohub-script-requirements.txt"
 	uv pip install --python "$UV_PROJECT_ENVIRONMENT" --no-build \
 		-r "$UV_PROJECT_ENVIRONMENT/marimohub-script-requirements.txt"

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -116,7 +116,7 @@ describe('SandboxProvisioner', () => {
 				launchStrategy: 'uv-script-pins',
 			});
 
-			// Pins apply last within the checked setup command, before marimo starts.
+			// Notebook pins apply last, except marimo remains at the image version.
 			const cmd = calls.exec.find((command) => command.includes('uv sync --inexact'))!;
 			const order = [
 				cmd.indexOf('uv sync --inexact'),
@@ -126,6 +126,7 @@ describe('SandboxProvisioner', () => {
 			];
 			expect(Math.min(...order)).toBeGreaterThanOrEqual(0);
 			expect(order).toEqual([...order].sort((a, b) => a - b));
+			expect(cmd).toContain('--prune marimo');
 			expect(calls.startProcess[0].cmd).toContain("marimo edit 'apps/dash.py'");
 			expect(calls.startProcess[0].cmd).not.toContain('uv sync');
 		});

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -118,12 +118,19 @@ describe('buildMarimoLaunch', () => {
 			expect(ensureEnv).toContain('uv venv');
 			expect(exportCmd).toContain("uv export --script 'apps/my app.py'");
 			expect(exportCmd).toContain('--format requirements-txt');
+			expect(exportCmd).toContain('--prune marimo');
 			expect(installCmd).toContain('uv pip install');
 			// The env `uv run --no-sync` resolves — never VIRTUAL_ENV, which uv run
 			// ignores and would leave the pins invisible to the kernel.
 			expect(installCmd).toContain('--python "${UV_PROJECT_ENVIRONMENT:-.venv}"');
 			expect(installCmd).toContain('--no-build');
 			expect(plan.start).toMatch(/^uv run --no-sync marimo /);
+		});
+
+		it('keeps the image marimo version instead of the script pin', () => {
+			const [, , , ensureMarimo, exportCmd] = plan.setup;
+			expect(ensureMarimo).toContain('marimo==$MARIMOHUB_MARIMO_VERSION');
+			expect(exportCmd).toContain('--prune marimo');
 		});
 
 		it('writes the requirements file inside the pin env', () => {

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -127,12 +127,6 @@ describe('buildMarimoLaunch', () => {
 			expect(plan.start).toMatch(/^uv run --no-sync marimo /);
 		});
 
-		it('keeps the image marimo version instead of the script pin', () => {
-			const [, , , ensureMarimo, exportCmd] = plan.setup;
-			expect(ensureMarimo).toContain('marimo==$MARIMOHUB_MARIMO_VERSION');
-			expect(exportCmd).toContain('--prune marimo');
-		});
-
 		it('writes the requirements file inside the pin env', () => {
 			// Per-sandbox and lifecycle-managed on every backend — nothing left on a
 			// shared host /tmp, no clobbering between concurrent local launches.

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -118,15 +118,17 @@ export const MARIMO_LAUNCH_STRATEGIES = {
 	}),
 
 	// Git-synced notebooks with PEP 723 inline metadata: the pyproject layer runs
-	// first, then the script's pins install into the same base env — last, so they
-	// win. --no-hashes because hash checking rejects the unhashed base env.
+	// first, then the script's pins install into the same base env. Prune marimo's
+	// dependency tree so a notebook's inline marimo pin cannot replace the
+	// bytecode-compiled image version. --no-hashes because hash checking rejects
+	// the unhashed base env.
 	'uv-script-pins': (p) => ({
 		setup: [
 			CAPTURE_MARIMO_VERSION,
 			PYPROJECT_LAYER_SETUP,
 			`{ [ -d ${PIN_ENV} ] || uv venv ${PIN_ENV}; }`,
 			ENSURE_MARIMO,
-			`uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt --no-hashes -o ${SCRIPT_REQUIREMENTS}`,
+			`uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt --no-hashes --prune marimo -o ${SCRIPT_REQUIREMENTS}`,
 			`uv pip install --python ${PIN_ENV} --no-build -r ${SCRIPT_REQUIREMENTS}`,
 		],
 		start: `uv run --no-sync ${marimoCommand(p)}`,


### PR DESCRIPTION
The `uv-script-pins` launch strategy now runs `uv export --script ... --prune marimo` so a notebook's inline `marimo` pin can't replace the bytecode-compiled image version. Notebook dependencies used only by marimo are dropped; direct notebook dependencies stay. Docs, acceptance test, and unit tests updated to match.


Closes MO-7472