### PR TITLE
Tag session provisioning logs with image, profile, session id, and trace

### DIFF
--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -107,7 +107,7 @@ describe('Session routes', () => {
 		return data.session_id as string;
 	}
 
-	it('logs best-effort integration warnings when provisioning a session', async () => {
+	it('logs resolved provisioning context and best-effort integration warnings', async () => {
 		const warning =
 			'Integration "staging" uses its notebook snippet because "prod" owns automatic discovery.';
 		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -117,6 +117,10 @@ describe('Session routes', () => {
 				userId: ACTOR,
 				compute: makeFakeCompute(),
 				deps: {
+					sandbox: sandboxConfig({
+						images: ['registry.example/marimo:py313'],
+						computeProfile: 'gpu',
+					}),
 					integrations: {
 						resolveForSession: async () => ({
 							files: [],
@@ -128,11 +132,14 @@ describe('Session routes', () => {
 				},
 			}).request;
 
-			await expectOk<ApiSession>(await request('POST', sessionsPath()));
+			const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
 			const line = log.mock.calls.find((call) =>
 				String(call[0]).includes('session_provision'),
 			)?.[0];
 			expect(JSON.parse(String(line))).toMatchObject({
+				session_id: session.session_id,
+				image: 'registry.example/marimo:py313',
+				compute_profile: 'gpu',
 				integration_warning_count: 1,
 				integration_warnings: [warning],
 			});

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1070,6 +1070,8 @@ app.openapi(createSession, async (c) => {
 	const observer = logObserver({
 		event: 'session_provision',
 		sandbox_id: sandboxId,
+		image,
+		compute_profile: appliedComputeProfile.name,
 		project_id: pid,
 		notebook_id: nid,
 		user_id: user.id,
@@ -1092,6 +1094,7 @@ app.openapi(createSession, async (c) => {
 					editor_sandbox_sharing: mode === 'edit' ? sharing : undefined,
 					authorization_expires_at: authorizationExpiresAt,
 				});
+				observer.tag('session_id', session.session_id);
 			})
 			// The pre-flight cap check alone is raceable; re-rank now that this
 			// session is visible to every concurrent create.

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
+import { context, trace } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { CWSandboxNotFoundError } from '@coreweave/cwsandbox';
 import type { SandboxInfo } from '@coreweave/cwsandbox';
 import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/compute-commons';
@@ -134,6 +137,35 @@ describe('CoreWeaveCompute', () => {
 				expect(JSON.stringify(ensureEvent)).not.toContain('ada@example.com');
 			} finally {
 				warn.mockRestore();
+			}
+		});
+
+		it('correlates the ensure event with the active trace', async () => {
+			const provider = new BasicTracerProvider();
+			trace.setGlobalTracerProvider(provider);
+			context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			try {
+				await provider.getTracer('test').startActiveSpan('session-provision', async (span) => {
+					try {
+						const world = makeWorld();
+						await makeCompute(world).create(SANDBOX_ID).exec('true');
+
+						const event = warn.mock.calls
+							.map(([message]) => JSON.parse(String(message)) as Record<string, unknown>)
+							.find((record) => record.event === 'coreweave_ensure');
+						expect(event).toMatchObject({
+							trace_id: span.spanContext().traceId,
+							span_id: span.spanContext().spanId,
+						});
+					} finally {
+						span.end();
+					}
+				});
+			} finally {
+				warn.mockRestore();
+				trace.disable();
+				context.disable();
 			}
 		});
 

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -74,6 +74,7 @@ import type {
 	Seconds,
 	Timings,
 } from '@marimo-hub/core';
+import { traceContext } from '@marimo-hub/core';
 import type {
 	CreateSandboxOptions,
 	ExecOptions,
@@ -345,6 +346,7 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		console.warn(
 			JSON.stringify({
 				ts: new Date().toISOString(),
+				...traceContext(),
 				event: 'coreweave_ensure',
 				sandbox_id: this.id,
 				reconnected: Boolean(existing),

--- a/packages/compute-coreweave/src/tracing.test.ts
+++ b/packages/compute-coreweave/src/tracing.test.ts
@@ -14,9 +14,7 @@ import {
 	SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
-import { createSandboxId } from '@marimo-hub/core';
-import { CoreWeaveCompute } from './index';
-import { fakeProcess, makeWorld, procResult } from './testWorld';
+import { fakeProcess, procResult } from './testWorld';
 import { instrumentCoreWeaveTransport } from './tracing';
 
 const exporter = new InMemorySpanExporter();
@@ -155,34 +153,6 @@ describe('instrumentCoreWeaveTransport', () => {
 		expect(requestSpan?.status.code).toBe(SpanStatusCode.ERROR);
 		expect(requestSpan?.attributes['error.type']).toBe('Error');
 		expect(requestSpan?.events.some((event) => event.name === 'exception')).toBe(true);
-	});
-
-	it('correlates the ensure event with the active trace', async () => {
-		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-		try {
-			await provider.getTracer('test').startActiveSpan('session-provision', async (span) => {
-				try {
-					const world = makeWorld();
-					const instance = new CoreWeaveCompute(
-						{ apiKey: 'key', image: 'image' },
-						world.client,
-					).create(createSandboxId(), { reuse: false });
-					await instance.ready?.();
-
-					const event = warn.mock.calls
-						.map(([message]) => JSON.parse(String(message)) as Record<string, unknown>)
-						.find((record) => record.event === 'coreweave_ensure');
-					expect(event).toMatchObject({
-						trace_id: span.spanContext().traceId,
-						span_id: span.spanContext().spanId,
-					});
-				} finally {
-					span.end();
-				}
-			});
-		} finally {
-			warn.mockRestore();
-		}
 	});
 
 	it('keeps a command span open and records a failure after the handshake', async () => {

--- a/packages/compute-coreweave/src/tracing.test.ts
+++ b/packages/compute-coreweave/src/tracing.test.ts
@@ -14,7 +14,9 @@ import {
 	SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
-import { fakeProcess, procResult } from './testWorld';
+import { createSandboxId } from '@marimo-hub/core';
+import { CoreWeaveCompute } from './index';
+import { fakeProcess, makeWorld, procResult } from './testWorld';
 import { instrumentCoreWeaveTransport } from './tracing';
 
 const exporter = new InMemorySpanExporter();
@@ -153,6 +155,34 @@ describe('instrumentCoreWeaveTransport', () => {
 		expect(requestSpan?.status.code).toBe(SpanStatusCode.ERROR);
 		expect(requestSpan?.attributes['error.type']).toBe('Error');
 		expect(requestSpan?.events.some((event) => event.name === 'exception')).toBe(true);
+	});
+
+	it('correlates the ensure event with the active trace', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		try {
+			await provider.getTracer('test').startActiveSpan('session-provision', async (span) => {
+				try {
+					const world = makeWorld();
+					const instance = new CoreWeaveCompute(
+						{ apiKey: 'key', image: 'image' },
+						world.client,
+					).create(createSandboxId(), { reuse: false });
+					await instance.ready?.();
+
+					const event = warn.mock.calls
+						.map(([message]) => JSON.parse(String(message)) as Record<string, unknown>)
+						.find((record) => record.event === 'coreweave_ensure');
+					expect(event).toMatchObject({
+						trace_id: span.spanContext().traceId,
+						span_id: span.spanContext().spanId,
+					});
+				} finally {
+					span.end();
+				}
+			});
+		} finally {
+			warn.mockRestore();
+		}
 	});
 
 	it('keeps a command span open and records a failure after the handshake', async () => {


### PR DESCRIPTION
Enriches the `session_provision` log with the resolved image, compute profile, and session id, and adds trace/span context to the CoreWeave `coreweave_ensure` log so provisioning can be correlated end to end.