### PR TITLE
Reduce bucket GETs from session create and polling (MO-7476)

### DIFF
--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -1665,8 +1665,8 @@ describe('Session routes', () => {
 		// First session succeeds (running, counts toward the cap).
 		await expectOk(await capped('POST', sessionsPath()));
 
-		// A DIFFERENT notebook would be a second concurrent sandbox → rejected with 429
-		// before provisioning. (Re-POSTing the SAME notebook would RESUME, not be capped.)
+		// A DIFFERENT notebook would be a second concurrent sandbox → rejected with 429.
+		// (Re-POSTing the SAME notebook would RESUME, not be capped.)
 		const otherNb = await createServices(bucket).notebooks.createNotebook(
 			pid,
 			{ title: 'NB2', description: 'd', code: 'import marimo as mo' },
@@ -1678,11 +1678,44 @@ describe('Session routes', () => {
 		// A 429 carries a backoff hint so the client doesn't have to guess.
 		expect(capRes.headers.get('Retry-After')).toBe('5');
 
-		// Only the first notebook has a session record.
+		// The authoritative cap check runs after record creation but before provisioning,
+		// and records the rejection for polling clients.
 		expect(await createServices(bucket).sessions.listSessions(nid)).toHaveLength(1);
+		const rejected = await createServices(bucket).sessions.listSessions(otherNb.id as NotebookId);
+		expect(rejected).toHaveLength(1);
+		expect(rejected[0]).toMatchObject({
+			status: 'failed',
+			error: { code: 'RESOURCE_EXHAUSTED' },
+		});
+	});
+
+	it('scans deployment-wide sessions once when enforcing the per-user cap', async () => {
+		const services = createServices(bucket);
+		const unrelatedProject = createProjectId();
+		const unrelated = await services.sessions.createSession({
+			project_id: unrelatedProject,
+			notebook_id: createNotebookId(),
+			user_id: STRANGER,
+		});
+		const listSpy = vi.spyOn(bucket, 'list');
+		const getSpy = vi.spyOn(bucket, 'get');
+		const capped = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: makeFakeCompute(),
+			maxConcurrentSessionsPerUser: 5,
+		}).request;
+
+		await expectOk(await capped('POST', sessionsPath()));
+
 		expect(
-			await createServices(bucket).sessions.listSessions(otherNb.id as NotebookId),
-		).toHaveLength(0);
+			listSpy.mock.calls.filter(([options]) => options?.prefix === paths.sessionsPrefix),
+		).toHaveLength(1);
+		expect(
+			getSpy.mock.calls.filter(
+				([key]) => key === paths.session(unrelatedProject, unrelated.session_id),
+			),
+		).toHaveLength(1);
 	});
 
 	it('POST /sessions reuses an existing running session instead of provisioning anew', async () => {

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -306,7 +306,7 @@ describe('Session routes', () => {
 		expect(data.error).toBeUndefined();
 	});
 
-	it('passes the configured sandbox startup timeout through to the kernel port wait', async () => {
+	it('uses the configured sandbox startup timeout to bound the kernel port wait', async () => {
 		const sb = makeFakeSandbox();
 		const api = createTestApi({
 			bucket,
@@ -315,7 +315,10 @@ describe('Session routes', () => {
 			deps: { sandbox: sandboxConfig({ startupTimeoutMs: Millis.seconds(300) }) },
 		}).request;
 		await expectOk<ApiSession>(await api('POST', sessionsPath()));
-		expect(sb.calls.waitForPortOptions).toEqual([{ timeout: 300_000 }]);
+		expect(sb.calls.waitForPortOptions).toHaveLength(1);
+		const timeout = sb.calls.waitForPortOptions[0]!.timeout;
+		expect(timeout).toBeGreaterThan(299_000);
+		expect(timeout).toBeLessThanOrEqual(300_000);
 	});
 
 	it('surfaces a startup timeout as a 503 naming the timeout, on the response AND the record', async () => {

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -462,11 +462,13 @@ function capsFor(deps: ApiDeps, mode: SessionMode, pid: ProjectId, userId: UserI
 				max: deps.policy.maxAppsPerProject,
 				message: CAP_REACHED.appsPerProject,
 				queue: () => sessions.listActiveAppsForProject(pid),
+				preflight: true,
 			},
 			{
 				max: maxSessions,
 				message: CAP_REACHED.appsPerUser,
 				queue: () => sessions.listActiveForUser(userId, 'project'),
+				preflight: false,
 			},
 		];
 	}
@@ -475,14 +477,16 @@ function capsFor(deps: ApiDeps, mode: SessionMode, pid: ProjectId, userId: UserI
 			max: maxSessions,
 			message: CAP_REACHED.sessionsPerUser,
 			queue: () => sessions.listActiveForUser(userId),
+			preflight: false,
 		},
 	];
 }
 
 /**
  * Cost-DoS guards, checked after reuse so a reconnect/attach never trips them.
- * Cheap pre-flight: rejects before any record or sandbox exists. Not sufficient
- * on its own — see `assertCapAfterCreate`.
+ * The project-scoped app cap gets a cheap pre-flight before any record exists.
+ * User caps skip it because their queue scans every retained session in the
+ * deployment; `assertCapAfterCreate` is the authoritative guard for all caps.
  */
 async function enforceSessionCap(
 	deps: ApiDeps,
@@ -492,7 +496,7 @@ async function enforceSessionCap(
 	excludedSessionId?: SessionId,
 ): Promise<void> {
 	for (const cap of capsFor(deps, mode, pid, userId)) {
-		if (!cap.max || cap.max <= 0) continue;
+		if (!cap.preflight || !cap.max || cap.max <= 0) continue;
 		const queued = (await cap.queue()).filter(
 			(session) => session.session_id !== excludedSessionId,
 		);

--- a/packages/core/src/services/runtime/SessionService.countActive.test.ts
+++ b/packages/core/src/services/runtime/SessionService.countActive.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ACTOR, advanceTime, MemoryBucket, restoreClock, uid } from '../../testing';
-import { createNotebookId, createProjectId } from '../../ids';
+import { createNotebookId, createProjectId, SessionId } from '../../ids';
 import type { UserId } from '../../ids';
+import { paths } from '../../paths';
 import { SessionService } from './SessionService';
 
 /**
@@ -66,5 +67,34 @@ describe('SessionService.countActiveForUser', () => {
 
 		// Only the single live (running) session should be counted.
 		expect(await sessions.countActiveForUser(ACTOR)).toBe(1);
+	});
+
+	it('ranks a running incumbent before a same-millisecond starting candidate', async () => {
+		const incumbent = await sessions.createSession({
+			notebook_id: notebookId,
+			project_id: projectId,
+			user_id: ACTOR,
+			session_id: SessionId.parse('sess-zzzzzzzzzzzzzzzz'),
+		});
+		await sessions.setRunning(projectId, incumbent.session_id, 'https://sandbox.example');
+		const candidate = await sessions.createSession({
+			notebook_id: createNotebookId(),
+			project_id: projectId,
+			user_id: ACTOR,
+			session_id: SessionId.parse('sess-0000000000000000'),
+		});
+		const startedAt = '2026-08-26T17:54:00.135Z';
+		for (const session of [incumbent, candidate]) {
+			const stored = await sessions.getSession(projectId, session.session_id);
+			await bucket.put(
+				paths.session(projectId, session.session_id),
+				JSON.stringify({ ...stored, started_at: startedAt }),
+			);
+		}
+
+		expect((await sessions.listActiveForUser(ACTOR)).map((session) => session.session_id)).toEqual([
+			incumbent.session_id,
+			candidate.session_id,
+		]);
 	});
 });

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -95,8 +95,16 @@ const TAKEOVER_DRAIN_STAGE_ORDER: Record<TakeoverDrainStage, number> = {
  * position from the same records, which is what lets the create route's cap
  * recheck pick one winner instead of every racer rejecting the others.
  */
-const byStartOrder = (a: Session, b: Session) =>
-	a.started_at.localeCompare(b.started_at) || a.session_id.localeCompare(b.session_id);
+const byCapOrder = (a: Session, b: Session) => {
+	// A running session already cleared the cap and cannot be displaced by a new
+	// starting record whose random id sorts first in the same millisecond.
+	const admissionOrder = Number(a.status !== 'running') - Number(b.status !== 'running');
+	return (
+		admissionOrder ||
+		a.started_at.localeCompare(b.started_at) ||
+		a.session_id.localeCompare(b.session_id)
+	);
+};
 
 export class SessionService {
 	constructor(
@@ -680,7 +688,7 @@ export class SessionService {
 					active.includes(s.status) &&
 					sessionModePolicy(s).capScope === capScope,
 			)
-			.sort(byStartOrder);
+			.sort(byCapOrder);
 	}
 
 	/**
@@ -700,7 +708,7 @@ export class SessionService {
 		const sessions = await this.scanProject(projectId, (session) => session);
 		return sessions
 			.filter((s) => active.includes(s.status) && sessionModePolicy(s).capScope === 'project')
-			.sort(byStartOrder);
+			.sort(byCapOrder);
 	}
 
 	/**

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -652,10 +652,8 @@ export class SessionService {
 	/**
 	 * Count a user's active sessions (`starting`/`running`) — `terminating` is
 	 * excluded so a stop immediately frees a slot. The create-session route uses
-	 * this to enforce a concurrent-session cap (a cost-DoS guard against a runaway
-	 * client) — as a pre-flight only, since count→create is not atomic; the route
-	 * re-ranks via `listActiveForUser` once the record exists. The per-notebook
-	 * reuse in `findReusable` is what stops a refresh loop from tripping it.
+	 * `listActiveForUser` to rank a new record for its concurrent-session cap; the
+	 * per-notebook reuse in `findReusable` keeps refresh loops from tripping it.
 	 */
 	async countActiveForUser(userId: UserId, capScope: 'user' | 'project' = 'user'): Promise<number> {
 		return (await this.listActiveForUser(userId, capScope)).length;
@@ -687,10 +685,9 @@ export class SessionService {
 
 	/**
 	 * Count a project's active app sessions, for the per-project app cap
-	 * (`MARIMOHUB_MAX_APPS_PER_PROJECT`). Pre-flight only, like
-	 * `countActiveForUser`; the user-blind reuse in `findReusable` keeps an
-	 * attach from ever tripping it. `terminating` is excluded (matching the
-	 * user cap): a stop frees the slot while teardown finishes, so the live
+	 * (`MARIMOHUB_MAX_APPS_PER_PROJECT`). The user-blind reuse in `findReusable`
+	 * keeps an attach from ever tripping it. `terminating` is excluded (matching
+	 * the user cap): a stop frees the slot while teardown finishes, so the live
 	 * sandbox count can briefly exceed the cap.
 	 */
 	async countActiveAppsForProject(projectId: ProjectId): Promise<number> {

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -35,7 +35,7 @@ import type {
 } from '../types';
 
 /** How often the notebook table re-polls runtime status, in ms. */
-const SESSIONS_POLL_INTERVAL_MS = 5_000;
+const SESSIONS_POLL_INTERVAL_MS = 30_000;
 
 /**
  * Deployment-scoped facts (identity, version, capabilities): fixed for the life
@@ -1633,6 +1633,7 @@ export function useProjectSessionsQuery(projectId: string, enabled = true) {
 				)
 			).items,
 		refetchInterval: SESSIONS_POLL_INTERVAL_MS,
+		staleTime: SESSIONS_POLL_INTERVAL_MS,
 		enabled,
 	});
 }

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -232,7 +232,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 		? (users?.[endedByUserId]?.name ?? users?.[endedByUserId]?.email ?? endedByUserId)
 		: undefined;
 
-	// App pages watch the project's sessions (5s poll) to know whether the
+	// App pages watch the project's sessions to know whether the
 	// notebook is being edited: the periodic snapshotter commits a version every
 	// ~2 minutes mid-edit, so the staleness banner is suppressed until editing
 	// stops — otherwise it would flap (with a disconnect-everyone CTA) the whole

--- a/packages/web/src/hooks/useNotebookSession.test.tsx
+++ b/packages/web/src/hooks/useNotebookSession.test.tsx
@@ -505,7 +505,7 @@ describe('useNotebookSession', () => {
 
 		// Run-watch tick adopts the starting replacement.
 		await act(async () => {
-			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(30_000);
 		});
 		await settleHook();
 		expect(result.current.session?.session_id).toBe('sess-2');
@@ -664,7 +664,7 @@ describe('useNotebookSession (app mode)', () => {
 
 		stopped = true;
 		await act(async () => {
-			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(30_000);
 		});
 
 		expect(result.current.ended).toBe('terminated');
@@ -696,7 +696,7 @@ describe('useNotebookSession (app mode)', () => {
 
 		reaped = true;
 		await act(async () => {
-			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(30_000);
 		});
 
 		expect(result.current.ended).toBe('gone');
@@ -729,7 +729,7 @@ describe('useNotebookSession (app mode)', () => {
 
 		revoked = true;
 		await act(async () => {
-			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(30_000);
 		});
 		await settleHook();
 
@@ -770,7 +770,7 @@ describe('useNotebookSession (app mode)', () => {
 
 		swapped = true;
 		await act(async () => {
-			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(30_000);
 		});
 		await settleHook();
 
@@ -838,7 +838,7 @@ describe('useNotebookSession (app mode)', () => {
 
 		swapped = true;
 		await act(async () => {
-			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(30_000);
 		});
 		await settleHook();
 
@@ -1004,7 +1004,7 @@ describe('useNotebookSession (app mode)', () => {
 		expect(result.current.session?.session_id).toBe('sess-1');
 
 		await act(async () => {
-			await vi.advanceTimersByTimeAsync(10_000);
+			await vi.advanceTimersByTimeAsync(30_000);
 		});
 
 		act(() => result.current.restart());

--- a/packages/web/src/hooks/useNotebookSession.ts
+++ b/packages/web/src/hooks/useNotebookSession.ts
@@ -27,7 +27,7 @@ const STARTUP_TIMEOUT_GRACE_MS = 30_000;
  * How often a running page re-checks its session. This surfaces app stops and
  * exclusive-editor takeovers as terminal UI instead of leaving a dead iframe.
  */
-const RUN_WATCH_INTERVAL_MS = 10_000;
+const RUN_WATCH_INTERVAL_MS = 30_000;
 
 export interface SessionError {
 	message: string;


### PR DESCRIPTION
Session create issued two deployment-wide user-cap scans (each a full `_system/sessions/**` list plus a per-object GET, ~50 GETs), and the web polled sessions aggressively.

- Drop the raceable pre-flight user-cap scan; rely solely on the authoritative post-create scan (`assertCapAfterCreate`). The project-scoped app-cap pre-flight stays.
- Slow session polling from 5s → 30s (with matching `staleTime`) and the running-session watch from 10s → 30s.
- Add regression coverage that unrelated retained sessions are listed/fetched only once during create.

Closes MO-7476.