### PR TITLE
Flag a slow sandbox boot as a probable cold image pull (MO-7466)

### DIFF
--- a/packages/api/src/routes/admin.test.ts
+++ b/packages/api/src/routes/admin.test.ts
@@ -445,6 +445,58 @@ describe('Admin routes', () => {
 			});
 		});
 
+		it('flags a slow boot in the diagnostic log line as a probable cold image pull', async () => {
+			const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+			try {
+				const { instance } = makeFakeSandbox();
+				instance.drainTimings = vi
+					.fn()
+					.mockReturnValueOnce({ find: 4, create: 900, boot: 16_500 })
+					.mockReturnValue({});
+				const { compute } = computeFor(instance);
+				const { request } = superAdminApi({ compute, sandbox: sandboxConfig });
+
+				const report = await expectOk<any>(
+					await request('POST', '/admin/debug/sandbox-startup', {}),
+				);
+				expect(report.startup_timings_ms).toEqual({ find: 4, create: 900, boot: 16_500 });
+				expect(report).not.toHaveProperty('hint');
+
+				const event = log.mock.calls
+					.map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+					.find((e) => e.event === 'sandbox_startup_diagnostic');
+				expect(event).toMatchObject({
+					ok: true,
+					hint: expect.stringContaining('cold-pulled the sandbox image'),
+				});
+			} finally {
+				log.mockRestore();
+			}
+		});
+
+		it('omits the slow-boot hint when boot is within the warm-node range', async () => {
+			const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+			try {
+				const { instance } = makeFakeSandbox();
+				instance.drainTimings = vi
+					.fn()
+					.mockReturnValueOnce({ find: 4, create: 900, boot: 4_000 })
+					.mockReturnValue({});
+				const { compute } = computeFor(instance);
+				const { request } = superAdminApi({ compute, sandbox: sandboxConfig });
+
+				await expectOk<any>(await request('POST', '/admin/debug/sandbox-startup', {}));
+
+				const event = log.mock.calls
+					.map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+					.find((e) => e.event === 'sandbox_startup_diagnostic');
+				expect(event).toBeDefined();
+				expect(event).not.toHaveProperty('hint');
+			} finally {
+				log.mockRestore();
+			}
+		});
+
 		it('uses deployment defaults when both selections are omitted', async () => {
 			const { instance } = makeFakeSandbox();
 			const { compute, create } = computeFor(instance);

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -103,6 +103,16 @@ const UV_BENCHMARK_SYNC_COMMAND = [
 	'exit "$status"',
 ].join('\n');
 
+/**
+ * A container start on a warm node is a few seconds. A `boot` timing above this
+ * is almost always the node pulling the sandbox image because the tag was not
+ * in its cache; the fix is operational (pre-pull the tags on the sandbox node
+ * pool), so the log line says so instead of leaving it to be rediscovered.
+ */
+const SLOW_BOOT_MS = 10_000;
+const SLOW_BOOT_HINT =
+	'boot > 10 s usually means the node cold-pulled the sandbox image; pre-pull the configured image tags on the sandbox node pool';
+
 const SandboxStartupPhaseSchema = z
 	.object({
 		status: z.enum(['ok', 'failed', 'skipped']),
@@ -670,6 +680,7 @@ app.openapi(testSandboxStartup, async (c) => {
 					},
 		startup_timings_ms: report.startup_timings_ms,
 		counters: report.counters,
+		...((report.startup_timings_ms.boot ?? 0) > SLOW_BOOT_MS ? { hint: SLOW_BOOT_HINT } : {}),
 	});
 	return c.json({ success: true, data: report }, 200);
 });

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -447,6 +447,43 @@ describe('CoreWeaveCompute', () => {
 			expect(waits[0].intervalMs).toBeLessThan(1000);
 		});
 
+		it('flags a boot over 10 s as a probable cold image pull', async () => {
+			vi.useFakeTimers({ toFake: ['Date'] });
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			try {
+				const world = makeWorld({
+					waitImpl: async () => {
+						vi.setSystemTime(Date.now() + 16_500);
+					},
+				});
+				await makeCompute(world).create(SANDBOX_ID, { reuse: false }).exec('true');
+				const ensureEvent = warn.mock.calls
+					.map(([message]) => JSON.parse(String(message)) as Record<string, unknown>)
+					.find((event) => event.event === 'coreweave_ensure');
+				expect(ensureEvent).toMatchObject({
+					boot_ms: 16_500,
+					slow_boot_hint: expect.stringContaining('cold-pulled the sandbox image'),
+				});
+			} finally {
+				warn.mockRestore();
+				vi.useRealTimers();
+			}
+		});
+
+		it('does not flag a warm-node boot', async () => {
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			try {
+				await makeCompute(makeWorld()).create(SANDBOX_ID, { reuse: false }).exec('true');
+				const ensureEvent = warn.mock.calls
+					.map(([message]) => JSON.parse(String(message)) as Record<string, unknown>)
+					.find((event) => event.event === 'coreweave_ensure');
+				expect(ensureEvent).toBeDefined();
+				expect(ensureEvent).not.toHaveProperty('slow_boot_hint');
+			} finally {
+				warn.mockRestore();
+			}
+		});
+
 		it('does not re-wait when reconnecting to a live sandbox', async () => {
 			const world = makeWorld();
 			const compute = makeCompute(world);

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -124,6 +124,15 @@ const PORT_WAIT_FIRST_CHUNK_MS = 2_000;
  * round-trip, so this trades a few extra polls for that rounding.
  */
 const BOOT_POLL_INTERVAL_MS = 100;
+/**
+ * A container start on a warm node is ~1–6 s. Above this, `boot` is almost
+ * always the node pulling the sandbox image because the tag was not in its
+ * cache (a cold registry pull of the ~650 MB image is 16–30 s), which the
+ * operator fixes by pre-pulling the configured tags on the sandbox node pool.
+ */
+const SLOW_BOOT_MS = 10_000;
+const SLOW_BOOT_HINT =
+	'boot > 10 s usually means the node cold-pulled the sandbox image; pre-pull the configured image tags on the sandbox node pool';
 
 /**
  * Process states a kernel never comes back from. `failed` is a stream fault (a
@@ -359,6 +368,7 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				find_ms: t1 - t0,
 				create_ms: t2 - t1,
 				boot_ms: t3 - t2,
+				...(t3 - t2 > SLOW_BOOT_MS ? { slow_boot_hint: SLOW_BOOT_HINT } : {}),
 				...(this.config.profileNames?.length ? { profile_names: this.config.profileNames } : {}),
 				...(this.userHome ? { user_home_attached: true } : {}),
 			}),

--- a/packages/compute-coreweave/src/testWorld.ts
+++ b/packages/compute-coreweave/src/testWorld.ts
@@ -87,6 +87,8 @@ function recordWrite(fake: FakeSandbox) {
 export function makeWorld(opts?: {
 	runImpl?: (cmd: readonly string[]) => Promise<ProcessResult>;
 	startImpl?: (cmd: readonly string[]) => Promise<CommandProcess>;
+	/** Runs inside the boot `wait()`; use it to simulate a slow boot. */
+	waitImpl?: () => Promise<void>;
 	/** State for started processes; omit to leave them running. */
 	proc?: FakeProcessState;
 }) {
@@ -96,6 +98,7 @@ export function makeWorld(opts?: {
 	const registry = new Map<string, { fake: FakeSandbox; tags: string[] }>();
 	let seq = 0;
 	const runImpl = opts?.runImpl ?? (async () => procResult());
+	const waitImpl = opts?.waitImpl ?? (async () => {});
 
 	function build(sandboxId: string) {
 		const fake: FakeSandbox = {
@@ -111,6 +114,7 @@ export function makeWorld(opts?: {
 			sandboxId,
 			wait: async (options?: { intervalMs?: number }) => {
 				fake.waitCalls.push(options ?? {});
+				await waitImpl();
 			},
 			commands: {
 				run: async (command: readonly string[]) => {


### PR DESCRIPTION
- `coreweave_ensure` (packages/compute-coreweave) adds `slow_boot_hint` when `boot_ms > 10 s`.
- `sandbox_startup_diagnostic` (packages/api admin route) adds `hint` when `startup_timings_ms.boot > 10 s`.

Both say: *boot > 10 s usually means the node cold-pulled the sandbox image; pre-pull the configured image tags on the sandbox node pool.* A warm-node container start is ~1–6 s; 16–30 s is the cold ghcr.io pull of the ~650 MB image (2026-08-26 evidence in the issue).

Log-only — the diagnostic report schema is unchanged, so no OpenAPI regen. `packages/api` can't import the adapter (dependency rule), so each package keeps its own constant.
