### PR TITLE
docs: show how to pre-pull the sandbox image on kernel nodes (MO-7466)

### DIFF
--- a/docs/deploying/cks.md
+++ b/docs/deploying/cks.md
@@ -572,6 +572,57 @@ sync + `kubectl rollout restart`.
 filesystem (venv, caches) on teardown and restores it next session. See
 [Configuration](../configuration.md#coreweave-sandbox) for the trade-offs.
 
+### Pre-pull the sandbox image
+
+Sandbox pods run on your sandbox node pool and pull `MARIMOHUB_COMPUTE_IMAGE`
+through the node's image cache. A node that does not have the tag yet pays a
+full registry pull on the session's critical path (≈20 s for a 650 MB image
+from ghcr.io), and a registry hiccup fails the start outright. This hits every
+new node in the pool and every tag you roll. The `coreweave_ensure` and
+`sandbox_startup_diagnostic` log events flag it: `boot_ms` over 10 s carries a
+`slow_boot_hint`.
+
+Keep every tag warm with a DaemonSet on the pool — one init container per
+image, then an idle holder:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sandbox-image-prepuller
+spec:
+  selector:
+    matchLabels: { app: sandbox-image-prepuller }
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate: { maxUnavailable: 100% } # warm every node at once
+  template:
+    metadata:
+      labels: { app: sandbox-image-prepuller }
+    spec:
+      nodeSelector:
+        compute.coreweave.com/node-pool: sandboxes # your sandbox pool
+      tolerations: [{ operator: Exists }]
+      imagePullSecrets: [{ name: ghcr-credentials }] # optional for a public image
+      initContainers:
+        # One per tag in MARIMOHUB_COMPUTE_IMAGE (and MARIMOHUB_DATA_PREVIEW_IMAGE).
+        - name: pull-py313
+          image: ghcr.io/marimo-team/marimo-sandbox:py3.13-marimo0.23.16
+          imagePullPolicy: Always
+          command: ['/bin/true']
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.10
+          resources:
+            requests: { cpu: 1m, memory: 8Mi }
+```
+
+Use `imagePullPolicy: Always` on the pull containers: sandbox pods pull with
+`Always`, so when you re-push a tag the prepuller must fetch the new digest
+rather than hold the old one. An unchanged tag costs one manifest check.
+Re-apply (with a changed pod annotation so the pods roll) whenever you change
+`MARIMOHUB_COMPUTE_IMAGE`, before rolling the hub.
+
 ## Production cautions
 
 - Pin the chart version; upgrade deliberately (`helm upgrade --version …`).

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -111,9 +111,13 @@ the image pull. If starts are slow:
    stale otherwise) and pays a registry round-trip on every start. Override
    with `MARIMOHUB_COMPUTE_KUBERNETES_IMAGE_PULL_POLICY` if you know better.
 2. **Pre-pull the image on kernel nodes.** The first session on a new node
-   pays the full pull. Run a small DaemonSet with the sandbox image, or an
-   image-cache operator such as
-   [kube-fledged](https://github.com/senthilrch/kube-fledged).
+   pays the full pull. Run a DaemonSet on the kernel pool with one init
+   container per image tag — see the
+   [example on the CKS page](./cks.md#pre-pull-the-sandbox-image), swapping
+   the `nodeSelector` for your pool — or an image-cache operator such as
+   [kube-fledged](https://github.com/senthilrch/kube-fledged). Match the pull
+   policy to the kernel pods': `IfNotPresent` for a digest/pinned image,
+   `Always` for a tag you re-push.
 3. **Check scheduling.** Tight CPU/memory/GPU requests, taints, or a cold
    autoscaler show up as a large `schedule_ms` and `FailedScheduling` events.
 

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -481,7 +481,7 @@ export class SandboxProvisioner {
 			workspacePrefix,
 			...(options.gitPrefix ? { excludeRelativeRoots: ['.git'] } : {}),
 		});
-		if (!options.gitPrefix) return await load;
+		if (!options.gitPrefix) return load;
 		const gitPrefix = options.gitPrefix;
 		const restoreGit = async (): Promise<WorkspaceRestoreStats> => {
 			try {


### PR DESCRIPTION
- **`docs/deploying/cks.md`** — new "Pre-pull the sandbox image" section: why boot depends on the per-node image cache (new node / rolled tag / registry hiccup → slow or failed start, surfaced by `slow_boot_hint`), a copy-paste prepuller DaemonSet (one init container per tag, `pause` holder), and why the pull containers use `Always`.
- **`docs/deploying/kubernetes.md`** — the existing "pre-pull" bullet now links to that example and states the pull-policy rule (`IfNotPresent` for pinned, `Always` for re-pushed tags), matching how the native backend picks the kernel pod's policy.