### PR TITLE
Add environment setup benchmark to sandbox diagnostics

### DIFF
--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -9,7 +9,7 @@ ENV MARIMO_VERSION=${MARIMO_VERSION}
 
 COPY --from=ghcr.io/astral-sh/uv:0.12.1@sha256:cf4eedcaa81655197f625739489effcbe71b61ceb1506f332c3facae5deceded /uv /uvx /usr/local/bin/
 
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates locales \
+RUN apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates locales \
  && sed -i 's/^# *en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
  && locale-gen \
  && rm -rf /var/lib/apt/lists/*

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -778,6 +778,8 @@ components:
           type: object
           additionalProperties:
             type: number
+        environment_setup_benchmark:
+          $ref: '#/components/schemas/SandboxEnvironmentSetupBenchmark'
       required:
         - ok
         - sandbox_id
@@ -793,6 +795,7 @@ components:
         - cleanup
         - startup_timings_ms
         - counters
+        - environment_setup_benchmark
     SandboxStartupPhase:
       type: object
       properties:
@@ -835,6 +838,30 @@ components:
             - command
             - stdout
             - stderr
+    SandboxEnvironmentSetupBenchmark:
+      type:
+        - object
+        - 'null'
+      properties:
+        tool:
+          type: string
+          minLength: 1
+          example: uv
+        runtime_probe:
+          $ref: '#/components/schemas/SandboxStartupCommand'
+        artifact_download:
+          $ref: '#/components/schemas/SandboxStartupCommand'
+        prepare:
+          $ref: '#/components/schemas/SandboxStartupCommand'
+        install:
+          $ref: '#/components/schemas/SandboxStartupCommand'
+      required:
+        - tool
+        - runtime_probe
+        - artifact_download
+        - prepare
+        - install
+      description: The optional fixed-package benchmark, or null when it was not requested
     SandboxStartupRequest:
       type: object
       properties:
@@ -844,6 +871,10 @@ components:
         compute_profile:
           type: string
           minLength: 1
+        environment_setup_benchmark:
+          type: boolean
+          description: Run the fixed-package uv, wheel-download, runtime, and
+            CPU-throttling benchmark
       additionalProperties: false
     DeploymentConfig:
       type: object
@@ -5155,9 +5186,11 @@ paths:
         - Admin
       summary: Measure sandbox startup and command latency
       description: Creates a fresh ephemeral sandbox, uses the first fixed echo
-        command as the readiness probe, measures a second fixed echo command,
-        and destroys the sandbox. Runtime failures are returned as a partial
-        report. Super-admin only and session-only.
+        command as the readiness probe, and measures a second fixed echo
+        command. An optional fresh-sandbox uv benchmark also records runtime and
+        CPU limits, files.pythonhosted.org throughput, uv phase timings, and CPU
+        throttling counters. The sandbox is always destroyed. Runtime failures
+        are returned as a partial report. Super-admin only and session-only.
       security: *a2
       requestBody:
         required: true

--- a/packages/api/src/routes/admin.test.ts
+++ b/packages/api/src/routes/admin.test.ts
@@ -332,10 +332,117 @@ describe('Admin routes', () => {
 				cleanup: { status: 'ok' },
 				startup_timings_ms: { find: 4, create: 12, boot: 34 },
 				counters: { execs: 2 },
+				environment_setup_benchmark: null,
 			});
 			expect(report.handle.duration_ms).toEqual(expect.any(Number));
 			expect(report.total_ms).toEqual(expect.any(Number));
 			expect(await deps.services.sessions.countActiveForUser(ACTOR)).toBe(0);
+		});
+
+		it('runs the optional uv, wheel download, runtime, and CPU throttle benchmark', async () => {
+			const { instance } = makeFakeSandbox();
+			instance.exec = vi
+				.fn()
+				.mockResolvedValueOnce(execResult(true, 'Hello\n', ''))
+				.mockResolvedValueOnce(execResult(true, 'Hello\n', ''))
+				.mockResolvedValueOnce(
+					execResult(
+						true,
+						'kernel_version=Linux version 4.4.0\nnproc=2\ncpu.max=200000 100000\n',
+						'',
+					),
+				)
+				.mockResolvedValueOnce(
+					execResult(
+						true,
+						'size_download=15313630\ntime_total=1.25\nspeed_download=12250904\n',
+						'',
+					),
+				)
+				.mockResolvedValueOnce(execResult(true, 'Resolved 15 packages in 120ms\n', ''))
+				.mockResolvedValueOnce(
+					execResult(
+						true,
+						'Resolved 15 packages in 1ms\nPrepared 9 packages in 9.2s\nInstalled 9 packages in 80ms\nnr_throttled 4\nnr_throttled 19\n',
+						'',
+					),
+				);
+			const { compute } = computeFor(instance);
+			const { request } = superAdminApi({ compute, sandbox: sandboxConfig });
+
+			const report = await expectOk<any>(
+				await request('POST', '/admin/debug/sandbox-startup', {
+					environment_setup_benchmark: true,
+				}),
+			);
+
+			expect(instance.exec).toHaveBeenCalledTimes(6);
+			expect(instance.exec).toHaveBeenNthCalledWith(
+				3,
+				expect.stringContaining('/sys/fs/cgroup/cpu.max'),
+				{ timeout: 30_000 },
+			);
+			expect(instance.exec).toHaveBeenNthCalledWith(
+				4,
+				expect.stringContaining('botocore-1.43.36-py3-none-any.whl'),
+				{ timeout: 60_000 },
+			);
+			expect(instance.exec).toHaveBeenNthCalledWith(
+				5,
+				expect.stringContaining('uv lock --no-cache'),
+				{ timeout: 120_000 },
+			);
+			expect(instance.exec).toHaveBeenNthCalledWith(
+				6,
+				expect.stringContaining('uv sync --frozen --inexact --no-compile-bytecode --no-build -v'),
+				{ timeout: 300_000 },
+			);
+			expect(report).toMatchObject({
+				ok: true,
+				environment_setup_benchmark: {
+					tool: 'uv',
+					runtime_probe: { status: 'ok', stdout: expect.stringContaining('nproc=2') },
+					artifact_download: {
+						status: 'ok',
+						stdout: expect.stringContaining('size_download=15313630'),
+					},
+					prepare: { status: 'ok', stdout: expect.stringContaining('Resolved 15 packages') },
+					install: { status: 'ok', stdout: expect.stringContaining('Prepared 9 packages') },
+				},
+			});
+		});
+
+		it('returns the independent measurements when uv lock preparation fails', async () => {
+			const { instance } = makeFakeSandbox();
+			instance.exec = vi
+				.fn()
+				.mockResolvedValueOnce(execResult(true, 'Hello\n', ''))
+				.mockResolvedValueOnce(execResult(true, 'Hello\n', ''))
+				.mockResolvedValueOnce(execResult(true, 'nproc=2\n', ''))
+				.mockResolvedValueOnce(execResult(true, 'time_total=1.25\n', ''))
+				.mockResolvedValueOnce(
+					execResult(false, '', 'failed to resolve dependencies', 'COMMAND_FAILED'),
+				);
+			const { compute } = computeFor(instance);
+			const { request } = superAdminApi({ compute, sandbox: sandboxConfig });
+
+			const report = await expectOk<any>(
+				await request('POST', '/admin/debug/sandbox-startup', {
+					environment_setup_benchmark: true,
+				}),
+			);
+
+			expect(instance.exec).toHaveBeenCalledTimes(5);
+			expect(report).toMatchObject({
+				ok: false,
+				environment_setup_benchmark: {
+					tool: 'uv',
+					runtime_probe: { status: 'ok' },
+					artifact_download: { status: 'ok' },
+					prepare: { status: 'failed', stderr: 'failed to resolve dependencies' },
+					install: { status: 'skipped', duration_ms: null },
+				},
+			});
 		});
 
 		it('uses deployment defaults when both selections are omitted', async () => {

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -29,7 +29,79 @@ import { pageSchema } from '../pagination';
 
 const ECHO_COMMAND = 'echo "Hello"';
 const STEADY_STATE_EXEC_TIMEOUT_MS = 30_000;
+const UV_BENCHMARK_RUNTIME_TIMEOUT_MS = 30_000;
+const UV_BENCHMARK_DOWNLOAD_TIMEOUT_MS = 60_000;
+const UV_BENCHMARK_LOCK_TIMEOUT_MS = 120_000;
+const UV_BENCHMARK_SYNC_TIMEOUT_MS = 300_000;
+const UV_BENCHMARK_TIMEOUT_MS =
+	UV_BENCHMARK_RUNTIME_TIMEOUT_MS +
+	UV_BENCHMARK_DOWNLOAD_TIMEOUT_MS +
+	UV_BENCHMARK_LOCK_TIMEOUT_MS +
+	UV_BENCHMARK_SYNC_TIMEOUT_MS;
 const CLEANUP_LEASE_HEADROOM_MS = 60_000;
+const UV_BENCHMARK_DIR = '/tmp/marimohub-uv-sync-benchmark';
+const BOTOCORE_WHEEL_URL =
+	'https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl';
+
+const UV_BENCHMARK_RUNTIME_COMMAND = [
+	'set -eu',
+	"printf 'uname='",
+	'uname -a',
+	"printf 'kernel_osrelease='",
+	'cat /proc/sys/kernel/osrelease',
+	"printf 'kernel_version='",
+	'cat /proc/version',
+	"printf 'nproc='",
+	'nproc',
+	'printf \'UV_PROJECT_ENVIRONMENT=%s\\n\' "${UV_PROJECT_ENVIRONMENT:-unset}"',
+	'printf \'UV_CACHE_DIR=%s\\n\' "${UV_CACHE_DIR:-unset}"',
+	"if [ -d /proc/gvisor ]; then printf 'runtime_probe=gvisor (/proc/gvisor)\\n'; elif dmesg 2>&1 | grep -qi gvisor; then printf 'runtime_probe=gvisor (dmesg)\\n'; else printf 'runtime_probe=no-gvisor-marker\\n'; fi",
+	"printf '%s\\n' '--- dmesg (first 20 lines) ---'",
+	"dmesg 2>&1 | sed -n '1,20p' || true",
+	"printf '%s\\n' '--- /proc/1/status ---'",
+	"grep -E '^(Seccomp|Seccomp_filters|Cpus_allowed_list):' /proc/1/status || true",
+	'for path in /sys/fs/cgroup/cpu.max /sys/fs/cgroup/cpu.stat /sys/fs/cgroup/cpu/cpu.cfs_quota_us /sys/fs/cgroup/cpu/cpu.cfs_period_us /sys/fs/cgroup/cpu/cpu.stat; do if [ -r "$path" ]; then printf \'%s\\n\' "--- $path ---"; cat "$path"; fi; done',
+].join('\n');
+
+const UV_BENCHMARK_DOWNLOAD_COMMAND = [
+	'set -eu',
+	'curl --fail --location --silent --show-error --output /dev/null',
+	"--write-out 'http_code=%{http_code}\\nsize_download=%{size_download}\\ntime_namelookup=%{time_namelookup}\\ntime_connect=%{time_connect}\\ntime_appconnect=%{time_appconnect}\\ntime_starttransfer=%{time_starttransfer}\\ntime_total=%{time_total}\\nspeed_download=%{speed_download}\\n'",
+	`'${BOTOCORE_WHEEL_URL}'`,
+].join(' ');
+
+const UV_BENCHMARK_LOCK_COMMAND = [
+	'set -eu',
+	`benchmark_dir='${UV_BENCHMARK_DIR}'`,
+	'rm -rf "$benchmark_dir"',
+	'mkdir -p "$benchmark_dir"',
+	"printf '%s\\n' '[project]' 'name = \"marimohub-uv-benchmark\"' 'version = \"0.0.0\"' 'requires-python = \">=3.13\"' 'dependencies = [' '  \"boto3==1.43.36\",' '  \"botocore==1.43.36\",' '  \"moutils==0.4.4\",' '  \"obstore==0.11.0\",' ']' > \"$benchmark_dir/pyproject.toml\"",
+	'cd "$benchmark_dir"',
+	'uv lock --no-cache',
+].join('\n');
+
+const UV_BENCHMARK_SYNC_COMMAND = [
+	'set -u',
+	`benchmark_dir='${UV_BENCHMARK_DIR}'`,
+	'cd "$benchmark_dir"',
+	'record_cpu_stat() {',
+	'  label="$1"',
+	'  if [ -r /sys/fs/cgroup/cpu.stat ]; then',
+	'    printf "%s\\n" "--- $label /sys/fs/cgroup/cpu.stat ---"',
+	'    cat /sys/fs/cgroup/cpu.stat',
+	'  elif [ -r /sys/fs/cgroup/cpu/cpu.stat ]; then',
+	'    printf "%s\\n" "--- $label /sys/fs/cgroup/cpu/cpu.stat ---"',
+	'    cat /sys/fs/cgroup/cpu/cpu.stat',
+	'  fi',
+	'}',
+	'record_cpu_stat cpu_before',
+	'status=0',
+	'uv sync --frozen --inexact --no-compile-bytecode --no-build -v > "$benchmark_dir/uv-sync.log" 2>&1 || status=$?',
+	'grep -E \'(^|[[:space:]])(Resolved|Prepared|Installed) [0-9]+ package\' "$benchmark_dir/uv-sync.log" || true',
+	'record_cpu_stat cpu_after',
+	'if [ "$status" -ne 0 ]; then tail -n 100 "$benchmark_dir/uv-sync.log" >&2; fi',
+	'exit "$status"',
+].join('\n');
 
 const SandboxStartupPhaseSchema = z
 	.object({
@@ -50,9 +122,23 @@ const SandboxStartupRequestSchema = z
 	.object({
 		image: z.string().min(1).optional(),
 		compute_profile: z.string().min(1).optional(),
+		environment_setup_benchmark: z.boolean().optional().openapi({
+			description:
+				'Run the fixed-package uv, wheel-download, runtime, and CPU-throttling benchmark',
+		}),
 	})
 	.strict()
 	.openapi('SandboxStartupRequest');
+
+const SandboxEnvironmentSetupBenchmarkSchema = z
+	.object({
+		tool: z.string().min(1).openapi({ example: 'uv' }),
+		runtime_probe: SandboxStartupCommandSchema,
+		artifact_download: SandboxStartupCommandSchema,
+		prepare: SandboxStartupCommandSchema,
+		install: SandboxStartupCommandSchema,
+	})
+	.openapi('SandboxEnvironmentSetupBenchmark');
 
 const SandboxStartupReportSchema = z
 	.object({
@@ -70,12 +156,16 @@ const SandboxStartupReportSchema = z
 		cleanup: SandboxStartupPhaseSchema,
 		startup_timings_ms: z.record(z.string(), z.number().nonnegative()),
 		counters: z.record(z.string(), z.number()),
+		environment_setup_benchmark: SandboxEnvironmentSetupBenchmarkSchema.nullable().openapi({
+			description: 'The optional fixed-package benchmark, or null when it was not requested',
+		}),
 	})
 	.openapi('SandboxStartupReport');
 
 type SandboxStartupPhase = z.infer<typeof SandboxStartupPhaseSchema>;
 type SandboxStartupCommand = z.infer<typeof SandboxStartupCommandSchema>;
 type SandboxStartupReport = z.infer<typeof SandboxStartupReportSchema>;
+type EnvironmentSetupBenchmark = NonNullable<SandboxStartupReport['environment_setup_benchmark']>;
 
 function elapsed(started: number): number {
 	return performance.now() - started;
@@ -85,12 +175,22 @@ function skippedPhase(): SandboxStartupPhase {
 	return { status: 'skipped', duration_ms: null };
 }
 
-function skippedCommand(): SandboxStartupCommand {
+function skippedCommand(command = ECHO_COMMAND): SandboxStartupCommand {
 	return {
 		...skippedPhase(),
-		command: ECHO_COMMAND,
+		command,
 		stdout: '',
 		stderr: '',
+	};
+}
+
+function skippedEnvironmentSetupBenchmark(): EnvironmentSetupBenchmark {
+	return {
+		tool: 'uv',
+		runtime_probe: skippedCommand(UV_BENCHMARK_RUNTIME_COMMAND),
+		artifact_download: skippedCommand(UV_BENCHMARK_DOWNLOAD_COMMAND),
+		prepare: skippedCommand(UV_BENCHMARK_LOCK_COMMAND),
+		install: skippedCommand(UV_BENCHMARK_SYNC_COMMAND),
 	};
 }
 
@@ -102,22 +202,26 @@ function failedPhase(started: number, error: unknown): SandboxStartupPhase {
 	};
 }
 
-async function runEcho(sandbox: SandboxInstance, timeout: number): Promise<SandboxStartupCommand> {
+async function runCommand(
+	sandbox: SandboxInstance,
+	command: string,
+	timeout: number,
+): Promise<SandboxStartupCommand> {
 	const started = performance.now();
 	try {
-		const result = await sandbox.exec(ECHO_COMMAND, { timeout });
+		const result = await sandbox.exec(command, { timeout });
 		return result.success
 			? {
 					status: 'ok',
 					duration_ms: elapsed(started),
-					command: ECHO_COMMAND,
+					command,
 					stdout: result.stdout,
 					stderr: result.stderr,
 				}
 			: {
 					status: 'failed',
 					duration_ms: elapsed(started),
-					command: ECHO_COMMAND,
+					command,
 					stdout: result.stdout,
 					stderr: result.stderr,
 					failure_code: result.error.code,
@@ -125,11 +229,19 @@ async function runEcho(sandbox: SandboxInstance, timeout: number): Promise<Sandb
 	} catch (error) {
 		return {
 			...failedPhase(started, error),
-			command: ECHO_COMMAND,
+			command,
 			stdout: '',
 			stderr: '',
 		};
 	}
+}
+
+function runEcho(sandbox: SandboxInstance, timeout: number): Promise<SandboxStartupCommand> {
+	return runCommand(sandbox, ECHO_COMMAND, timeout);
+}
+
+function commandLogSummary(command: SandboxStartupCommand) {
+	return { status: command.status, duration_ms: command.duration_ms };
 }
 
 function selectedImage(
@@ -241,8 +353,10 @@ const testSandboxStartup = createRoute({
 	summary: 'Measure sandbox startup and command latency',
 	description:
 		'Creates a fresh ephemeral sandbox, uses the first fixed echo command as the readiness ' +
-		'probe, measures a second fixed echo command, and destroys the sandbox. Runtime failures ' +
-		'are returned as a partial report. Super-admin only and session-only.',
+		'probe, and measures a second fixed echo command. An optional fresh-sandbox uv benchmark ' +
+		'also records runtime and CPU limits, files.pythonhosted.org throughput, uv phase timings, ' +
+		'and CPU throttling counters. The sandbox is always destroyed. Runtime failures are returned ' +
+		'as a partial report. Super-admin only and session-only.',
 	security: SESSION_ONLY_SECURITY,
 	request: { body: jsonBody(SandboxStartupRequestSchema) },
 	responses: {
@@ -379,7 +493,10 @@ app.openapi(testSandboxStartup, async (c) => {
 	const acquired = await diagnosticLease.acquire(
 		user.id,
 		sandboxId,
-		startupTimeoutMs + STEADY_STATE_EXEC_TIMEOUT_MS + CLEANUP_LEASE_HEADROOM_MS,
+		startupTimeoutMs +
+			STEADY_STATE_EXEC_TIMEOUT_MS +
+			(body.environment_setup_benchmark ? UV_BENCHMARK_TIMEOUT_MS : 0) +
+			CLEANUP_LEASE_HEADROOM_MS,
 	);
 	if (!acquired) {
 		throw new ResourceExhaustedError('A sandbox startup test is already running');
@@ -392,6 +509,9 @@ app.openapi(testSandboxStartup, async (c) => {
 	let readiness = skippedCommand();
 	let exec = skippedCommand();
 	let cleanup = skippedPhase();
+	const environmentSetupBenchmark = body.environment_setup_benchmark
+		? skippedEnvironmentSetupBenchmark()
+		: null;
 	let startupTimings: Record<string, number> = {};
 	let counters: Record<string, number> = {};
 
@@ -424,6 +544,30 @@ app.openapi(testSandboxStartup, async (c) => {
 			}
 			if (readiness.status === 'ok') {
 				exec = await runEcho(sandbox, STEADY_STATE_EXEC_TIMEOUT_MS);
+				if (environmentSetupBenchmark) {
+					environmentSetupBenchmark.runtime_probe = await runCommand(
+						sandbox,
+						UV_BENCHMARK_RUNTIME_COMMAND,
+						UV_BENCHMARK_RUNTIME_TIMEOUT_MS,
+					);
+					environmentSetupBenchmark.artifact_download = await runCommand(
+						sandbox,
+						UV_BENCHMARK_DOWNLOAD_COMMAND,
+						UV_BENCHMARK_DOWNLOAD_TIMEOUT_MS,
+					);
+					environmentSetupBenchmark.prepare = await runCommand(
+						sandbox,
+						UV_BENCHMARK_LOCK_COMMAND,
+						UV_BENCHMARK_LOCK_TIMEOUT_MS,
+					);
+					if (environmentSetupBenchmark.prepare.status === 'ok') {
+						environmentSetupBenchmark.install = await runCommand(
+							sandbox,
+							UV_BENCHMARK_SYNC_COMMAND,
+							UV_BENCHMARK_SYNC_TIMEOUT_MS,
+						);
+					}
+				}
 			}
 		}
 	} finally {
@@ -469,11 +613,20 @@ app.openapi(testSandboxStartup, async (c) => {
 		}
 	}
 
+	const benchmarkOk =
+		environmentSetupBenchmark === null ||
+		[
+			environmentSetupBenchmark.runtime_probe,
+			environmentSetupBenchmark.artifact_download,
+			environmentSetupBenchmark.prepare,
+			environmentSetupBenchmark.install,
+		].every((command) => command.status === 'ok');
 	const report: SandboxStartupReport = {
 		ok:
 			handle.status === 'ok' &&
 			readiness.status === 'ok' &&
 			exec.status === 'ok' &&
+			benchmarkOk &&
 			cleanup.status === 'ok',
 		sandbox_id: sandboxId,
 		image: image ?? null,
@@ -488,6 +641,7 @@ app.openapi(testSandboxStartup, async (c) => {
 		cleanup,
 		startup_timings_ms: startupTimings,
 		counters,
+		environment_setup_benchmark: environmentSetupBenchmark,
 	};
 	logEvent({
 		level: report.ok ? 'info' : 'error',
@@ -502,6 +656,18 @@ app.openapi(testSandboxStartup, async (c) => {
 		readiness_ms: report.readiness.duration_ms,
 		exec_ms: report.exec.duration_ms,
 		cleanup_ms: report.cleanup.duration_ms,
+		environment_setup_benchmark:
+			report.environment_setup_benchmark === null
+				? null
+				: {
+						tool: report.environment_setup_benchmark.tool,
+						runtime_probe: commandLogSummary(report.environment_setup_benchmark.runtime_probe),
+						artifact_download: commandLogSummary(
+							report.environment_setup_benchmark.artifact_download,
+						),
+						prepare: commandLogSummary(report.environment_setup_benchmark.prepare),
+						install: commandLogSummary(report.environment_setup_benchmark.install),
+					},
 		startup_timings_ms: report.startup_timings_ms,
 		counters: report.counters,
 	});

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -351,7 +351,7 @@ export interface paths {
 		put?: never;
 		/**
 		 * Measure sandbox startup and command latency
-		 * @description Creates a fresh ephemeral sandbox, uses the first fixed echo command as the readiness probe, measures a second fixed echo command, and destroys the sandbox. Runtime failures are returned as a partial report. Super-admin only and session-only.
+		 * @description Creates a fresh ephemeral sandbox, uses the first fixed echo command as the readiness probe, and measures a second fixed echo command. An optional fresh-sandbox uv benchmark also records runtime and CPU limits, files.pythonhosted.org throughput, uv phase timings, and CPU throttling counters. The sandbox is always destroyed. Runtime failures are returned as a partial report. Super-admin only and session-only.
 		 */
 		post: operations['admin.debug.sandboxStartup'];
 		delete?: never;
@@ -1704,6 +1704,7 @@ export interface components {
 			counters: {
 				[key: string]: number;
 			};
+			environment_setup_benchmark: components['schemas']['SandboxEnvironmentSetupBenchmark'];
 		};
 		SandboxStartupPhase: {
 			/** @enum {string} */
@@ -1721,9 +1722,20 @@ export interface components {
 			/** @enum {string} */
 			failure_code?: 'COMMAND_FAILED' | 'SPAWN_FAILED' | 'BACKEND_ERROR';
 		};
+		/** @description The optional fixed-package benchmark, or null when it was not requested */
+		SandboxEnvironmentSetupBenchmark: {
+			/** @example uv */
+			tool: string;
+			runtime_probe: components['schemas']['SandboxStartupCommand'];
+			artifact_download: components['schemas']['SandboxStartupCommand'];
+			prepare: components['schemas']['SandboxStartupCommand'];
+			install: components['schemas']['SandboxStartupCommand'];
+		} | null;
 		SandboxStartupRequest: {
 			image?: string;
 			compute_profile?: string;
+			/** @description Run the fixed-package uv, wheel-download, runtime, and CPU-throttling benchmark */
+			environment_setup_benchmark?: boolean;
 		};
 		DeploymentConfig: {
 			deployment: components['schemas']['AdminDeployment'];

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -238,6 +238,7 @@ export function useDeploymentConfigQuery() {
 export interface SandboxStartupTestInput {
 	image?: string;
 	compute_profile?: string;
+	environment_setup_benchmark?: boolean;
 }
 
 export function useRunSandboxStartupTest(startupTimeoutSeconds = 120) {
@@ -246,7 +247,8 @@ export function useRunSandboxStartupTest(startupTimeoutSeconds = 120) {
 			apiData(
 				apiClient.POST('/api/v1/admin/debug/sandbox-startup', {
 					body,
-					timeout: startupTimeoutSeconds * 1000 + 60_000,
+					timeout:
+						startupTimeoutSeconds * 1000 + (body.environment_setup_benchmark ? 570_000 : 60_000),
 				}),
 			),
 		meta: { suppressErrorToast: true },

--- a/packages/web/src/components/Admin/AdminDebugPage.test.tsx
+++ b/packages/web/src/components/Admin/AdminDebugPage.test.tsx
@@ -42,7 +42,44 @@ function report(overrides: Partial<SandboxStartupReport> = {}): SandboxStartupRe
 		cleanup: { status: 'ok', duration_ms: 154 },
 		startup_timings_ms: { find: 4, create: 12, boot: 1700 },
 		counters: { execs: 2 },
+		environment_setup_benchmark: null,
 		...overrides,
+	};
+}
+
+function environmentSetupBenchmark(): NonNullable<
+	SandboxStartupReport['environment_setup_benchmark']
+> {
+	return {
+		tool: 'uv',
+		runtime_probe: {
+			status: 'ok',
+			duration_ms: 30,
+			command: 'uname -a',
+			stdout: 'nproc=2\ncpu.max=200000 100000\n',
+			stderr: '',
+		},
+		artifact_download: {
+			status: 'ok',
+			duration_ms: 1250,
+			command: 'curl https://files.pythonhosted.org/botocore.whl',
+			stdout: 'size_download=15313630\ntime_total=1.25\n',
+			stderr: '',
+		},
+		prepare: {
+			status: 'ok',
+			duration_ms: 120,
+			command: 'uv lock --no-cache',
+			stdout: 'Resolved 15 packages in 120ms\n',
+			stderr: '',
+		},
+		install: {
+			status: 'ok',
+			duration_ms: 9300,
+			command: 'uv sync --frozen -v',
+			stdout: 'Prepared 9 packages in 9.2s\nInstalled 9 packages in 80ms\n',
+			stderr: '',
+		},
 	};
 }
 
@@ -60,7 +97,9 @@ describe('AdminDebugPage', () => {
 				const url = String(input);
 				requests.push({ url, body: typeof init?.body === 'string' ? init.body : undefined });
 				if (url === '/api/v1/capabilities') return jsonOk(CAPABILITIES);
-				if (url === '/api/v1/admin/debug/sandbox-startup') return jsonOk(report());
+				if (url === '/api/v1/admin/debug/sandbox-startup') {
+					return jsonOk(report({ environment_setup_benchmark: environmentSetupBenchmark() }));
+				}
 				throw new Error(`unexpected fetch: ${url}`);
 			}),
 		);
@@ -72,6 +111,9 @@ describe('AdminDebugPage', () => {
 		).toBeInTheDocument();
 		await user.click(await screen.findByRole('radio', { name: /py313/i }));
 		await user.click(screen.getByRole('radio', { name: /gpu/i }));
+		await user.click(
+			screen.getByRole('switch', { name: /Fresh sandbox uv sync benchmark disabled/i }),
+		);
 		await user.click(screen.getByRole('button', { name: 'Run startup test' }));
 
 		expect(await screen.findByRole('heading', { name: 'Latest report' })).toBeInTheDocument();
@@ -81,10 +123,15 @@ describe('AdminDebugPage', () => {
 		expect(bootTiming?.textContent?.replaceAll(/\D/g, '')).toBe('1700');
 		expect(screen.getByText('Readiness (first echo)')).toBeInTheDocument();
 		expect(screen.getByText('Single exec (second echo)')).toBeInTheDocument();
+		expect(screen.getByText('Fresh sandbox uv sync benchmark')).toBeInTheDocument();
+		expect(screen.getByText('Runtime and CPU limits')).toBeInTheDocument();
+		expect(screen.getByText('uv sync (fresh sandbox)')).toBeInTheDocument();
+		expect(screen.getByText(/Prepared 9 packages/)).toBeInTheDocument();
 		expect(screen.getAllByText('Hello')).toHaveLength(2);
 		expect(JSON.parse(requests.at(-1)?.body ?? '')).toEqual({
 			image: 'registry.example/sandbox:py313',
 			compute_profile: 'gpu',
+			environment_setup_benchmark: true,
 		});
 	});
 
@@ -166,6 +213,7 @@ describe('AdminDebugPage', () => {
 		expect(screen.getAllByRole('radio').every((radio) => radio.hasAttribute('disabled'))).toBe(
 			true,
 		);
+		expect(screen.getByRole('switch')).toBeDisabled();
 		finish?.(jsonOk(report()));
 		await screen.findByText('sb-first');
 	});

--- a/packages/web/src/components/Admin/AdminDebugPage.tsx
+++ b/packages/web/src/components/Admin/AdminDebugPage.tsx
@@ -12,6 +12,7 @@ import type { SandboxStartupReport } from '@/types';
 
 type StartupCommand = SandboxStartupReport['readiness'];
 type StartupPhase = SandboxStartupReport['handle'];
+type EnvironmentSetupBenchmark = NonNullable<SandboxStartupReport['environment_setup_benchmark']>;
 
 const CONFIGURED_IMAGE_PREFIX = 'configured-image:';
 const durationFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
@@ -192,6 +193,10 @@ function StartupReport({ report }: { report: SandboxStartupReport }) {
 				<CommandResult label="Single exec (second echo)" result={report.exec} />
 			</div>
 
+			{report.environment_setup_benchmark ? (
+				<EnvironmentSetupBenchmarkReport benchmark={report.environment_setup_benchmark} />
+			) : null}
+
 			{report.cleanup.error && (
 				<div>
 					<h3 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-destructive">
@@ -210,6 +215,30 @@ function StartupReport({ report }: { report: SandboxStartupReport }) {
 				{' · '}counters <code>{JSON.stringify(report.counters)}</code>
 			</div>
 		</section>
+	);
+}
+
+function EnvironmentSetupBenchmarkReport({ benchmark }: { benchmark: EnvironmentSetupBenchmark }) {
+	return (
+		<div>
+			<h3 className="mb-1 text-sm font-semibold">Fresh sandbox uv sync benchmark</h3>
+			<p className="mb-3 text-xs text-muted-foreground">
+				Pinned boto3, botocore, moutils, and obstore against the image&apos;s configured environment
+				and cache. CPU counters bracket only the measured sync.
+			</p>
+			<div className="grid gap-4">
+				<CommandResult label="Runtime and CPU limits" result={benchmark.runtime_probe} />
+				<CommandResult
+					label="Raw wheel download (botocore 1.43.36, 15.3 MB)"
+					result={benchmark.artifact_download}
+				/>
+				<CommandResult
+					label="Create uv.lock (not part of sync timing)"
+					result={benchmark.prepare}
+				/>
+				<CommandResult label="uv sync (fresh sandbox)" result={benchmark.install} />
+			</div>
+		</div>
 	);
 }
 
@@ -234,6 +263,7 @@ export default function AdminDebugPage() {
 		defaultValues: {
 			image: DEFAULT_BASE_IMAGE,
 			computeProfile: DEFAULT_COMPUTE_PROFILE,
+			environmentSetupBenchmark: false,
 		},
 		onSubmit: async ({ value }) => {
 			const image = value.image.startsWith(CONFIGURED_IMAGE_PREFIX)
@@ -245,6 +275,7 @@ export default function AdminDebugPage() {
 					...(value.computeProfile === DEFAULT_COMPUTE_PROFILE
 						? {}
 						: { compute_profile: value.computeProfile }),
+					...(value.environmentSetupBenchmark ? { environment_setup_benchmark: true } : {}),
 				});
 			} catch {
 				return;
@@ -302,6 +333,25 @@ export default function AdminDebugPage() {
 								options={profileOptions}
 								isDisabled={unavailable || run.isPending}
 							/>
+						)}
+					</form.AppField>
+				</div>
+
+				<div className="mt-5 rounded-lg border bg-card px-4 py-3">
+					<form.AppField name="environmentSetupBenchmark">
+						{(field) => (
+							<field.SwitchField isDisabled={unavailable || run.isPending}>
+								{(selected) => (
+									<span className="flex flex-col text-left">
+										<span className="text-sm font-medium">
+											Fresh sandbox uv sync benchmark {selected ? 'enabled' : 'disabled'}
+										</span>
+										<span className="text-xs text-muted-foreground">
+											Adds a raw wheel download, runtime probe, and fixed four-package sync.
+										</span>
+									</span>
+								)}
+							</field.SwitchField>
 						)}
 					</form.AppField>
 				</div>

--- a/packages/web/src/components/form/fields/SwitchField.tsx
+++ b/packages/web/src/components/form/fields/SwitchField.tsx
@@ -7,14 +7,19 @@ import { useFieldContext } from '../form-context';
 export interface SwitchFieldProps {
 	/** Renders the label/content beside the toggle, given the current state. */
 	children: (isSelected: boolean) => ReactNode;
+	isDisabled?: boolean;
 }
 
 /** A boolean toggle bound to its enclosing `form.AppField`. */
-export function SwitchField({ children }: SwitchFieldProps) {
+export function SwitchField({ children, isDisabled }: SwitchFieldProps) {
 	const field = useFieldContext<boolean>();
 	return (
-		<AriaSwitchField isSelected={field.state.value} onChange={field.handleChange}>
-			<SwitchButton className="flex cursor-pointer items-center gap-3 outline-none">
+		<AriaSwitchField
+			isDisabled={isDisabled}
+			isSelected={field.state.value}
+			onChange={field.handleChange}
+		>
+			<SwitchButton className="flex cursor-pointer items-center gap-3 outline-none disabled:cursor-not-allowed disabled:opacity-50">
 				{({ isSelected }) => (
 					<>
 						<span


### PR DESCRIPTION
Adds an opt-in environment setup benchmark to the admin sandbox startup diagnostic for MO-7469.

- Measures runtime and CPU/cgroup details, raw package-artifact download throughput, lock preparation, and environment installation phase timings.
- Keeps the public API implementation-neutral through generic environment setup naming, phase names, and tool metadata.
- Adds curl to the sandbox image and updates the admin UI, tests, OpenAPI schema, and generated client.