### PR TITLE
perf(runtime): parallelize sandbox setup and credential injection

### DIFF
--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -12,7 +12,12 @@ import {
 	MemoryBucket,
 	setupTestEnv,
 } from '../../testing';
-import type { FilesystemSnapshots, SandboxInstance, SandboxProvider } from '../../ports/sandbox';
+import type {
+	ExecResult,
+	FilesystemSnapshots,
+	SandboxInstance,
+	SandboxProvider,
+} from '../../ports/sandbox';
 import type { NotebookService } from '../content/NotebookService';
 import { SandboxProvisioner } from './SandboxProvisioner';
 import type { BucketConfig, WorkspaceLoadStrategies } from './SandboxProvisioner';
@@ -23,6 +28,16 @@ const bucketConfig: BucketConfig = {
 	name: 'test-bucket',
 	endpoint: 'https://r2.example',
 };
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
 
 /**
  * A fake provider that ALSO implements the optional `FilesystemSnapshots`
@@ -169,6 +184,45 @@ describe('SandboxProvisioner', () => {
 			expect(calls.setEnvVars).toContainEqual({ A: '1' });
 		});
 
+		it('runs environment setup while sessionEnv is still resolving', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const sessionEnv = deferred<{ vars: Record<string, string> }>();
+			const setupStarted = deferred<void>();
+			const releaseSetup = deferred<void>();
+			const setupCompleted = deferred<void>();
+			const exec = instance.exec.bind(instance);
+			instance.exec = async (command, options) => {
+				if (command.includes('uv sync --inexact')) {
+					setupStarted.resolve(undefined);
+					await releaseSetup.promise;
+				}
+				const result = await exec(command, options);
+				if (command.includes('uv sync --inexact')) setupCompleted.resolve(undefined);
+				return result;
+			};
+
+			const provision = new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				sessionEnv: sessionEnv.promise,
+			});
+
+			await setupStarted.promise;
+			expect(calls.setEnvVars).toHaveLength(0);
+			expect(calls.startProcess).toHaveLength(0);
+
+			releaseSetup.resolve(undefined);
+			await setupCompleted.promise;
+			expect(calls.startProcess).toHaveLength(0);
+
+			sessionEnv.resolve({ vars: { A: '1' } });
+			await provision;
+			expect(calls.sequence).toEqual(['setEnvVars', 'startProcess']);
+		});
+
 		it('forwards the resolved base image to provider.create', async () => {
 			const { instance } = makeFakeSandbox();
 			const compute = fakeComputeFrom(instance);
@@ -221,6 +275,67 @@ describe('SandboxProvisioner', () => {
 
 			expect(calls.destroy).toBe(1);
 		});
+
+		it('aborts when sessionEnv rejects after environment setup finishes', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const sessionEnv = deferred<undefined>();
+			const setupCompleted = deferred<void>();
+			const exec = instance.exec.bind(instance);
+			instance.exec = async (command, options) => {
+				const result = await exec(command, options);
+				if (command.includes('uv sync --inexact')) setupCompleted.resolve(undefined);
+				return result;
+			};
+
+			const provision = new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				sessionEnv: sessionEnv.promise,
+			});
+
+			await setupCompleted.promise;
+			sessionEnv.reject(new Error('secret_resolution_failed'));
+			await expect(provision).rejects.toThrow('secret_resolution_failed');
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
+		});
+
+		it('surfaces an injection failure without waiting for environment setup', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const setupStarted = deferred<void>();
+			const releaseSetup = deferred<void>();
+			const exec = instance.exec.bind(instance);
+			instance.exec = async (command, options) => {
+				if (command.includes('uv sync --inexact')) {
+					setupStarted.resolve(undefined);
+					await releaseSetup.promise;
+				}
+				return exec(command, options);
+			};
+			instance.setEnvVars = async () => {
+				throw new Error('credential_write_failed');
+			};
+
+			const provision = new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				sessionEnv: { vars: { A: '1' } },
+			});
+
+			await setupStarted.promise;
+			await expect(provision).rejects.toThrow(
+				'Failed to start sandbox while injecting session credentials',
+			);
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
+			releaseSetup.resolve(undefined);
+		}, 1_000);
 
 		it('merges adapter-drained timings onto the result as reachable_*', async () => {
 			const { instance } = makeFakeSandbox();
@@ -300,6 +415,45 @@ describe('SandboxProvisioner', () => {
 				expect(setupIndex).toBeGreaterThanOrEqual(0);
 				expect(configured.calls.execOptions[setupIndex]?.timeout).toBe(300_000);
 				expect(configured.calls.waitForPortOptions).toEqual([{ timeout: 270_000 }]);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('does not start a supervised kernel after injection exhausts the startup deadline', async () => {
+			vi.useFakeTimers();
+			try {
+				const { instance, calls } = makeFakeSandbox();
+				const sessionEnv = deferred<undefined>();
+				const setupCompleted = deferred<void>();
+				const exec = instance.exec.bind(instance);
+				instance.ready = async () => {};
+				instance.exec = async (command, options) => {
+					const result = await exec(command, options);
+					if (command.includes('uv sync --inexact')) setupCompleted.resolve(undefined);
+					return result;
+				};
+				const launchProcess = vi.fn<NonNullable<SandboxInstance['launchProcess']>>(async () => {
+					throw new Error('launch should not run');
+				});
+				instance.launchProcess = launchProcess;
+
+				const provision = new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					sessionEnv: sessionEnv.promise,
+					startupTimeoutMs: Millis.seconds(1),
+				});
+
+				await setupCompleted.promise;
+				await vi.advanceTimersByTimeAsync(1_000);
+				sessionEnv.resolve(undefined);
+				await expect(provision).rejects.toThrow(/not ready within the 1s startup timeout/);
+				expect(launchProcess).not.toHaveBeenCalled();
+				expect(calls.destroy).toBe(1);
 			} finally {
 				vi.useRealTimers();
 			}
@@ -548,14 +702,18 @@ describe('SandboxProvisioner', () => {
 		// A command round-trip is the dominant unit of startup cost on a remote
 		// backend (~220ms each on CoreWeave), so these lock in the count.
 		describe('command round-trips', () => {
-			it('prefers combined launch and keeps its phase timings', async () => {
+			it('uses combined launch after checked setup and keeps phase timings', async () => {
 				const { instance, calls } = makeFakeSandbox();
 				instance.ready = async () => {};
-				instance.launchProcess = async (command, options) => ({
-					success: true,
-					process: await instance.startProcess(command, { cwd: options.cwd }),
-					timings: { setup: 41, start: 3, waitport: 17 },
-				});
+				let launchOptions: Parameters<NonNullable<SandboxInstance['launchProcess']>>[1] | undefined;
+				instance.launchProcess = async (command, options) => {
+					launchOptions = options;
+					return {
+						success: true,
+						process: await instance.startProcess(command, { cwd: options.cwd }),
+						timings: { setup: 0, start: 3, waitport: 17 },
+					};
+				};
 
 				const result = await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
 					sandboxId,
@@ -565,9 +723,16 @@ describe('SandboxProvisioner', () => {
 					bucket: bucketConfig,
 				});
 
-				expect(calls.exec).toHaveLength(0);
+				expect(calls.exec).toHaveLength(1);
+				expect(calls.exec[0]).toContain('uv sync');
 				expect(calls.startProcess).toHaveLength(1);
-				expect(result.timings).toMatchObject({ setup: 41, start: 3, waitport: 17 });
+				expect(result.timings).toMatchObject({
+					setup: expect.any(Number),
+					start: 3,
+					waitport: 17,
+				});
+				expect(launchOptions?.setup).toBeUndefined();
+				expect(launchOptions?.startupTimeout).toBeLessThanOrEqual(120_000);
 			});
 
 			it('a copy-path provision spends one checked setup exec', async () => {
@@ -688,6 +853,73 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess).toHaveLength(0);
 			expect(calls.destroy).toBe(1);
 		});
+
+		it('stops a hanging environment setup at the shared startup deadline', async () => {
+			vi.useFakeTimers();
+			const pendingSetup = deferred<ExecResult>();
+			try {
+				const { instance, calls } = makeFakeSandbox();
+				const exec = instance.exec.bind(instance);
+				instance.exec = (command, options) =>
+					command.includes('uv sync') ? pendingSetup.promise : exec(command, options);
+
+				const provision = new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					startupTimeoutMs: Millis.seconds(1),
+				});
+				const failure = expect(provision).rejects.toThrow(
+					'Failed to prepare the notebook Python environment within the 1s startup timeout',
+				);
+				await vi.advanceTimersByTimeAsync(1_000);
+
+				await failure;
+				expect(calls.startProcess).toHaveLength(0);
+				expect(calls.destroy).toBe(1);
+			} finally {
+				pendingSetup.resolve({ success: true, stdout: '', stderr: '' });
+				vi.useRealTimers();
+			}
+		});
+
+		it('surfaces a setup failure without waiting for sessionEnv', async () => {
+			const { instance: base, calls } = makeFakeSandbox();
+			const sessionEnv = deferred<undefined>();
+			const setupStarted = deferred<void>();
+			const instance: SandboxInstance = {
+				...base,
+				async exec(command, options) {
+					if (!command.includes('uv sync')) return base.exec(command, options);
+					calls.exec.push(command);
+					calls.execOptions.push(options);
+					setupStarted.resolve(undefined);
+					return {
+						success: false,
+						stdout: '',
+						stderr: 'resolution failed',
+						error: { code: 'COMMAND_FAILED' },
+					};
+				},
+			};
+
+			const provision = new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				sessionEnv: sessionEnv.promise,
+			});
+
+			await setupStarted.promise;
+			await expect(provision).rejects.toMatchObject({ code: 'PYTHON_ENV_SETUP_FAILED' });
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
+			sessionEnv.resolve(undefined);
+		}, 1_000);
 
 		it.each([
 			[

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -15,6 +15,7 @@ import { logOperationalError } from '../../operationalLog';
 import type {
 	ComputeResources,
 	ExecResult,
+	SandboxLaunchResult,
 	SandboxUserHome,
 	SandboxInstance,
 	SandboxProcess,
@@ -24,7 +25,7 @@ import { Stopwatch } from '../../timing';
 import type { Timings } from '../../timing';
 import { captureFilesystemSnapshot, createOrRestoreSandbox } from '../content/filesystemSnapshots';
 import { buildMarimoLaunch, DEFAULT_LAUNCH_STRATEGY } from './marimoLaunch';
-import type { MarimoLaunchStrategyName } from './marimoLaunch';
+import type { MarimoLaunchPlan, MarimoLaunchStrategyName } from './marimoLaunch';
 import { shellQuote } from './shell';
 import type { NotebookService } from '../content/NotebookService';
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
@@ -173,7 +174,7 @@ export interface ProvisionResult {
 	url: string;
 	/** Whether files were loaded via manual copy (true) or bucket mount (false) */
 	usedFallback: boolean;
-	/** Wall-clock total and per-phase ms: handle, reachable, files, inject, start, waitport, expose. */
+	/** Wall-clock total and per-phase ms: handle, reachable, files, inject, setup, start, waitport, expose. */
 	timings: Timings;
 	/**
 	 * Non-duration measurements for the same wide event — workspace objects/bytes
@@ -181,6 +182,38 @@ export interface ProvisionResult {
 	 * reported as milliseconds.
 	 */
 	counters: Record<string, number>;
+}
+
+interface MarimoStartup {
+	plan: MarimoLaunchPlan;
+	deadline: {
+		startedAt: number;
+		timeoutMs: number;
+	};
+}
+
+type SandboxLaunchFailure = Extract<SandboxLaunchResult, { success: false }>;
+
+function remainingStartupMs(startup: MarimoStartup): number {
+	const { startedAt, timeoutMs } = startup.deadline;
+	return timeoutMs === 0 ? 0 : Math.max(0, timeoutMs - (Date.now() - startedAt));
+}
+
+function pythonEnvironmentSetupTimeout(timeoutMs: number): PythonEnvironmentSetupError {
+	return new PythonEnvironmentSetupError(
+		`Failed to prepare the notebook Python environment within the ${Math.round(timeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`,
+	);
+}
+
+function kernelReadinessTimeoutStep(timeoutMs: number): string {
+	return `starting the marimo kernel: not ready within the ${Math.round(timeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`;
+}
+
+function formatKernelLogs(stdout: string, stderr: string): string {
+	return [stdout, stderr]
+		.filter((value) => value.trim())
+		.join('\n')
+		.trim();
 }
 
 /**
@@ -202,6 +235,69 @@ function provisionFailure(step: string, err: unknown): UnavailableError {
 	// failed on, credentials included, and this string is shown to the caller and
 	// persisted on the session record.
 	return new UnavailableError(parts.join(' '), { cause: err });
+}
+
+function supervisedLaunchFailure(result: SandboxLaunchFailure, timeoutMs: number): Error {
+	if (result.reason === 'setup_timeout') return pythonEnvironmentSetupTimeout(timeoutMs);
+	if (result.reason === 'setup_exit') {
+		return pythonEnvironmentSetupFailure({
+			success: false,
+			stdout: result.stdout,
+			stderr: result.stderr,
+			error: { code: 'COMMAND_FAILED' },
+		});
+	}
+	const step =
+		result.reason === 'readiness_timeout'
+			? kernelReadinessTimeoutStep(timeoutMs)
+			: 'starting the marimo kernel';
+	const logs = formatKernelLogs(result.stdout, result.stderr);
+	return provisionFailure(
+		logs ? `${step}; kernel output:\n${logs}` : step,
+		new Error(result.reason),
+	);
+}
+
+async function readKernelLogs(process: SandboxProcess | undefined): Promise<string> {
+	if (!process) return '';
+	try {
+		const { stdout, stderr } = await process.getLogs();
+		return formatKernelLogs(stdout, stderr);
+	} catch {
+		// The process or sandbox may already be gone.
+		return '';
+	}
+}
+
+function adapterAttributedKernelCrash(error: unknown): boolean {
+	// Only the first line is adapter attribution; later lines may contain echoed kernel output.
+	const attribution = error instanceof Error ? error.message.split('\n', 1)[0] : '';
+	return /before port \d+/.test(attribution);
+}
+
+function kernelLaunchFailureStep(
+	error: unknown,
+	startup: MarimoStartup,
+	portWaitStarted: boolean,
+): string {
+	const { startedAt, timeoutMs } = startup.deadline;
+	const timedOut =
+		portWaitStarted && !adapterAttributedKernelCrash(error) && Date.now() - startedAt >= timeoutMs;
+	return timedOut ? kernelReadinessTimeoutStep(timeoutMs) : 'starting the marimo kernel';
+}
+
+function executeEnvironmentSetup(
+	sandbox: SandboxInstance,
+	command: string,
+	startup: MarimoStartup,
+): Promise<ExecResult> {
+	const timeoutMs = remainingStartupMs(startup);
+	const pending = sandbox.exec(command, { timeout: timeoutMs });
+	if (startup.deadline.timeoutMs === 0) return pending;
+	return withDeadline(pending, {
+		timeoutMs,
+		timeoutError: () => pythonEnvironmentSetupTimeout(startup.deadline.timeoutMs),
+	});
 }
 
 /**
@@ -406,12 +502,13 @@ export class SandboxProvisioner {
 			});
 		const injectSessionEnv = () =>
 			withSandboxSpan(sw, 'inject', (time) => this.injectSessionEnv(sandbox, options, time));
-		const startMarimoKernel = () => this.startMarimoKernel(sandbox, options, mountPath, sw);
+		const setupEnvironment = () => this.setupEnvironment(sandbox, options, mountPath, sw);
+		const launchKernel = (startup: MarimoStartup) =>
+			this.launchKernel(sandbox, mountPath, sw, startup);
 		const exposeKernel = () => this.exposeKernel(sandbox, options, sw);
 
-		// The workspace load and the credential inject touch disjoint targets (the
-		// mount path vs. credential file paths + env vars), so they overlap; the
-		// kernel start needs both. Note `files`/`inject` timings overlap too.
+		// Setup reads only the loaded workspace, so credential resolution and injection
+		// can overlap it. The kernel still waits for both to finish.
 		const { load, expose } = await all({
 			async reachable() {
 				await ensureReachable();
@@ -424,10 +521,14 @@ export class SandboxProvisioner {
 				await this.$.reachable;
 				await injectSessionEnv();
 			},
-			async start() {
+			async setup() {
 				await this.$.load;
+				return setupEnvironment();
+			},
+			async start() {
+				const startup = await this.$.setup;
 				await this.$.inject;
-				await startMarimoKernel();
+				await launchKernel(startup);
 			},
 			async expose() {
 				await this.$.start;
@@ -553,143 +654,114 @@ export class SandboxProvisioner {
 		});
 	}
 
-	private async startMarimoKernel(
+	private async setupEnvironment(
 		sandbox: SandboxInstance,
 		options: ProvisionOptions,
 		mountPath: string,
 		sw: Stopwatch,
-	): Promise<void> {
-		const launch = buildMarimoLaunch(
-			{
-				notebookFile: options.entryNotebook ?? 'notebook.py',
-				port: MARIMO_PORT,
-				host: '0.0.0.0',
-				mode: options.launchMode,
-				assetUrl: options.assetUrl,
-				baseUrl: options.baseUrl,
-			},
-			options.launchStrategy,
-		);
-		const startupTimeoutMs = options.startupTimeoutMs ?? DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS;
-		const startupStart = Date.now();
-		if (sandbox.launchProcess) {
-			let launched: Awaited<ReturnType<NonNullable<SandboxInstance['launchProcess']>>>;
-			try {
-				launched = await sandbox.launchProcess(launch.start, {
-					...(launch.setup.length > 0 ? { setup: launch.setup.join(' && ') } : {}),
-					cwd: mountPath,
+	): Promise<MarimoStartup> {
+		const startup: MarimoStartup = {
+			plan: buildMarimoLaunch(
+				{
+					notebookFile: options.entryNotebook ?? 'notebook.py',
 					port: MARIMO_PORT,
-					waitForPort: { mode: 'tcp' },
-					startupTimeout: startupTimeoutMs,
-				});
-			} catch (error) {
-				throw provisionFailure('starting the marimo kernel', error);
-			}
-			Object.assign(sw.timings, launched.timings);
-			if (launched.success) return;
-			if (launched.reason === 'setup_timeout') {
-				throw new PythonEnvironmentSetupError(
-					`Failed to prepare the notebook Python environment within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`,
-				);
-			}
-			if (launched.reason === 'setup_exit') {
-				throw pythonEnvironmentSetupFailure({
-					success: false,
-					stdout: launched.stdout,
-					stderr: launched.stderr,
-					error: { code: 'COMMAND_FAILED' },
-				});
-			}
-			const step =
-				launched.reason === 'readiness_timeout'
-					? `starting the marimo kernel: not ready within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`
-					: 'starting the marimo kernel';
-			const kernelLogs = [launched.stdout, launched.stderr]
-				.filter((value) => value.trim())
-				.join('\n')
-				.trim();
+					host: '0.0.0.0',
+					mode: options.launchMode,
+					assetUrl: options.assetUrl,
+					baseUrl: options.baseUrl,
+				},
+				options.launchStrategy,
+			),
+			deadline: {
+				startedAt: Date.now(),
+				timeoutMs: options.startupTimeoutMs ?? DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS,
+			},
+		};
+		if (startup.plan.setup.length === 0) return startup;
+
+		const command = `cd ${shellQuote(mountPath)} && ${startup.plan.setup.join(' && ')}`;
+		try {
+			await withSandboxSpan(
+				sw,
+				'setup',
+				async (time) => {
+					const result = await time(() => executeEnvironmentSetup(sandbox, command, startup));
+					if (!result.success) throw pythonEnvironmentSetupFailure(result);
+				},
+				{ launch_strategy: options.launchStrategy ?? DEFAULT_LAUNCH_STRATEGY },
+			);
+		} catch (error) {
+			if (error instanceof PythonEnvironmentSetupError) throw error;
+			throw provisionFailure('preparing the notebook Python environment', error);
+		}
+		return startup;
+	}
+
+	private async launchKernel(
+		sandbox: SandboxInstance,
+		mountPath: string,
+		sw: Stopwatch,
+		startup: MarimoStartup,
+	): Promise<void> {
+		const launchProcess = sandbox.launchProcess?.bind(sandbox);
+		if (launchProcess) {
+			await this.launchSupervisedKernel(launchProcess, mountPath, sw, startup);
+			return;
+		}
+		await this.launchKernelProcess(sandbox, mountPath, sw, startup);
+	}
+
+	private async launchSupervisedKernel(
+		launchProcess: NonNullable<SandboxInstance['launchProcess']>,
+		mountPath: string,
+		sw: Stopwatch,
+		startup: MarimoStartup,
+	): Promise<void> {
+		const timeoutMs = remainingStartupMs(startup);
+		if (startup.deadline.timeoutMs !== 0 && timeoutMs === 0) {
 			throw provisionFailure(
-				kernelLogs ? `${step}; kernel output:\n${kernelLogs}` : step,
-				new Error(launched.reason),
+				kernelReadinessTimeoutStep(startup.deadline.timeoutMs),
+				new Error('readiness_timeout'),
 			);
 		}
-		if (launch.setup.length > 0) {
-			const command = `cd ${shellQuote(mountPath)} && ${launch.setup.join(' && ')}`;
-			const setupTimeoutMs =
-				startupTimeoutMs === 0 ? 0 : Math.max(0, startupTimeoutMs - (Date.now() - startupStart));
-			try {
-				await withSandboxSpan(
-					sw,
-					'setup',
-					async (time) => {
-						const setup = await time(() => {
-							const pending = sandbox.exec(command, { timeout: setupTimeoutMs });
-							return startupTimeoutMs === 0
-								? pending
-								: withDeadline(pending, {
-										timeoutMs: setupTimeoutMs,
-										timeoutError: () =>
-											new PythonEnvironmentSetupError(
-												`Failed to prepare the notebook Python environment within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`,
-											),
-									});
-						});
-						if (!setup.success) throw pythonEnvironmentSetupFailure(setup);
-					},
-					{ launch_strategy: options.launchStrategy ?? DEFAULT_LAUNCH_STRATEGY },
-				);
-			} catch (error) {
-				if (error instanceof PythonEnvironmentSetupError) throw error;
-				throw provisionFailure('preparing the notebook Python environment', error);
-			}
+
+		let result: SandboxLaunchResult;
+		try {
+			result = await launchProcess(startup.plan.start, {
+				cwd: mountPath,
+				port: MARIMO_PORT,
+				waitForPort: { mode: 'tcp' },
+				startupTimeout: timeoutMs,
+			});
+		} catch (error) {
+			throw provisionFailure('starting the marimo kernel', error);
 		}
+		sw.timings.start = result.timings.start;
+		sw.timings.waitport = result.timings.waitport;
+		if (!result.success) throw supervisedLaunchFailure(result, startup.deadline.timeoutMs);
+	}
+
+	private async launchKernelProcess(
+		sandbox: SandboxInstance,
+		mountPath: string,
+		sw: Stopwatch,
+		startup: MarimoStartup,
+	): Promise<void> {
 		let process: SandboxProcess | undefined;
-		let portWaitStart: number | undefined;
+		let portWaitStarted = false;
 		try {
 			const proc = await withSandboxSpan(sw, 'start', (time) =>
-				time(() => sandbox.startProcess(launch.start, { cwd: mountPath })),
+				time(() => sandbox.startProcess(startup.plan.start, { cwd: mountPath })),
 			);
 			process = proc;
-			portWaitStart = Date.now();
-			const portWaitTimeoutMs =
-				startupTimeoutMs === 0 ? 0 : Math.max(0, startupTimeoutMs - (portWaitStart - startupStart));
+			portWaitStarted = true;
 			await withSandboxSpan(sw, 'waitport', (time) =>
-				time(() => proc.waitForPort(MARIMO_PORT, { timeout: portWaitTimeoutMs })),
+				time(() => proc.waitForPort(MARIMO_PORT, { timeout: remainingStartupMs(startup) })),
 			);
-		} catch (err) {
-			// Surface the kernel's own output so a startup crash isn't an opaque
-			// "exited before ready". Best-effort.
-			let kernelLogs = '';
-			if (process) {
-				try {
-					const { stdout, stderr } = await process.getLogs();
-					kernelLogs = [stdout, stderr]
-						.filter((s) => s.trim())
-						.join('\n')
-						.trim();
-				} catch {
-					// getLogs can fail once the process/sandbox is gone — ignore.
-				}
-			}
-			// `provisionFailure` drops the adapter's message, so a deadline-shaped
-			// failure must be classified here or the caller can't tell "kernel took
-			// too long" (raise the timeout) from "kernel crashed" (read the logs).
-			// A wait that consumed the full window is a timeout — unless the adapter
-			// already attributed the failure to the process ("… before port N …",
-			// the shared wording of the exited-early errors): crash detection can
-			// land arbitrarily close to the deadline, and elapsed time alone would
-			// then tell the operator to raise the timeout for a crash. Only the
-			// FIRST line is the adapter's attribution — the rest is appended
-			// process output, which can echo a "before port" phrase into a genuine
-			// timeout message.
-			const attribution = err instanceof Error ? err.message.split('\n', 1)[0] : '';
-			const crashed = /before port \d+/.test(attribution);
-			const timedOut =
-				!crashed && portWaitStart !== undefined && Date.now() - startupStart >= startupTimeoutMs;
-			const step = timedOut
-				? `starting the marimo kernel: not ready within the ${Math.round(startupTimeoutMs / 1000)}s startup timeout (MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS)`
-				: 'starting the marimo kernel';
-			throw provisionFailure(kernelLogs ? `${step}; kernel output:\n${kernelLogs}` : step, err);
+		} catch (error) {
+			const logs = await readKernelLogs(process);
+			const step = kernelLaunchFailureStep(error, startup, portWaitStarted);
+			throw provisionFailure(logs ? `${step}; kernel output:\n${logs}` : step, error);
 		}
 	}
 


### PR DESCRIPTION
Runs sandbox Python environment setup as soon as the workspace load completes, in parallel with session credential resolution and injection. Kernel launch still waits for both phases.

Preserves the shared startup deadline, per-phase timing semantics, fail-closed credential behavior, and early setup-failure propagation.

Fixes MO-7474.