### PR TITLE
fetat(git): Add packed workspace restore fast path

### DIFF
--- a/development_docs/bucket_spec.md
+++ b/development_docs/bucket_spec.md
@@ -157,6 +157,7 @@ s3-bucket/
                         ├── pyproject.toml      ← local dependency snapshot
                         ├── workspace/          ← Git sources only: complete synced tree
                         ├── git/                ← pull-mode Git sources only: credential-free `.git` payload
+                        ├── workspace.zip       ← optional packed startup copy of workspace + `.git`
                         ├── notebook.html       ← optional snapshot (see below)
                         └── session.json        ← optional snapshot (see below)
 ```
@@ -176,6 +177,10 @@ For a `git` source, each sync writes a complete tree under
 `versions/{vid}/workspace/`. The source pointer selects one immutable version.
 The notebook has no mutable workspace mirror. A session receives a copy of the
 selected version and cannot write changes back.
+Each synced version keeps a best-effort `workspace.zip` copy of the final sandbox
+tree. Provisioning prefers this single object and falls back to the canonical
+`workspace/` and `git/` objects when it is absent or invalid. The packed copy is
+created for combined workspace and Git inputs up to 32 MiB.
 
 ### 3.2 Complete Path Reference
 
@@ -222,6 +227,7 @@ selected version and cannot write changes back.
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/version.json`              | JSON     | Version metadata: saved_at, author, message, parent_id, optional snapshot descriptors.                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/workspace/`                | any      | Complete immutable tree from one Git sync. Present only for a `git` source version.                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/git/`                      | any      | Immutable credential-free `.git` payload for a pull-mode source version. Restored into the sandbox workdir at provision and pruned with the enclosing version.                                                                                                                                                                                                                                                                                                                                         |
+| `projects/{pid}/notebooks/{nid}/versions/{vid}/workspace.zip`             | ZIP      | Optional duplicate of the final synced sandbox tree used only as a startup fast path. Pull-mode Git metadata is stored under `.git/`. Canonical reads and fallback restores continue to use `workspace/` and `git/`.                                                                                                                                                                                                                                                                                   |
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/notebook.html`             | HTML     | **Optional.** Rendered HTML snapshot, copied from `__marimo__/notebook.html` on session teardown. Immutable once written.                                                                                                                                                                                                                                                                                                                                                                              |
 | `projects/{pid}/notebooks/{nid}/versions/{vid}/session.json`              | JSON     | **Optional.** marimo session state (cell outputs), copied from `__marimo__/session/{notebook}.py.json` on teardown. Immutable.                                                                                                                                                                                                                                                                                                                                                                         |
 
@@ -361,7 +367,8 @@ with a notebook-scoped sync token. Pull mode has no token. The hub reads the
 GitHub branch and creates a credential-free shallow Git directory through the
 source-control adapter. Both modes store repository files under
 `versions/{vid}/workspace/`. Pull mode also stores `.git` content under the
-sibling `versions/{vid}/git/` prefix.
+sibling `versions/{vid}/git/` prefix. The optional `workspace.zip` startup
+artifact duplicates the final sandbox tree and is pruned with the enclosing version.
 See the [sync guide](../docs/syncing.md) for the API and token lifecycle.
 
 ### 4.7 `versions/{vid}/version.json`

--- a/docs/syncing.md
+++ b/docs/syncing.md
@@ -45,6 +45,19 @@ Each sync writes the repository files into a fresh
 notebook's source pointer. Concurrent syncs cannot combine files from different
 versions. The source pointer always references one complete version.
 
+Each synced version stores a best-effort packed copy of the final workspace for
+sandbox startup. Pull-mode archives include the credential-free Git directory
+under `.git/`. Startup transfers and extracts this single object when available.
+If the object is absent or extraction fails, provisioning restores the canonical
+per-file objects. Packing is limited to 32 MiB of combined workspace and Git
+input, and Git object files are stored without recompression.
+
+Provisioning counters describe the transferred representation. A packed restore
+reports `files_objects=1` and compressed archive bytes in `files_bytes`; a
+canonical restore reports its individual object count and stored byte total. The
+`files_archive_used`, `files_archive_missing`, and `files_archive_failed`
+counters identify the selected path.
+
 ## Create a synced notebook
 
 ```http

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -184,7 +184,10 @@ describe('Session routes', () => {
 		// Nested on purpose: catches a workspace-relative vs repo-relative join bug.
 		const ENTRY = 'apps/dash.py';
 
-		async function createSyncedNotebook(entryCode: string): Promise<NotebookId> {
+		async function createSyncedNotebook(
+			entryCode: string,
+			syncMode: 'push' | 'pull' = 'push',
+		): Promise<NotebookId> {
 			const services = createServices(bucket);
 			const { meta } = await services.notebooks.synced.create(
 				pid,
@@ -194,6 +197,7 @@ describe('Session routes', () => {
 					repo: 'org/repo',
 					branch: 'main',
 					entry_notebook: ENTRY,
+					sync_mode: syncMode,
 				},
 				ACTOR,
 			);
@@ -203,12 +207,17 @@ describe('Session routes', () => {
 				root_path: '',
 				commit: 'commit-aaaa',
 				files: [{ path: ENTRY, bytes: enc(entryCode) }],
+				...(syncMode === 'pull'
+					? { git_files: [{ path: 'HEAD', bytes: enc('ref: refs/heads/main\n') }] }
+					: {}),
 			});
 			return meta.id;
 		}
 
 		const entryReads = (spy: { mock: { calls: unknown[][] } }) =>
 			spy.mock.calls.filter(([key]) => String(key).endsWith(ENTRY)).length;
+		const archiveReads = (spy: { mock: { calls: unknown[][] } }) =>
+			spy.mock.calls.filter(([key]) => String(key).endsWith('/workspace.zip')).length;
 
 		async function startSessionApi(notebookId: NotebookId) {
 			const sb = makeFakeSandbox();
@@ -234,17 +243,20 @@ describe('Session routes', () => {
 			expect(cmd).toContain('uv sync --inexact');
 		});
 
-		it('uses the project-managed env for a git-synced notebook without inline metadata', async () => {
-			const synced = await createSyncedNotebook('import marimo');
+		it('uses a packed pull workspace and the project-managed env without inline metadata', async () => {
+			const synced = await createSyncedNotebook('import marimo', 'pull');
+			const get = vi.spyOn(bucket, 'get');
 			const { sb, post } = await startSessionApi(synced);
 			await expectOk<ApiSession>(await post());
-			expect(
-				sb.calls.exec.some(
-					(command) =>
-						command.startsWith('python3 ') &&
-						command.includes('/workspace/.marimohub-packed-restore/extract.py'),
-				),
-			).toBe(true);
+			const extract = sb.calls.exec.find(
+				(command) =>
+					command.startsWith('python3 ') &&
+					command.includes('/workspace/.marimohub-packed-restore/extract.py'),
+			)!;
+			expect(extract).toMatch(/ 1$/);
+			expect(archiveReads(get)).toBe(1);
+			// Launch-strategy detection reads the entry once; a canonical fallback would read it again.
+			expect(entryReads(get)).toBe(1);
 			const setup = sb.calls.exec.find((command) => command.includes('uv sync --inexact'))!;
 			expect(setup).not.toContain('uv export');
 		});

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -238,6 +238,13 @@ describe('Session routes', () => {
 			const synced = await createSyncedNotebook('import marimo');
 			const { sb, post } = await startSessionApi(synced);
 			await expectOk<ApiSession>(await post());
+			expect(
+				sb.calls.exec.some(
+					(command) =>
+						command.startsWith('python3 ') &&
+						command.includes('/workspace/.marimohub-packed-restore/extract.py'),
+				),
+			).toBe(true);
 			const setup = sb.calls.exec.find((command) => command.includes('uv sync --inexact'))!;
 			expect(setup).not.toContain('uv export');
 		});

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -915,6 +915,7 @@ app.openapi(createSession, async (c) => {
 		? paths.project(pid).notebook(nid).version(syncedVersionId)
 		: undefined;
 	const workspacePrefix = syncedVersionPaths?.workspacePrefix;
+	const workspaceArchive = syncedVersionPaths?.workspaceArchive;
 	const gitPrefix =
 		notebook.source.type === 'git' && notebook.source.sync_mode === 'pull'
 			? syncedVersionPaths?.gitPrefix
@@ -1319,6 +1320,7 @@ app.openapi(createSession, async (c) => {
 								: workspacePolicy.loadMode,
 						workspacePrefix,
 						gitPrefix,
+						workspaceArchive,
 					});
 					({ url, usedFallback } = provisionResult);
 					// Per-phase durations onto the session_provision event.

--- a/packages/core/src/integrations/packedWorkspace.test.ts
+++ b/packages/core/src/integrations/packedWorkspace.test.ts
@@ -1,0 +1,146 @@
+import { unzipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import {
+	createPackedWorkspaceArchive,
+	isPackedWorkspaceInputWithinLimit,
+	packedWorkspaceInputBytes,
+} from './packedWorkspace';
+
+const encode = (value: string) => new TextEncoder().encode(value);
+const decode = (value: Uint8Array) => new TextDecoder().decode(value);
+
+function zipCompressionMethods(archive: Uint8Array): Map<string, number> {
+	const methods = new Map<string, number>();
+	const view = new DataView(archive.buffer, archive.byteOffset, archive.byteLength);
+	for (let offset = 0; offset <= archive.byteLength - 46; offset++) {
+		if (view.getUint32(offset, true) !== 0x02014b50) continue;
+		const nameLength = view.getUint16(offset + 28, true);
+		const name = decode(archive.subarray(offset + 46, offset + 46 + nameLength));
+		methods.set(name, view.getUint16(offset + 10, true));
+	}
+	return methods;
+}
+
+describe('createPackedWorkspaceArchive', () => {
+	it('packs nested, hidden, and binary workspace files', () => {
+		const archive = createPackedWorkspaceArchive({
+			workspace: new Map([
+				['app.py', encode('print(1)')],
+				['data/.hidden', encode('secret')],
+				['data/blob.bin', new Uint8Array([0, 255, 1])],
+				['分析/empty.txt', new Uint8Array()],
+			]),
+		});
+
+		const files = unzipSync(archive);
+		expect(Object.keys(files).sort()).toEqual([
+			'app.py',
+			'data/.hidden',
+			'data/blob.bin',
+			'分析/empty.txt',
+		]);
+		expect(decode(files['app.py'])).toBe('print(1)');
+		expect(files['data/blob.bin']).toEqual(new Uint8Array([0, 255, 1]));
+		expect(files['分析/empty.txt']).toHaveLength(0);
+	});
+
+	it('replaces workspace .git entries with separately materialized Git metadata', () => {
+		const archive = createPackedWorkspaceArchive({
+			workspace: new Map([
+				['app.py', encode('print(1)')],
+				['.gitignore', encode('.venv')],
+				['.git/HEAD', encode('workspace head')],
+				['.git/config', encode('workspace config')],
+			]),
+			git: new Map([
+				['HEAD', encode('ref: refs/heads/main\n')],
+				['objects/pack/data', new Uint8Array([1, 2, 3])],
+			]),
+		});
+
+		const files = unzipSync(archive);
+		expect(Object.keys(files).sort()).toEqual([
+			'.git/HEAD',
+			'.git/objects/pack/data',
+			'.gitignore',
+			'app.py',
+		]);
+		expect(decode(files['.git/HEAD'])).toBe('ref: refs/heads/main\n');
+	});
+
+	it.each(['', '/app.py', 'dir/', 'dir//app.py', './app.py', '../app.py', 'dir/../app.py', 'a\\b'])(
+		'rejects unsafe workspace path %j',
+		(path) => {
+			expect(() =>
+				createPackedWorkspaceArchive({ workspace: new Map([[path, encode('bad')]]) }),
+			).toThrow('Unsafe packed workspace path');
+		},
+	);
+
+	it('rejects unsafe Git paths after placing them under .git', () => {
+		expect(() =>
+			createPackedWorkspaceArchive({
+				workspace: new Map([['app.py', encode('ok')]]),
+				git: new Map([['../escape', encode('bad')]]),
+			}),
+		).toThrow('Unsafe packed workspace path');
+	});
+
+	it('rejects duplicate paths even when a map-like input yields them', () => {
+		const workspace = {
+			*[Symbol.iterator]() {
+				yield ['app.py', encode('first')] as const;
+				yield ['app.py', encode('second')] as const;
+			},
+		} as unknown as ReadonlyMap<string, Uint8Array>;
+
+		expect(() => createPackedWorkspaceArchive({ workspace })).toThrow(
+			'Duplicate packed workspace path: app.py',
+		);
+	});
+
+	it('packs object prototype names as ordinary paths', () => {
+		const archive = createPackedWorkspaceArchive({
+			workspace: new Map([
+				['__proto__', encode('prototype')],
+				['constructor', encode('constructor')],
+			]),
+		});
+
+		const files = unzipSync(archive);
+		expect(decode(Reflect.get(files, '__proto__'))).toBe('prototype');
+		expect(decode(Reflect.get(files, 'constructor'))).toBe('constructor');
+	});
+
+	it('stores pre-compressed Git objects without deflating them again', () => {
+		const archive = createPackedWorkspaceArchive({
+			workspace: new Map([['app.py', encode('print(1)')]]),
+			git: new Map([
+				['HEAD', encode('ref: refs/heads/main\n')],
+				['objects/pack/pack-a.pack', new Uint8Array([1, 2, 3])],
+			]),
+		});
+
+		expect(zipCompressionMethods(archive)).toEqual(
+			new Map([
+				['app.py', 8],
+				['.git/HEAD', 8],
+				['.git/objects/pack/pack-a.pack', 0],
+			]),
+		);
+	});
+
+	it('counts only archive entries when enforcing the synchronous packing limit', () => {
+		const input = {
+			workspace: new Map([
+				['app.py', new Uint8Array(2)],
+				['.git/HEAD', new Uint8Array(100)],
+			]),
+			git: new Map([['HEAD', new Uint8Array(3)]]),
+		};
+
+		expect(packedWorkspaceInputBytes(input)).toBe(5);
+		expect(isPackedWorkspaceInputWithinLimit(input, 5)).toBe(true);
+		expect(isPackedWorkspaceInputWithinLimit(input, 4)).toBe(false);
+	});
+});

--- a/packages/core/src/integrations/packedWorkspace.ts
+++ b/packages/core/src/integrations/packedWorkspace.ts
@@ -1,0 +1,68 @@
+import { Zip, ZipDeflate, ZipPassThrough } from 'fflate';
+import { isSafeWorkspacePath } from './remoteWorkspace';
+
+const PACKED_WORKSPACE_COMPRESSION_LEVEL = 1;
+export const MAX_PACKED_WORKSPACE_INPUT_BYTES = 32 * 1024 * 1024;
+
+export interface PackedWorkspaceInput {
+	workspace: ReadonlyMap<string, Uint8Array>;
+	git?: ReadonlyMap<string, Uint8Array>;
+}
+
+function addEntry(entries: Map<string, Uint8Array>, path: string, bytes: Uint8Array): void {
+	if (!isSafeWorkspacePath(path)) throw new Error(`Unsafe packed workspace path: ${path}`);
+	if (entries.has(path)) throw new Error(`Duplicate packed workspace path: ${path}`);
+	entries.set(path, bytes);
+}
+
+function encodeZip(entries: ReadonlyMap<string, Uint8Array>): Uint8Array {
+	const chunks: Uint8Array[] = [];
+	const archive = new Zip((error, chunk) => {
+		if (error) throw error;
+		chunks.push(new Uint8Array(chunk));
+	});
+	for (const [path, bytes] of entries) {
+		const file = path.startsWith('.git/objects/')
+			? new ZipPassThrough(path)
+			: new ZipDeflate(path, { level: PACKED_WORKSPACE_COMPRESSION_LEVEL });
+		archive.add(file);
+		file.push(bytes, true);
+	}
+	archive.end();
+
+	const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+	const result = new Uint8Array(size);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
+}
+
+export function packedWorkspaceInputBytes(input: PackedWorkspaceInput): number {
+	let total = 0;
+	for (const [path, bytes] of input.workspace) {
+		if (input.git && (path === '.git' || path.startsWith('.git/'))) continue;
+		total += bytes.byteLength;
+	}
+	for (const bytes of input.git?.values() ?? []) total += bytes.byteLength;
+	return total;
+}
+
+export function isPackedWorkspaceInputWithinLimit(
+	input: PackedWorkspaceInput,
+	limit = MAX_PACKED_WORKSPACE_INPUT_BYTES,
+): boolean {
+	return packedWorkspaceInputBytes(input) <= limit;
+}
+
+export function createPackedWorkspaceArchive(input: PackedWorkspaceInput): Uint8Array {
+	const entries = new Map<string, Uint8Array>();
+	for (const [path, bytes] of input.workspace) {
+		if (input.git && (path === '.git' || path.startsWith('.git/'))) continue;
+		addEntry(entries, path, bytes);
+	}
+	for (const [path, bytes] of input.git ?? []) addEntry(entries, `.git/${path}`, bytes);
+	return encodeZip(entries);
+}

--- a/packages/core/src/paths.test.ts
+++ b/packages/core/src/paths.test.ts
@@ -88,6 +88,7 @@ describe('paths', () => {
 			  "html": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/notebook.html",
 			  "meta": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/version.json",
 			  "session": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/session.json",
+			  "workspaceArchive": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/workspace.zip",
 			  "workspaceFile": [Function],
 			  "workspacePrefix": "projects/proj_01HXY11111ABCDEFGHJKMN/notebooks/nb_01HXYZ22222PQRSTUVWXYZ/versions/ver_01HXYZ33333RSTUVWXYZAB/workspace/",
 			}

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -16,6 +16,8 @@ export interface VersionPaths {
 	code: string;
 	deps: string;
 	meta: string;
+	/** Optional packed copy fast path for restoring a synced sandbox. */
+	workspaceArchive: string;
 	workspacePrefix: string;
 	workspaceFile: (rel: string) => string;
 	/** Pull-source Git metadata, stored outside the workspace mirror. */
@@ -100,6 +102,7 @@ function versionPaths(base: string, vid: VersionId): VersionPaths {
 		code: `${prefix}/notebook.py`,
 		deps: `${prefix}/pyproject.toml`,
 		meta: `${prefix}/version.json`,
+		workspaceArchive: `${prefix}/workspace.zip`,
 		workspacePrefix: `${workspace}/`,
 		workspaceFile: (rel: string) => `${workspace}/${rel}`,
 		gitPrefix: `${git}/`,

--- a/packages/core/src/services/content/SyncedNotebookService.test.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { unzipSync } from 'fflate';
 import { MAX_WORKSPACE_FILE_BYTES } from '../../constants';
 import { PreconditionFailedError } from '../../errors';
 import { ACTOR, restoreClock, setupTestEnv, useFakeClock } from '../../testing';
@@ -12,6 +13,7 @@ import type { NotebookService } from './NotebookService';
 import type { ProjectService } from './ProjectService';
 import { SyncedNotebookService } from './SyncedNotebookService';
 import type { CreateSyncedNotebookInput } from '../../integrations/syncedSource';
+import { MAX_PACKED_WORKSPACE_INPUT_BYTES } from '../../integrations/packedWorkspace';
 
 const enc = (s: string) => new TextEncoder().encode(s);
 
@@ -474,6 +476,76 @@ describe('SyncedNotebookService', () => {
 			expect(await (await bucket.get(version.gitFile('objects/pack/pack-a.pack')))!.text()).toBe(
 				'pack',
 			);
+			const archive = await (await bucket.get(version.workspaceArchive))!.bytes();
+			const packed = unzipSync(archive);
+			expect(new TextDecoder().decode(packed['app.py'])).toBe('import marimo');
+			expect(new TextDecoder().decode(packed['.git/HEAD'])).toBe('ref: refs/heads/main\n');
+		});
+
+		it('keeps the canonical version when the packed archive write fails', async () => {
+			const { meta } = await notebooks.synced.create(projectId, CREATE_INPUT, ACTOR);
+			const realPut = bucket.put.bind(bucket);
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+			const put = vi.spyOn(bucket, 'put').mockImplementation((key, value, options) => {
+				if (key.endsWith('/workspace.zip')) throw new Error('archive storage unavailable');
+				return realPut(key, value, options);
+			});
+
+			try {
+				const synced = await notebooks.synced.sync(projectId, meta.id, syncInput('commit-aaaa'));
+				const version = paths.project(projectId).notebook(meta.id).version(synced.versionId!);
+				expect(await (await bucket.get(version.workspaceFile('app.py')))!.text()).toBe(
+					'import marimo',
+				);
+				expect(await bucket.get(version.workspaceArchive)).toBeNull();
+				expect((await notebooks.getNotebook(projectId, meta.id)).meta.status).toBe('active');
+			} finally {
+				put.mockRestore();
+				log.mockRestore();
+			}
+		});
+
+		it('skips synchronous packing when the combined input exceeds its limit', async () => {
+			const { meta } = await notebooks.synced.create(projectId, CREATE_INPUT, ACTOR);
+			const halfPlusOne = new Uint8Array(Math.floor(MAX_PACKED_WORKSPACE_INPUT_BYTES / 2) + 1);
+			const synced = await notebooks.synced.sync(projectId, meta.id, {
+				...syncInput('commit-aaaa'),
+				files: [
+					{ path: 'app.py', bytes: halfPlusOne },
+					{ path: 'data.bin', bytes: halfPlusOne },
+				],
+			});
+			const version = paths.project(projectId).notebook(meta.id).version(synced.versionId!);
+
+			expect(await bucket.get(version.workspaceArchive)).toBeNull();
+			expect((await bucket.get(version.workspaceFile('app.py')))!.size).toBe(
+				halfPlusOne.byteLength,
+			);
+			expect((await bucket.get(version.workspaceFile('data.bin')))!.size).toBe(
+				halfPlusOne.byteLength,
+			);
+		});
+
+		it('removes the packed archive when a canonical workspace write fails', async () => {
+			const { meta } = await notebooks.synced.create(projectId, CREATE_INPUT, ACTOR);
+			const realPut = bucket.put.bind(bucket);
+			const put = vi.spyOn(bucket, 'put').mockImplementation((key, value, options) => {
+				if (key.includes('/versions/') && key.endsWith('/workspace/app.py')) {
+					throw new Error('canonical storage unavailable');
+				}
+				return realPut(key, value, options);
+			});
+
+			try {
+				await expect(
+					notebooks.synced.sync(projectId, meta.id, syncInput('commit-aaaa')),
+				).rejects.toThrow('canonical storage unavailable');
+				const versionsPrefix = `${paths.project(projectId).notebook(meta.id).base}/versions/`;
+				expect((await bucket.list({ prefix: versionsPrefix })).objects).toHaveLength(0);
+				expect(await notebooks.listVersions(projectId, meta.id)).toHaveLength(0);
+			} finally {
+				put.mockRestore();
+			}
 		});
 
 		it('rejects a pull sync without Git metadata', async () => {
@@ -762,6 +834,9 @@ describe('SyncedNotebookService', () => {
 				pending_config: { repo: 'new/repo' },
 			});
 			expect(await env.notebooks.listVersions(pid, meta.id)).toHaveLength(1);
+			const versionsPrefix = `${paths.project(pid).notebook(meta.id).base}/versions/`;
+			const stored = await env.bucket.list({ prefix: versionsPrefix });
+			expect(stored.objects.filter(({ key }) => key.endsWith('/workspace.zip'))).toHaveLength(1);
 		});
 	});
 

--- a/packages/core/src/services/content/SyncedNotebookService.ts
+++ b/packages/core/src/services/content/SyncedNotebookService.ts
@@ -34,6 +34,11 @@ import { listAllKeys } from '../catalog/storage';
 import type { GitSource, NotebookMeta, Source } from '../../schema';
 import { loadNotebookCatalogPatch } from './catalogProjection';
 import { toSyncedWorkspaceFileMap } from '../../integrations/remoteWorkspace';
+import {
+	createPackedWorkspaceArchive,
+	isPackedWorkspaceInputWithinLimit,
+	packedWorkspaceInputBytes,
+} from '../../integrations/packedWorkspace';
 
 interface SyncedNotebookServiceHooks {
 	getNotebook: (
@@ -125,7 +130,12 @@ export class SyncedNotebookService {
 			listAllKeys(this.bucket, versionPaths.workspacePrefix),
 			listAllKeys(this.bucket, versionPaths.gitPrefix),
 		]);
-		await this.bucket.delete([versionPaths.meta, ...workspaceKeys, ...gitKeys]);
+		await this.bucket.delete([
+			versionPaths.meta,
+			versionPaths.workspaceArchive,
+			...workspaceKeys,
+			...gitKeys,
+		]);
 	}
 
 	async rotateToken(projectId: ProjectId, notebookId: NotebookId): Promise<{ sync_token: string }> {
@@ -231,6 +241,35 @@ export class SyncedNotebookService {
 		const now = new Date().toISOString();
 		const versionId = createVersionId();
 		const versionPaths = nb.version(versionId);
+		let workspaceArchive: Uint8Array | undefined;
+		const archiveInput = {
+			workspace: prepared.files,
+			...(gitFiles ? { git: gitFiles } : {}),
+		};
+		this.metrics.gauge(
+			'sync.workspace_archive_input_bytes',
+			packedWorkspaceInputBytes(archiveInput),
+		);
+		if (isPackedWorkspaceInputWithinLimit(archiveInput)) {
+			try {
+				workspaceArchive = createPackedWorkspaceArchive(archiveInput);
+				this.metrics.gauge('sync.workspace_archive_bytes', workspaceArchive.byteLength);
+			} catch (error) {
+				this.metrics.increment('sync.workspace_archive_build_failed');
+				logOperationalError(
+					'sync_workspace_archive_build_failed',
+					{
+						operation: 'notebook.sync.workspace_archive.build',
+						project_id: projectId,
+						notebook_id: notebookId,
+						recovered: true,
+					},
+					error,
+				);
+			}
+		} else {
+			this.metrics.increment('sync.workspace_archive_skipped_input_limit');
+		}
 		const version = buildVersion({
 			versionId,
 			notebookId,
@@ -254,6 +293,31 @@ export class SyncedNotebookService {
 				compensableWrite(
 					[
 						() => this.bucket.put(versionPaths.meta, JSON.stringify(version)),
+						...(workspaceArchive
+							? [
+									async () => {
+										try {
+											await this.bucket.put(versionPaths.workspaceArchive, workspaceArchive, {
+												httpMetadata: { contentType: 'application/zip' },
+											});
+											this.metrics.increment('sync.workspace_archive_stored');
+										} catch (error) {
+											this.metrics.increment('sync.workspace_archive_write_failed');
+											logOperationalError(
+												'sync_workspace_archive_write_failed',
+												{
+													operation: 'notebook.sync.workspace_archive.write',
+													object: versionPaths.workspaceArchive,
+													project_id: projectId,
+													notebook_id: notebookId,
+													recovered: true,
+												},
+												error,
+											);
+										}
+									},
+								]
+							: []),
 						...[...prepared.files.entries()].map(
 							([path, bytes]) =>
 								() =>

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -774,6 +774,191 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess[0].cmd).toContain("marimo edit 'apps/my_app.py'");
 		});
 
+		it('restores a packed synced workspace without listing or fetching individual files', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			const archive = new Uint8Array([80, 75, 3, 4]);
+			await bucketHandle.put(version.workspaceArchive, archive);
+			await bucketHandle.put(version.workspaceFile('app.py'), 'canonical');
+			await bucketHandle.put(version.gitFile('HEAD'), 'ref: refs/heads/main\n');
+			const list = vi.spyOn(bucketHandle, 'list');
+			const get = vi.spyOn(bucketHandle, 'get');
+
+			const result = await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				bucketHandle,
+				workspaceLoadMode: 'copy-only',
+				workspacePrefix: version.workspacePrefix,
+				gitPrefix: version.gitPrefix,
+				workspaceArchive: version.workspaceArchive,
+			});
+
+			expect(list).not.toHaveBeenCalled();
+			expect(get).toHaveBeenCalledTimes(1);
+			expect(get).toHaveBeenCalledWith(version.workspaceArchive);
+			expect(calls.writeFiles).toHaveLength(1);
+			expect(calls.writeFiles[0]).toHaveLength(2);
+			expect(
+				calls.writeFiles[0].every(({ path }) =>
+					path.startsWith(`${MOUNT_PATH}/.marimohub-packed-restore/`),
+				),
+			).toBe(true);
+			expect(calls.writeFile.some((file) => file.path.endsWith('app.py'))).toBe(false);
+			expect(calls.exec.some((command) => command.startsWith('python3 '))).toBe(true);
+			expect(calls.exec.find((command) => command.startsWith('python3 '))).toMatch(/ 1$/);
+			expect(result.counters).toMatchObject({
+				files_objects: 1,
+				files_bytes: archive.byteLength,
+				files_archive_used: 1,
+				files_archive_missing: 0,
+				files_archive_failed: 0,
+				files_archive_bytes: archive.byteLength,
+			});
+		});
+
+		it('does not bypass the mount strategy when an archive is passed outside copy-only mode', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceArchive, new Uint8Array([80, 75, 3, 4]));
+			const get = vi.spyOn(bucketHandle, 'get');
+
+			await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				bucketHandle,
+				workspaceArchive: version.workspaceArchive,
+			});
+
+			expect(get).not.toHaveBeenCalledWith(version.workspaceArchive);
+			expect(calls.mountBucket).toHaveLength(1);
+			expect(calls.exec.some((command) => command.startsWith('python3 '))).toBe(false);
+		});
+
+		it('falls back to canonical objects when the packed workspace is absent', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceFile('app.py'), 'canonical');
+
+			const result = await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				bucketHandle,
+				workspaceLoadMode: 'copy-only',
+				workspacePrefix: version.workspacePrefix,
+				workspaceArchive: version.workspaceArchive,
+			});
+
+			expect(calls.writeFile).toContainEqual({
+				path: `${MOUNT_PATH}/app.py`,
+				content: expect.anything(),
+			});
+			expect(result.counters).toMatchObject({
+				files_archive_used: 0,
+				files_archive_missing: 1,
+				files_archive_failed: 0,
+			});
+		});
+
+		it('cleans up and falls back when packed extraction fails', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const exec = instance.exec.bind(instance);
+			instance.exec = async (command, options) => {
+				const result = await exec(command, options);
+				return command.startsWith('python3 ')
+					? {
+							success: false,
+							stdout: '',
+							stderr: 'invalid archive',
+							error: { code: 'COMMAND_FAILED' },
+						}
+					: result;
+			};
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceArchive, new Uint8Array([1, 2, 3]));
+			await bucketHandle.put(version.workspaceFile('app.py'), 'canonical');
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			try {
+				const result = await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					bucketHandle,
+					workspaceLoadMode: 'copy-only',
+					workspacePrefix: version.workspacePrefix,
+					workspaceArchive: version.workspaceArchive,
+				});
+
+				expect(calls.exec.some((command) => command.startsWith('rm -rf -- '))).toBe(true);
+				expect(calls.writeFile).toContainEqual({
+					path: `${MOUNT_PATH}/app.py`,
+					content: expect.anything(),
+				});
+				expect(result.counters).toMatchObject({
+					files_archive_used: 0,
+					files_archive_missing: 0,
+					files_archive_failed: 1,
+				});
+			} finally {
+				log.mockRestore();
+			}
+		});
+
+		it('falls back to canonical objects when fetching the packed archive fails', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const bucketHandle = new MemoryBucket();
+			const version = paths.project(projectId).notebook(notebookId).version(createVersionId());
+			await bucketHandle.put(version.workspaceFile('app.py'), 'canonical');
+			const realGet = bucketHandle.get.bind(bucketHandle);
+			vi.spyOn(bucketHandle, 'get').mockImplementation((key) => {
+				if (key === version.workspaceArchive) throw new Error('archive read unavailable');
+				return realGet(key);
+			});
+			const log = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			try {
+				const result = await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					bucketHandle,
+					workspaceLoadMode: 'copy-only',
+					workspacePrefix: version.workspacePrefix,
+					workspaceArchive: version.workspaceArchive,
+				});
+
+				expect(calls.writeFile).toContainEqual({
+					path: `${MOUNT_PATH}/app.py`,
+					content: expect.anything(),
+				});
+				expect(result.counters).toMatchObject({
+					files_archive_used: 0,
+					files_archive_missing: 0,
+					files_archive_failed: 1,
+				});
+			} finally {
+				log.mockRestore();
+			}
+		});
+
 		it('classifies a combined-launch setup failure the same way', async () => {
 			const { instance, calls } = makeFakeSandbox();
 			instance.launchProcess = async () => ({

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -29,6 +29,7 @@ import { shellQuote } from './shell';
 import type { NotebookService } from '../content/NotebookService';
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
 import type { WorkspaceRestoreStats } from './sandboxFiles';
+import { restorePackedWorkspace } from './packedWorkspaceRestore';
 
 /**
  * Default wait for marimo to bind its port (override per deployment via
@@ -166,6 +167,8 @@ export interface ProvisionOptions {
 	workspacePrefix?: string;
 	/** Pull-source Git metadata restored into `<workdir>/.git`. */
 	gitPrefix?: string;
+	/** Optional packed copy of a synced workspace and its Git metadata. */
+	workspaceArchive?: string;
 }
 
 export interface ProvisionResult {
@@ -265,6 +268,8 @@ export interface WorkspaceLoadResult {
 	usedFallback: boolean;
 	/** What the copy moved; absent when the workspace was mounted instead. */
 	stats?: WorkspaceRestoreStats;
+	archiveStatus?: 'used' | 'missing' | 'failed';
+	archiveBytes?: number;
 }
 
 export interface WorkspaceLoadStrategy {
@@ -440,6 +445,12 @@ export class SandboxProvisioner {
 			counters.files_objects = load.stats.objectCount;
 			counters.files_bytes = load.stats.bytes;
 		}
+		if (load.archiveStatus) {
+			counters.files_archive_used = load.archiveStatus === 'used' ? 1 : 0;
+			counters.files_archive_missing = load.archiveStatus === 'missing' ? 1 : 0;
+			counters.files_archive_failed = load.archiveStatus === 'failed' ? 1 : 0;
+			if (load.archiveBytes !== undefined) counters.files_archive_bytes = load.archiveBytes;
+		}
 		// Last: the adapter's command count is only final once every phase has run.
 		Object.assign(counters, sandbox.drainCounters?.() ?? {});
 
@@ -462,6 +473,59 @@ export class SandboxProvisioner {
 	}
 
 	private async loadWorkspace(
+		sandbox: SandboxInstance,
+		options: ProvisionOptions,
+		mountPath: string,
+		workspacePrefix: string,
+	): Promise<WorkspaceLoadResult> {
+		if (
+			options.workspaceLoadMode === 'copy-only' &&
+			options.workspaceArchive &&
+			options.bucketHandle
+		) {
+			const packed = await restorePackedWorkspace(
+				sandbox,
+				options.bucketHandle,
+				options.workspaceArchive,
+				mountPath,
+				Boolean(options.gitPrefix),
+			);
+			if (packed.status === 'restored') {
+				return {
+					usedFallback: true,
+					stats: { objectCount: 1, bytes: packed.archiveBytes },
+					archiveStatus: 'used',
+					archiveBytes: packed.archiveBytes,
+				};
+			}
+			if (packed.status === 'failed') {
+				logOperationalError(
+					'packed_workspace_restore_failed',
+					{
+						operation: 'session.workspace_archive.restore',
+						object: options.workspaceArchive,
+						project_id: options.projectId,
+						notebook_id: options.notebookId,
+						recovered: true,
+					},
+					packed.error,
+				);
+			}
+			const fallback = await this.loadWorkspaceObjects(
+				sandbox,
+				options,
+				mountPath,
+				workspacePrefix,
+			);
+			return {
+				...fallback,
+				archiveStatus: packed.status === 'missing' ? 'missing' : 'failed',
+			};
+		}
+		return this.loadWorkspaceObjects(sandbox, options, mountPath, workspacePrefix);
+	}
+
+	private async loadWorkspaceObjects(
 		sandbox: SandboxInstance,
 		options: ProvisionOptions,
 		mountPath: string,

--- a/packages/core/src/services/runtime/packedWorkspaceRestore.test.ts
+++ b/packages/core/src/services/runtime/packedWorkspaceRestore.test.ts
@@ -172,7 +172,7 @@ describe('packed workspace extractor', () => {
 		expect(() => readFileSync(join(destination, 'app.py'))).toThrow();
 	});
 
-	it('rejects symlinks and incomplete pull-mode Git metadata', () => {
+	it('rejects symlinks, FIFOs, and incomplete pull-mode Git metadata', () => {
 		for (const attrs of [0o120777 * 65536, 0o010644 * 65536]) {
 			const special = zipSync({ link: [encode('target'), { os: 3, attrs }] });
 			expect(runExtractor(special, false).result.status).toBe(1);
@@ -183,6 +183,17 @@ describe('packed workspace extractor', () => {
 			git: new Map([['config', encode('config')]]),
 		});
 		expect(runExtractor(withoutHead, true).result.status).toBe(1);
+	});
+
+	it.each([
+		{ label: 'S_IFREG with 0o644 permissions', mode: 0o100644 },
+		{ label: 'permission-only 0o644', mode: 0o000644 },
+	])('restores a regular file encoded as $label', ({ mode }) => {
+		const archive = zipSync({ 'app.py': [encode('print(1)'), { os: 3, attrs: mode * 65536 }] });
+		const { destination, result } = runExtractor(archive, false);
+
+		expect(result.status, result.stderr.toString()).toBe(0);
+		expect(readFileSync(join(destination, 'app.py'), 'utf8')).toBe('print(1)');
 	});
 
 	it('rejects a truncated archive', () => {

--- a/packages/core/src/services/runtime/packedWorkspaceRestore.test.ts
+++ b/packages/core/src/services/runtime/packedWorkspaceRestore.test.ts
@@ -1,0 +1,482 @@
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { zipSync } from 'fflate';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createPackedWorkspaceArchive } from '../../integrations/packedWorkspace';
+import type { BucketObjectBody } from '../../ports/bucket';
+import { makeFakeSandbox, MemoryBucket } from '../../testing';
+import { EXTRACT_PACKED_WORKSPACE, restorePackedWorkspace } from './packedWorkspaceRestore';
+
+const encode = (value: string) => new TextEncoder().encode(value);
+const temporaryDirectories: string[] = [];
+const MAX_FILE_BYTES = 25 * 1024 * 1024;
+const MAX_TRANSPORT_BYTES = 256 * 1024 * 1024;
+
+function patchZip(
+	archive: Uint8Array,
+	patch: (view: DataView, offset: number) => void,
+): Uint8Array {
+	const result = new Uint8Array(archive);
+	const view = new DataView(result.buffer, result.byteOffset, result.byteLength);
+	for (let offset = 0; offset <= result.length - 4; offset++) patch(view, offset);
+	return result;
+}
+
+function setZipFlags(archive: Uint8Array, flags: number): Uint8Array {
+	return patchZip(archive, (view, offset) => {
+		const signature = view.getUint32(offset, true);
+		if (signature === 0x04034b50) view.setUint16(offset + 6, flags, true);
+		if (signature === 0x02014b50) view.setUint16(offset + 8, flags, true);
+	});
+}
+
+function corruptZipCrc(archive: Uint8Array): Uint8Array {
+	return patchZip(archive, (view, offset) => {
+		const signature = view.getUint32(offset, true);
+		if (signature === 0x04034b50) view.setUint32(offset + 14, 0, true);
+		if (signature === 0x02014b50) view.setUint32(offset + 16, 0, true);
+	});
+}
+
+function setCentralSizes(archive: Uint8Array, sizes: number[]): Uint8Array {
+	let index = 0;
+	const result = patchZip(archive, (view, offset) => {
+		if (view.getUint32(offset, true) !== 0x02014b50) return;
+		if (index >= sizes.length) throw new Error('ZIP has more entries than expected');
+		view.setUint32(offset + 24, sizes[index], true);
+		index++;
+	});
+	if (index !== sizes.length) throw new Error('ZIP has fewer entries than expected');
+	return result;
+}
+
+function renameZipEntry(archive: Uint8Array, from: string, to: string): Uint8Array {
+	if (from.length !== to.length) throw new Error('ZIP entry replacements must have equal lengths');
+	const result = new Uint8Array(archive);
+	const source = encode(from);
+	const replacement = encode(to);
+	for (let offset = 0; offset <= result.length - source.length; offset++) {
+		if (source.every((byte, index) => result[offset + index] === byte)) {
+			result.set(replacement, offset);
+		}
+	}
+	return result;
+}
+
+function bucketObject(bytes: Uint8Array, size = bytes.byteLength): BucketObjectBody {
+	return {
+		key: 'workspace.zip',
+		etag: 'etag-1',
+		size,
+		uploaded: new Date(0),
+		text: async () => '',
+		json: async <T>() => ({}) as T,
+		bytes: async () => bytes,
+	};
+}
+
+function runExtractor(archive: Uint8Array, requireGit: boolean, readOnlyParent = false) {
+	const root = mkdtempSync(join(tmpdir(), 'marimohub-packed-'));
+	temporaryDirectories.push(root);
+	const destination = join(root, 'workspace');
+	const temporaryRoot = join(destination, '.marimohub-packed-restore');
+	const script = join(temporaryRoot, 'extract.py');
+	const archivePath = join(temporaryRoot, 'workspace.zip');
+	mkdirSync(temporaryRoot, { recursive: true });
+	writeFileSync(script, EXTRACT_PACKED_WORKSPACE);
+	writeFileSync(archivePath, archive);
+	if (readOnlyParent) chmodSync(root, 0o555);
+	let result: ReturnType<typeof spawnSync>;
+	try {
+		result = spawnSync('python3', [
+			script,
+			archivePath,
+			temporaryRoot,
+			destination,
+			requireGit ? '1' : '0',
+		]);
+	} finally {
+		if (readOnlyParent) chmodSync(root, 0o755);
+	}
+	return {
+		root,
+		destination,
+		result,
+	};
+}
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe('packed workspace extractor', () => {
+	it('restores binary workspace files and required Git metadata', () => {
+		const archive = createPackedWorkspaceArchive({
+			workspace: new Map([
+				['app.py', encode('print(1)')],
+				['data/blob.bin', new Uint8Array([0, 255, 1])],
+				['分析/empty.txt', new Uint8Array()],
+			]),
+			git: new Map([['HEAD', encode('ref: refs/heads/main\n')]]),
+		});
+		const { destination, result } = runExtractor(archive, true, true);
+
+		expect(result.status, result.stderr.toString()).toBe(0);
+		expect(readFileSync(join(destination, 'app.py'), 'utf8')).toBe('print(1)');
+		expect(readFileSync(join(destination, 'data/blob.bin'))).toEqual(Buffer.from([0, 255, 1]));
+		expect(readFileSync(join(destination, '分析/empty.txt'))).toHaveLength(0);
+		expect(readFileSync(join(destination, '.git/HEAD'), 'utf8')).toBe('ref: refs/heads/main\n');
+	});
+
+	it('rejects traversal paths before replacing an existing destination', () => {
+		const root = mkdtempSync(join(tmpdir(), 'marimohub-packed-'));
+		temporaryDirectories.push(root);
+		const destination = join(root, 'workspace');
+		const temporaryRoot = join(destination, '.marimohub-packed-restore');
+		const archivePath = join(temporaryRoot, 'workspace.zip');
+		const scriptPath = join(temporaryRoot, 'extract.py');
+		mkdirSync(temporaryRoot, { recursive: true });
+		writeFileSync(join(destination, 'keep.txt'), 'keep');
+		writeFileSync(scriptPath, EXTRACT_PACKED_WORKSPACE);
+		writeFileSync(archivePath, zipSync({ '../escape.txt': encode('bad') }));
+
+		const result = spawnSync('python3', [scriptPath, archivePath, temporaryRoot, destination, '0']);
+
+		expect(result.status).toBe(1);
+		expect(readFileSync(join(destination, 'keep.txt'), 'utf8')).toBe('keep');
+	});
+
+	it('refuses to merge into a non-empty workspace', () => {
+		const archive = createPackedWorkspaceArchive({
+			workspace: new Map([['app.py', encode('print(1)')]]),
+		});
+		const root = mkdtempSync(join(tmpdir(), 'marimohub-packed-'));
+		temporaryDirectories.push(root);
+		const destination = join(root, 'workspace');
+		const temporaryRoot = join(destination, '.marimohub-packed-restore');
+		const script = join(temporaryRoot, 'extract.py');
+		const archivePath = join(temporaryRoot, 'workspace.zip');
+		mkdirSync(temporaryRoot, { recursive: true });
+		writeFileSync(join(destination, 'keep.txt'), 'keep');
+		writeFileSync(script, EXTRACT_PACKED_WORKSPACE);
+		writeFileSync(archivePath, archive);
+
+		const result = spawnSync('python3', [script, archivePath, temporaryRoot, destination, '0']);
+
+		expect(result.status).toBe(1);
+		expect(readFileSync(join(destination, 'keep.txt'), 'utf8')).toBe('keep');
+		expect(() => readFileSync(join(destination, 'app.py'))).toThrow();
+	});
+
+	it('rejects symlinks and incomplete pull-mode Git metadata', () => {
+		for (const attrs of [0o120777 * 65536, 0o010644 * 65536]) {
+			const special = zipSync({ link: [encode('target'), { os: 3, attrs }] });
+			expect(runExtractor(special, false).result.status).toBe(1);
+		}
+
+		const withoutHead = createPackedWorkspaceArchive({
+			workspace: new Map([['app.py', encode('print(1)')]]),
+			git: new Map([['config', encode('config')]]),
+		});
+		expect(runExtractor(withoutHead, true).result.status).toBe(1);
+	});
+
+	it('rejects a truncated archive', () => {
+		const archive = createPackedWorkspaceArchive({
+			workspace: new Map([['app.py', encode('print(1)')]]),
+		});
+		expect(runExtractor(archive.subarray(0, archive.byteLength - 10), false).result.status).toBe(1);
+	});
+
+	it('rejects empty, directory-bearing, encrypted, duplicate, and CRC-invalid archives', () => {
+		const empty = zipSync({});
+		const directory = zipSync({ 'data/': new Uint8Array() });
+		const encrypted = setZipFlags(zipSync({ 'app.py': encode('print(1)') }), 1);
+		const duplicate = renameZipEntry(
+			zipSync({ 'one.py': encode('first'), 'two.py': encode('second') }),
+			'two.py',
+			'one.py',
+		);
+		const badCrc = corruptZipCrc(zipSync({ 'app.py': encode('not empty') }));
+		const absolute = zipSync({ '/app.py': encode('bad') });
+		const backslash = zipSync({ 'dir\\app.py': encode('bad') });
+		const emptySegment = zipSync({ 'dir//app.py': encode('bad') });
+
+		for (const archive of [
+			empty,
+			directory,
+			encrypted,
+			duplicate,
+			badCrc,
+			absolute,
+			backslash,
+			emptySegment,
+		]) {
+			expect(runExtractor(archive, false).result.status).toBe(1);
+		}
+	});
+
+	it('rejects declared per-file and aggregate workspace limits before extraction', () => {
+		const perFile = setCentralSizes(zipSync({ 'large.bin': new Uint8Array() }), [
+			MAX_FILE_BYTES + 1,
+		]);
+		const aggregate = setCentralSizes(
+			zipSync(
+				Object.fromEntries(
+					Array.from({ length: 5 }, (_, index) => [`${index}.bin`, new Uint8Array()]),
+				),
+			),
+			[MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, 1],
+		);
+
+		expect(runExtractor(perFile, false).result.status).toBe(1);
+		expect(runExtractor(aggregate, false).result.status).toBe(1);
+	});
+
+	it('enforces Git aggregate and file-count limits separately from workspace limits', () => {
+		const aggregate = setCentralSizes(
+			zipSync({
+				'.git/HEAD': new Uint8Array(),
+				'.git/objects/1': new Uint8Array(),
+				'.git/objects/2': new Uint8Array(),
+				'.git/objects/3': new Uint8Array(),
+				'.git/objects/4': new Uint8Array(),
+			}),
+			[MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, MAX_FILE_BYTES, 1],
+		);
+		const tooMany = zipSync({
+			'.git/HEAD': new Uint8Array(),
+			...Object.fromEntries(
+				Array.from({ length: 1000 }, (_, index) => [`.git/objects/${index}`, new Uint8Array()]),
+			),
+		});
+
+		expect(runExtractor(aggregate, true).result.status).toBe(1);
+		expect(runExtractor(tooMany, true).result.status).toBe(1);
+	});
+
+	it('rejects more than 1000 workspace files', () => {
+		const archive = zipSync(
+			Object.fromEntries(
+				Array.from({ length: 1001 }, (_, index) => [`${index}.txt`, new Uint8Array()]),
+			),
+		);
+
+		expect(runExtractor(archive, false).result.status).toBe(1);
+	});
+
+	it('rejects an archive path reserved for restore files', () => {
+		const archive = zipSync({
+			'.marimohub-packed-restore/payload': encode('conflict'),
+		});
+		expect(runExtractor(archive, false).result.status).toBe(1);
+	});
+});
+
+describe('restorePackedWorkspace', () => {
+	it('returns missing without creating temporary sandbox files', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const result = await restorePackedWorkspace(
+			instance,
+			new MemoryBucket(),
+			'workspace.zip',
+			'/workspace',
+			false,
+		);
+
+		expect(result).toEqual({ status: 'missing' });
+		expect(calls.writeFiles).toHaveLength(0);
+		expect(calls.exec).toHaveLength(0);
+	});
+
+	it('rejects unsafe working directories before fetching the archive', async () => {
+		for (const workingDir of [
+			'workspace',
+			'/',
+			'//',
+			'/workspace//nested',
+			'/workspace/../other',
+			'/workspace\\other',
+		]) {
+			const { instance } = makeFakeSandbox();
+			const bucket = new MemoryBucket();
+			const get = vi.spyOn(bucket, 'get');
+
+			const result = await restorePackedWorkspace(
+				instance,
+				bucket,
+				'workspace.zip',
+				workingDir,
+				false,
+			);
+
+			expect(result.status).toBe('failed');
+			expect(get).not.toHaveBeenCalled();
+		}
+	});
+
+	it('rejects an oversized object without reading or writing its body', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const bucket = new MemoryBucket();
+		const bytes = vi.fn(async () => new Uint8Array());
+		const object = bucketObject(new Uint8Array(), MAX_TRANSPORT_BYTES + 1);
+		object.bytes = bytes;
+		vi.spyOn(bucket, 'get').mockResolvedValue(object);
+
+		const result = await restorePackedWorkspace(
+			instance,
+			bucket,
+			'workspace.zip',
+			'/workspace',
+			false,
+		);
+
+		expect(result.status).toBe('failed');
+		expect(bytes).not.toHaveBeenCalled();
+		expect(calls.writeFiles).toHaveLength(0);
+		expect(calls.exec.some((command) => command.startsWith('rm -rf -- '))).toBe(true);
+	});
+
+	it('rejects a body whose byte length differs from object metadata', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const bucket = new MemoryBucket();
+		vi.spyOn(bucket, 'get').mockResolvedValue(bucketObject(new Uint8Array([1, 2, 3]), 4));
+
+		const result = await restorePackedWorkspace(
+			instance,
+			bucket,
+			'workspace.zip',
+			'/workspace',
+			false,
+		);
+
+		expect(result.status).toBe('failed');
+		expect(calls.writeFiles).toHaveLength(0);
+	});
+
+	it('cleans temporary paths when fetching, writing, or extracting the archive fails', async () => {
+		for (const failure of ['fetch', 'body', 'write', 'exec'] as const) {
+			const { instance, calls } = makeFakeSandbox();
+			const bucket = new MemoryBucket();
+			if (failure === 'fetch') {
+				vi.spyOn(bucket, 'get').mockRejectedValue(new Error('storage unavailable'));
+			} else {
+				const object = bucketObject(new Uint8Array([1, 2, 3]));
+				if (failure === 'body') {
+					object.bytes = async () => {
+						throw new Error('archive body unavailable');
+					};
+				}
+				vi.spyOn(bucket, 'get').mockResolvedValue(object);
+				if (failure === 'write') {
+					instance.writeFiles = async () => {
+						throw new Error('sandbox write unavailable');
+					};
+				}
+				if (failure === 'exec') {
+					const exec = instance.exec.bind(instance);
+					instance.exec = async (command, options) => {
+						if (command.startsWith('python3 ')) throw new Error('sandbox exec unavailable');
+						return exec(command, options);
+					};
+				}
+			}
+
+			const result = await restorePackedWorkspace(
+				instance,
+				bucket,
+				'workspace.zip',
+				'/workspace',
+				false,
+			);
+
+			expect(result.status).toBe('failed');
+			expect(calls.exec.some((command) => command.startsWith('rm -rf -- '))).toBe(true);
+		}
+	});
+
+	it('normalizes a trailing slash and keeps every temporary path inside the workdir', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const bucket = new MemoryBucket();
+		vi.spyOn(bucket, 'get').mockResolvedValue(bucketObject(new Uint8Array([1, 2, 3])));
+
+		const result = await restorePackedWorkspace(
+			instance,
+			bucket,
+			'workspace.zip',
+			'/workspace/',
+			false,
+		);
+
+		expect(result).toEqual({ status: 'restored', archiveBytes: 3 });
+		expect(calls.writeFiles).toHaveLength(1);
+		expect(calls.writeFiles[0]).toHaveLength(2);
+		expect(
+			calls.writeFiles[0].every(({ path }) =>
+				path.startsWith('/workspace/.marimohub-packed-restore/'),
+			),
+		).toBe(true);
+		expect(calls.exec[0]).toContain("'/workspace/.marimohub-packed-restore'");
+		expect(calls.exec[0]).not.toContain('/workspace.marimohub');
+	});
+
+	it('includes extractor stderr in the recovered failure', async () => {
+		const { instance } = makeFakeSandbox();
+		const exec = instance.exec.bind(instance);
+		instance.exec = async (command, options) => {
+			if (command.startsWith('python3 ')) {
+				return {
+					success: false,
+					stdout: '',
+					stderr: 'packed workspace extraction failed: BadZipFile: invalid central directory',
+					error: { code: 'COMMAND_FAILED' },
+				};
+			}
+			return exec(command, options);
+		};
+		const bucket = new MemoryBucket();
+		vi.spyOn(bucket, 'get').mockResolvedValue(bucketObject(new Uint8Array([1, 2, 3])));
+
+		const result = await restorePackedWorkspace(
+			instance,
+			bucket,
+			'workspace.zip',
+			'/workspace',
+			false,
+		);
+
+		expect(result).toMatchObject({ status: 'failed' });
+		if (result.status === 'failed') {
+			expect(result.error).toHaveProperty(
+				'message',
+				expect.stringContaining('BadZipFile: invalid central directory'),
+			);
+		}
+	});
+
+	it('preserves the primary failure when temporary cleanup also fails', async () => {
+		const { instance } = makeFakeSandbox();
+		const bucket = new MemoryBucket();
+		vi.spyOn(bucket, 'get').mockRejectedValue(new Error('storage unavailable'));
+		instance.exec = async () => {
+			throw new Error('cleanup unavailable');
+		};
+
+		const result = await restorePackedWorkspace(
+			instance,
+			bucket,
+			'workspace.zip',
+			'/workspace',
+			false,
+		);
+
+		expect(result).toMatchObject({
+			status: 'failed',
+			error: new Error('storage unavailable'),
+		});
+	});
+});

--- a/packages/core/src/services/runtime/packedWorkspaceRestore.ts
+++ b/packages/core/src/services/runtime/packedWorkspaceRestore.ts
@@ -1,0 +1,197 @@
+import { MAX_WORKSPACE_FILE_BYTES } from '../../constants';
+import { MAX_DECOMPRESSED_ARCHIVE_BYTES } from '../../integrations/workspaceArchive';
+import type { Bucket } from '../../ports/bucket';
+import { MAX_GIT_DIRECTORY_BYTES, MAX_GIT_DIRECTORY_FILES } from '../../ports/sourceControl';
+import type { SandboxInstance } from '../../ports/sandbox';
+import { shellQuote } from './shell';
+
+const MAX_WORKSPACE_FILES = 1000;
+// Valid workspace and Git trees top out at 200 MiB; the remainder covers ZIP metadata.
+const MAX_PACKED_ARCHIVE_BYTES = 256 * 1024 * 1024;
+
+export const EXTRACT_PACKED_WORKSPACE = String.raw`
+import os
+import shutil
+import stat
+import sys
+import zipfile
+
+archive, temporary_root, destination, require_git_value = sys.argv[1:]
+require_git = require_git_value == '1'
+workspace_file_limit = ${MAX_WORKSPACE_FILES}
+workspace_byte_limit = ${MAX_DECOMPRESSED_ARCHIVE_BYTES}
+git_file_limit = ${MAX_GIT_DIRECTORY_FILES}
+git_byte_limit = ${MAX_GIT_DIRECTORY_BYTES}
+per_file_limit = ${MAX_WORKSPACE_FILE_BYTES}
+
+def fail(message):
+    raise ValueError(message)
+
+def group_for(name):
+    return 'git' if require_git and name.startswith('.git/') else 'workspace'
+
+def check_limit(group, count, size):
+    file_limit = git_file_limit if group == 'git' else workspace_file_limit
+    byte_limit = git_byte_limit if group == 'git' else workspace_byte_limit
+    if count > file_limit or size > byte_limit:
+        fail('archive limits exceeded')
+
+exit_code = 0
+try:
+    destination = os.path.abspath(destination)
+    temporary_root = os.path.abspath(temporary_root)
+    staging = os.path.join(temporary_root, 'tree')
+    temporary_name = os.path.basename(temporary_root)
+    if (
+        destination == os.path.abspath(os.sep)
+        or os.path.dirname(temporary_root) != destination
+        or not os.path.isdir(destination)
+        or os.path.islink(destination)
+    ):
+        fail('unsafe extraction destination')
+    shutil.rmtree(staging, ignore_errors=True)
+    os.makedirs(staging)
+    staging_prefix = staging + os.sep
+    declared_counts = {'workspace': 0, 'git': 0}
+    declared_bytes = {'workspace': 0, 'git': 0}
+    seen = set()
+    infos = []
+    with zipfile.ZipFile(archive) as packed:
+        for info in packed.infolist():
+            name = info.filename
+            if info.flag_bits & 1 or info.is_dir():
+                fail('unsupported archive entry')
+            if not name or name.startswith('/') or '\\' in name or '\x00' in name:
+                fail('unsafe archive path')
+            parts = name.split('/')
+            if any(not part or part in ('.', '..') for part in parts) or name in seen:
+                fail('unsafe or duplicate archive path')
+            if parts[0] == temporary_name:
+                fail('archive path conflicts with restore files')
+            mode = (info.external_attr >> 16) & 0xFFFF
+            file_type = stat.S_IFMT(mode)
+            if file_type not in (0, stat.S_IFREG):
+                fail('special archive entry')
+            if info.file_size < 0 or info.file_size > per_file_limit:
+                fail('archive file limit exceeded')
+            group = group_for(name)
+            declared_counts[group] += 1
+            declared_bytes[group] += info.file_size
+            check_limit(group, declared_counts[group], declared_bytes[group])
+            target = os.path.abspath(os.path.join(staging, *parts))
+            if not target.startswith(staging_prefix):
+                fail('unsafe archive path')
+            seen.add(name)
+            infos.append((info, target, group))
+
+        if require_git and '.git/HEAD' not in seen:
+            fail('Git metadata is incomplete')
+        if not infos:
+            fail('archive is empty')
+
+        actual_counts = {'workspace': 0, 'git': 0}
+        actual_bytes = {'workspace': 0, 'git': 0}
+        for info, target, group in infos:
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            file_bytes = 0
+            with packed.open(info) as source, open(target, 'xb') as output:
+                while True:
+                    chunk = source.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    file_bytes += len(chunk)
+                    actual_bytes[group] += len(chunk)
+                    if file_bytes > per_file_limit:
+                        fail('archive file limit exceeded')
+                    check_limit(group, actual_counts[group] + 1, actual_bytes[group])
+                    output.write(chunk)
+            if file_bytes != info.file_size:
+                fail('archive file size mismatch')
+            actual_counts[group] += 1
+
+    if set(os.listdir(destination)) != {temporary_name}:
+        fail('workspace is not empty')
+    for name in os.listdir(staging):
+        os.replace(os.path.join(staging, name), os.path.join(destination, name))
+except Exception as error:
+    print(
+        'packed workspace extraction failed: ' + type(error).__name__ + ': ' + str(error),
+        file=sys.stderr,
+    )
+    exit_code = 1
+finally:
+    try:
+        shutil.rmtree(temporary_root)
+    except FileNotFoundError:
+        pass
+    except Exception as error:
+        print('packed workspace cleanup failed: ' + type(error).__name__, file=sys.stderr)
+        exit_code = 1
+
+raise SystemExit(exit_code)
+`.trimStart();
+
+export type PackedWorkspaceRestoreResult =
+	| { status: 'missing' }
+	| { status: 'restored'; archiveBytes: number }
+	| { status: 'failed'; error: unknown };
+
+function normalizeWorkingDir(workingDir: string): string {
+	const normalized = workingDir.replace(/\/+$/, '');
+	const parts = normalized.slice(1).split('/');
+	if (
+		!normalized.startsWith('/') ||
+		normalized === '' ||
+		normalized.includes('\\') ||
+		normalized.includes('\0') ||
+		parts.some((part) => part === '' || part === '.' || part === '..')
+	) {
+		throw new Error('Packed workspace restore requires a non-root absolute working directory');
+	}
+	return normalized;
+}
+
+export async function restorePackedWorkspace(
+	sandbox: SandboxInstance,
+	bucket: Bucket,
+	archiveKey: string,
+	workingDir: string,
+	requireGit: boolean,
+): Promise<PackedWorkspaceRestoreResult> {
+	let cleanup: (() => Promise<unknown>) | undefined;
+	try {
+		const normalizedWorkingDir = normalizeWorkingDir(workingDir);
+		const temporaryRoot = `${normalizedWorkingDir}/.marimohub-packed-restore`;
+		const archivePath = `${temporaryRoot}/workspace.zip`;
+		const scriptPath = `${temporaryRoot}/extract.py`;
+		cleanup = () => sandbox.exec(`rm -rf -- ${shellQuote(temporaryRoot)}`);
+		const object = await bucket.get(archiveKey);
+		if (!object) return { status: 'missing' };
+		if (object.size > MAX_PACKED_ARCHIVE_BYTES) {
+			throw new Error('Packed workspace archive exceeds the transport limit');
+		}
+		const archive = await object.bytes();
+		if (archive.byteLength !== object.size) {
+			throw new Error('Packed workspace archive size changed while reading');
+		}
+		await sandbox.writeFiles([
+			{ path: archivePath, content: archive },
+			{ path: scriptPath, content: EXTRACT_PACKED_WORKSPACE },
+		]);
+		const result = await sandbox.exec(
+			`python3 ${shellQuote(scriptPath)} ${shellQuote(archivePath)} ${shellQuote(temporaryRoot)} ${shellQuote(normalizedWorkingDir)} ${requireGit ? '1' : '0'}`,
+		);
+		if (!result.success) {
+			const detail = result.stderr.trim().slice(-2000);
+			throw new Error(
+				detail
+					? `Packed workspace extraction failed: ${detail}`
+					: 'Packed workspace extraction failed',
+			);
+		}
+		return { status: 'restored', archiveBytes: archive.byteLength };
+	} catch (error) {
+		await cleanup?.().catch(() => {});
+		return { status: 'failed', error };
+	}
+}


### PR DESCRIPTION
Store a best-effort packed workspace artifact alongside canonical synced files and restore it during copy-only sandbox provisioning. Missing or invalid archives fall back to the canonical per-file path.

The restore validates packed contents, stages extraction entirely within the sandbox workdir, bounds synchronous packing, avoids recompressing Git objects, and records archive usage and recovered failures. Cleanup, pruning, storage documentation, and failure-path coverage include the packed representation.