### PR TITLE
Benchmark a single absent package (boto3) in the sandbox uv sync diagnostic

### DIFF
--- a/packages/api/src/routes/admin.test.ts
+++ b/packages/api/src/routes/admin.test.ts
@@ -384,7 +384,7 @@ describe('Admin routes', () => {
 			);
 			expect(instance.exec).toHaveBeenNthCalledWith(
 				4,
-				expect.stringContaining('botocore-1.43.36-py3-none-any.whl'),
+				expect.stringContaining('botocore-1.43.80-py3-none-any.whl'),
 				{ timeout: 60_000 },
 			);
 			expect(instance.exec).toHaveBeenNthCalledWith(

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -40,8 +40,12 @@ const UV_BENCHMARK_TIMEOUT_MS =
 	UV_BENCHMARK_SYNC_TIMEOUT_MS;
 const CLEANUP_LEASE_HEADROOM_MS = 60_000;
 const UV_BENCHMARK_DIR = '/tmp/marimohub-uv-sync-benchmark';
+// boto3 (and its botocore dependency) is absent from the sandbox base image, so
+// `uv sync` below does real install work. A "popular" package that ships in the
+// image — e.g. pandas — would already be satisfied and the sync phase would
+// measure nothing.
 const BOTOCORE_WHEEL_URL =
-	'https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl';
+	'https://files.pythonhosted.org/packages/64/93/7bba357266450f7d3e3075ee4d2f1e1d96c1617e40d8065c558485baed78/botocore-1.43.80-py3-none-any.whl';
 
 const UV_BENCHMARK_RUNTIME_COMMAND = [
 	'set -eu',
@@ -75,7 +79,7 @@ const UV_BENCHMARK_LOCK_COMMAND = [
 	`benchmark_dir='${UV_BENCHMARK_DIR}'`,
 	'rm -rf "$benchmark_dir"',
 	'mkdir -p "$benchmark_dir"',
-	"printf '%s\\n' '[project]' 'name = \"marimohub-uv-benchmark\"' 'version = \"0.0.0\"' 'requires-python = \">=3.13\"' 'dependencies = [' '  \"boto3==1.43.36\",' '  \"botocore==1.43.36\",' '  \"moutils==0.4.4\",' '  \"obstore==0.11.0\",' ']' > \"$benchmark_dir/pyproject.toml\"",
+	"printf '%s\\n' '[project]' 'name = \"marimohub-uv-benchmark\"' 'version = \"0.0.0\"' 'requires-python = \">=3.13\"' 'dependencies = [' '  \"boto3==1.43.80\",' ']' > \"$benchmark_dir/pyproject.toml\"",
 	'cd "$benchmark_dir"',
 	'uv lock --no-cache',
 ].join('\n');

--- a/packages/web/src/components/Admin/AdminDebugPage.test.tsx
+++ b/packages/web/src/components/Admin/AdminDebugPage.test.tsx
@@ -63,7 +63,7 @@ function environmentSetupBenchmark(): NonNullable<
 			status: 'ok',
 			duration_ms: 1250,
 			command: 'curl https://files.pythonhosted.org/botocore.whl',
-			stdout: 'size_download=15313630\ntime_total=1.25\n',
+			stdout: 'size_download=15728640\ntime_total=1.25\n',
 			stderr: '',
 		},
 		prepare: {

--- a/packages/web/src/components/Admin/AdminDebugPage.tsx
+++ b/packages/web/src/components/Admin/AdminDebugPage.tsx
@@ -223,13 +223,13 @@ function EnvironmentSetupBenchmarkReport({ benchmark }: { benchmark: Environment
 		<div>
 			<h3 className="mb-1 text-sm font-semibold">Fresh sandbox uv sync benchmark</h3>
 			<p className="mb-3 text-xs text-muted-foreground">
-				Pinned boto3, botocore, moutils, and obstore against the image&apos;s configured environment
-				and cache. CPU counters bracket only the measured sync.
+				Pinned boto3 (absent from the base image, so the sync does real work) against the
+				image&apos;s configured environment and cache. CPU counters bracket only the measured sync.
 			</p>
 			<div className="grid gap-4">
 				<CommandResult label="Runtime and CPU limits" result={benchmark.runtime_probe} />
 				<CommandResult
-					label="Raw wheel download (botocore 1.43.36, 15.3 MB)"
+					label="Raw wheel download (botocore 1.43.80, 15.0 MB)"
 					result={benchmark.artifact_download}
 				/>
 				<CommandResult


### PR DESCRIPTION
Collapses the environment-setup benchmark added in #238 from four pinned dependencies (`boto3`, `botocore`, `moutils`, `obstore`) to a **single top-level pin**.

`boto3` is the most-downloaded package on PyPI and is **absent** from the base image, so the sync does real install work (uv resolves `botocore`/`s3transfer` transitively). The raw-wheel download probe uses its `botocore` 15 MB wheel, so the whole benchmark is one coherent stack.
