### PR TITLE
marimohub: log slow sandbox setup diagnostics

### DIFF
--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -147,7 +147,7 @@ describe('prepareMarimoCommand (pure)', () => {
 			{ notebookFile: 'apps/dash.py', port: 2718, host: '0.0.0.0' },
 			'uv-script-pins',
 		);
-		const command = [...plan.setup, plan.start].join(' && ');
+		const command = [...plan.setup.map(({ command }) => command), plan.start].join(' && ');
 		const prepared = prepareMarimoCommand(command, '0.0.0.0');
 		expect(prepared.split(' && ').slice(0, -1)).toEqual(command.split(' && ').slice(0, -1));
 		expect(prepared).toContain('uv run --with marimo --no-sync marimo edit');
@@ -165,7 +165,9 @@ describe('uv-script-pins setup execution', () => {
 	const setup = buildMarimoLaunch(
 		{ notebookFile: 'app.py', port: 2718, host: '127.0.0.1' },
 		'uv-script-pins',
-	).setup.join(' && ');
+	)
+		.setup.map(({ command }) => command)
+		.join(' && ');
 
 	async function runSetup(extraEnv: NodeJS.ProcessEnv, pyproject?: string, parserExit?: number) {
 		const dir = await mkdtemp(path.join(os.tmpdir(), 'marimohub-uvstub-'));
@@ -177,15 +179,12 @@ describe('uv-script-pins setup execution', () => {
 			'#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$UV_LOG"\nif [ "$1" = venv ]; then mkdir -p "$2"; fi\n',
 			{ mode: 0o755 },
 		);
-		await writeFile(
-			path.join(dir, 'python3'),
-			`#!/bin/sh\ncase "$2" in\n*importlib.metadata*) printf '\\n';;\n*) exit ${parserExit ?? 2};;\nesac\n`,
-			{ mode: 0o755 },
-		);
+		await writeFile(path.join(dir, 'python3'), `#!/bin/sh\nexit ${parserExit ?? 2}\n`, {
+			mode: 0o755,
+		});
 		if (pyproject !== undefined) await writeFile(path.join(workdir, 'pyproject.toml'), pyproject);
 		const env: NodeJS.ProcessEnv = {
 			...process.env,
-			MARIMO_VERSION: '0.0-test',
 			PATH: `${dir}:${process.env.PATH}`,
 			UV_LOG: logFile,
 		};
@@ -222,8 +221,8 @@ describe('uv-script-pins setup execution', () => {
 		}
 	});
 
-	it('continues when neither MARIMO_VERSION nor installed marimo metadata provides a pin', async () => {
-		const { log } = await runSetup({ MARIMO_VERSION: undefined });
+	it('does not inspect or install marimo during setup', async () => {
+		const { log } = await runSetup({});
 		expect(log).not.toContain('marimo==');
 		expect(log).toContain('export --script app.py');
 	});

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -131,19 +131,80 @@ describe('SandboxProvisioner', () => {
 				launchStrategy: 'uv-script-pins',
 			});
 
-			// Notebook pins apply last, except marimo remains at the image version.
+			// Notebook pins apply last; their export prunes marimo so the image owns it.
 			const cmd = calls.exec.find((command) => command.includes('uv sync --inexact'))!;
 			const order = [
 				cmd.indexOf('uv sync --inexact'),
-				cmd.indexOf('marimo==$MARIMOHUB_MARIMO_VERSION'),
 				cmd.indexOf("uv export --script 'apps/dash.py'"),
 				cmd.lastIndexOf('uv pip install'),
 			];
 			expect(Math.min(...order)).toBeGreaterThanOrEqual(0);
 			expect(order).toEqual([...order].sort((a, b) => a - b));
 			expect(cmd).toContain('--prune marimo');
+			expect(cmd).toContain('--no-install-package marimo');
+			expect(cmd).not.toContain('MARIMOHUB_MARIMO_VERSION');
+			expect(cmd).not.toContain('marimo==');
 			expect(calls.startProcess[0].cmd).toContain("marimo edit 'apps/dash.py'");
 			expect(calls.startProcess[0].cmd).not.toContain('uv sync');
+		});
+
+		it('records setup step timings and logs bounded uv output when setup is slow', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-08-26T13:47:00Z'));
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			try {
+				const { instance: base, calls } = makeFakeSandbox();
+				const instance: SandboxInstance = {
+					...base,
+					async exec(command, options) {
+						if (!command.includes('uv sync')) return base.exec(command, options);
+						calls.exec.push(command);
+						vi.setSystemTime(Date.now() + 2_100);
+						return {
+							success: true,
+							stdout: '',
+							stderr: [
+								'__MARIMOHUB_SETUP__ step pyproject_layer 1000000000',
+								'x'.repeat(5_000),
+								'Resolved 42 packages in 1.5s',
+								'Prepared 12 packages in 0.4s',
+								'Installed 12 packages in 0.1s',
+								'__MARIMOHUB_SETUP__ complete 3100000000',
+							].join('\n'),
+						};
+					},
+				};
+
+				const result = await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+				});
+
+				expect(result.timings).toMatchObject({
+					setup_pyproject_layer: 2_100,
+				});
+				expect(calls.exec.find((command) => command.includes('uv sync'))).toContain(
+					'__MARIMOHUB_SETUP__ step pyproject_layer',
+				);
+
+				expect(warn).toHaveBeenCalledOnce();
+				const record = JSON.parse(String(warn.mock.calls[0][0])) as Record<string, unknown>;
+				expect(record).toMatchObject({
+					level: 'warn',
+					event: 'sandbox_setup_slow',
+					provision_setup_ms: 2_100,
+					provision_setup_pyproject_layer_ms: 2_100,
+				});
+				const stderrTail = String(record.setup_stderr_tail);
+				expect(new TextEncoder().encode(stderrTail).byteLength).toBeLessThanOrEqual(4_096);
+				expect(stderrTail).toContain('Installed 12 packages in 0.1s');
+			} finally {
+				vi.useRealTimers();
+				warn.mockRestore();
+			}
 		});
 
 		it('defaults to the project-managed env when no launch strategy is given', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.tracing.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.tracing.test.ts
@@ -5,7 +5,7 @@ import {
 	InMemorySpanExporter,
 	SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { createNotebookId, createProjectId, createSandboxId } from '../../ids';
 import { fakeComputeFrom, makeFakeSandbox } from '../../testing';
 import { SandboxProvisioner } from './SandboxProvisioner';
@@ -114,5 +114,51 @@ describe('SandboxProvisioner tracing', () => {
 			.find((candidate) => candidate.name === 'sandbox.waitport');
 		expect(span?.status.code).toBe(SpanStatusCode.ERROR);
 		expect(span?.events.some((event) => event.name === 'exception')).toBe(true);
+	});
+
+	it('includes the active trace context on slow setup logs', async () => {
+		const { instance } = makeFakeSandbox();
+		instance.ready = async () => {};
+		const exec = instance.exec.bind(instance);
+		instance.exec = async (command, options) => {
+			if (!command.includes('uv sync')) return exec(command, options);
+			vi.setSystemTime(Date.now() + 2_500);
+			return {
+				success: true,
+				stdout: '',
+				stderr: [
+					'__MARIMOHUB_SETUP__ step pyproject_layer 1000000000',
+					'__MARIMOHUB_SETUP__ complete 3500000000',
+				].join('\n'),
+			};
+		};
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-08-26T13:47:00Z'));
+		try {
+			let expectedTraceId = '';
+			let expectedSpanId = '';
+			await provider.getTracer('test').startActiveSpan('session.provision', async (span) => {
+				expectedTraceId = span.spanContext().traceId;
+				expectedSpanId = span.spanContext().spanId;
+				try {
+					await new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+						sandboxId,
+						projectId,
+						notebookId,
+						hostname: 'localhost',
+						bucket,
+					});
+				} finally {
+					span.end();
+				}
+			});
+
+			const record = JSON.parse(String(warn.mock.calls[0][0])) as Record<string, unknown>;
+			expect(record).toMatchObject({ trace_id: expectedTraceId, span_id: expectedSpanId });
+		} finally {
+			vi.useRealTimers();
+			warn.mockRestore();
+		}
 	});
 });

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -10,6 +10,7 @@ import { PythonEnvironmentSetupError, UnavailableError } from '../../errors';
 import type { NotebookId, ProjectId, SandboxId, UserId } from '../../ids';
 import { workspaceSourcePolicy } from '../../integrations/remoteWorkspace';
 import type { WorkspaceLoadMode } from '../../integrations/remoteWorkspace';
+import { emitLogRecord } from '../../logs';
 import { paths } from '../../paths';
 import { logOperationalError } from '../../operationalLog';
 import type {
@@ -23,6 +24,7 @@ import type {
 } from '../../ports/sandbox';
 import { Stopwatch } from '../../timing';
 import type { Timings } from '../../timing';
+import { traceContext } from '../../tracing';
 import { captureFilesystemSnapshot, createOrRestoreSandbox } from '../content/filesystemSnapshots';
 import { buildMarimoLaunch, DEFAULT_LAUNCH_STRATEGY } from './marimoLaunch';
 import type { MarimoLaunchPlan, MarimoLaunchStrategyName } from './marimoLaunch';
@@ -39,6 +41,11 @@ import type { WorkspaceRestoreStats } from './sandboxFiles';
  * first boot). See marimoLaunch.ts.
  */
 export const DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS = Millis.minutes(2);
+export const SLOW_SANDBOX_SETUP_MS = Millis.seconds(2);
+const SETUP_OUTPUT_TAIL_BYTES = 4 * 1024;
+const SETUP_MARKER = '__MARIMOHUB_SETUP__';
+const SETUP_STEP_MARKER = /^__MARIMOHUB_SETUP__ step ([a-z0-9_]{1,64}) (\d{1,20})$/;
+const SETUP_COMPLETE_MARKER = /^__MARIMOHUB_SETUP__ complete (\d{1,20})$/;
 /**
  * Default sandbox working directory. Override per-deployment via the `workdir`
  * option (config: MARIMOHUB_COMPUTE_WORKDIR) when the sandbox image's user can't
@@ -46,6 +53,92 @@ export const DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS = Millis.minutes(2);
  * `/workspace`, so writes there fail with a permission/file-IO error.
  */
 const DEFAULT_WORKDIR = '/workspace';
+
+interface SetupDiagnostics {
+	stderr: string;
+	timings: Timings;
+}
+
+function instrumentSetup(steps: readonly { name: string; command: string }[]): string {
+	const commands = steps.flatMap(({ name, command }) => [
+		`printf '\\n${SETUP_MARKER} step ${name} %s\\n' "$(date +%s%N)" >&2`,
+		command,
+	]);
+	commands.push(`printf '\\n${SETUP_MARKER} complete %s\\n' "$(date +%s%N)" >&2`);
+	return commands.join(' && ');
+}
+
+function parseSetupDiagnostics(stderr: string): SetupDiagnostics {
+	const timings: Timings = {};
+	const markers: { name: string; at: bigint }[] = [];
+	const setupOutput: string[] = [];
+	let inSetup = false;
+
+	for (const line of stderr.split(/\r?\n/)) {
+		const step = SETUP_STEP_MARKER.exec(line);
+		if (step) {
+			inSetup = true;
+			markers.push({ name: step[1], at: BigInt(step[2]) });
+			continue;
+		}
+		const complete = SETUP_COMPLETE_MARKER.exec(line);
+		if (complete) {
+			markers.push({ name: 'complete', at: BigInt(complete[1]) });
+			inSetup = false;
+			continue;
+		}
+		if (inSetup) setupOutput.push(line);
+	}
+
+	for (let index = 0; index + 1 < markers.length; index++) {
+		const current = markers[index];
+		const next = markers[index + 1];
+		if (current.name === 'complete' || next.at < current.at) continue;
+		timings[current.name] = Math.round(Number(next.at - current.at) / 1_000_000);
+	}
+
+	return { stderr: setupOutput.join('\n').trim(), timings };
+}
+
+function setupDiagnostics(stdout: string, stderr: string): SetupDiagnostics {
+	return parseSetupDiagnostics(stderr.includes(SETUP_MARKER) ? stderr : stdout);
+}
+
+function utf8Tail(value: string, maxBytes: number): string {
+	const encoded = new TextEncoder().encode(value);
+	if (encoded.byteLength <= maxBytes) return value;
+	let start = encoded.byteLength - maxBytes;
+	while ((encoded[start] & 0xc0) === 0x80) start++;
+	return new TextDecoder().decode(encoded.slice(start));
+}
+
+function logSlowSetup(
+	options: ProvisionOptions,
+	setupMs: number,
+	diagnostics: SetupDiagnostics,
+): void {
+	if (setupMs <= SLOW_SANDBOX_SETUP_MS) return;
+	const timingFields = Object.fromEntries(
+		Object.entries(diagnostics.timings).map(([step, ms]) => [`provision_setup_${step}_ms`, ms]),
+	);
+	const record = {
+		ts: new Date().toISOString(),
+		...traceContext(),
+		level: 'warn',
+		event: 'sandbox_setup_slow',
+		sandbox_id: options.sandboxId,
+		project_id: options.projectId,
+		notebook_id: options.notebookId,
+		launch_strategy: options.launchStrategy ?? DEFAULT_LAUNCH_STRATEGY,
+		provision_setup_ms: setupMs,
+		...timingFields,
+		setup_stderr_tail: utf8Tail(diagnostics.stderr, SETUP_OUTPUT_TAIL_BYTES),
+	};
+	try {
+		console.warn(JSON.stringify(record));
+	} catch {}
+	emitLogRecord(record);
+}
 
 function pythonEnvironmentSetupFailure(result: ExecResult): PythonEnvironmentSetupError {
 	const output = `${result.stdout}\n${result.stderr}`;
@@ -679,13 +772,18 @@ export class SandboxProvisioner {
 		};
 		if (startup.plan.setup.length === 0) return startup;
 
-		const command = `cd ${shellQuote(mountPath)} && ${startup.plan.setup.join(' && ')}`;
+		const command = `cd ${shellQuote(mountPath)} && ${instrumentSetup(startup.plan.setup)}`;
+		let diagnostics: SetupDiagnostics | undefined;
 		try {
 			await withSandboxSpan(
 				sw,
 				'setup',
 				async (time) => {
 					const result = await time(() => executeEnvironmentSetup(sandbox, command, startup));
+					diagnostics = setupDiagnostics(result.stdout, result.stderr);
+					for (const [step, ms] of Object.entries(diagnostics.timings)) {
+						sw.timings[`setup_${step}`] = ms;
+					}
 					if (!result.success) throw pythonEnvironmentSetupFailure(result);
 				},
 				{ launch_strategy: options.launchStrategy ?? DEFAULT_LAUNCH_STRATEGY },
@@ -693,6 +791,8 @@ export class SandboxProvisioner {
 		} catch (error) {
 			if (error instanceof PythonEnvironmentSetupError) throw error;
 			throw provisionFailure('preparing the notebook Python environment', error);
+		} finally {
+			if (diagnostics) logSlowSetup(options, sw.timings.setup, diagnostics);
 		}
 		return startup;
 	}

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -76,7 +76,7 @@ describe('buildMarimoLaunch', () => {
 	});
 
 	it('initializes only a pyproject with marimohub metadata', () => {
-		const [, setup] = buildMarimoLaunch(BASE).setup;
+		const [{ command: setup }] = buildMarimoLaunch(BASE).setup;
 		expect(setup).toContain('uv init');
 		expect(setup).toContain('--bare');
 		expect(setup).toContain('--no-package');
@@ -84,22 +84,24 @@ describe('buildMarimoLaunch', () => {
 		expect(setup).toContain('--description "Built in marimohub"');
 	});
 
-	it('restores the image marimo pin if project sync replaced the environment', () => {
-		const [capture, , ensure] = buildMarimoLaunch(BASE).setup;
-		expect(capture).toContain("${MARIMO_VERSION:-$(python3 -c 'import importlib.metadata as m;");
-		expect(capture).toContain('m.distributions()');
-		expect(ensure).toContain('uv pip install');
-		expect(ensure).toContain('marimo==$MARIMOHUB_MARIMO_VERSION');
+	it('names each setup layer for provision timing fields', () => {
+		expect(buildMarimoLaunch(BASE).setup.map(({ name }) => name)).toEqual(['pyproject_layer']);
 	});
 
-	it('continues without restoring marimo when the image provides no version', () => {
-		const [capture, , ensure] = buildMarimoLaunch(BASE).setup;
-		expect(capture).toContain('), ""))');
-		expect(ensure).toContain('[ -z "$MARIMOHUB_MARIMO_VERSION" ] ||');
+	it('leaves the image-owned marimo installation untouched', () => {
+		for (const strategy of ['uv-sync-edit', 'uv-script-pins'] as const) {
+			const setup = buildMarimoLaunch(BASE, strategy)
+				.setup.map(({ command }) => command)
+				.join('\n');
+			expect(setup).toContain('--no-install-package marimo');
+			expect(setup).not.toContain('MARIMOHUB_MARIMO_VERSION');
+			expect(setup).not.toContain('importlib.metadata');
+			expect(setup).not.toContain('marimo==');
+		}
 	});
 
 	it('reserves exit code 2 for no dependencies and propagates TOML parse failures', () => {
-		const [, pyproject] = buildMarimoLaunch(BASE).setup;
+		const [{ command: pyproject }] = buildMarimoLaunch(BASE).setup;
 		expect(pyproject).toContain('import pathlib,sys,tomllib');
 		expect(pyproject).not.toContain("find_spec('tomllib')");
 		expect(pyproject).toContain('else 2');
@@ -111,10 +113,14 @@ describe('buildMarimoLaunch', () => {
 		const plan = buildMarimoLaunch({ ...BASE, notebookFile: 'apps/my app.py' }, 'uv-script-pins');
 
 		it('layers pyproject first, then exports and installs the script pins', () => {
-			expect(plan.setup).toHaveLength(6);
-			const [, pyproject, ensureEnv, ensureMarimo, exportCmd, installCmd] = plan.setup;
+			expect(plan.setup).toHaveLength(4);
+			const [
+				{ command: pyproject },
+				{ command: ensureEnv },
+				{ command: exportCmd },
+				{ command: installCmd },
+			] = plan.setup;
 			expect(pyproject).toContain('uv sync --inexact');
-			expect(ensureMarimo).toContain('marimo==$MARIMOHUB_MARIMO_VERSION');
 			expect(ensureEnv).toContain('uv venv');
 			expect(exportCmd).toContain("uv export --script 'apps/my app.py'");
 			expect(exportCmd).toContain('--format requirements-txt');
@@ -130,7 +136,7 @@ describe('buildMarimoLaunch', () => {
 		it('writes the requirements file inside the pin env', () => {
 			// Per-sandbox and lifecycle-managed on every backend — nothing left on a
 			// shared host /tmp, no clobbering between concurrent local launches.
-			const [, , , , exportCmd, installCmd] = plan.setup;
+			const [, , { command: exportCmd }, { command: installCmd }] = plan.setup;
 			const [, exportTarget] = /-o (\S+)/.exec(exportCmd) ?? [];
 			expect(exportTarget).toBe(
 				'"${UV_PROJECT_ENVIRONMENT:-.venv}/marimohub-script-requirements.txt"',
@@ -139,11 +145,11 @@ describe('buildMarimoLaunch', () => {
 		});
 
 		it('keeps every environment setup layer strict', () => {
-			for (const command of plan.setup) expect(command).not.toContain('|| true');
+			for (const { command } of plan.setup) expect(command).not.toContain('|| true');
 		});
 
 		it('reuses the exact uv-sync-edit pyproject layer', () => {
-			expect(plan.setup[1]).toBe(buildMarimoLaunch(BASE, 'uv-sync-edit').setup[1]);
+			expect(plan.setup[0].command).toBe(buildMarimoLaunch(BASE, 'uv-sync-edit').setup[0].command);
 		});
 
 		it('installs the pins in app mode too (setup is mode-invariant)', () => {
@@ -160,7 +166,7 @@ describe('buildMarimoLaunch', () => {
 				{ ...BASE, notebookFile: "apps/it's a && b.py" },
 				'uv-script-pins',
 			);
-			expect(hostile.setup[4]).toContain(`--script 'apps/it'\\''s a && b.py'`);
+			expect(hostile.setup[2].command).toContain(`--script 'apps/it'\\''s a && b.py'`);
 		});
 	});
 });

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -24,9 +24,14 @@ export interface MarimoLaunchParams {
 
 export interface MarimoLaunchPlan {
 	/** Commands run (via exec, in the notebook dir) before the kernel. */
-	setup: string[];
+	setup: MarimoSetupStep[];
 	/** The long-running command that starts marimo (via startProcess). */
 	start: string;
+}
+
+export interface MarimoSetupStep {
+	name: string;
+	command: string;
 }
 
 export type MarimoLaunchStrategy = (params: MarimoLaunchParams) => MarimoLaunchPlan;
@@ -80,7 +85,7 @@ function marimoCommand(p: MarimoLaunchParams, extraFlags = ''): string {
 // stall the launch. The image must NOT set UV_COMPILE_BYTECODE (it would
 // conflict with --no-compile-bytecode). A failure is fatal: the provisioner
 // reports it as PYTHON_ENV_SETUP_FAILED before starting the kernel.
-const PYPROJECT_LAYER_SETUP = `{ status=0; python3 -c "import pathlib,sys,tomllib;path=pathlib.Path('pyproject.toml');data=tomllib.loads(path.read_text()) if path.exists() else {};sys.exit(0 if data.get('project',{}).get('dependencies') else 2)" || status=$?; if [ "$status" -eq 0 ]; then uv sync --inexact --no-compile-bytecode --no-build; elif [ "$status" -eq 2 ]; then if ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then rm -f pyproject.toml && uv init --bare --no-package --vcs none --name notebook --description "Built in marimohub"; fi; else exit "$status"; fi; }`;
+const PYPROJECT_LAYER_SETUP = `{ status=0; python3 -c "import pathlib,sys,tomllib;path=pathlib.Path('pyproject.toml');data=tomllib.loads(path.read_text()) if path.exists() else {};sys.exit(0 if data.get('project',{}).get('dependencies') else 2)" || status=$?; if [ "$status" -eq 0 ]; then uv sync --inexact --no-install-package marimo --no-compile-bytecode --no-build; elif [ "$status" -eq 2 ]; then if ! grep -q '^\\[project\\]' pyproject.toml 2>/dev/null; then rm -f pyproject.toml && uv init --bare --no-package --vcs none --name notebook --description "Built in marimohub"; fi; else exit "$status"; fi; }`;
 
 // The env the kernel's `uv run --no-sync` will use — uv resolves the project
 // env as UV_PROJECT_ENVIRONMENT, else `.venv` in the project dir. Deliberately
@@ -90,12 +95,6 @@ const PYPROJECT_LAYER_SETUP = `{ status=0; python3 -c "import pathlib,sys,tomlli
 // whose contract pre-creates UV_PROJECT_ENVIRONMENT.
 const PIN_ENV_EXPANSION = '${UV_PROJECT_ENVIRONMENT:-.venv}';
 const PIN_ENV = `"${PIN_ENV_EXPANSION}"`;
-
-// uv replaces the whole environment when requires-python selects another
-// interpreter. Capture the image's marimo pin before sync, then restore it only
-// if the resulting environment no longer contains that version.
-const CAPTURE_MARIMO_VERSION = `MARIMOHUB_MARIMO_VERSION="\${MARIMO_VERSION:-$(python3 -c 'import importlib.metadata as m;print(next((d.version for d in m.distributions() if (d.metadata["Name"] or "").lower() == "marimo"), ""))')}"`;
-const ENSURE_MARIMO = `{ [ -z "$MARIMOHUB_MARIMO_VERSION" ] || [ "$(uv run --no-sync python -c 'import importlib.metadata as m;print(m.version("marimo"))' 2>/dev/null)" = "$MARIMOHUB_MARIMO_VERSION" ] || uv pip install --python ${PIN_ENV} --no-build "marimo==$MARIMOHUB_MARIMO_VERSION"; }`;
 
 // Inside the pin env: per-sandbox on every backend (a container's env dies
 // with it; a local sandbox's .venv is removed with its root), so nothing
@@ -108,12 +107,12 @@ export const MARIMO_LAUNCH_STRATEGIES = {
 	// marimohub's default. The sandbox image pre-installs marimo (pinned) plus
 	// popular libraries into the project env (UV_PROJECT_ENVIRONMENT), so the base
 	// case needs no install and startup is near-instant. A notebook's own deps live
-	// in pyproject.toml; `uv sync --inexact` adds them to that env without removing
-	// the pre-installed base, then `--no-sync` runs marimo straight from it. Unlike
+	// in pyproject.toml; `uv sync --inexact --no-install-package marimo` adds them
+	// without replacing the image-owned marimo, then `--no-sync` runs straight from it. Unlike
 	// marimo's `--sandbox` (which force-refreshes when a notebook declares no
 	// inline deps), this never refetches.
 	'uv-sync-edit': (p) => ({
-		setup: [CAPTURE_MARIMO_VERSION, PYPROJECT_LAYER_SETUP, ENSURE_MARIMO],
+		setup: [{ name: 'pyproject_layer', command: PYPROJECT_LAYER_SETUP }],
 		start: `uv run --no-sync ${marimoCommand(p)}`,
 	}),
 
@@ -124,12 +123,16 @@ export const MARIMO_LAUNCH_STRATEGIES = {
 	// the unhashed base env.
 	'uv-script-pins': (p) => ({
 		setup: [
-			CAPTURE_MARIMO_VERSION,
-			PYPROJECT_LAYER_SETUP,
-			`{ [ -d ${PIN_ENV} ] || uv venv ${PIN_ENV}; }`,
-			ENSURE_MARIMO,
-			`uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt --no-hashes --prune marimo -o ${SCRIPT_REQUIREMENTS}`,
-			`uv pip install --python ${PIN_ENV} --no-build -r ${SCRIPT_REQUIREMENTS}`,
+			{ name: 'pyproject_layer', command: PYPROJECT_LAYER_SETUP },
+			{ name: 'ensure_pin_env', command: `{ [ -d ${PIN_ENV} ] || uv venv ${PIN_ENV}; }` },
+			{
+				name: 'export_script_pins',
+				command: `uv export --script ${shellQuote(p.notebookFile)} --format requirements-txt --no-hashes --prune marimo -o ${SCRIPT_REQUIREMENTS}`,
+			},
+			{
+				name: 'install_script_pins',
+				command: `uv pip install --python ${PIN_ENV} --no-build -r ${SCRIPT_REQUIREMENTS}`,
+			},
 		],
 		start: `uv run --no-sync ${marimoCommand(p)}`,
 	}),


### PR DESCRIPTION
Logs a `sandbox_setup_slow` event when environment setup exceeds two seconds, including the active trace context, bounded uv stderr, total setup time, and timings for each named setup step.

Keeps marimo owned by the sandbox image by pruning it from script pins, excluding it from `uv sync`, and removing the version check and reinstall path.