### PR TITLE
compute-coreweave: drop the mkdir exec before AddFile

### DIFF
--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -384,7 +384,7 @@ describe('CoreWeaveCompute', () => {
 			]);
 
 			const fake = [...world.registry.values()][0].fake;
-			// AddFile creates parents itself, so a write costs no command round-trip.
+			// No mkdir round-trip: AddFile creates parents.
 			expect(fake.runCalls).toHaveLength(0);
 			expect(inst.drainCounters!()).toEqual({ execs: 0 });
 			// The whole set goes to the SDK in ONE write call, bytes passed through
@@ -412,7 +412,7 @@ describe('CoreWeaveCompute', () => {
 			await inst.writeFiles([{ path: '/workspace/notebook.py', content: 'x' }]);
 			const fake = world.registry.get('cw-1')!.fake;
 			expect(fake.runCalls).toHaveLength(0);
-			// The bootstrap still rides the first real command.
+			// Bootstrap rides the next command.
 			await inst.exec('true');
 			expect(fake.runCalls).toHaveLength(1);
 			expect(fake.runCalls[0][2]).toContain('addressing_style = virtual');
@@ -431,11 +431,11 @@ describe('CoreWeaveCompute', () => {
 				});
 				await inst.writeFiles([{ path: '/mnt/ada@example.com/notes.md', content: 'x' }]);
 				const fake = world.registry.get('cw-1')!.fake;
-				// The link must exist before AddFile can `mkdir -p` a plain dir in its place.
+				// Link first, or AddFile creates a plain dir in its place.
 				expect(fake.runCalls).toHaveLength(1);
 				expect(fake.runCalls[0][2]).toContain("ln -s '/var/run/marimohub/user-home'");
 				expect(fake.batchWrites).toHaveLength(1);
-				// Consumed: a later command carries no second bootstrap.
+				// Consumed once.
 				await inst.exec('true');
 				expect(fake.runCalls[1][2]).not.toContain('ln -s');
 			} finally {
@@ -936,7 +936,7 @@ describe('CoreWeaveCompute', () => {
 			const fake = [...world.registry.values()][0].fake;
 			// The bytes ride the SDK write API verbatim…
 			expect(fake.batchWrites.at(-1)![0].content).toBe(big);
-			// …and no exec argv carries them (there is none at all).
+			// …and no exec carries them.
 			expect(fake.runCalls).toHaveLength(0);
 		});
 

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -373,7 +373,7 @@ describe('CoreWeaveCompute', () => {
 	});
 
 	describe('writeFiles()', () => {
-		it('collapses the per-file mkdirs into one exec, then writes the set in one call', async () => {
+		it('writes the set in one call with no exec in front of it', async () => {
 			const world = makeWorld();
 			const inst = makeCompute(world).create(SANDBOX_ID, { reuse: false });
 
@@ -384,11 +384,9 @@ describe('CoreWeaveCompute', () => {
 			]);
 
 			const fake = [...world.registry.values()][0].fake;
-			// One mkdir covering both parents (deduped) — not one per file.
-			const mkdirs = fake.runCalls.filter((c) => c[2]?.startsWith('mkdir -p '));
-			expect(mkdirs).toHaveLength(1);
-			expect(mkdirs[0][2]).toContain(`'/w'`);
-			expect(mkdirs[0][2]).toContain(`'/w/data'`);
+			// AddFile creates parents itself, so a write costs no command round-trip.
+			expect(fake.runCalls).toHaveLength(0);
+			expect(inst.drainCounters!()).toEqual({ execs: 0 });
 			// The whole set goes to the SDK in ONE write call, bytes passed through
 			// verbatim (FileContent is string | Uint8Array — no base64 armoring).
 			expect(fake.batchWrites).toHaveLength(1);
@@ -403,6 +401,46 @@ describe('CoreWeaveCompute', () => {
 			const world = makeWorld();
 			await makeCompute(world).create(SANDBOX_ID, { reuse: false }).writeFiles([]);
 			expect(world.created).toHaveLength(0); // never even resolves the sandbox
+		});
+
+		it('defers the armed bootstrap past writes outside the user home', async () => {
+			const world = makeWorld();
+			const inst = makeCompute(world, { ...baseConfig, objectStorageBuckets: ['org-data'] }).create(
+				SANDBOX_ID,
+				{ reuse: false },
+			);
+			await inst.writeFiles([{ path: '/workspace/notebook.py', content: 'x' }]);
+			const fake = world.registry.get('cw-1')!.fake;
+			expect(fake.runCalls).toHaveLength(0);
+			// The bootstrap still rides the first real command.
+			await inst.exec('true');
+			expect(fake.runCalls).toHaveLength(1);
+			expect(fake.runCalls[0][2]).toContain('addressing_style = virtual');
+		});
+
+		it('flushes the armed bootstrap before a write beneath the user home', async () => {
+			const world = makeWorld();
+			const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+			try {
+				const inst = makeCompute(world, {
+					...baseConfig,
+					userHomeProfileNames: ['marimohub-user-home'],
+				}).create(SANDBOX_ID, {
+					reuse: false,
+					userHome: { key: 'ada@example.com', path: '/mnt/ada@example.com' },
+				});
+				await inst.writeFiles([{ path: '/mnt/ada@example.com/notes.md', content: 'x' }]);
+				const fake = world.registry.get('cw-1')!.fake;
+				// The link must exist before AddFile can `mkdir -p` a plain dir in its place.
+				expect(fake.runCalls).toHaveLength(1);
+				expect(fake.runCalls[0][2]).toContain("ln -s '/var/run/marimohub/user-home'");
+				expect(fake.batchWrites).toHaveLength(1);
+				// Consumed: a later command carries no second bootstrap.
+				await inst.exec('true');
+				expect(fake.runCalls[1][2]).not.toContain('ln -s');
+			} finally {
+				warn.mockRestore();
+			}
 		});
 	});
 
@@ -845,18 +883,12 @@ describe('CoreWeaveCompute', () => {
 			});
 		});
 
-		it('writeFiles creates the parent directory first (nested path)', async () => {
+		it('writeFiles leaves parent-directory creation to AddFile (nested path)', async () => {
 			const world = makeWorld();
 			const inst = makeCompute(world).create(SANDBOX_ID);
 			await inst.writeFiles([{ path: '/tmp/marimohub-config/marimo/marimo.toml', content: 'x' }]);
 			const fake = [...world.registry.values()][0].fake;
-			expect(
-				fake.runCalls.some(
-					(c) =>
-						c.join(' ').includes('mkdir -p') &&
-						c.join(' ').includes('/tmp/marimohub-config/marimo'),
-				),
-			).toBe(true);
+			expect(fake.runCalls.some((c) => c.join(' ').includes('mkdir -p'))).toBe(false);
 			expect(fake.batchWrites.at(-1)![0]).toMatchObject({
 				path: '/tmp/marimohub-config/marimo/marimo.toml',
 				content: 'x',
@@ -904,10 +936,8 @@ describe('CoreWeaveCompute', () => {
 			const fake = [...world.registry.values()][0].fake;
 			// The bytes ride the SDK write API verbatim…
 			expect(fake.batchWrites.at(-1)![0].content).toBe(big);
-			// …and no exec argv (only the small mkdir) carries them.
-			for (const call of fake.runCalls) {
-				expect(call[2].length).toBeLessThan(big.length);
-			}
+			// …and no exec argv carries them (there is none at all).
+			expect(fake.runCalls).toHaveLength(0);
 		});
 
 		it('exposePort rejects when resolveExposedUrl throws', async () => {

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -519,19 +519,12 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	async writeFiles(files: readonly SandboxFileWrite[]): Promise<void> {
 		if (files.length === 0) return;
 		const sandbox = await this.ensure();
-		// The gateway's AddFile `mkdir -p`s the parent itself (confirmed with
-		// CoreWeave), so no exec precedes the write: the provision's `files` and
-		// `inject` phases each cost one AddFile round-trip, and the armed bootstrap
-		// rides the first real command (`setup`) instead.
-		//
-		// The one ordering hazard: the bootstrap is what links the user home into
-		// place, and a write beneath that path before the link exists would
-		// materialize it as a plain directory — so flush the bootstrap first in that
-		// case. Nothing on the provision path writes there today.
+		// AddFile creates parent directories itself. The bootstrap links the user
+		// home into place, so a write beneath it must not race ahead of that.
 		if (this.pendingBootstrap && this.writesUnderUserHome(files)) {
 			await this.exec('true');
 		}
-		// The SDK's FileContent is `string | Uint8Array`, so bytes pass straight through.
+		// FileContent is `string | Uint8Array`, so bytes pass straight through.
 		await sandbox.files.write(files.map((f) => ({ path: f.path, content: f.content })));
 	}
 

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -311,8 +311,6 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	private lastEnsureTimings?: Timings;
 	/** Shell snippet to splice onto the next command; see `takeBootstrap`. */
 	private pendingBootstrap?: string;
-	/** Directories already `mkdir -p`'d in this sandbox, so re-issuing is skipped. */
-	private readonly createdDirs = new Set<string>();
 	/** Blocking commands sent to this sandbox — one wide-event field per provision. */
 	private execCount = 0;
 
@@ -521,22 +519,27 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	async writeFiles(files: readonly SandboxFileWrite[]): Promise<void> {
 		if (files.length === 0) return;
 		const sandbox = await this.ensure();
-		// The SDK's files.write does not create parent dirs, so mkdir first — once for
-		// every parent, not per file. Its multi-file write is Promise.all over per-file
-		// RPCs, so collapsing these execs (not the writes) is what removes round-trips.
-		// Dirs already created in this sandbox are skipped, so a workspace restored in
-		// N byte-bounded batches pays one mkdir rather than N.
-		const dirs = new Set<string>();
-		for (const f of files) {
-			const dir = f.path.slice(0, f.path.lastIndexOf('/'));
-			if (dir && !this.createdDirs.has(dir)) dirs.add(dir);
-		}
-		if (dirs.size > 0) {
-			await this.exec(`mkdir -p ${[...dirs].map(shellQuote).join(' ')}`);
-			for (const dir of dirs) this.createdDirs.add(dir);
+		// The gateway's AddFile `mkdir -p`s the parent itself (confirmed with
+		// CoreWeave), so no exec precedes the write: the provision's `files` and
+		// `inject` phases each cost one AddFile round-trip, and the armed bootstrap
+		// rides the first real command (`setup`) instead.
+		//
+		// The one ordering hazard: the bootstrap is what links the user home into
+		// place, and a write beneath that path before the link exists would
+		// materialize it as a plain directory — so flush the bootstrap first in that
+		// case. Nothing on the provision path writes there today.
+		if (this.pendingBootstrap && this.writesUnderUserHome(files)) {
+			await this.exec('true');
 		}
 		// The SDK's FileContent is `string | Uint8Array`, so bytes pass straight through.
 		await sandbox.files.write(files.map((f) => ({ path: f.path, content: f.content })));
+	}
+
+	private writesUnderUserHome(files: readonly SandboxFileWrite[]): boolean {
+		const home = this.userHome?.path;
+		if (!home) return false;
+		const prefix = home.endsWith('/') ? home : `${home}/`;
+		return files.some((f) => f.path === home || f.path.startsWith(prefix));
 	}
 
 	async listFiles(path: string, options?: ListFilesOptions): Promise<ListFilesResult> {


### PR DESCRIPTION

Every `writeFiles` on CoreWeave ran a `sh -lc 'mkdir -p …'` exec before its `AddFile` RPCs, on the assumption that the SDK does not create parent directories. CoreWeave confirmed the gateway's `AddFile` does `mkdir -p` on the parent itself (fails only if an ancestor is unwritable or is a file), so that exec was pure overhead.

- `CoreWeaveSandboxInstance.writeFiles` goes straight to `files.write`; the `createdDirs` bookkeeping is gone.
- The armed bootstrap (AWS `~/.aws/config`, user-home symlink) used to ride that first mkdir; it now rides the first real command, which on the provision path is `setup`. That is still before the kernel starts, and nothing in `files`/`inject` depends on it (`/workspace`, `/tmp/marimohub-config`, `/tmp/marimohub-integrations`).
- One ordering hazard guarded: a write beneath `userHome.path` before the bootstrap has linked it would make `AddFile` materialize a plain directory there. `writeFiles` flushes the pending bootstrap first in that case. Nothing writes there today.

The `writeFiles` port contract ("creates parent directories") is unchanged — it's now fulfilled by the gateway.
