### PR TITLE
Add bottom page padding and restyle suspend button

### DIFF
--- a/packages/web/src/components/Admin/AdminUsersPage.tsx
+++ b/packages/web/src/components/Admin/AdminUsersPage.tsx
@@ -151,7 +151,12 @@ export default function AdminUsersPage() {
 									>
 										<Button
 											size="sm"
-											variant={user.suspended_at ? 'default' : 'danger'}
+											variant={user.suspended_at ? 'default' : 'ghost'}
+											className={
+												user.suspended_at
+													? undefined
+													: 'text-destructive hover:bg-destructive/10 hover:text-destructive'
+											}
 											isDisabled={isSelfSuspend}
 											onPress={() => suspensionDialog.open(user)}
 										>

--- a/packages/web/src/components/ui/PageLayout.tsx
+++ b/packages/web/src/components/ui/PageLayout.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react';
 export function PageContainer({ children }: { children: ReactNode }) {
 	return (
 		<div className="flex flex-1 justify-center overflow-y-auto p-8 max-md:p-3">
-			<div className="w-full max-w-3xl">{children}</div>
+			<div className="w-full max-w-3xl pb-8 max-md:pb-5">{children}</div>
 		</div>
 	);
 }


### PR DESCRIPTION
Adds bottom padding to `PageContainer` so scrollable content isn't flush against the viewport edge, and restyles the admin suspend-user button from a solid danger button to a ghost variant with destructive text.