### PR TITLE
Pre-release cleanup: extensible admin enums, launch-protocol DRY, docs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -172,11 +172,12 @@ It is the one grant that overrides the per-project role model. Only super admins
 can manage [organization-wide integrations](./integrations.md#organization-wide-integrations).
 Project roles never grant this access.
 
-The web application gives super admins deployment users, settings, and audit-log
-pages. From the users page they can suspend or reactivate anyone except
-themselves. The audit page uses `GET /api/v1/events`. This endpoint returns at
-most 30 UTC days per query. Project managers retain access to each project's
-daily audit log.
+The web application gives super admins access to the users, settings, audit-log,
+and debug pages. They can suspend or reactivate any other user from the users
+page. The audit page uses `GET /api/v1/events`, which returns at most 30 UTC days
+per query. The debug page runs the
+[sandbox startup diagnostic](./operations.md#sandbox-startup-diagnostic).
+Project managers retain access to each project's daily audit log.
 
 Existing non-owner Admin memberships remain valid and can be demoted or removed,
 but the API does not allow new Admin assignments. A deployment introducing

--- a/docs/deploying/cks.md
+++ b/docs/deploying/cks.md
@@ -578,9 +578,9 @@ Sandbox pods run on your sandbox node pool and pull `MARIMOHUB_COMPUTE_IMAGE`
 through the node's image cache. A node that does not have the tag yet pays a
 full registry pull on the session's critical path (≈20 s for a 650 MB image
 from ghcr.io), and a registry hiccup fails the start outright. This hits every
-new node in the pool and every tag you roll. The `coreweave_ensure` and
-`sandbox_startup_diagnostic` log events flag it: `boot_ms` over 10 s carries a
-`slow_boot_hint`.
+new node in the pool and every tag you roll. Both `coreweave_ensure` and
+[`sandbox_startup_diagnostic`](../operations.md#sandbox-startup-diagnostic) flag
+this condition. A `boot_ms` value of more than 10 s includes a `slow_boot_hint`.
 
 Keep every tag warm with a DaemonSet on the pool — one init container per
 image, then an idle holder:

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -143,8 +143,10 @@ kubectl -n marimo-kernels describe pod mh-<id>       # conditions + events
 
 Large `image_pull_ms` → steps 1–2. Large `schedule_ms` → step 3. Large
 `waitport_ms` with the others small → the kernel env itself is slow to boot
-(e.g. `uv` resolving packages on first run — see
-[Sandbox image](../sandbox-image.md)).
+(for example, `uv` resolving packages on the first run — see
+[Sandbox image](../sandbox-image.md)). Super admins can reproduce a cold start
+with the
+[sandbox startup diagnostic](../operations.md#sandbox-startup-diagnostic).
 
 ## Topology
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -20,6 +20,25 @@ the image".
 - `GET /api/v1/version` → deploy version, image, backends, and process start time;
   handy for confirming what's running.
 
+### Sandbox startup diagnostic
+
+Super admins can measure sandbox startup from the **Admin → Debug** page. This
+session-only page calls `POST /api/v1/admin/debug/sandbox-startup` and rejects
+PATs.
+
+Each run creates a temporary sandbox with the selected image and compute
+profile. A fixed echo command checks readiness. A second echo measures
+steady-state exec latency. The diagnostic always destroys the sandbox. It
+reports create, readiness, exec, cleanup, and backend startup timings.
+
+An optional environment-setup benchmark runs a fresh `uv sync` for a pinned
+package that is not in the base image. It also measures a runtime and CPU-limit
+probe and wheel-download throughput.
+
+A bucket lease limits each admin to one active diagnostic. A concurrent request
+returns `429`. Each run emits a `sandbox_startup_diagnostic` wide log event with
+the same timings as the report.
+
 At boot the server runs the same preflight and logs each check. The two failure
 classes behave differently on purpose:
 
@@ -106,7 +125,9 @@ over inline literals so they stay out of `helm get values`. A secrets manager
 
 The server emits **structured wide-event logs** (one JSON line per request /
 maintenance cycle) carrying backend signals — catalog CAS contention, reaper
-activity, snapshot timing. Ship stdout to your log pipeline and alert on
+activity, snapshot timing. When a sandbox environment setup takes longer than
+2 s, a `sandbox_setup_slow` warning records per-step timings and up to 4 KiB of
+trailing stderr. Ship stdout to your log pipeline and alert on
 `level: error` events (e.g. `boot_failed`, `unhandled_rejection`). Set an OTLP
 endpoint (see [Logs](#logs-opentelemetry) below) to also ship these lines over
 OpenTelemetry, so they outlive the pod after a redeploy.
@@ -118,7 +139,12 @@ tracing: one SERVER span per request through the Hono server, honoring inbound
 W3C `traceparent` headers, with nested spans for every domain-service and
 storage call (`NotebookService.getNotebook`, `Bucket.get`, …). Span attributes
 are limited to resource identifiers and bucket keys — request payloads,
-tokens, and emails are never recorded. `OTEL_SERVICE_NAME`, `OTEL_TRACES_SAMPLER` /
+tokens, and emails are never recorded. Sandbox provisioning emits phase spans
+such as `sandbox.reachable`, `sandbox.files`, `sandbox.setup`, and
+`sandbox.waitport`. The CoreWeave compute adapter emits a CLIENT span for each
+gateway request. These spans contain only endpoint, method, timing, and sandbox
+ID attributes. They never contain request payloads or credentials.
+`OTEL_SERVICE_NAME`, `OTEL_TRACES_SAMPLER` /
 `OTEL_TRACES_SAMPLER_ARG`, `OTEL_EXPORTER_OTLP_HEADERS`, and
 `OTEL_SDK_DISABLED` behave per the [OTEL spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
 Only the OTLP exporter (the spec default) is implemented; any other

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -55,13 +55,13 @@ marimohub copies the notebook into the image and launches the kernel itself,
 reusing the image's pre-installed environment. With cwd `/workspace`:
 
 ```sh
-uv sync --inexact --no-compile-bytecode   # add the notebook's deps to the base env (skipped when it declares none)
+uv sync --inexact --no-install-package marimo --no-compile-bytecode --no-build   # add the notebook's deps (skipped when it declares none)
 uv run --no-sync marimo edit notebook.py --headless --no-token --host 0.0.0.0 --port 2718
 ```
 
-Before `uv sync`, marimohub records the pinned marimo version from
-`MARIMO_VERSION` or the installed package. If uv replaces the environment to
-change Python versions, marimohub reinstalls that version before the kernel starts.
+During the sync, `--no-install-package marimo` keeps the image's pinned marimo
+version even if the notebook declares another version. `--no-build` permits only
+wheels, so a source build cannot run arbitrary code or delay startup.
 
 If a git-synced notebook's entry file contains
 [PEP 723](https://peps.python.org/pep-0723/) inline metadata, marimohub runs three

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,6 +108,9 @@ this). See [Sandbox image](/sandbox-image).
 Pre-install marimo and common libraries into the image's project environment so
 the startup `uv sync --inexact` only adds notebook-specific dependencies. See
 [Sandbox image → Why pre-install (not just cache)](/sandbox-image#why-pre-install-not-just-cache).
+Super admins can use **Admin → Debug** to run the
+[sandbox startup diagnostic](/operations#sandbox-startup-diagnostic) and measure
+each startup phase.
 
 ### Kubernetes kernel stays Pending or reports Unschedulable
 

--- a/examples/e2b-template/README.md
+++ b/examples/e2b-template/README.md
@@ -50,7 +50,7 @@ marimo + the base libraries are pre-installed into `/opt/venv`
 starts instantly for a notebook that only uses them:
 
 ```sh
-uv sync --inexact --no-compile-bytecode   # add the notebook's deps, keep the base
+uv sync --inexact --no-install-package marimo --no-compile-bytecode --no-build   # add the notebook's deps, keep the base
 uv run --no-sync marimo edit notebook.py …
 ```
 

--- a/examples/sandbox-image/README.md
+++ b/examples/sandbox-image/README.md
@@ -37,7 +37,7 @@ deliberate, manual step, never automatic.
 The provisioner runs in `/workspace`:
 
 ```sh
-uv sync --inexact --no-compile-bytecode   # add the notebook's deps, keep the pre-installed base
+uv sync --inexact --no-install-package marimo --no-compile-bytecode --no-build   # add the notebook's deps, keep the pre-installed base
 uv run --no-sync marimo edit notebook.py …
 ```
 

--- a/examples/sandbox-image/acceptance-test.sh
+++ b/examples/sandbox-image/acceptance-test.sh
@@ -119,7 +119,7 @@ TOML
 launch_kernel() { # $1 = container id
 	docker exec "$1" sh -lc '
 		cd /workspace
-		[ ! -s pyproject.toml ] || uv sync --inexact --no-compile-bytecode --no-build
+		[ ! -s pyproject.toml ] || uv sync --inexact --no-install-package marimo --no-compile-bytecode --no-build
 	'
 	docker exec -d "$1" sh -lc '
 		cd /workspace

--- a/examples/sandbox-image/acceptance-test.sh
+++ b/examples/sandbox-image/acceptance-test.sh
@@ -174,27 +174,30 @@ got="$(docker run --rm "$IMAGE" sh -lc 'cd /workspace && uv run --no-sync python
 [ "$got" = "$mv" ] || fail "pre-installed marimo is ${got:-none}, expected pinned $mv"
 ok "marimo pinned to $mv (pre-installed; launch never upgrades it)"
 
-# --- 2c. a notebook may replace the warm env with a newer Python ------------
-echo "==> 2c. Python-version replacement"
+# --- 2c. a requires-python bump replaces the warm env; marimo is image-owned -
+# Mirrors the active setup steps in marimoLaunch.ts (`uv sync
+# --no-install-package marimo`, then script pins with `--prune marimo`): the
+# image must let uv replace the whole environment (writable env parent), and
+# marimo is never reinstalled into the replaced env — the launch flow keeps it
+# image-owned, so neither the sync nor the notebook's own `marimo!=` pin may
+# put a different marimo there.
+echo "==> 2c. Python-version replacement (marimo stays image-owned)"
 cid="$(run_detached "$IMAGE" sleep infinity)"
 provision_python314_notebook "$cid" "$mv"
 docker exec "$cid" sh -lc '
 	set -e
 	cd /workspace
-	marimohub_marimo_version="${MARIMO_VERSION:-$(python3 -c "import importlib.metadata as m;print(m.version(\"marimo\"))")}"
-	uv sync --inexact --no-compile-bytecode --no-build
-	installed_marimo="$(uv run --no-sync python -c "import importlib.metadata as m;print(m.version(\"marimo\"))" 2>/dev/null || true)"
-	[ "$installed_marimo" = "$marimohub_marimo_version" ] || \
-		uv pip install --python "$UV_PROJECT_ENVIRONMENT" --no-build \
-			"marimo==$marimohub_marimo_version"
+	uv sync --inexact --no-install-package marimo --no-compile-bytecode --no-build
+	[ -d "$UV_PROJECT_ENVIRONMENT" ] || uv venv "$UV_PROJECT_ENVIRONMENT"
 	uv export --script notebook.py --format requirements-txt --no-hashes --prune marimo \
 		-o "$UV_PROJECT_ENVIRONMENT/marimohub-script-requirements.txt"
 	uv pip install --python "$UV_PROJECT_ENVIRONMENT" --no-build \
 		-r "$UV_PROJECT_ENVIRONMENT/marimohub-script-requirements.txt"
 	uv run --no-sync python -c \
-		"import click,marimo,os,sys; assert sys.version_info[:2] >= (3,14); assert marimo.__version__ == os.environ[\"MARIMO_VERSION\"]"
-' || fail "uv could not replace the warm environment with Python 3.14"
-ok "Python 3.14 replaces the warm environment and starts with script pins"
+		"import click,requests,sys; assert sys.version_info[:2] >= (3,14)"
+	! uv run --no-sync python -c "import marimo" 2>/dev/null
+' || fail "requires-python bump: env not replaced, script pins failed, or marimo leaked into the replaced env"
+ok "uv replaces the env for requires-python >= 3.14; marimo stays image-owned (never reinstalled)"
 docker rm -f "$cid" >/dev/null 2>&1
 
 # --- 3. provisioner flow: kernel serves HTTP 200 on 2718 ---------------------

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -805,6 +805,10 @@ components:
             - ok
             - failed
             - skipped
+            - unknown
+          description: 'Known values: ok, failed, skipped. Unrecognized values normalize
+            to unknown.'
+          example: ok
         duration_ms:
           type:
             - number
@@ -834,6 +838,10 @@ components:
                 - COMMAND_FAILED
                 - SPAWN_FAILED
                 - BACKEND_ERROR
+                - unknown
+              description: 'Known values: COMMAND_FAILED, SPAWN_FAILED, BACKEND_ERROR.
+                Unrecognized values normalize to unknown.'
+              example: COMMAND_FAILED
           required:
             - command
             - stdout
@@ -5193,7 +5201,8 @@ paths:
         are returned as a partial report. Super-admin only and session-only.
       security: *a2
       requestBody:
-        required: true
+        required: false
+        description: Optional; omit to use the deployment defaults.
         content:
           application/json:
             schema:

--- a/packages/api/src/log.ts
+++ b/packages/api/src/log.ts
@@ -1,18 +1,9 @@
-/**
- * Minimal structured logger. Emits one JSON object per event so lines are
- * machine-parseable in log aggregators (no pino/winston — keeps the Cloudflare
- * Workers build dependency-free; `traceContext` is the pure OTEL facade, so
- * that still holds).
- */
-import { emitLogRecord, traceContext } from '@marimo-hub/core';
+// `logEvent` lives in core (next to the OTEL logs bridge it mirrors into) so
+// core services and adapters can emit the same wide events; re-exported here
+// for the API's existing call sites.
+import { logEvent } from '@marimo-hub/core';
 
-export function logEvent(fields: Record<string, unknown>): void {
-	const record = { ts: new Date().toISOString(), ...traceContext(), ...fields };
-	console.log(JSON.stringify(record));
-	// Mirror to the OTEL logs pipeline (a no-op facade until an entrypoint wires a
-	// LoggerProvider — the Cloudflare Worker never does, so its build stays clean).
-	emitLogRecord(record);
-}
+export { logEvent };
 
 /**
  * An error's identity with no free-form text — enough to triage a provider

--- a/packages/api/src/routes/admin.test.ts
+++ b/packages/api/src/routes/admin.test.ts
@@ -514,6 +514,20 @@ describe('Admin routes', () => {
 			});
 		});
 
+		it('accepts a request with no body at all', async () => {
+			const { instance } = makeFakeSandbox();
+			const { compute, create } = computeFor(instance);
+			const { request } = superAdminApi({ compute, sandbox: sandboxConfig });
+
+			const report = await expectOk<any>(await request('POST', '/admin/debug/sandbox-startup'));
+			expect(create).toHaveBeenCalledTimes(1);
+			expect(report).toMatchObject({
+				image: 'registry.example/sandbox:default',
+				compute_profile: 'small',
+				environment_setup_benchmark: null,
+			});
+		});
+
 		it('rejects unknown configured selections before creating a sandbox', async () => {
 			const { instance } = makeFakeSandbox();
 			const { compute, create } = computeFor(instance);

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -19,7 +19,7 @@ import {
 	createApp,
 	DeploymentConfigResponseSchema,
 	errorResponses,
-	jsonBody,
+	extensibleResponseEnum,
 	jsonContent,
 	SESSION_ONLY_SECURITY,
 	toComputeResourcesResponse,
@@ -119,7 +119,7 @@ const SLOW_BOOT_HINT =
 
 const SandboxStartupPhaseSchema = z
 	.object({
-		status: z.enum(['ok', 'failed', 'skipped']),
+		status: extensibleResponseEnum(['ok', 'failed', 'skipped'], 'ok'),
 		duration_ms: z.number().nonnegative().nullable(),
 		error: z.record(z.string(), z.unknown()).optional(),
 	})
@@ -129,7 +129,10 @@ const SandboxStartupCommandSchema = SandboxStartupPhaseSchema.extend({
 	command: z.string().openapi({ example: ECHO_COMMAND }),
 	stdout: z.string(),
 	stderr: z.string(),
-	failure_code: z.enum(['COMMAND_FAILED', 'SPAWN_FAILED', 'BACKEND_ERROR']).optional(),
+	failure_code: extensibleResponseEnum(
+		['COMMAND_FAILED', 'SPAWN_FAILED', 'BACKEND_ERROR'],
+		'COMMAND_FAILED',
+	).optional(),
 }).openapi('SandboxStartupCommand');
 
 const SandboxStartupRequestSchema = z
@@ -372,7 +375,13 @@ const testSandboxStartup = createRoute({
 		'and CPU throttling counters. The sandbox is always destroyed. Runtime failures are returned ' +
 		'as a partial report. Super-admin only and session-only.',
 	security: SESSION_ONLY_SECURITY,
-	request: { body: jsonBody(SandboxStartupRequestSchema) },
+	request: {
+		body: {
+			content: { 'application/json': { schema: SandboxStartupRequestSchema } },
+			required: false,
+			description: 'Optional; omit to use the deployment defaults.',
+		},
+	},
 	responses: {
 		200: jsonContent(
 			z.object({ success: z.literal(true), data: SandboxStartupReportSchema }),
@@ -490,7 +499,7 @@ app.openapi(testSandboxStartup, async (c) => {
 	assertSessionAuthenticated(c, 'run sandbox startup diagnostics');
 	assertSuperAdmin(user, deps.policy);
 
-	const body = c.req.valid('json');
+	const body = c.req.valid('json') ?? {};
 	const image = selectedImage(deps.sandbox.images ?? [], body.image);
 	const profile = selectedComputeProfile(
 		deps.sandbox.computeProfiles ?? [],

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -1707,8 +1707,12 @@ export interface components {
 			environment_setup_benchmark: components['schemas']['SandboxEnvironmentSetupBenchmark'];
 		};
 		SandboxStartupPhase: {
-			/** @enum {string} */
-			status: 'ok' | 'failed' | 'skipped';
+			/**
+			 * @description Known values: ok, failed, skipped. Unrecognized values normalize to unknown.
+			 * @example ok
+			 * @enum {string}
+			 */
+			status: 'ok' | 'failed' | 'skipped' | 'unknown';
 			duration_ms: number | null;
 			error?: {
 				[key: string]: unknown;
@@ -1719,8 +1723,12 @@ export interface components {
 			command: string;
 			stdout: string;
 			stderr: string;
-			/** @enum {string} */
-			failure_code?: 'COMMAND_FAILED' | 'SPAWN_FAILED' | 'BACKEND_ERROR';
+			/**
+			 * @description Known values: COMMAND_FAILED, SPAWN_FAILED, BACKEND_ERROR. Unrecognized values normalize to unknown.
+			 * @example COMMAND_FAILED
+			 * @enum {string}
+			 */
+			failure_code?: 'COMMAND_FAILED' | 'SPAWN_FAILED' | 'BACKEND_ERROR' | 'unknown';
 		};
 		/** @description The optional fixed-package benchmark, or null when it was not requested */
 		SandboxEnvironmentSetupBenchmark: {
@@ -4945,7 +4953,8 @@ export interface operations {
 			path?: never;
 			cookie?: never;
 		};
-		requestBody: {
+		/** @description Optional; omit to use the deployment defaults. */
+		requestBody?: {
 			content: {
 				'application/json': components['schemas']['SandboxStartupRequest'];
 			};

--- a/packages/compute-cloudflare/src/index.test.ts
+++ b/packages/compute-cloudflare/src/index.test.ts
@@ -5,6 +5,7 @@ import { listFilesFailure } from '@marimo-hub/core/ports';
 import {
 	computeContract,
 	CONTRACT_NON_DIRECTORY_PATH,
+	scriptContractLaunch,
 } from '@marimo-hub/core/testing/compute-contract';
 
 /**
@@ -466,6 +467,20 @@ function primeContractFakes() {
 				: { success: true, stdout: '', stderr: '' },
 	);
 	fakeSandbox.execStream.mockImplementation(async () => new ReadableStream());
+	// The adapter's launch rides the SDK process API (launchWithProcess): script
+	// the supervisor transcript into getLogs and answer readiness per the script.
+	fakeSandbox.startProcess.mockImplementation(async (cmd: string) => {
+		const launch = scriptContractLaunch(cmd);
+		return {
+			id: 'contract-proc',
+			command: cmd,
+			kill: async () => {},
+			waitForPort: async (port: number) => {
+				if (!launch?.portOpen) throw new Error(`timed out waiting for port ${port}`);
+			},
+			getLogs: async () => ({ stdout: '', stderr: launch?.transcript ?? '' }),
+		};
+	});
 	fakeSandbox.readFile.mockImplementation(async () => ({ success: false }));
 	fakeSandbox.writeFile.mockResolvedValue(undefined);
 	fakeSandbox.listFiles.mockImplementation(async () => ({ success: true, files: [] }));
@@ -486,6 +501,7 @@ computeContract(
 	{
 		semantics: {
 			failingCommand: 'mh-contract-fail',
+			launch: {},
 			// The SDK failure shape does not distinguish an absent file.
 			absentFile: { path: '/contract-absent.txt', code: 'READ_FAILED' },
 		},

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -527,6 +527,13 @@ describe('launch protocol', () => {
 		});
 	});
 
+	it('keeps a marker followed by a non-object payload as ordinary output', () => {
+		const marker = '__MARIMOHUB_LAUNCH_n1__';
+		const stdout = `${marker}null\n${marker}5\n${marker}"ready"\n${marker}[1]\n`;
+		const parsed = parseLaunchOutput({ stdout, stderr: '' }, 'n1');
+		expect(parsed).toEqual({ stdout, stderr: '', outcome: undefined });
+	});
+
 	it('preserves output before a protocol record in the same fragmented line', () => {
 		const marker = '__MARIMOHUB_LAUNCH_n1__';
 		const parsed = parseLaunchOutput(
@@ -792,6 +799,15 @@ describe('OutputTail', () => {
 describe('LaunchProtocolTracker', () => {
 	const marker = '__MARIMOHUB_LAUNCH_n1__';
 	const readyLine = `${marker}{"event":"ready","setupMs":3,"waitportMs":4}\n`;
+
+	it('ignores a marker with a non-object payload without throwing', () => {
+		const tracker = new LaunchProtocolTracker('n1');
+		tracker.feed('stdout', `${marker}null\n${marker}5\n`);
+		expect(tracker.outcome).toBeUndefined();
+		expect(tracker.setupCompleted).toBe(false);
+		tracker.feed('stdout', readyLine);
+		expect(tracker.outcome).toEqual({ kind: 'ready', setupMs: 3, waitportMs: 4 });
+	});
 
 	it('parses a marker line split across two feed chunks', () => {
 		const tracker = new LaunchProtocolTracker('n1');

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -16,6 +16,7 @@ import {
 	mapWithConcurrency,
 	NOT_A_DIRECTORY_EXIT_CODE,
 	NOT_A_DIRECTORY_MARKER,
+	OutputTail,
 	parseFindFilesOutput,
 	parseLaunchOutput,
 	pollUntilReady,
@@ -594,6 +595,110 @@ describe('launch protocol', () => {
 		expect(timeout).toBe(Number.POSITIVE_INFINITY);
 	});
 
+	it('returns success with the supervisor timings once the port opens', async () => {
+		const result = await launchWithProcess({
+			setup: 'uv sync',
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 1000,
+			start: async (command) => {
+				const nonce = command.match(/'([a-f0-9]{32})'/)?.[1];
+				if (!nonce) throw new Error('missing launch nonce');
+				return {
+					waitForPort: async () => {},
+					getLogs: async () => ({
+						stdout: 'kernel output\n',
+						stderr:
+							`__MARIMOHUB_LAUNCH_${nonce}__{"event":"setup_complete","setupMs":11,"waitportMs":0}\n` +
+							`__MARIMOHUB_LAUNCH_${nonce}__{"event":"ready","setupMs":11,"waitportMs":22}\n`,
+					}),
+				};
+			},
+		});
+		expect(result).toMatchObject({
+			success: true,
+			timings: { setup: 11, start: expect.any(Number), waitport: 22 },
+		});
+	});
+
+	it('maps a getLogs failure after a readiness failure to transport_failure', async () => {
+		const result = await launchWithProcess({
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 1000,
+			start: async () => ({
+				waitForPort: async () => {
+					throw new Error('probe lost');
+				},
+				getLogs: async () => {
+					throw new Error('logs unavailable');
+				},
+			}),
+		});
+		expect(result).toMatchObject({
+			success: false,
+			reason: 'transport_failure',
+			stdout: '',
+			stderr: 'logs unavailable',
+		});
+	});
+
+	it('maps a getLogs failure after readiness to transport_failure', async () => {
+		const result = await launchWithProcess({
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 1000,
+			start: async () => ({
+				waitForPort: async () => {},
+				getLogs: async () => {
+					throw new Error('logs unavailable');
+				},
+			}),
+		});
+		expect(result).toMatchObject({
+			success: false,
+			reason: 'transport_failure',
+			stderr: 'logs unavailable',
+		});
+	});
+
+	it('blames an unfinished setup for an expired deadline (setup_timeout)', async () => {
+		let now = 0;
+		const result = await launchWithProcess({
+			setup: 'uv sync',
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 10,
+			now: () => now,
+			start: async () => ({
+				waitForPort: async () => {
+					now = 20;
+					throw new Error('timed out waiting for port 2718');
+				},
+				getLogs: async () => ({ stdout: '', stderr: '' }),
+			}),
+		});
+		expect(result).toMatchObject({ success: false, reason: 'setup_timeout' });
+		if (result.success) throw new Error('expected a launch failure');
+		// An unfinished setup is charged the whole remaining budget.
+		expect(result.timings.setup).toBe(10);
+	});
+
+	it('classifies an early process exit via the readiness error message as kernel_exit', async () => {
+		const result = await launchWithProcess({
+			command: 'marimo edit',
+			port: 2718,
+			startupTimeout: 60_000,
+			start: async () => ({
+				waitForPort: async () => {
+					throw new Error('process exited (code 9) before port 2718 was ready.\nboom');
+				},
+				getLogs: async () => ({ stdout: '', stderr: 'boom\n' }),
+			}),
+		});
+		expect(result).toMatchObject({ success: false, reason: 'kernel_exit', stderr: 'boom\n' });
+	});
+
 	it('preserves a setup failure and its output through the compatibility launcher', async () => {
 		const result = await launchWithProcess({
 			setup: 'uv sync',
@@ -641,5 +746,44 @@ describe('base64Encode', () => {
 	it('round-trips arbitrary bytes including a NUL and high bytes', () => {
 		const bytes = new Uint8Array([0x00, 0xff, 0xfe, 0x80, 0x7f]);
 		expect(base64Encode(bytes)).toBe(btoa('\x00\xff\xfe\x80\x7f'));
+	});
+});
+
+describe('OutputTail', () => {
+	const utf8Bytes = (text: string) => new TextEncoder().encode(text).byteLength;
+
+	it('keeps short output verbatim', () => {
+		const tail = new OutputTail(16);
+		tail.append('abc');
+		tail.append('def');
+		expect(tail.text).toBe('abcdef');
+	});
+
+	it('keeps only the trailing bytes once the cap is exceeded', () => {
+		const tail = new OutputTail(8);
+		tail.append('0123456789');
+		tail.append('abcdef');
+		expect(tail.text).toBe('89abcdef');
+	});
+
+	it('enforces the byte cap on multibyte output', () => {
+		const tail = new OutputTail(4);
+		tail.append('€€');
+		expect(tail.text).toBe('€');
+		expect(utf8Bytes(tail.text)).toBeLessThanOrEqual(4);
+	});
+
+	it('trims on a character boundary instead of splitting a multibyte sequence', () => {
+		const tail = new OutputTail(8);
+		tail.append('a€€€');
+		expect(tail.text).toBe('€€');
+		expect(utf8Bytes(tail.text)).toBeLessThanOrEqual(8);
+	});
+
+	it('stays within the cap across many multibyte appends', () => {
+		const tail = new OutputTail(64);
+		for (let i = 0; i < 100; i++) tail.append('данные-😀');
+		expect(utf8Bytes(tail.text)).toBeLessThanOrEqual(64);
+		expect(tail.text.endsWith('данные-😀')).toBe(true);
 	});
 });

--- a/packages/compute-commons/src/index.test.ts
+++ b/packages/compute-commons/src/index.test.ts
@@ -16,6 +16,7 @@ import {
 	mapWithConcurrency,
 	NOT_A_DIRECTORY_EXIT_CODE,
 	NOT_A_DIRECTORY_MARKER,
+	LaunchProtocolTracker,
 	OutputTail,
 	parseFindFilesOutput,
 	parseLaunchOutput,
@@ -785,5 +786,61 @@ describe('OutputTail', () => {
 		for (let i = 0; i < 100; i++) tail.append('данные-😀');
 		expect(utf8Bytes(tail.text)).toBeLessThanOrEqual(64);
 		expect(tail.text.endsWith('данные-😀')).toBe(true);
+	});
+});
+
+describe('LaunchProtocolTracker', () => {
+	const marker = '__MARIMOHUB_LAUNCH_n1__';
+	const readyLine = `${marker}{"event":"ready","setupMs":3,"waitportMs":4}\n`;
+
+	it('parses a marker line split across two feed chunks', () => {
+		const tracker = new LaunchProtocolTracker('n1');
+		tracker.feed('stderr', readyLine.slice(0, 20));
+		expect(tracker.outcome).toBeUndefined();
+		tracker.feed('stderr', readyLine.slice(20));
+		expect(tracker.outcome).toEqual({ kind: 'ready', setupMs: 3, waitportMs: 4 });
+	});
+
+	it('keeps setup_complete latched through more noise than any capped tail retains', () => {
+		const tracker = new LaunchProtocolTracker('n1');
+		tracker.feed('stderr', `${marker}{"event":"setup_complete","setupMs":9,"waitportMs":0}\n`);
+		for (let i = 0; i < 80; i++) tracker.feed('stderr', `${'x'.repeat(1024)}\n`);
+		expect(tracker.setupCompleted).toBe(true);
+		expect(tracker.outcome).toBeUndefined();
+	});
+
+	it('sees a terminal marker buried at the start of one huge chunk', () => {
+		const tracker = new LaunchProtocolTracker('n1');
+		tracker.feed('stderr', `${readyLine}${'noise\n'.repeat(20_000)}`);
+		expect(tracker.outcome).toEqual({ kind: 'ready', setupMs: 3, waitportMs: 4 });
+	});
+
+	it('the last terminal event wins, matching parseLaunchOutput', () => {
+		const tracker = new LaunchProtocolTracker('n1');
+		tracker.feed('stderr', readyLine);
+		tracker.feed(
+			'stderr',
+			`${marker}{"event":"kernel_exit","setupMs":3,"waitportMs":8,"exitCode":2}\n`,
+		);
+		expect(tracker.outcome).toEqual({
+			kind: 'kernel_exit',
+			setupMs: 3,
+			waitportMs: 8,
+			exitCode: 2,
+		});
+	});
+
+	it('tracks streams independently and reads a mid-line marker after unterminated output', () => {
+		const tracker = new LaunchProtocolTracker('n1');
+		tracker.feed('stdout', 'partial stdout without newline');
+		tracker.feed('stderr', `unterminated setup output${readyLine}`);
+		expect(tracker.outcome).toEqual({ kind: 'ready', setupMs: 3, waitportMs: 4 });
+	});
+
+	it('the carry cap does not lose a marker straddling a chunk boundary after a long unterminated line', () => {
+		const tracker = new LaunchProtocolTracker('n1');
+		tracker.feed('stderr', 'g'.repeat(100 * 1024) + readyLine.slice(0, 15));
+		tracker.feed('stderr', readyLine.slice(15));
+		expect(tracker.outcome).toEqual({ kind: 'ready', setupMs: 3, waitportMs: 4 });
 	});
 });

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -338,6 +338,47 @@ export function buildLaunchCommand(options: {
 	};
 }
 
+/**
+ * Parse one output line (trailing newline stripped) for a supervisor marker.
+ * Markers can appear mid-line after unterminated kernel output, so the match is
+ * an `indexOf`, not a prefix check. Returns `undefined` when the line carries no
+ * valid marker payload; otherwise the marker's event, the text preceding it, and
+ * the structured outcome when the event is terminal.
+ */
+function parseMarkerLine(
+	line: string,
+	marker: string,
+): { before: string; event?: string; outcome?: LaunchProtocolOutcome } | undefined {
+	const index = line.indexOf(marker);
+	if (index === -1) return undefined;
+	let value: { event?: string; setupMs?: number; waitportMs?: number; exitCode?: number };
+	try {
+		value = JSON.parse(line.slice(index + marker.length)) as {
+			event?: string;
+			setupMs?: number;
+			waitportMs?: number;
+			exitCode?: number;
+		};
+	} catch {
+		return undefined;
+	}
+	const event = value.event;
+	const outcome: LaunchProtocolOutcome | undefined =
+		event === 'ready' ||
+		event === 'setup_exit' ||
+		event === 'setup_timeout' ||
+		event === 'kernel_exit' ||
+		event === 'readiness_timeout'
+			? {
+					kind: event,
+					setupMs: Math.max(0, value.setupMs ?? 0),
+					waitportMs: Math.max(0, value.waitportMs ?? 0),
+					...(value.exitCode === undefined ? {} : { exitCode: value.exitCode }),
+				}
+			: undefined;
+	return { before: line.slice(0, index), event, ...(outcome ? { outcome } : {}) };
+}
+
 function parseProtocolText(
 	text: string,
 	nonce: string,
@@ -349,39 +390,13 @@ function parseProtocolText(
 	const events: LaunchProtocolOutcome[] = [];
 	const kept: string[] = [];
 	for (const line of text.split(/(?<=\n)/)) {
-		const normalized = line.replace(/\r?\n$/, '');
-		const index = normalized.indexOf(marker);
-		if (index === -1) {
+		const parsed = parseMarkerLine(line.replace(/\r?\n$/, ''), marker);
+		if (!parsed) {
 			kept.push(line);
 			continue;
 		}
-		const json = normalized.slice(index + marker.length);
-		try {
-			const value = JSON.parse(json) as {
-				event?: string;
-				setupMs?: number;
-				waitportMs?: number;
-				exitCode?: number;
-			};
-			if (
-				value.event === 'ready' ||
-				value.event === 'setup_exit' ||
-				value.event === 'setup_timeout' ||
-				value.event === 'kernel_exit' ||
-				value.event === 'readiness_timeout'
-			) {
-				events.push({
-					kind: value.event,
-					setupMs: Math.max(0, value.setupMs ?? 0),
-					waitportMs: Math.max(0, value.waitportMs ?? 0),
-					...(value.exitCode === undefined ? {} : { exitCode: value.exitCode }),
-				});
-			}
-			const beforeMarker = normalized.slice(0, index);
-			if (beforeMarker) kept.push(beforeMarker);
-		} catch {
-			kept.push(line);
-		}
+		if (parsed.outcome) events.push(parsed.outcome);
+		if (parsed.before) kept.push(parsed.before);
 	}
 	return { text: kept.join(''), events };
 }
@@ -418,6 +433,60 @@ export function errorMessage(err: unknown): string {
  */
 export function setupCompleteMarker(nonce: string): string {
 	return `__MARIMOHUB_LAUNCH_${nonce}__{"event":"setup_complete"`;
+}
+
+/**
+ * Cap on the tracker's per-stream carry of an unterminated line. A supervisor
+ * marker line is ~200 bytes, so any marker straddling a chunk boundary lies
+ * within the trailing 1 KiB — kernel garbage without newlines must not grow the
+ * carry unboundedly.
+ */
+const TRACKER_CARRY_MAX_CHARS = 1024;
+
+/**
+ * Latches launch-protocol state from RAW output chunks, before any truncation.
+ * Adapters that retain only a capped {@link OutputTail} of kernel output must
+ * derive `setupCompleted`/`outcome` from this instead of re-scanning the tail:
+ * a marker can be evicted from the tail by later output, misclassifying (e.g.)
+ * a `readiness_timeout` as `setup_timeout`. O(1) memory — only the latched
+ * state and a small per-stream carry for lines split across chunks.
+ */
+export class LaunchProtocolTracker {
+	private readonly marker: string;
+	private readonly carries = { stdout: '', stderr: '' };
+	private lastOutcome: LaunchProtocolOutcome | undefined;
+	private setupSeen = false;
+
+	constructor(nonce: string) {
+		this.marker = `__MARIMOHUB_LAUNCH_${nonce}__`;
+	}
+
+	feed(stream: 'stdout' | 'stderr', chunk: string): void {
+		const text = this.carries[stream] + chunk;
+		// The supervisor always terminates a marker line with a newline, so only
+		// complete lines are scanned; the unterminated remainder is carried.
+		const lastNewline = text.lastIndexOf('\n');
+		if (lastNewline !== -1) {
+			for (const line of text.slice(0, lastNewline).split('\n')) {
+				const parsed = parseMarkerLine(line.replace(/\r$/, ''), this.marker);
+				if (!parsed) continue;
+				if (parsed.event === 'setup_complete') this.setupSeen = true;
+				if (parsed.outcome) this.lastOutcome = parsed.outcome;
+			}
+		}
+		const carry = lastNewline === -1 ? text : text.slice(lastNewline + 1);
+		this.carries[stream] = carry.slice(-TRACKER_CARRY_MAX_CHARS);
+	}
+
+	/** Last terminal event seen (last one wins, matching {@link parseLaunchOutput}). */
+	get outcome(): LaunchProtocolOutcome | undefined {
+		return this.lastOutcome;
+	}
+
+	/** Latched once a `setup_complete` marker is seen. */
+	get setupCompleted(): boolean {
+		return this.setupSeen;
+	}
 }
 
 export interface LaunchTimings {

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -399,6 +399,128 @@ export function parseLaunchOutput(
 	};
 }
 
+/**
+ * How long after the startup deadline a terminal launch marker may still arrive
+ * over the adapter's log/stream channel before the launch is classified locally.
+ * Generous on purpose: it is only paid on timeout paths, and a too-short grace
+ * risks misclassifying a completed setup as `setup_timeout`.
+ */
+export const LAUNCH_MARKER_GRACE_MS = 250;
+
+export function errorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The sniff string proving the supervisor finished setup — checked on timeout
+ * paths to distinguish `setup_timeout` from `readiness_timeout` even when the
+ * marker line is interleaved with other output.
+ */
+export function setupCompleteMarker(nonce: string): string {
+	return `__MARIMOHUB_LAUNCH_${nonce}__{"event":"setup_complete"`;
+}
+
+export interface LaunchTimings {
+	setup: number;
+	start: number;
+	waitport: number;
+}
+
+/** The failure arm of the port's `SandboxLaunchResult` (structurally compatible). */
+export interface LaunchFailureResult {
+	success: false;
+	reason: LaunchProtocolFailure | 'transport_failure';
+	exitCode?: number;
+	stdout: string;
+	stderr: string;
+	timings: LaunchTimings;
+}
+
+/** Launch failed before/outside the supervised protocol: no output, only the error. */
+export function transportFailureResult(err: unknown, timings: LaunchTimings): LaunchFailureResult {
+	return {
+		success: false,
+		reason: 'transport_failure',
+		stdout: '',
+		stderr: errorMessage(err),
+		timings,
+	};
+}
+
+/** Map a terminal (non-`ready`) supervisor outcome onto the launch-result envelope. */
+export function launchOutcomeResult(
+	kind: LaunchProtocolFailure,
+	outcome: Pick<LaunchProtocolOutcome, 'setupMs' | 'waitportMs' | 'exitCode'>,
+	output: { stdout: string; stderr: string },
+	start: number,
+): LaunchFailureResult {
+	return {
+		success: false,
+		reason: kind,
+		...(outcome.exitCode === undefined ? {} : { exitCode: outcome.exitCode }),
+		stdout: output.stdout,
+		stderr: output.stderr,
+		timings: { setup: outcome.setupMs, start, waitport: outcome.waitportMs },
+	};
+}
+
+/**
+ * The deadline passed with no terminal marker: blame setup if one was requested
+ * and never completed (charging it the whole remaining budget), else readiness.
+ */
+export function launchTimeoutResult(options: {
+	setup: boolean;
+	setupCompleted: boolean;
+	startupTimeout: number;
+	output: { stdout: string; stderr: string };
+	start: number;
+	waitport: number;
+}): LaunchFailureResult {
+	const reason = options.setup && !options.setupCompleted ? 'setup_timeout' : 'readiness_timeout';
+	return {
+		success: false,
+		reason,
+		stdout: options.output.stdout,
+		stderr: options.output.stderr,
+		timings: {
+			setup: reason === 'setup_timeout' ? Math.max(0, options.startupTimeout - options.start) : 0,
+			start: options.start,
+			waitport: options.waitport,
+		},
+	};
+}
+
+/** Default cap for retained kernel output — these buffers exist for error reporting only. */
+export const LAUNCH_OUTPUT_TAIL_BYTES = 64 * 1024;
+
+/**
+ * Capped accumulator keeping only the trailing `maxBytes` (UTF-8, cut on a
+ * character boundary) of appended text. Adapters that pump a kernel's live
+ * stdout/stderr into strings use this so retained output stays bounded for the
+ * sandbox's whole lifetime instead of growing with every chunk.
+ */
+export class OutputTail {
+	private value = '';
+
+	constructor(private readonly maxBytes: number = LAUNCH_OUTPUT_TAIL_BYTES) {}
+
+	append(chunk: string): void {
+		this.value += chunk;
+		// UTF-8 emits at most 3 bytes per UTF-16 code unit, so a short value
+		// cannot exceed the cap — skip the encode until that guarantee is gone.
+		if (this.value.length * 3 <= this.maxBytes) return;
+		const encoded = new TextEncoder().encode(this.value);
+		if (encoded.byteLength <= this.maxBytes) return;
+		let start = encoded.byteLength - this.maxBytes;
+		while ((encoded[start] & 0xc0) === 0x80) start++;
+		this.value = new TextDecoder().decode(encoded.subarray(start));
+	}
+
+	get text(): string {
+		return this.value;
+	}
+}
+
 export interface LaunchableProcess {
 	waitForPort(
 		port: number,
@@ -411,16 +533,9 @@ export type ProcessLaunchResult<P extends LaunchableProcess> =
 	| {
 			success: true;
 			process: P;
-			timings: { setup: number; start: number; waitport: number };
+			timings: LaunchTimings;
 	  }
-	| {
-			success: false;
-			reason: LaunchProtocolFailure | 'transport_failure';
-			exitCode?: number;
-			stdout: string;
-			stderr: string;
-			timings: { setup: number; start: number; waitport: number };
-	  };
+	| LaunchFailureResult;
 
 /**
  * Compatibility implementation for process APIs that expose readiness and logs
@@ -443,13 +558,11 @@ export async function launchWithProcess<P extends LaunchableProcess>(options: {
 	try {
 		process = await options.start(built.command);
 	} catch (error) {
-		return {
-			success: false,
-			reason: 'transport_failure',
-			stdout: '',
-			stderr: error instanceof Error ? error.message : String(error),
-			timings: { setup: 0, start: Math.max(0, now() - launchStarted), waitport: 0 },
-		};
+		return transportFailureResult(error, {
+			setup: 0,
+			start: Math.max(0, now() - launchStarted),
+			waitport: 0,
+		});
 	}
 	const start = now() - launchStarted;
 	const waitStarted = now();
@@ -470,34 +583,27 @@ export async function launchWithProcess<P extends LaunchableProcess>(options: {
 		let setupCompleted = false;
 		try {
 			const logs = await process.getLogs();
-			setupCompleted = `${logs.stdout}\n${logs.stderr}`.includes(
-				`__MARIMOHUB_LAUNCH_${built.nonce}__{"event":"setup_complete"`,
-			);
+			setupCompleted = `${logs.stdout}\n${logs.stderr}`.includes(setupCompleteMarker(built.nonce));
 			parsed = parseLaunchOutput(logs, built.nonce);
 		} catch (logError) {
-			return {
-				success: false,
-				reason: 'transport_failure',
-				stdout: '',
-				stderr: logError instanceof Error ? logError.message : String(logError),
-				timings: {
-					setup: 0,
-					start,
-					waitport: Math.max(0, now() - waitStarted),
-				},
-			};
+			return transportFailureResult(logError, {
+				setup: 0,
+				start,
+				waitport: Math.max(0, now() - waitStarted),
+			});
 		}
 		const outcome = parsed.outcome;
+		if (outcome && outcome.kind !== 'ready') {
+			return launchOutcomeResult(outcome.kind, outcome, parsed, start);
+		}
 		const deadlineExpired =
 			options.startupTimeout !== 0 && now() - launchStarted >= options.startupTimeout;
 		const reason =
-			outcome?.kind && outcome.kind !== 'ready'
-				? outcome.kind
-				: options.setup && deadlineExpired && !setupCompleted
-					? 'setup_timeout'
-					: /before port \d+/.test(error instanceof Error ? error.message.split('\n', 1)[0] : '')
-						? 'kernel_exit'
-						: 'readiness_timeout';
+			options.setup && deadlineExpired && !setupCompleted
+				? 'setup_timeout'
+				: /before port \d+/.test(error instanceof Error ? error.message.split('\n', 1)[0] : '')
+					? 'kernel_exit'
+					: 'readiness_timeout';
 		return {
 			success: false,
 			reason,
@@ -517,13 +623,11 @@ export async function launchWithProcess<P extends LaunchableProcess>(options: {
 	try {
 		parsed = parseLaunchOutput(await process.getLogs(), built.nonce);
 	} catch (error) {
-		return {
-			success: false,
-			reason: 'transport_failure',
-			stdout: '',
-			stderr: error instanceof Error ? error.message : String(error),
-			timings: { setup: 0, start, waitport: Math.max(0, now() - waitStarted) },
-		};
+		return transportFailureResult(error, {
+			setup: 0,
+			start,
+			waitport: Math.max(0, now() - waitStarted),
+		});
 	}
 	return {
 		success: true,

--- a/packages/compute-commons/src/index.ts
+++ b/packages/compute-commons/src/index.ts
@@ -351,17 +351,21 @@ function parseMarkerLine(
 ): { before: string; event?: string; outcome?: LaunchProtocolOutcome } | undefined {
 	const index = line.indexOf(marker);
 	if (index === -1) return undefined;
-	let value: { event?: string; setupMs?: number; waitportMs?: number; exitCode?: number };
+	let parsed: unknown;
 	try {
-		value = JSON.parse(line.slice(index + marker.length)) as {
-			event?: string;
-			setupMs?: number;
-			waitportMs?: number;
-			exitCode?: number;
-		};
+		parsed = JSON.parse(line.slice(index + marker.length));
 	} catch {
 		return undefined;
 	}
+	// A marker followed by a non-object payload (`null`, a scalar, an array) is
+	// not a supervisor event — keep it as ordinary output instead of throwing.
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return undefined;
+	const value = parsed as {
+		event?: string;
+		setupMs?: number;
+		waitportMs?: number;
+		exitCode?: number;
+	};
 	const event = value.event;
 	const outcome: LaunchProtocolOutcome | undefined =
 		event === 'ready' ||

--- a/packages/compute-container/src/docker.test.ts
+++ b/packages/compute-container/src/docker.test.ts
@@ -10,6 +10,7 @@ import {
 import { DockerCompute, spawnDockerRunner } from './docker';
 import {
 	containerCliContract,
+	contractLaunchCliHandler,
 	createRecordingContainerRunner as fakeRunner,
 	defaultContainerCliHandler as defaultHandler,
 } from './testing';
@@ -550,10 +551,13 @@ describe('DockerCompute', () => {
 
 computeContract(
 	'DockerCompute',
-	() =>
-		new DockerCompute(
+	() => {
+		const launchHandler = contractLaunchCliHandler();
+		return new DockerCompute(
 			{},
 			fakeRunner((args) => {
+				const launch = launchHandler(args);
+				if (launch) return launch;
 				if (args.at(-1) === 'false') return { stdout: '', stderr: 'failed', exitCode: 1 };
 				if (isContractNonDirectoryFindCommand(args.at(-1))) {
 					return {
@@ -564,10 +568,11 @@ computeContract(
 				}
 				return defaultHandler(args);
 			}).runner,
-		),
+		);
+	},
 	{
 		mountFallsBack: true,
-		semantics: { failingCommand: 'false' },
+		semantics: { failingCommand: 'false', launch: {} },
 	},
 );
 

--- a/packages/compute-container/src/index.ts
+++ b/packages/compute-container/src/index.ts
@@ -9,12 +9,17 @@ import {
 	buildGitCloneCommand,
 	buildLaunchCommand,
 	classifyListFilesFailure,
+	LAUNCH_MARKER_GRACE_MS,
+	launchOutcomeResult,
+	launchTimeoutResult,
 	mapWithConcurrency,
 	parseLaunchOutput,
 	parseFindFilesOutput,
 	pollUntilReady,
 	removeUndefined,
+	setupCompleteMarker,
 	shellQuote,
+	transportFailureResult,
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
@@ -51,7 +56,6 @@ const NAME_PREFIX = 'marimohub-sbx-';
 const DEFAULT_LABEL_KEY = 'marimohub.sandbox';
 const DEFAULT_IMAGE = 'ghcr.io/marimo-team/marimo:latest';
 const EXEC_TIMEOUT_GRACE_MS = 100;
-const LAUNCH_MARKER_GRACE_MS = 100;
 const EXEC_TIMEOUT_SUPERVISOR = `import os, signal, subprocess, sys
 process = subprocess.Popen(['sh', '-lc', sys.argv[2]], start_new_session=True)
 try:
@@ -419,13 +423,11 @@ class ContainerSandboxInstance implements SandboxInstance {
 				processId: options.processId,
 			});
 		} catch (error) {
-			return {
-				success: false,
-				reason: 'transport_failure',
-				stdout: '',
-				stderr: error instanceof Error ? error.message : String(error),
-				timings: { setup: 0, start: Math.max(0, Date.now() - launchStarted), waitport: 0 },
-			};
+			return transportFailureResult(error, {
+				setup: 0,
+				start: Math.max(0, Date.now() - launchStarted),
+				waitport: 0,
+			});
 		}
 
 		const start = Math.max(0, Date.now() - launchStarted);
@@ -439,13 +441,11 @@ class ContainerSandboxInstance implements SandboxInstance {
 			waited = await process.waitForLaunch(built.nonce, waitTimeout);
 		} catch (error) {
 			await process.kill().catch(() => {});
-			return {
-				success: false,
-				reason: 'transport_failure',
-				stdout: '',
-				stderr: error instanceof Error ? error.message : String(error),
-				timings: { setup: 0, start, waitport: Math.max(0, Date.now() - waitStarted) },
-			};
+			return transportFailureResult(error, {
+				setup: 0,
+				start,
+				waitport: Math.max(0, Date.now() - waitStarted),
+			});
 		}
 
 		const parsed = parseLaunchOutput({ stdout: waited.stdout, stderr: '' }, built.nonce);
@@ -468,14 +468,7 @@ class ContainerSandboxInstance implements SandboxInstance {
 			};
 		}
 		if (terminal) {
-			return {
-				success: false,
-				reason: terminal.kind,
-				...(terminal.exitCode === undefined ? {} : { exitCode: terminal.exitCode }),
-				stdout: parsed.stdout,
-				stderr: parsed.stderr,
-				timings: { setup: terminal.setupMs, start, waitport: terminal.waitportMs },
-			};
+			return launchOutcomeResult(terminal.kind, terminal, parsed, start);
 		}
 
 		await process.kill().catch(() => {});
@@ -491,21 +484,14 @@ class ContainerSandboxInstance implements SandboxInstance {
 			};
 		}
 
-		const setupCompleted = waited.stdout.includes(
-			`__MARIMOHUB_LAUNCH_${built.nonce}__{"event":"setup_complete"`,
-		);
-		const reason = options.setup && !setupCompleted ? 'setup_timeout' : 'readiness_timeout';
-		return {
-			success: false,
-			reason,
-			stdout: parsed.stdout,
-			stderr: parsed.stderr,
-			timings: {
-				setup: reason === 'setup_timeout' ? Math.max(0, options.startupTimeout - start) : 0,
-				start,
-				waitport: Math.max(0, Date.now() - waitStarted),
-			},
-		};
+		return launchTimeoutResult({
+			setup: Boolean(options.setup),
+			setupCompleted: waited.stdout.includes(setupCompleteMarker(built.nonce)),
+			startupTimeout: options.startupTimeout,
+			output: parsed,
+			start,
+			waitport: Math.max(0, Date.now() - waitStarted),
+		});
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/compute-container/src/podman.test.ts
+++ b/packages/compute-container/src/podman.test.ts
@@ -4,12 +4,15 @@ import {
 	isContractNonDirectoryFindCommand,
 } from '@marimo-hub/core/testing/compute-contract';
 import { PodmanCompute, spawnPodmanRunner } from './podman';
-import { containerCliContract } from './testing';
+import { containerCliContract, contractLaunchCliHandler } from './testing';
 import type { PodmanRunResult, PodmanRunner } from './podman';
 
 function fakeRunner(): PodmanRunner {
+	const launchHandler = contractLaunchCliHandler();
 	return {
 		async run(args): Promise<PodmanRunResult> {
+			const launch = launchHandler(args);
+			if (launch) return launch;
 			if (args[0] === 'inspect') return { stdout: '', stderr: 'not found', exitCode: 1 };
 			if (args[0] === 'port') {
 				return { stdout: '127.0.0.1:49153\n', stderr: '', exitCode: 0 };
@@ -36,5 +39,5 @@ containerCliContract(
 
 computeContract('PodmanCompute', () => new PodmanCompute({}, fakeRunner()), {
 	mountFallsBack: true,
-	semantics: { failingCommand: 'false' },
+	semantics: { failingCommand: 'false', launch: {} },
 });

--- a/packages/compute-container/src/testing.ts
+++ b/packages/compute-container/src/testing.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { SandboxId } from '@marimo-hub/core';
 import type { SandboxProvider } from '@marimo-hub/core/ports';
+import { scriptContractLaunch } from '@marimo-hub/core/testing/compute-contract';
+import type { ContractLaunchScript } from '@marimo-hub/core/testing/compute-contract';
 import { containerResourceArgs } from './index';
 import type { ContainerConfig, ContainerRunner, ContainerRunResult } from './index';
 
@@ -32,6 +34,29 @@ export function defaultContainerCliHandler(args: string[]): ContainerRunResult |
 	if (args[0] === 'inspect') return { stdout: '', stderr: 'not found', exitCode: 1 };
 	if (args[0] === 'port') return { stdout: '127.0.0.1:49153\n', stderr: '', exitCode: 0 };
 	return undefined;
+}
+
+/**
+ * Stateful CLI handler for the compute contract's `launchProcess` cases. The
+ * adapter starts the supervisor detached, then polls its log file with an
+ * in-container waiter (identified by its `terminal_events` script); the handler
+ * remembers the scripted transcript of the last contract launch and serves it
+ * from the waiter.
+ */
+export function contractLaunchCliHandler(): (args: string[]) => ContainerRunResult | undefined {
+	let launch: ContractLaunchScript | undefined;
+	return (args) => {
+		const cmd = args.at(-1) ?? '';
+		if (cmd.includes('terminal_events')) {
+			return { stdout: launch?.transcript ?? '', stderr: '', exitCode: 0 };
+		}
+		const scripted = scriptContractLaunch(cmd);
+		if (scripted) {
+			launch = scripted;
+			return { stdout: '', stderr: '', exitCode: 0 };
+		}
+		return;
+	};
 }
 
 export function containerCliContract(

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -14,7 +14,7 @@ import { listFilesFailure } from '@marimo-hub/core/ports';
 import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
 import { coreWeaveProfileResources, CoreWeaveCompute } from './index';
 import type { CoreWeaveClient, CoreWeaveConfig } from './index';
-import { fakeProcess, makeWorld, procResult } from './testWorld';
+import { contractLaunchProcess, fakeProcess, makeWorld, procResult } from './testWorld';
 
 /**
  * Tests for the CoreWeave compute adapter.
@@ -1058,7 +1058,8 @@ computeContract(
 					}
 					return procResult();
 				},
+				startImpl: async (command) => contractLaunchProcess(command) ?? fakeProcess(),
 			}),
 		),
-	{ mountFallsBack: true, semantics: { failingCommand: 'mh-contract-fail' } },
+	{ mountFallsBack: true, semantics: { failingCommand: 'mh-contract-fail', launch: {} } },
 );

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -631,6 +631,30 @@ describe('CoreWeaveCompute', () => {
 			expect(fake.runCalls).toHaveLength(0);
 		});
 
+		it('succeeds when the ready marker and >64 KiB of trailing noise arrive in one chunk', async () => {
+			const world = makeWorld({
+				startImpl: async (command) => {
+					const nonce = command.join(' ').match(/'([a-f0-9]{32})'/)?.[1];
+					if (!nonce) throw new Error('launch nonce missing from supervisor command');
+					async function* stderr() {
+						// The noise evicts the marker from the capped tail before inspect()
+						// runs; classification must come from the raw chunk.
+						yield `__MARIMOHUB_LAUNCH_${nonce}__{"event":"ready","setupMs":6,"waitportMs":11}\n${'x'.repeat(70 * 1024)}\n`;
+					}
+					return { ...fakeProcess(), stderr: stderr() };
+				},
+			});
+			const result = await makeCompute(world).create(SANDBOX_ID, { reuse: false }).launchProcess!(
+				'marimo edit',
+				{ port: 2718, startupTimeout: 120_000 },
+			);
+
+			expect(result).toMatchObject({
+				success: true,
+				timings: { setup: 6, start: expect.any(Number), waitport: 11 },
+			});
+		});
+
 		it('returns a structured setup failure without a readiness Exec', async () => {
 			const world = makeWorld({ startImpl: streamedOutcome('setup_exit') });
 			const inst = makeCompute(world).create(SANDBOX_ID, { reuse: false });

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -65,6 +65,7 @@ import {
 	errorMessage,
 	iterableToStream,
 	launchOutcomeResult,
+	LaunchProtocolTracker,
 	OutputTail,
 	parseLaunchOutput,
 	parseFindFilesOutput,
@@ -616,17 +617,25 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		});
 		const logs = () =>
 			parseLaunchOutput({ stdout: stdoutTail.text, stderr: stderrTail.text }, built.nonce);
+		// Fed raw chunks so a marker evicted from the capped tails (e.g. by a huge
+		// trailing burst in the same chunk) still classifies the launch.
+		const tracker = new LaunchProtocolTracker(built.nonce);
 		const inspect = () => {
 			if (settled) return;
-			const parsed = logs().outcome;
-			if (parsed) {
+			const terminal = tracker.outcome;
+			if (terminal) {
 				settled = true;
-				resolveOutcome(parsed);
+				resolveOutcome(terminal);
 			}
 		};
-		const pump = async (stream: AsyncIterable<string>, sink: OutputTail) => {
+		const pump = async (
+			stream: AsyncIterable<string>,
+			name: 'stdout' | 'stderr',
+			sink: OutputTail,
+		) => {
 			try {
 				for await (const chunk of stream) {
+					tracker.feed(name, chunk);
 					sink.append(chunk);
 					inspect();
 				}
@@ -637,8 +646,8 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				}
 			}
 		};
-		const stdoutDone = pump(proc.stdout, stdoutTail);
-		const stderrDone = pump(proc.stderr, stderrTail);
+		const stdoutDone = pump(proc.stdout, 'stdout', stdoutTail);
+		const stderrDone = pump(proc.stderr, 'stderr', stderrTail);
 		void Promise.allSettled([stdoutDone, stderrDone]).then(() => {
 			inspect();
 			if (!settled) {

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -62,12 +62,16 @@ import {
 	buildGitCloneCommand,
 	buildLaunchCommand,
 	classifyListFilesFailure,
+	errorMessage,
 	iterableToStream,
+	launchOutcomeResult,
+	OutputTail,
 	parseLaunchOutput,
 	parseFindFilesOutput,
 	portWaitCommand,
 	removeUndefined,
 	shellQuote,
+	transportFailureResult,
 	withEnvPrefix,
 } from '@marimo-hub/compute-commons';
 import type { LaunchProtocolOutcome } from '@marimo-hub/compute-commons';
@@ -78,7 +82,7 @@ import type {
 	Seconds,
 	Timings,
 } from '@marimo-hub/core';
-import { traceContext } from '@marimo-hub/core';
+import { logEvent } from '@marimo-hub/core';
 import type {
 	CreateSandboxOptions,
 	ExecOptions,
@@ -356,10 +360,8 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 			this.pendingBootstrap = this.createBootstrap();
 		}
 		this.lastEnsureTimings = { find: t1 - t0, create: t2 - t1, boot: t3 - t2 };
-		console.warn(
-			JSON.stringify({
-				ts: new Date().toISOString(),
-				...traceContext(),
+		logEvent(
+			{
 				event: 'coreweave_ensure',
 				sandbox_id: this.id,
 				reconnected: Boolean(existing),
@@ -369,7 +371,8 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				...(t3 - t2 > SLOW_BOOT_MS ? { slow_boot_hint: SLOW_BOOT_HINT } : {}),
 				...(this.config.profileNames?.length ? { profile_names: this.config.profileNames } : {}),
 				...(this.userHome ? { user_home_attached: true } : {}),
-			}),
+			},
+			{ channel: 'warn' },
 		);
 		return this.sandbox;
 	}
@@ -594,18 +597,16 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				cwd: options.cwd,
 			});
 		} catch (error) {
-			return {
-				success: false,
-				reason: 'transport_failure',
-				stdout: '',
-				stderr: error instanceof Error ? error.message : String(error),
-				timings: { setup: 0, start: Math.max(0, Date.now() - startedAt), waitport: 0 },
-			};
+			return transportFailureResult(error, {
+				setup: 0,
+				start: Math.max(0, Date.now() - startedAt),
+				waitport: 0,
+			});
 		}
 		const start = Date.now() - startedAt;
 		const waitStartedAt = Date.now();
-		let stdout = '';
-		let stderr = '';
+		const stdoutTail = new OutputTail();
+		const stderrTail = new OutputTail();
 		let settled = false;
 		let resolveOutcome!: (outcome: LaunchProtocolOutcome) => void;
 		let rejectOutcome!: (error: unknown) => void;
@@ -613,18 +614,20 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 			resolveOutcome = resolve;
 			rejectOutcome = reject;
 		});
+		const logs = () =>
+			parseLaunchOutput({ stdout: stdoutTail.text, stderr: stderrTail.text }, built.nonce);
 		const inspect = () => {
 			if (settled) return;
-			const parsed = parseLaunchOutput({ stdout, stderr }, built.nonce).outcome;
+			const parsed = logs().outcome;
 			if (parsed) {
 				settled = true;
 				resolveOutcome(parsed);
 			}
 		};
-		const pump = async (stream: AsyncIterable<string>, sink: (chunk: string) => void) => {
+		const pump = async (stream: AsyncIterable<string>, sink: OutputTail) => {
 			try {
 				for await (const chunk of stream) {
-					sink(chunk);
+					sink.append(chunk);
 					inspect();
 				}
 			} catch (error) {
@@ -634,8 +637,8 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				}
 			}
 		};
-		const stdoutDone = pump(proc.stdout, (chunk) => (stdout += chunk));
-		const stderrDone = pump(proc.stderr, (chunk) => (stderr += chunk));
+		const stdoutDone = pump(proc.stdout, stdoutTail);
+		const stderrDone = pump(proc.stderr, stderrTail);
 		void Promise.allSettled([stdoutDone, stderrDone]).then(() => {
 			inspect();
 			if (!settled) {
@@ -644,19 +647,17 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 			}
 		});
 
-		const logs = () => parseLaunchOutput({ stdout, stderr }, built.nonce);
 		let terminal: LaunchProtocolOutcome;
 		try {
 			terminal = await outcome;
 		} catch (error) {
 			await proc.cancel().catch(() => {});
 			const parsed = logs();
-			const transportMessage = error instanceof Error ? error.message : String(error);
 			return {
 				success: false,
 				reason: 'transport_failure',
 				stdout: parsed.stdout,
-				stderr: [parsed.stderr, transportMessage].filter(Boolean).join('\n'),
+				stderr: [parsed.stderr, errorMessage(error)].filter(Boolean).join('\n'),
 				timings: {
 					setup: 0,
 					start,
@@ -664,23 +665,14 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 				},
 			};
 		}
-		const timings = { setup: terminal.setupMs, start, waitport: terminal.waitportMs };
 		if (terminal.kind !== 'ready') {
-			const parsed = logs();
-			return {
-				success: false,
-				reason: terminal.kind,
-				...(terminal.exitCode === undefined ? {} : { exitCode: terminal.exitCode }),
-				stdout: parsed.stdout,
-				stderr: parsed.stderr,
-				timings,
-			};
+			return launchOutcomeResult(terminal.kind, terminal, logs(), start);
 		}
 
 		const exec = this.exec.bind(this);
 		return {
 			success: true,
-			timings,
+			timings: { setup: terminal.setupMs, start, waitport: terminal.waitportMs },
 			process: {
 				id: `cw-proc-${++PROC_SEQ}`,
 				command: cmd,
@@ -710,17 +702,17 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 		// marimo runs as a streamed command (not the sandbox main process), so drain
 		// its output in the background to back getLogs() and to surface errors if the
 		// port never opens.
-		let stdout = '';
-		let stderr = '';
-		const pump = async (stream: AsyncIterable<string>, sink: (chunk: string) => void) => {
+		const stdoutTail = new OutputTail();
+		const stderrTail = new OutputTail();
+		const pump = async (stream: AsyncIterable<string>, sink: OutputTail) => {
 			try {
-				for await (const chunk of stream) sink(chunk);
+				for await (const chunk of stream) sink.append(chunk);
 			} catch {
 				// stream cancelled/ended — best effort.
 			}
 		};
-		void pump(proc.stdout, (c) => (stdout += c));
-		void pump(proc.stderr, (c) => (stderr += c));
+		void pump(proc.stdout, stdoutTail);
+		void pump(proc.stderr, stderrTail);
 
 		const exec = this.exec.bind(this);
 		return {
@@ -754,7 +746,7 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 					// would otherwise burn the whole timeout before reporting.
 					if (TERMINAL_PROCESS_STATUSES.has(proc.status)) {
 						throw new Error(
-							`process ${proc.status} before port ${port} opened.\n${stderr || stdout}`.trim(),
+							`process ${proc.status} before port ${port} opened.\n${stderrTail.text || stdoutTail.text}`.trim(),
 						);
 					}
 					const seconds = Math.max(1, Math.ceil(Math.min(chunkMs, deadline - Date.now()) / 1000));
@@ -762,11 +754,11 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 					if ((await exec(portWaitCommand(port, seconds))).success) return;
 				}
 				throw new Error(
-					`timed out waiting for port ${port} after ${timeout}ms.\n${stderr || stdout}`,
+					`timed out waiting for port ${port} after ${timeout}ms.\n${stderrTail.text || stdoutTail.text}`,
 				);
 			},
 			async getLogs(): Promise<{ stdout: string; stderr: string }> {
-				return { stdout, stderr };
+				return { stdout: stdoutTail.text, stderr: stderrTail.text };
 			},
 		};
 	}

--- a/packages/compute-coreweave/src/testWorld.ts
+++ b/packages/compute-coreweave/src/testWorld.ts
@@ -12,6 +12,7 @@ import type {
 	ProcessResult,
 	SandboxInfo,
 } from '@coreweave/cwsandbox';
+import { scriptContractLaunch } from '@marimo-hub/core/testing/compute-contract';
 import type { CoreWeaveClient } from './index';
 
 export function procResult(over: Partial<ProcessResult> = {}): ProcessResult {
@@ -58,6 +59,33 @@ export function fakeProcess(state?: FakeProcessState): CommandProcess {
 		cancel: async () => {},
 		poll: () => exitCode,
 		wait: async () => procResult({ exitCode }),
+	};
+}
+
+/**
+ * `startImpl` piece for the compute contract's `launchProcess` cases: the
+ * adapter watches the started command's live streams for supervisor markers, so
+ * the fake emits the scripted transcript on stderr and stays "running".
+ * Returns undefined for anything that is not a contract launch.
+ */
+export function contractLaunchProcess(command: readonly string[]): CommandProcess | undefined {
+	const launch = scriptContractLaunch(command.at(-1));
+	if (!launch) return undefined;
+	async function* transcript(): AsyncGenerator<string> {
+		yield launch!.transcript;
+	}
+	async function* empty(): AsyncGenerator<string> {
+		// no output
+	}
+	return {
+		command: ['sh'] as unknown as CommandProcess['command'],
+		exitCode: undefined,
+		status: 'running',
+		stdout: empty(),
+		stderr: transcript(),
+		cancel: async () => {},
+		poll: () => {},
+		wait: async () => procResult(),
 	};
 }
 

--- a/packages/compute-coreweave/src/wandb.test.ts
+++ b/packages/compute-coreweave/src/wandb.test.ts
@@ -16,7 +16,7 @@ import {
 	withServiceAddressCache,
 } from './wandb';
 import type { WandbConfig } from './wandb';
-import { makeWorld, procResult } from './testWorld';
+import { contractLaunchProcess, fakeProcess, makeWorld, procResult } from './testWorld';
 
 const SANDBOX_ID = 'sb-abc' as SandboxId;
 
@@ -206,7 +206,8 @@ computeContract(
 					}
 					return procResult();
 				},
+				startImpl: async (command) => contractLaunchProcess(command) ?? fakeProcess(),
 			}).client,
 		),
-	{ mountFallsBack: true, semantics: { failingCommand: 'false' } },
+	{ mountFallsBack: true, semantics: { failingCommand: 'false', launch: {} } },
 );

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -3,10 +3,12 @@ import { NOT_A_DIRECTORY_EXIT_CODE, NOT_A_DIRECTORY_MARKER } from '@marimo-hub/c
 import { Seconds } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
-import { expectListFilesResult } from '@marimo-hub/core/testing';
+import type { SandboxLaunchResult } from '@marimo-hub/core/ports';
+import { expectLaunchResult, expectListFilesResult } from '@marimo-hub/core/testing';
 import {
 	computeContract,
 	isContractNonDirectoryFindCommand,
+	scriptContractLaunch,
 } from '@marimo-hub/core/testing/compute-contract';
 import { createE2bClient, E2bCompute } from './index';
 import type {
@@ -60,6 +62,8 @@ class FakeE2b implements E2bClient {
 			runResult?: (cmd: string) => E2bExecResult | undefined;
 			beforeCreate?: () => Promise<void>;
 			beforeKill?: (sandbox: FakeSandbox) => Promise<void>;
+			/** When true, `commands.runBackground` rejects (a failed process start). */
+			failBackground?: boolean;
 		} = {},
 	) {}
 
@@ -78,6 +82,7 @@ class FakeE2b implements E2bClient {
 					return { stdout: '', stderr: '', exitCode: 0 };
 				},
 				runBackground: async (cmd, options) => {
+					if (this.opts.failBackground) throw new Error('background start refused');
 					this.backgroundCalls.push({ cmd, options });
 					return {
 						kill: async () => {
@@ -528,6 +533,69 @@ describe('E2bCompute', () => {
 		expect(fake.runCalls.some((cmd) => cmd.includes('connect_ex'))).toBe(false);
 	});
 
+	describe('launchProcess failure paths', () => {
+		const launch = (
+			fake: FakeE2b,
+			options: { setup?: string } = {},
+		): Promise<SandboxLaunchResult> =>
+			new E2bCompute(baseConfig, fake).create(SANDBOX_ID).launchProcess!('run kernel', {
+				...options,
+				port: 2718,
+				startupTimeout: 5,
+			});
+
+		it('classifies an expired deadline with unfinished setup as setup_timeout and kills the kernel', async () => {
+			const fake = new FakeE2b();
+
+			const result = await launch(fake, { setup: 'run setup' });
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('setup_timeout');
+			expect(fake.killedBackgroundCommands).toBe(1);
+		});
+
+		it('classifies an expired deadline with no setup as readiness_timeout and kills the kernel', async () => {
+			const fake = new FakeE2b();
+
+			const result = await launch(fake);
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('readiness_timeout');
+			expect(fake.killedBackgroundCommands).toBe(1);
+		});
+
+		it('maps a getLogs failure to transport_failure and kills the kernel', async () => {
+			const fake = new FakeE2b({
+				runResult: (cmd) => {
+					if (cmd.startsWith('cat /tmp/marimohub-kernel.log')) throw new Error('logs unavailable');
+					return;
+				},
+			});
+
+			const result = await launch(fake);
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('transport_failure');
+			expect(result.stderr).toBe('logs unavailable');
+			expect(fake.killedBackgroundCommands).toBe(1);
+		});
+
+		it('maps a startProcess failure to transport_failure', async () => {
+			const fake = new FakeE2b({ failBackground: true });
+
+			const result = await launch(fake);
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('transport_failure');
+			expect(result.stderr).toBe('background start refused');
+			expect(fake.killedBackgroundCommands).toBe(0);
+		});
+	});
+
 	it('merges defined launch environment variables into the background command', async () => {
 		const state: { fake?: FakeE2b } = {};
 		const fake = new FakeE2b({
@@ -810,25 +878,34 @@ describe('createE2bClient', () => {
 
 computeContract(
 	'E2bCompute',
-	() =>
-		new E2bCompute(
-			baseConfig,
-			new FakeE2b({
-				failOn: (cmd) => cmd.includes('mh-contract-fail'),
-				runResult: (cmd) =>
-					isContractNonDirectoryFindCommand(cmd)
-						? {
-								stdout: '',
-								stderr: NOT_A_DIRECTORY_MARKER,
-								exitCode: NOT_A_DIRECTORY_EXIT_CODE,
-							}
-						: undefined,
-			}),
-		),
+	() => {
+		// The adapter reads kernel output via `cat` of the log file, so the fake
+		// serves the scripted supervisor transcript for the last launched command.
+		const state: { fake?: FakeE2b } = {};
+		const fake = new FakeE2b({
+			failOn: (cmd) => cmd.includes('mh-contract-fail'),
+			runResult: (cmd) => {
+				if (cmd.startsWith('cat /tmp/marimohub-kernel.log')) {
+					const launch = scriptContractLaunch(state.fake?.backgroundCalls.at(-1)?.cmd);
+					if (launch) return { stdout: launch.transcript, stderr: '', exitCode: 0 };
+				}
+				return isContractNonDirectoryFindCommand(cmd)
+					? {
+							stdout: '',
+							stderr: NOT_A_DIRECTORY_MARKER,
+							exitCode: NOT_A_DIRECTORY_EXIT_CODE,
+						}
+					: undefined;
+			},
+		});
+		state.fake = fake;
+		return new E2bCompute(baseConfig, fake);
+	},
 	{
 		mountFallsBack: true,
 		semantics: {
 			failingCommand: 'mh-contract-fail',
+			launch: {},
 			// The SDK does not distinguish a missing file from other read failures.
 			absentFile: { path: '/contract-absent.txt', code: 'READ_FAILED' },
 		},

--- a/packages/compute-e2b/src/index.ts
+++ b/packages/compute-e2b/src/index.ts
@@ -22,9 +22,15 @@ import {
 	buildGitCloneCommand,
 	buildLaunchCommand,
 	classifyListFilesFailure,
+	errorMessage,
+	LAUNCH_MARKER_GRACE_MS,
+	launchOutcomeResult,
+	launchTimeoutResult,
 	parseLaunchOutput,
 	parseFindFilesOutput,
 	pollUntilReady,
+	setupCompleteMarker,
+	transportFailureResult,
 	withEnvPrefix,
 } from '@marimo-hub/compute-commons';
 import { SandboxId, Seconds } from '@marimo-hub/core';
@@ -60,7 +66,6 @@ const OWNER_META_KEY = 'mh-owner';
 const DEFAULT_OWNER_TAG = 'marimohub';
 const KERNEL_LOG_PATH = '/tmp/marimohub-kernel.log';
 const LAUNCH_POLL_INTERVAL_MS = 50;
-const LAUNCH_MARKER_GRACE_MS = 250;
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => {
@@ -345,13 +350,11 @@ class E2bSandboxInstance implements SandboxInstance {
 				processId: options.processId,
 			});
 		} catch (error) {
-			return {
-				success: false,
-				reason: 'transport_failure',
-				stdout: '',
-				stderr: error instanceof Error ? error.message : String(error),
-				timings: { setup: 0, start: Math.max(0, Date.now() - launchStarted), waitport: 0 },
-			};
+			return transportFailureResult(error, {
+				setup: 0,
+				start: Math.max(0, Date.now() - launchStarted),
+				waitport: 0,
+			});
 		}
 
 		const start = Math.max(0, Date.now() - launchStarted);
@@ -366,53 +369,40 @@ class E2bSandboxInstance implements SandboxInstance {
 				logs = await process.getLogs();
 			} catch (error) {
 				await process.kill().catch(() => {});
-				return {
-					success: false,
-					reason: 'transport_failure',
-					stdout: '',
-					stderr: error instanceof Error ? error.message : String(error),
-					timings: { setup: 0, start, waitport: Math.max(0, Date.now() - waitStarted) },
-				};
+				return transportFailureResult(error, {
+					setup: 0,
+					start,
+					waitport: Math.max(0, Date.now() - waitStarted),
+				});
 			}
 
 			setupCompleted ||= `${logs.stdout}\n${logs.stderr}`.includes(
-				`__MARIMOHUB_LAUNCH_${built.nonce}__{"event":"setup_complete"`,
+				setupCompleteMarker(built.nonce),
 			);
 			const parsed = parseLaunchOutput(logs, built.nonce);
 			const outcome = parsed.outcome;
-			if (outcome?.kind === 'ready') {
-				return {
-					success: true,
-					process,
-					timings: { setup: outcome.setupMs, start, waitport: outcome.waitportMs },
-				};
-			}
 			if (outcome) {
-				return {
-					success: false,
-					reason: outcome.kind,
-					...(outcome.exitCode === undefined ? {} : { exitCode: outcome.exitCode }),
-					stdout: parsed.stdout,
-					stderr: parsed.stderr,
-					timings: { setup: outcome.setupMs, start, waitport: outcome.waitportMs },
-				};
+				if (outcome.kind === 'ready') {
+					return {
+						success: true,
+						process,
+						timings: { setup: outcome.setupMs, start, waitport: outcome.waitportMs },
+					};
+				}
+				return launchOutcomeResult(outcome.kind, outcome, parsed, start);
 			}
 
 			const now = Date.now();
 			if (deadline !== undefined && now >= deadline + LAUNCH_MARKER_GRACE_MS) {
 				await process.kill().catch(() => {});
-				const reason = options.setup && !setupCompleted ? 'setup_timeout' : 'readiness_timeout';
-				return {
-					success: false,
-					reason,
-					stdout: parsed.stdout,
-					stderr: parsed.stderr,
-					timings: {
-						setup: reason === 'setup_timeout' ? Math.max(0, options.startupTimeout - start) : 0,
-						start,
-						waitport: Math.max(0, now - waitStarted),
-					},
-				};
+				return launchTimeoutResult({
+					setup: Boolean(options.setup),
+					setupCompleted,
+					startupTimeout: options.startupTimeout,
+					output: parsed,
+					start,
+					waitport: Math.max(0, now - waitStarted),
+				});
 			}
 
 			const sleepFor =
@@ -633,7 +623,7 @@ async function defaultLoadSdk(): Promise<E2bSdk> {
 		throw new Error(
 			"MARIMOHUB_COMPUTE_BACKEND=e2b requires the 'e2b' SDK. Run `pnpm add e2b` and bake it into " +
 				"the server image, or inject it via createE2bClient's `loadSdk` on runtimes that can't " +
-				`dynamically import (e.g. Cloudflare Workers). (${err instanceof Error ? err.message : String(err)})`,
+				`dynamically import (e.g. Cloudflare Workers). (${errorMessage(err)})`,
 		);
 	}
 }

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -10,7 +10,9 @@ import { listFilesFailure } from '@marimo-hub/core/ports';
 import {
 	computeContract,
 	isContractNonDirectoryFindCommand,
+	scriptContractLaunch,
 } from '@marimo-hub/core/testing/compute-contract';
+import type { ContractLaunchScript } from '@marimo-hub/core/testing/compute-contract';
 import {
 	expectExecResult,
 	expectFileResult,
@@ -902,14 +904,35 @@ describe('KubernetesCompute', () => {
 
 computeContract(
 	'KubernetesCompute',
-	() =>
-		makeCompute(
+	() => {
+		// The adapter's launch rides startProcess: a detached in-pod supervisor plus
+		// an in-pod port waiter and a log-file `cat`. The fake plays the supervisor:
+		// it remembers the scripted transcript of the last contract launch, answers
+		// the port probe per its readiness, reports the supervisor dead for failed
+		// launches (so waitForPort aborts fast), and serves the transcript from the log.
+		let launch: ContractLaunchScript | undefined;
+		return makeCompute(
 			makeWorld({
 				execImpl: (command) => {
-					if (command.at(-1) === 'false') {
+					const cmd = command.at(-1) ?? '';
+					const scripted = scriptContractLaunch(cmd);
+					if (scripted) {
+						launch = scripted;
+						return { stdout: '123\n', stderr: '', exitCode: 0 };
+					}
+					if (cmd.includes('connect_ex(("127.0.0.1"')) {
+						return { stdout: '', stderr: '', exitCode: launch?.portOpen ? 0 : 1 };
+					}
+					if (cmd.startsWith('kill -0 ')) {
+						return { stdout: '', stderr: '', exitCode: launch?.portOpen ? 0 : 1 };
+					}
+					if (cmd.startsWith('cat /tmp/mh-proc-')) {
+						return { stdout: launch?.transcript ?? '', stderr: '', exitCode: 0 };
+					}
+					if (cmd === 'false') {
 						return { stdout: '', stderr: 'failed', exitCode: 1 };
 					}
-					if (isContractNonDirectoryFindCommand(command.at(-1))) {
+					if (isContractNonDirectoryFindCommand(cmd)) {
 						return {
 							stdout: '',
 							stderr: NOT_A_DIRECTORY_MARKER,
@@ -919,6 +942,7 @@ computeContract(
 					return;
 				},
 			}),
-		),
-	{ mountFallsBack: true, semantics: { failingCommand: 'false' } },
+		);
+	},
+	{ mountFallsBack: true, semantics: { failingCommand: 'false', launch: {} } },
 );

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -12,6 +12,8 @@ import { expectFileResult } from '@marimo-hub/core/testing';
 import {
 	computeContract,
 	CONTRACT_HIDDEN_FILE,
+	CONTRACT_LAUNCH_SETUP_EXIT_CODE,
+	CONTRACT_LAUNCH_SETUP_OUTPUT,
 	CONTRACT_SANDBOX_ID,
 	CONTRACT_VISIBLE_FILE,
 } from '@marimo-hub/core/testing/compute-contract';
@@ -62,7 +64,14 @@ afterEach(async () => {
  * A tiny HTTP server that binds whatever `--port` is passed (stands in for the
  * `marimo edit … --port 2718` command, so the adapter's port rewrite applies).
  */
-const SERVER_CMD = `node -e "const i=process.argv.indexOf('--port');const p=+process.argv[i+1];require('http').createServer((_,r)=>r.end('ok')).listen(p,'127.0.0.1')" -- --port 2718`;
+const serverCmdOn = (port: number) =>
+	`node -e "const i=process.argv.indexOf('--port');const p=+process.argv[i+1];require('http').createServer((_,r)=>r.end('ok')).listen(p,'127.0.0.1')" -- --port ${port}`;
+const SERVER_CMD = serverCmdOn(2718);
+
+// An uncommon port for the contract launch cases: the never-ready probes hit the
+// logical port directly (no `--port` to rewrite), and a developer's live marimo
+// on 2718 would make them false-ready.
+const CONTRACT_LAUNCH_LOCAL_PORT = 43119;
 
 describe('prepareMarimoCommand (pure)', () => {
 	it('passes non-`uv run` commands through untouched', () => {
@@ -857,6 +866,16 @@ computeContract('LocalCompute', () => new LocalCompute(), {
 					{ path: `/workspace/${CONTRACT_VISIBLE_FILE}`, content: 'v' },
 					{ path: `/workspace/${CONTRACT_HIDDEN_FILE}`, content: 'h' },
 				]),
+		},
+		launch: {
+			port: CONTRACT_LAUNCH_LOCAL_PORT,
+			shortStartupTimeout: 100,
+			commands: {
+				ready: serverCmdOn(CONTRACT_LAUNCH_LOCAL_PORT),
+				neverReady: 'sleep 30',
+				failingSetup: `printf '%s' '${CONTRACT_LAUNCH_SETUP_OUTPUT}' >&2; exit ${CONTRACT_LAUNCH_SETUP_EXIT_CODE}`,
+				hangingSetup: 'sleep 30',
+			},
 		},
 		envProbe: (name) => `printenv ${name}`,
 		preexistingEnv: {

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { NotFoundError, SandboxFilesystemNotADirectoryError } from 'modal';
 import type { SandboxId } from '@marimo-hub/core';
 import { listFilesFailure } from '@marimo-hub/core/ports';
-import { expectExecResult, expectFileResult } from '@marimo-hub/core/testing';
+import { expectExecResult, expectFileResult, expectLaunchResult } from '@marimo-hub/core/testing';
 import {
 	computeContract,
 	CONTRACT_HIDDEN_FILE,
+	CONTRACT_LAUNCH_SETUP_EXIT_CODE,
 	CONTRACT_VISIBLE_FILE,
+	scriptContractLaunch,
 } from '@marimo-hub/core/testing/compute-contract';
 import { modalProfileResources, ModalCompute } from './index';
 import type {
@@ -471,6 +473,146 @@ describe('ModalCompute', () => {
 		pending.resolve(0);
 	});
 
+	describe('launchProcess failure paths', () => {
+		/** A process whose streams never emit and whose wait never resolves. */
+		function hangingProcess(): ModalProcessLike {
+			return {
+				stdout: new ReadableStream<string>({ start() {} }),
+				stderr: new ReadableStream<string>({ start() {} }),
+				wait: () => new Promise<number>(() => {}),
+			};
+		}
+
+		function worldWith(execImpl: FakeSandbox['execImpl']) {
+			const world = makeWorld();
+			const sandbox = new FakeSandbox();
+			sandbox.execImpl = execImpl;
+			world.existing.set(SANDBOX_ID, sandbox);
+			return { world, sandbox };
+		}
+
+		const isKillCommand = (command: string[]) => command[2]?.includes('read -r pid') ?? false;
+
+		it('maps a spawn failure to transport_failure', async () => {
+			const { world } = worldWith(() => {
+				throw new Error('spawn refused');
+			});
+
+			const result = await makeCompute(world).create(SANDBOX_ID).launchProcess!('run kernel', {
+				port: 2718,
+				startupTimeout: 1000,
+			});
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('transport_failure');
+			expect(result.stderr).toBe('spawn refused');
+			expect(result.stdout).toBe('');
+		});
+
+		it('classifies a deadline with unfinished setup as setup_timeout and kills the process', async () => {
+			const { world, sandbox } = worldWith((command) =>
+				isKillCommand(command) ? processResult() : hangingProcess(),
+			);
+
+			const result = await makeCompute(world).create(SANDBOX_ID).launchProcess!('run kernel', {
+				setup: 'run setup',
+				port: 2718,
+				startupTimeout: 5,
+			});
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('setup_timeout');
+			expect(sandbox.execCalls.some((call) => isKillCommand(call.command))).toBe(true);
+		});
+
+		it('classifies a deadline with no setup as readiness_timeout and kills the process', async () => {
+			const { world, sandbox } = worldWith((command) =>
+				isKillCommand(command) ? processResult() : hangingProcess(),
+			);
+
+			const result = await makeCompute(world).create(SANDBOX_ID).launchProcess!('run kernel', {
+				port: 2718,
+				startupTimeout: 5,
+			});
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('readiness_timeout');
+			expect(sandbox.execCalls.some((call) => isKillCommand(call.command))).toBe(true);
+		});
+
+		it('still succeeds when the ready marker lands within the post-deadline grace window', async () => {
+			const { world } = worldWith((command) => {
+				const nonce = command[2]?.match(/[a-f0-9]{32}/)?.[0];
+				if (!nonce) return processResult();
+				return {
+					stdout: new ReadableStream<string>({ start() {} }),
+					stderr: new ReadableStream<string>({
+						start(controller) {
+							// Past the 50ms deadline, but well inside LAUNCH_MARKER_GRACE_MS.
+							setTimeout(() => {
+								controller.enqueue(
+									`__MARIMOHUB_LAUNCH_${nonce}__{"event":"ready","setupMs":1,"waitportMs":2}\n`,
+								);
+							}, 100);
+						},
+					}),
+					wait: () => new Promise<number>(() => {}),
+				};
+			});
+
+			const result = await makeCompute(world).create(SANDBOX_ID).launchProcess!('run kernel', {
+				port: 2718,
+				startupTimeout: 50,
+			});
+
+			expectLaunchResult(result, { success: true });
+		});
+
+		it('maps a stream that ends before readiness to transport_failure with merged stderr', async () => {
+			const { world } = worldWith((command) =>
+				isKillCommand(command) ? processResult() : processResult(0, '', 'kernel-noise\n'),
+			);
+
+			const result = await makeCompute(world).create(SANDBOX_ID).launchProcess!('run kernel', {
+				port: 2718,
+				startupTimeout: 60_000,
+			});
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('transport_failure');
+			expect(result.stderr).toContain('kernel-noise');
+			expect(result.stderr).toContain('Modal launch stream ended before reporting readiness');
+		});
+
+		it('carries the exit code of a non-ready terminal outcome (kernel_exit)', async () => {
+			const { world } = worldWith((command) => {
+				const nonce = command[2]?.match(/[a-f0-9]{32}/)?.[0];
+				if (!nonce) return processResult();
+				return processResult(
+					3,
+					'kernel stdout\n',
+					`__MARIMOHUB_LAUNCH_${nonce}__{"event":"kernel_exit","setupMs":4,"waitportMs":9,"exitCode":3}\n`,
+				);
+			});
+
+			const result = await makeCompute(world).create(SANDBOX_ID).launchProcess!('run kernel', {
+				port: 2718,
+				startupTimeout: 60_000,
+			});
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('kernel_exit');
+			expect(result.exitCode).toBe(3);
+			expect(result.stdout).toBe('kernel stdout\n');
+			expect(result.timings).toEqual({ setup: 4, start: expect.any(Number), waitport: 9 });
+		});
+	});
+
 	it('treats destroy of an absent sandbox as idempotent', async () => {
 		const world = makeWorld();
 		await expect(makeCompute(world).create(SANDBOX_ID).destroy()).resolves.toBeUndefined();
@@ -523,6 +665,23 @@ function contractWorld() {
 	world.client.sandboxes.create = async (app, image, options) => {
 		const sandbox = (await create(app, image, options)) as FakeSandbox;
 		sandbox.execImpl = (command) => {
+			const launch = scriptContractLaunch(command[2]);
+			if (launch) {
+				if (launch.kind === 'ready') {
+					// A live kernel: the ready marker arrives on stderr and the process
+					// keeps running (wait never resolves).
+					return {
+						stdout: textStream(''),
+						stderr: textStream(launch.transcript),
+						wait: () => new Promise<number>(() => {}),
+					};
+				}
+				return processResult(
+					launch.kind === 'setup_exit' ? CONTRACT_LAUNCH_SETUP_EXIT_CODE : 124,
+					'',
+					launch.transcript,
+				);
+			}
 			return command[2]?.includes('mh-contract-fail')
 				? processResult(1, '', 'scripted failure')
 				: processResult();
@@ -536,6 +695,7 @@ computeContract('ModalCompute', () => makeCompute(contractWorld()), {
 	mountFallsBack: true,
 	semantics: {
 		failingCommand: 'mh-contract-fail',
+		launch: {},
 		// Modal maps every filesystem read exception to READ_FAILED.
 		absentFile: { path: '/workspace/contract-absent.txt', code: 'READ_FAILED' },
 		hiddenFiles: {

--- a/packages/compute-modal/src/index.test.ts
+++ b/packages/compute-modal/src/index.test.ts
@@ -527,6 +527,38 @@ describe('ModalCompute', () => {
 			expect(sandbox.execCalls.some((call) => isKillCommand(call.command))).toBe(true);
 		});
 
+		it('classifies the deadline as readiness_timeout when completed setup was evicted from the capped tail', async () => {
+			const { world } = worldWith((command) => {
+				if (isKillCommand(command)) return processResult();
+				const nonce = command[2]?.match(/[a-f0-9]{32}/)?.[0];
+				if (!nonce) return processResult();
+				return {
+					stdout: new ReadableStream<string>({ start() {} }),
+					stderr: new ReadableStream<string>({
+						start(controller) {
+							controller.enqueue(
+								`__MARIMOHUB_LAUNCH_${nonce}__{"event":"setup_complete","setupMs":5,"waitportMs":0}\n`,
+							);
+							// Enough kernel noise to push the setup_complete marker out of the
+							// 64 KiB retained tail before the deadline expires.
+							controller.enqueue(`${'x'.repeat(70 * 1024)}\n`);
+						},
+					}),
+					wait: () => new Promise<number>(() => {}),
+				};
+			});
+
+			const result = await makeCompute(world).create(SANDBOX_ID).launchProcess!('run kernel', {
+				setup: 'run setup',
+				port: 2718,
+				startupTimeout: 5,
+			});
+
+			expectLaunchResult(result, { success: false });
+			if (result.success) throw new Error('expected a launch failure');
+			expect(result.reason).toBe('readiness_timeout');
+		});
+
 		it('classifies a deadline with no setup as readiness_timeout and kills the process', async () => {
 			const { world, sandbox } = worldWith((command) =>
 				isKillCommand(command) ? processResult() : hangingProcess(),

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -11,11 +11,11 @@ import {
 	errorMessage,
 	LAUNCH_MARKER_GRACE_MS,
 	launchOutcomeResult,
+	LaunchProtocolTracker,
 	launchTimeoutResult,
 	mapWithConcurrency,
 	OutputTail,
 	parseLaunchOutput,
-	setupCompleteMarker,
 	shellQuote,
 	transportFailureResult,
 	withEnvPrefix,
@@ -378,7 +378,9 @@ class ModalSandboxInstance implements SandboxInstance {
 	private async startProcessWithOutput(
 		cmd: string,
 		options?: StartProcessOptions,
-		onOutput?: (logs: { stdout: string; stderr: string }) => void,
+		// Raw per-stream chunks, observed BEFORE the capped-tail append so a caller
+		// can track protocol markers that later output would evict from the tail.
+		onOutput?: (chunk: { stream: 'stdout' | 'stderr'; text: string }) => void,
 	): Promise<{ process: SandboxProcess; completed: Promise<void> }> {
 		const pidPath = `/tmp/marimohub-process-${randomUUID()}.pid`;
 		const trackedCommand = [
@@ -399,12 +401,12 @@ class ModalSandboxInstance implements SandboxInstance {
 		let settled = false;
 		const execInSandbox = (command: string) => this.exec(command);
 		const stdoutDone = consumeStream(modalProcess.stdout, (chunk) => {
+			onOutput?.({ stream: 'stdout', text: chunk });
 			stdoutTail.append(chunk);
-			onOutput?.({ stdout: stdoutTail.text, stderr: stderrTail.text });
 		});
 		const stderrDone = consumeStream(modalProcess.stderr, (chunk) => {
+			onOutput?.({ stream: 'stderr', text: chunk });
 			stderrTail.append(chunk);
-			onOutput?.({ stdout: stdoutTail.text, stderr: stderrTail.text });
 		});
 		const exited = modalProcess
 			.wait()
@@ -484,9 +486,12 @@ class ModalSandboxInstance implements SandboxInstance {
 			resolveOutcome = resolve;
 			rejectOutcome = reject;
 		});
-		const inspect = (logs: { stdout: string; stderr: string }) => {
+		// Fed raw chunks so protocol state survives eviction from the capped tails.
+		const tracker = new LaunchProtocolTracker(built.nonce);
+		const inspect = (chunk: { stream: 'stdout' | 'stderr'; text: string }) => {
+			tracker.feed(chunk.stream, chunk.text);
 			if (settled) return;
-			const terminal = parseLaunchOutput(logs, built.nonce).outcome;
+			const terminal = tracker.outcome;
 			if (terminal) {
 				settled = true;
 				resolveOutcome(terminal);
@@ -562,12 +567,9 @@ class ModalSandboxInstance implements SandboxInstance {
 			}
 
 			await started.process.kill().catch(() => {});
-			const setupCompleted = `${logs.stdout}\n${logs.stderr}`.includes(
-				setupCompleteMarker(built.nonce),
-			);
 			return launchTimeoutResult({
 				setup: Boolean(options.setup),
-				setupCompleted,
+				setupCompleted: tracker.setupCompleted,
 				startupTimeout: options.startupTimeout,
 				output: parsed,
 				start,

--- a/packages/compute-modal/src/index.ts
+++ b/packages/compute-modal/src/index.ts
@@ -8,9 +8,16 @@ import {
 import {
 	buildLaunchCommand,
 	buildGitCloneCommand,
+	errorMessage,
+	LAUNCH_MARKER_GRACE_MS,
+	launchOutcomeResult,
+	launchTimeoutResult,
 	mapWithConcurrency,
+	OutputTail,
 	parseLaunchOutput,
+	setupCompleteMarker,
 	shellQuote,
+	transportFailureResult,
 	withEnvPrefix,
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
@@ -203,7 +210,6 @@ function delay(ms: number): Promise<void> {
 }
 
 let processSequence = 0;
-const LAUNCH_MARKER_GRACE_MS = 100;
 
 class ModalLaunchTimeoutError extends Error {
 	override readonly name = 'ModalLaunchTimeoutError';
@@ -387,18 +393,18 @@ class ModalSandboxInstance implements SandboxInstance {
 			env: options?.env,
 			timeout: options?.timeout,
 		});
-		let stdout = '';
-		let stderr = '';
+		const stdoutTail = new OutputTail();
+		const stderrTail = new OutputTail();
 		let exitCode: number | undefined;
 		let settled = false;
 		const execInSandbox = (command: string) => this.exec(command);
 		const stdoutDone = consumeStream(modalProcess.stdout, (chunk) => {
-			stdout += chunk;
-			onOutput?.({ stdout, stderr });
+			stdoutTail.append(chunk);
+			onOutput?.({ stdout: stdoutTail.text, stderr: stderrTail.text });
 		});
 		const stderrDone = consumeStream(modalProcess.stderr, (chunk) => {
-			stderr += chunk;
-			onOutput?.({ stdout, stderr });
+			stderrTail.append(chunk);
+			onOutput?.({ stdout: stdoutTail.text, stderr: stderrTail.text });
 		});
 		const exited = modalProcess
 			.wait()
@@ -436,7 +442,7 @@ class ModalSandboxInstance implements SandboxInstance {
 					if (exitCode !== undefined) {
 						await Promise.allSettled([stdoutDone, stderrDone]);
 						throw new Error(
-							`process exited (code ${exitCode}) before port ${port} was ready.\n${stderr || stdout}`,
+							`process exited (code ${exitCode}) before port ${port} was ready.\n${stderrTail.text || stdoutTail.text}`,
 						);
 					}
 					const probe = await execInSandbox(
@@ -448,12 +454,12 @@ class ModalSandboxInstance implements SandboxInstance {
 					await delay(250);
 				}
 				throw new Error(
-					`timed out waiting for port ${port} after ${timeout}ms.\n${stderr || stdout}`,
+					`timed out waiting for port ${port} after ${timeout}ms.\n${stderrTail.text || stdoutTail.text}`,
 				);
 			},
 			async getLogs(): Promise<{ stdout: string; stderr: string }> {
 				if (exitCode !== undefined) await completed.catch(() => {});
-				return { stdout, stderr };
+				return { stdout: stdoutTail.text, stderr: stderrTail.text };
 			},
 		};
 		return { process: sandboxProcess, completed };
@@ -499,13 +505,11 @@ class ModalSandboxInstance implements SandboxInstance {
 				inspect,
 			);
 		} catch (error) {
-			return {
-				success: false,
-				reason: 'transport_failure',
-				stdout: '',
-				stderr: error instanceof Error ? error.message : String(error),
-				timings: { setup: 0, start: Math.max(0, Date.now() - launchStarted), waitport: 0 },
-			};
+			return transportFailureResult(error, {
+				setup: 0,
+				start: Math.max(0, Date.now() - launchStarted),
+				waitport: 0,
+			});
 		}
 
 		const start = Math.max(0, Date.now() - launchStarted);
@@ -552,29 +556,23 @@ class ModalSandboxInstance implements SandboxInstance {
 					success: false,
 					reason: 'transport_failure',
 					stdout: parsed.stdout,
-					stderr: [parsed.stderr, error instanceof Error ? error.message : String(error)]
-						.filter(Boolean)
-						.join('\n'),
+					stderr: [parsed.stderr, errorMessage(error)].filter(Boolean).join('\n'),
 					timings: { setup: 0, start, waitport: Math.max(0, Date.now() - waitStarted) },
 				};
 			}
 
 			await started.process.kill().catch(() => {});
 			const setupCompleted = `${logs.stdout}\n${logs.stderr}`.includes(
-				`__MARIMOHUB_LAUNCH_${built.nonce}__{"event":"setup_complete"`,
+				setupCompleteMarker(built.nonce),
 			);
-			const reason = options.setup && !setupCompleted ? 'setup_timeout' : 'readiness_timeout';
-			return {
-				success: false,
-				reason,
-				stdout: parsed.stdout,
-				stderr: parsed.stderr,
-				timings: {
-					setup: reason === 'setup_timeout' ? Math.max(0, options.startupTimeout - start) : 0,
-					start,
-					waitport: Math.max(0, Date.now() - waitStarted),
-				},
-			};
+			return launchTimeoutResult({
+				setup: Boolean(options.setup),
+				setupCompleted,
+				startupTimeout: options.startupTimeout,
+				output: parsed,
+				start,
+				waitport: Math.max(0, Date.now() - waitStarted),
+			});
 		} finally {
 			if (timer) clearTimeout(timer);
 		}
@@ -601,14 +599,7 @@ class ModalSandboxInstance implements SandboxInstance {
 
 		await started.completed.catch(() => {});
 		const parsed = parseLaunchOutput(await started.process.getLogs(), built.nonce);
-		return {
-			success: false,
-			reason: terminal.kind,
-			...(terminal.exitCode === undefined ? {} : { exitCode: terminal.exitCode }),
-			stdout: parsed.stdout,
-			stderr: parsed.stderr,
-			timings,
-		};
+		return launchOutcomeResult(terminal.kind, terminal, parsed, start);
 	}
 
 	async exposePort(port: number, _options: ExposePortOptions): Promise<ExposePortResult> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,7 @@ export type { ArchiveFile, ParseWorkspaceArchiveOptions } from './integrations/w
 export { traceContext } from './tracing';
 
 // OTEL logs bridge — makes stdout wide-events durable when an entrypoint wires a provider
-export { emitLogRecord } from './logs';
+export { emitLogRecord, logEvent } from './logs';
 
 // Saga orchestrator (multi-step compensating operations)
 export * from './saga';

--- a/packages/core/src/logs.test.ts
+++ b/packages/core/src/logs.test.ts
@@ -4,8 +4,8 @@ import {
 	LoggerProvider,
 	SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { emitLogRecord } from './logs';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { emitLogRecord, logEvent } from './logs';
 
 // Runs first, before the beforeAll below registers a provider (that registration
 // is a hook, so it fires in the run phase — not at collection time like a bare
@@ -78,5 +78,61 @@ describe('emitLogRecord with a registered provider', () => {
 	it('preserves nested attribute structure', () => {
 		emitLogRecord({ level: 'error', event: 'op_failed', error: { name: 'Err', code: 'E1' } });
 		expect(only().attributes.error).toMatchObject({ name: 'Err', code: 'E1' });
+	});
+});
+
+describe('logEvent', () => {
+	it('writes one JSON line with the event fields', () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			logEvent({ level: 'info', event: 'session.start', sid: 'sess-1' });
+			expect(log).toHaveBeenCalledTimes(1);
+			expect(JSON.parse(log.mock.calls[0][0] as string)).toMatchObject({
+				event: 'session.start',
+				sid: 'sess-1',
+			});
+		} finally {
+			log.mockRestore();
+		}
+	});
+
+	it('writes via console.warn on the warn channel', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		try {
+			logEvent({ level: 'warn', event: 'slow' }, { channel: 'warn' });
+			expect(warn).toHaveBeenCalledTimes(1);
+		} finally {
+			warn.mockRestore();
+		}
+	});
+
+	it('still emits a line naming the event when fields are not serializable', () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			const circular: Record<string, unknown> = { event: 'sandbox_setup_slow' };
+			circular.self = circular;
+			logEvent(circular);
+			expect(log).toHaveBeenCalledTimes(1);
+			expect(JSON.parse(log.mock.calls[0][0] as string)).toMatchObject({
+				level: 'error',
+				event: 'log_event_serialization_failed',
+				attempted_event: 'sandbox_setup_slow',
+			});
+		} finally {
+			log.mockRestore();
+		}
+	});
+
+	it('survives a BigInt field with a non-string event', () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			logEvent({ count: 1n });
+			expect(JSON.parse(log.mock.calls[0][0] as string)).toMatchObject({
+				event: 'log_event_serialization_failed',
+				attempted_event: 'unknown',
+			});
+		} finally {
+			log.mockRestore();
+		}
 	});
 });

--- a/packages/core/src/logs.test.ts
+++ b/packages/core/src/logs.test.ts
@@ -123,6 +123,20 @@ describe('logEvent', () => {
 		}
 	});
 
+	it('falls back when a toJSON field makes the record serialize to a non-object', () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			logEvent({ event: 'wide', toJSON: () => {} });
+			expect(log).toHaveBeenCalledTimes(1);
+			expect(JSON.parse(log.mock.calls[0][0] as string)).toMatchObject({
+				event: 'log_event_serialization_failed',
+				attempted_event: 'wide',
+			});
+		} finally {
+			log.mockRestore();
+		}
+	});
+
 	it('survives a BigInt field with a non-string event', () => {
 		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
 		try {

--- a/packages/core/src/logs.ts
+++ b/packages/core/src/logs.ts
@@ -35,7 +35,13 @@ export function logEvent(
 	// (circular error, BigInt) must still leave a line naming the lost event.
 	let line: string;
 	try {
-		line = JSON.stringify(record);
+		// A `toJSON` field spread onto the record can make stringify return
+		// `undefined` or a scalar without throwing — that also loses the event.
+		const serialized: unknown = JSON.stringify(record);
+		if (typeof serialized !== 'string' || !serialized.startsWith('{')) {
+			throw new TypeError('record did not serialize to an object');
+		}
+		line = serialized;
 	} catch {
 		const attempted = fields.event;
 		try {

--- a/packages/core/src/logs.ts
+++ b/packages/core/src/logs.ts
@@ -6,6 +6,7 @@
  */
 import type { AnyValue, AnyValueMap } from '@opentelemetry/api-logs';
 import { logs, SeverityNumber } from '@opentelemetry/api-logs';
+import { traceContext } from './tracing';
 
 const SEVERITY: Record<string, SeverityNumber> = {
 	debug: SeverityNumber.DEBUG,
@@ -17,6 +18,24 @@ const SEVERITY: Record<string, SeverityNumber> = {
 // The proxy binds to the real provider once registered, so caching before startup
 // is safe — and getLogger is not free per the api-logs docs.
 let cachedLogger: ReturnType<typeof logs.getLogger> | undefined;
+
+/**
+ * Wide-event logger: one JSON object per line (machine-parseable, no
+ * pino/winston — keeps Workers builds dependency-free) with the active trace
+ * ids merged in, mirrored to the OTEL logs pipeline via {@link emitLogRecord}.
+ * `channel: 'warn'` writes via `console.warn` for events that should stand out
+ * on a terminal; the OTLP severity comes from `fields.level` either way.
+ */
+export function logEvent(
+	fields: Record<string, unknown>,
+	options?: { channel?: 'log' | 'warn' },
+): void {
+	const record = { ts: new Date().toISOString(), ...traceContext(), ...fields };
+	try {
+		(options?.channel === 'warn' ? console.warn : console.log)(JSON.stringify(record));
+	} catch {}
+	emitLogRecord(record);
+}
 
 /**
  * Mirror a `logEvent` record to the OTEL logs pipeline: `level` sets the

--- a/packages/core/src/logs.ts
+++ b/packages/core/src/logs.ts
@@ -31,8 +31,26 @@ export function logEvent(
 	options?: { channel?: 'log' | 'warn' },
 ): void {
 	const record = { ts: new Date().toISOString(), ...traceContext(), ...fields };
+	// Same two-stage fallback as logOperationalError: a non-serializable field
+	// (circular error, BigInt) must still leave a line naming the lost event.
+	let line: string;
 	try {
-		(options?.channel === 'warn' ? console.warn : console.log)(JSON.stringify(record));
+		line = JSON.stringify(record);
+	} catch {
+		const attempted = fields.event;
+		try {
+			line = JSON.stringify({
+				ts: record.ts,
+				level: 'error',
+				event: 'log_event_serialization_failed',
+				attempted_event: typeof attempted === 'string' ? attempted.slice(0, 128) : 'unknown',
+			});
+		} catch {
+			line = '{"level":"error","event":"log_event_serialization_failed"}';
+		}
+	}
+	try {
+		(options?.channel === 'warn' ? console.warn : console.log)(line);
 	} catch {}
 	emitLogRecord(record);
 }

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -10,7 +10,7 @@ import { PythonEnvironmentSetupError, UnavailableError } from '../../errors';
 import type { NotebookId, ProjectId, SandboxId, UserId } from '../../ids';
 import { workspaceSourcePolicy } from '../../integrations/remoteWorkspace';
 import type { WorkspaceLoadMode } from '../../integrations/remoteWorkspace';
-import { emitLogRecord } from '../../logs';
+import { logEvent } from '../../logs';
 import { paths } from '../../paths';
 import { logOperationalError } from '../../operationalLog';
 import type {
@@ -24,7 +24,6 @@ import type {
 } from '../../ports/sandbox';
 import { Stopwatch } from '../../timing';
 import type { Timings } from '../../timing';
-import { traceContext } from '../../tracing';
 import { captureFilesystemSnapshot, createOrRestoreSandbox } from '../content/filesystemSnapshots';
 import { buildMarimoLaunch, DEFAULT_LAUNCH_STRATEGY } from './marimoLaunch';
 import type { MarimoLaunchPlan, MarimoLaunchStrategyName } from './marimoLaunch';
@@ -122,23 +121,20 @@ function logSlowSetup(
 	const timingFields = Object.fromEntries(
 		Object.entries(diagnostics.timings).map(([step, ms]) => [`provision_setup_${step}_ms`, ms]),
 	);
-	const record = {
-		ts: new Date().toISOString(),
-		...traceContext(),
-		level: 'warn',
-		event: 'sandbox_setup_slow',
-		sandbox_id: options.sandboxId,
-		project_id: options.projectId,
-		notebook_id: options.notebookId,
-		launch_strategy: options.launchStrategy ?? DEFAULT_LAUNCH_STRATEGY,
-		provision_setup_ms: setupMs,
-		...timingFields,
-		setup_stderr_tail: utf8Tail(diagnostics.stderr, SETUP_OUTPUT_TAIL_BYTES),
-	};
-	try {
-		console.warn(JSON.stringify(record));
-	} catch {}
-	emitLogRecord(record);
+	logEvent(
+		{
+			level: 'warn',
+			event: 'sandbox_setup_slow',
+			sandbox_id: options.sandboxId,
+			project_id: options.projectId,
+			notebook_id: options.notebookId,
+			launch_strategy: options.launchStrategy ?? DEFAULT_LAUNCH_STRATEGY,
+			provision_setup_ms: setupMs,
+			...timingFields,
+			setup_stderr_tail: utf8Tail(diagnostics.stderr, SETUP_OUTPUT_TAIL_BYTES),
+		},
+		{ channel: 'warn' },
+	);
 }
 
 function pythonEnvironmentSetupFailure(result: ExecResult): PythonEnvironmentSetupError {

--- a/packages/core/src/testing/assertions.ts
+++ b/packages/core/src/testing/assertions.ts
@@ -4,7 +4,12 @@ import { paths } from '../paths';
 import { AppClaimSchema } from '../schema';
 import type { NotebookId, ProjectId, SessionId } from '../ids';
 import type { Bucket } from '../ports/bucket';
-import type { ExecResult, ListFilesResult, ReadFileResult } from '../ports/sandbox';
+import type {
+	ExecResult,
+	ListFilesResult,
+	ReadFileResult,
+	SandboxLaunchResult,
+} from '../ports/sandbox';
 
 /** Assert that an async operation rejects with `NotFoundError`. */
 export async function expectNotFound(fn: () => Promise<unknown>): Promise<void> {
@@ -77,6 +82,37 @@ export function expectFileResult(
 		expect(['NOT_FOUND', 'READ_FAILED', 'BACKEND_ERROR']).toContain(received.error.code);
 	}
 	for (const key of Object.keys(expected) as (keyof ReadFileResult)[]) {
+		expect(received[key], key).toEqual(expected[key]);
+	}
+}
+
+/**
+ * Assert a `SandboxLaunchResult` envelope and match the given fields. Both arms
+ * carry timings; the failure arm additionally carries a typed reason and the
+ * captured output strings. Omitted fields aren't checked, so
+ * `expectLaunchResult(res, { success: false })` only pins the envelope shape.
+ */
+export function expectLaunchResult(
+	received: SandboxLaunchResult,
+	expected: Partial<SandboxLaunchResult> = {},
+): void {
+	expect(typeof received.success).toBe('boolean');
+	expect(typeof received.timings.setup).toBe('number');
+	expect(typeof received.timings.start).toBe('number');
+	expect(typeof received.timings.waitport).toBe('number');
+	if (!received.success) {
+		expect([
+			'setup_exit',
+			'setup_timeout',
+			'kernel_exit',
+			'readiness_timeout',
+			'transport_failure',
+		]).toContain(received.reason);
+		expect(typeof received.stdout).toBe('string');
+		expect(typeof received.stderr).toBe('string');
+		if (received.exitCode !== undefined) expect(typeof received.exitCode).toBe('number');
+	}
+	for (const key of Object.keys(expected) as (keyof SandboxLaunchResult)[]) {
 		expect(received[key], key).toEqual(expected[key]);
 	}
 }

--- a/packages/core/src/testing/computeContract.ts
+++ b/packages/core/src/testing/computeContract.ts
@@ -15,7 +15,12 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import type { SandboxId } from '../ids';
 import type { SandboxInstance, SandboxProvider } from '../ports/sandbox';
-import { expectExecResult, expectFileResult, expectListFilesResult } from './assertions';
+import {
+	expectExecResult,
+	expectFileResult,
+	expectLaunchResult,
+	expectListFilesResult,
+} from './assertions';
 
 export const CONTRACT_SANDBOX_ID = 'sb-aaaaaaaaaaaaaaaa' as SandboxId;
 export const CONTRACT_VISIBLE_FILE = 'contract-visible.txt';
@@ -24,6 +29,109 @@ export const CONTRACT_NON_DIRECTORY_PATH = '/workspace/contract-file.txt';
 
 export function isContractNonDirectoryFindCommand(command: string | undefined): boolean {
 	return Boolean(command?.includes('find ') && command.includes(CONTRACT_NON_DIRECTORY_PATH));
+}
+
+export const CONTRACT_LAUNCH_PORT = 2718;
+export const CONTRACT_LAUNCH_READY_COMMAND = 'mh-contract-launch-ready';
+export const CONTRACT_LAUNCH_NEVER_READY_COMMAND = 'mh-contract-launch-never-ready';
+export const CONTRACT_LAUNCH_FAILING_SETUP = 'mh-contract-setup-fail';
+export const CONTRACT_LAUNCH_HANGING_SETUP = 'mh-contract-setup-hang';
+export const CONTRACT_LAUNCH_SETUP_EXIT_CODE = 7;
+export const CONTRACT_LAUNCH_SETUP_OUTPUT = 'contract setup failed';
+
+export interface ContractLaunchScript {
+	kind: 'ready' | 'setup_exit' | 'setup_timeout' | 'readiness_timeout';
+	/** Marker lines the fake supervisor emits over the adapter's log/stream channel. */
+	transcript: string;
+	/** Whether the kernel port answers (only the ready case). */
+	portOpen: boolean;
+}
+
+/**
+ * Script the launch-supervisor transcript a backend fake should surface for a
+ * contract launch, keyed off the sentinel setup/kernel commands embedded in the
+ * supervised command string. Returns undefined for anything that is not a
+ * contract launch, so fakes can call it on every command they see.
+ *
+ * The marker format duplicates the compute-commons launch protocol on purpose:
+ * `core` cannot depend on `@marimo-hub/compute-commons` (the dependency rule
+ * bans `compute-*` imports), and the wire format IS what this contract pins.
+ */
+export function scriptContractLaunch(
+	command: string | undefined,
+): ContractLaunchScript | undefined {
+	// The launch nonce is the only 32-hex run in a supervised command, however
+	// many times the adapter re-quotes or wraps it.
+	const nonce = command?.match(/[0-9a-f]{32}/)?.[0];
+	if (!command || !nonce) return undefined;
+	const line = (event: string, values: Record<string, number>) =>
+		`__MARIMOHUB_LAUNCH_${nonce}__${JSON.stringify({ event, ...values })}\n`;
+	if (command.includes(CONTRACT_LAUNCH_FAILING_SETUP)) {
+		return {
+			kind: 'setup_exit',
+			portOpen: false,
+			transcript: `${CONTRACT_LAUNCH_SETUP_OUTPUT}\n${line('setup_exit', {
+				setupMs: 5,
+				waitportMs: 0,
+				exitCode: CONTRACT_LAUNCH_SETUP_EXIT_CODE,
+			})}`,
+		};
+	}
+	if (command.includes(CONTRACT_LAUNCH_HANGING_SETUP)) {
+		return {
+			kind: 'setup_timeout',
+			portOpen: false,
+			transcript: line('setup_timeout', { setupMs: 10, waitportMs: 0 }),
+		};
+	}
+	if (command.includes(CONTRACT_LAUNCH_NEVER_READY_COMMAND)) {
+		return {
+			kind: 'readiness_timeout',
+			portOpen: false,
+			transcript:
+				line('setup_complete', { setupMs: 0, waitportMs: 0 }) +
+				line('readiness_timeout', { setupMs: 0, waitportMs: 10 }),
+		};
+	}
+	if (command.includes(CONTRACT_LAUNCH_READY_COMMAND)) {
+		return {
+			kind: 'ready',
+			portOpen: true,
+			transcript:
+				line('setup_complete', { setupMs: 0, waitportMs: 0 }) +
+				line('ready', { setupMs: 0, waitportMs: 3 }),
+		};
+	}
+	return undefined;
+}
+
+/**
+ * Opt-in `launchProcess` cases. A fake-backed adapter scripts the supervisor
+ * transcript with {@link scriptContractLaunch} and opts in with `launch: {}`;
+ * a backend that executes for real (local) overrides `commands` with runnable
+ * equivalents whose behavior matches each sentinel.
+ */
+export interface ComputeContractLaunchSemantics {
+	/** Port passed to `launchProcess` (a fake may ignore it). */
+	port?: number;
+	/** Deadline for the ready and setup-exit cases. */
+	startupTimeout?: number;
+	/** Tiny deadline for the timeout-classification cases. */
+	shortStartupTimeout?: number;
+	commands?: {
+		/** Kernel command that reaches readiness on `port`. */
+		ready?: string;
+		/** Kernel command that never opens the port. */
+		neverReady?: string;
+		/** Setup command that exits with `setupExitCode` after emitting `setupFailureOutput`. */
+		failingSetup?: string;
+		/** Setup command that never completes within `shortStartupTimeout`. */
+		hangingSetup?: string;
+	};
+	/** Substring expected in the captured setup-failure output. */
+	setupFailureOutput?: string;
+	/** Exit code the failing setup reports. */
+	setupExitCode?: number;
 }
 
 const CONTRACT_ID = CONTRACT_SANDBOX_ID;
@@ -84,6 +192,8 @@ export type ComputeContractSemantics = {
 	absentFile?: { path: string; code: 'NOT_FOUND' | 'READ_FAILED' };
 	/** Directory listing whose seed creates the contract's visible and hidden fixtures. */
 	hiddenFiles?: { dir: string; seed: (inst: SandboxInstance) => Promise<void> };
+	/** `launchProcess` cases; opt in with `{}` once the fake scripts the launch protocol. */
+	launch?: ComputeContractLaunchSemantics;
 } & EnvironmentSemantics;
 
 export function computeContract(
@@ -242,6 +352,66 @@ export function computeContract(
 				expect(defaultNames).not.toContain(CONTRACT_HIDDEN_FILE);
 				const withHidden = await inst.listFiles(hiddenFiles.dir, { includeHidden: true });
 				expect(withHidden.files.map((f) => f.name)).toContain(CONTRACT_HIDDEN_FILE);
+			});
+		}
+
+		if (semantics.launch !== undefined) {
+			const launch = semantics.launch;
+			const port = launch.port ?? CONTRACT_LAUNCH_PORT;
+			const startupTimeout = launch.startupTimeout ?? 15_000;
+			const shortStartupTimeout = launch.shortStartupTimeout ?? 100;
+			const commands = {
+				ready: launch.commands?.ready ?? CONTRACT_LAUNCH_READY_COMMAND,
+				neverReady: launch.commands?.neverReady ?? CONTRACT_LAUNCH_NEVER_READY_COMMAND,
+				failingSetup: launch.commands?.failingSetup ?? CONTRACT_LAUNCH_FAILING_SETUP,
+				hangingSetup: launch.commands?.hangingSetup ?? CONTRACT_LAUNCH_HANGING_SETUP,
+			};
+
+			describe('launchProcess', () => {
+				it('drives setup + readiness to a successful launch with timings', async () => {
+					const inst = provider.create(CONTRACT_ID);
+					expect(typeof inst.launchProcess).toBe('function');
+					const result = await inst.launchProcess!(commands.ready, { port, startupTimeout });
+					expectLaunchResult(result, { success: true });
+					if (!result.success) throw new Error(`launch failed: ${JSON.stringify(result)}`);
+					await result.process.kill().catch(() => {});
+				}, 20_000);
+
+				it('maps a non-zero setup exit to setup_exit with its output and exit code', async () => {
+					const result = await provider.create(CONTRACT_ID).launchProcess!(commands.ready, {
+						setup: commands.failingSetup,
+						port,
+						startupTimeout,
+					});
+					expectLaunchResult(result, { success: false });
+					if (result.success) throw new Error('expected a launch failure');
+					expect(result.reason).toBe('setup_exit');
+					expect(result.exitCode).toBe(launch.setupExitCode ?? CONTRACT_LAUNCH_SETUP_EXIT_CODE);
+					expect(result.stdout + result.stderr).toContain(
+						launch.setupFailureOutput ?? CONTRACT_LAUNCH_SETUP_OUTPUT,
+					);
+				}, 20_000);
+
+				it('classifies an expired deadline with no setup as readiness_timeout', async () => {
+					const result = await provider.create(CONTRACT_ID).launchProcess!(commands.neverReady, {
+						port,
+						startupTimeout: shortStartupTimeout,
+					});
+					expectLaunchResult(result, { success: false });
+					if (result.success) throw new Error('expected a launch failure');
+					expect(result.reason).toBe('readiness_timeout');
+				}, 20_000);
+
+				it('blames an unfinished setup for an expired deadline (setup_timeout)', async () => {
+					const result = await provider.create(CONTRACT_ID).launchProcess!(commands.neverReady, {
+						setup: commands.hangingSetup,
+						port,
+						startupTimeout: shortStartupTimeout,
+					});
+					expectLaunchResult(result, { success: false });
+					if (result.success) throw new Error('expected a launch failure');
+					expect(result.reason).toBe('setup_timeout');
+				}, 20_000);
 			});
 		}
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -321,7 +321,7 @@ export default defineConfig({
 			},
 			{
 				// Entrypoints, examples, and dedicated logging modules write to stdout.
-				files: ['apps/server/**', 'examples/**', 'scripts/**', '**/log.ts'],
+				files: ['apps/server/**', 'examples/**', 'scripts/**', '**/log.ts', '**/logs.ts'],
 				rules: {
 					'eslint/no-console': 'off',
 				},


### PR DESCRIPTION
Pre-release checklist fixes for the next version, all non-breaking:

- Admin sandbox-startup endpoint: `status`/`failure_code` now use `extensibleResponseEnum`, request body optional (`{}` no longer required); specs regenerated.
- `logEvent` moved to core so services and adapters share one wide-event logger; fixes `coreweave_ensure` never reaching OTLP log export.
- Launch-protocol result assembly deduped into compute-commons helpers; drifted `LAUNCH_MARKER_GRACE_MS` unified at 250ms.
- New `OutputTail` caps retained kernel stdout/stderr at a 64 KiB UTF-8-safe tail (was unbounded for the sandbox lifetime in coreweave/modal).
- `computeContract` gained `launchProcess` conformance cases (ready / setup_exit / readiness_timeout / setup_timeout) run by all 9 adapter suites — kubernetes and cloudflare previously had zero launch coverage; new `expectLaunchResult` helper; modal/e2b failure-path tests. +51 tests.
- Docs: sandbox startup diagnostic section (+cross-links), corrected stale `sandbox-image.md` uv behavior, admin debug page in auth.md, new spans and wide events in operations.md.