### PR TITLE
Support R2 Iceberg catalogs in DuckDB

### DIFF
--- a/development_docs/duckdb_wasm_iceberg_broker.md
+++ b/development_docs/duckdb_wasm_iceberg_broker.md
@@ -2,10 +2,13 @@
 
 ## Status
 
-The Node DuckDB-Wasm runtime supports guarded, read-only Iceberg REST access.
-The runtime advertises `iceberg-http` only when the composition root supplies a parent broker session factory.
+The Node DuckDB-Wasm runtime provides guarded, read-only access to Iceberg REST catalogs.
+When the composition root supplies a parent broker session factory, the runtime advertises
+`iceberg-http`.
 
-The runtime rejects host path enumeration and mutation through every Node filesystem callback, including when `httpfs` requires DuckDB external access to remain enabled. The unbrokered runtime also rejects all remote protocols.
+Every Node filesystem callback blocks host-path enumeration and mutation. This restriction also
+applies when `httpfs` requires DuckDB external access. The unbrokered runtime blocks all remote
+protocols.
 
 ## Request path
 
@@ -21,13 +24,21 @@ API request
   -> close the broker session and terminate or recycle the worker
 ```
 
-The worker receives dummy DuckDB credentials. Real catalog and S3 credentials stay in the parent process.
+The worker receives dummy catalog credentials. Explicit S3 credentials stay in the parent process.
 
-For brokered Run SQL requests, the parent also removes rendered integration files and environment variables from the worker request.
+For an R2 Data Catalog, temporary SigV4 credentials enter the disposable worker. The broker forwards
+signed requests only to the bucket derived from the trusted catalog URI. The parent adds
+`X-Iceberg-Access-Delegation: vended-credentials` to each R2 catalog request. This header asks the
+catalog to return temporary storage credentials.
+
+For brokered Run SQL requests, the parent removes rendered integration files and environment
+variables from the worker request.
 
 ## Supported configuration
 
-The Iceberg REST integration must use this configuration:
+The Iceberg REST integration supports two configurations.
+
+The explicit S3 configuration requires:
 
 - no authentication or bearer-token authentication
 - a catalog URL without query parameters
@@ -40,9 +51,33 @@ The Iceberg REST integration must use this configuration:
 - system TLS without custom headers or extra properties
 - the default PyIceberg runtime and REST client options
 
+The R2 Data Catalog configuration requires:
+
+- a recognized R2 Data Catalog URI
+- bearer-token authentication
+- catalog storage
+- `access_delegation: vended_credentials`
+- system TLS without custom headers or extra properties
+- the default PyIceberg runtime and REST client options
+
+The R2 route derives its storage endpoint and bucket from the catalog URI. R2 does not require these
+explicit S3 fields:
+
+- an endpoint
+- client options or credentials
+- broker read locations
+- virtual-hosted bucket constraints
+
+The catalog scopes temporary SigV4 credentials to the R2 permissions of the bearer token.
+
+Catalog and path-style storage prefixes must not overlap. A bucket named `iceberg` must use
+`https://catalog.cloudflarestorage.com/{account}/iceberg`. The account-scoped
+`https://{account}.r2.cloudflarestorage.com/iceberg/iceberg` form is not SQL-ready.
+
 Other Iceberg configurations use the fixed PyIceberg sandbox preview.
 
-Each read location contains an S3 bucket and prefix. The broker denies every object URL outside these prefixes.
+For explicit S3, each read location contains a bucket and prefix. The broker denies object URLs
+outside these prefixes.
 
 ## Broker policy
 
@@ -53,47 +88,65 @@ A broker session contains these controls:
 - an allowlist of `GET` and `HEAD` methods
 - parent-owned authorization or signing functions
 - request, redirect, cumulative-byte, and single-response limits
-- at most four concurrent requests, with response-byte reservations reconciled to actual bodies
+- at most four concurrent requests
+- response-byte reservations that adjust to actual response sizes
 
 The worker can submit safe protocol headers such as `Range` and `If-None-Match`.
-The broker rejects worker authorization, cookie, host, proxy, forwarding, and Iceberg access-delegation headers.
+The broker drops worker-supplied authorization, cookie, host, proxy, forwarding, and Iceberg
+access-delegation headers. It also drops dummy DuckDB signatures on parent-authenticated routes.
+For R2, the parent adds the fixed access-delegation header only to the catalog route. Only R2 storage
+routes can receive catalog-vended SigV4 headers. Catalog routes and other buckets cannot receive them.
 
-The Node transport does not follow redirects. The broker authorizes each redirect target and applies the credentials for that route.
-As a result, a catalog credential cannot move to an object-store route.
+The Node transport does not follow redirects. The broker authorizes each redirect target and then
+applies the credentials for that route. Thus, catalog credentials cannot move to an object-store
+route.
 
-The transport resolves each hostname once. It rejects forbidden addresses and pins the socket to the checked address set.
-It disables connection pooling so every request uses its newly validated address set.
-DNS, connection, headers, and body reads share one deadline bounded by the execution deadline.
+The transport resolves each hostname once. It rejects forbidden addresses and pins the socket to
+the checked address set. The transport disables connection pooling, so each request uses a newly
+checked address set. DNS lookup, connection, headers, and body reads share the execution deadline.
 `MARIMOHUB_INTEGRATIONS_PROBE=private` permits private and loopback targets for private deployments.
 
 ## Worker bridge
 
-DuckDB-Wasm uses synchronous `XMLHttpRequest` calls. The worker waits on a `SharedArrayBuffer` while the parent completes each request.
+DuckDB-Wasm uses synchronous `XMLHttpRequest` calls. The worker waits on a `SharedArrayBuffer` while
+the parent completes each request.
 
 The bridge has fixed header and body buffers. A single response cannot exceed 16 MiB.
-The broker also applies a 64 MiB cumulative response limit and a 512-request limit to each session.
-Each remote request must echo the nonce bound to its current execution. A stale or mismatched nonce closes the session and terminates the worker.
+Each broker session has a 64 MiB cumulative response limit and a 512-request limit. Each remote
+request must echo the nonce for its current execution. A stale or incorrect nonce closes the session
+and terminates the worker.
 
-The parent closes the broker session after success, failure, cancellation, or runtime shutdown. Session closure aborts active transport requests.
-Preview workers that process brokered data are dedicated to that execution and disposed afterward; a previously used pooled worker is never promoted into a brokered execution.
+The parent closes the broker session after success, failure, cancellation, or runtime shutdown.
+Session closure aborts active transport requests. A preview worker that processes brokered data runs
+only that execution and then stops. A pooled worker cannot become a brokered worker after use.
 
-The broker emits low-cardinality metrics for authorization outcomes, redirects, exhausted budgets, response bytes, and request and transport latency. The runtime also records bridge failures and worker termination reasons. Metric tags contain only fixed outcome, reason, method, route, status-class, and budget values; they never contain URLs, capability IDs, or credentials.
+The broker emits low-cardinality metrics for authorization outcomes, redirects, exhausted budgets,
+response bytes, and latency. The runtime also records bridge failures and worker termination reasons.
+Metric tags contain only fixed outcome, reason, method, route, status-class, and budget values. They
+never contain URLs, capability IDs, or credentials.
 
 ## Extensions
 
-The runtime packages signed DuckDB 1.4.3 Wasm extensions for `iceberg`, `httpfs`, `parquet`, and `avro`.
-The worker loads these files from the local package and checks their SHA-256 digests.
-It advertises `iceberg-http` only after all four extensions load successfully during initialization.
-A checked-in manifest couples their origin and hashes to the pinned DuckDB-Wasm and embedded DuckDB versions; a drift test verifies the package pin, engine badge, and packaged bytes.
+The runtime packages signed DuckDB 1.4.3 Wasm extensions for `iceberg`, `httpfs`, `parquet`, and
+`avro`. The worker loads these files from the local package and checks their SHA-256 digests. It
+advertises `iceberg-http` only after all four extensions load during initialization. A checked-in
+manifest binds their origin and hashes to the pinned DuckDB-Wasm and embedded DuckDB versions. A
+drift test checks the package pin, engine badge, and packaged bytes.
 
 Automatic extension installation, automatic extension loading, and community extensions remain disabled.
 The extension-download origin accepts only the four pinned file names.
 
 ## Tests
 
-Unit tests cover route authorization, credential separation, redirects, expiry, cancellation, bounded parallelism, byte limits, S3 signing, private-address policy, and per-request DNS pinning.
+Unit tests cover authorization, credential separation, redirects, expiry, cancellation, concurrency,
+byte limits, S3 signing, private-address policy, and DNS pinning. An integration test runs the
+packaged DuckDB-Wasm Iceberg extension through the worker bridge. The test checks that the R2 catalog
+transport receives the parent-owned bearer token and access-delegation header.
 
-The live test seeds a populated Iceberg snapshot in the local Iceberg REST and MinIO services. It executes the production preview and Run SQL planners, then verifies that catalog metadata, manifest-list, manifest, and Iceberg data-file requests all cross the worker bridge. It also reads a standalone signed Parquet object. The catalog-conformance workflow runs this test and its adversarial broker unit suites in CI.
+The live test seeds an Iceberg snapshot in the local Iceberg REST and MinIO services. It runs the
+production preview and Run SQL plans. The test checks that catalog metadata, manifest-list, manifest,
+and data-file requests cross the worker bridge. It also reads a signed Parquet object. The catalog
+conformance workflow runs this test and the adversarial broker unit tests in CI.
 
 Run the live test with these commands:
 

--- a/development_docs/integrations.md
+++ b/development_docs/integrations.md
@@ -173,9 +173,11 @@ The configured runtime advertises `iceberg-http` and uses a parent-owned HTTP br
 The worker submits synchronous requests through fixed shared-memory buffers.
 The parent authorizes each target, injects credentials, checks DNS results, and pins the socket.
 
-The Iceberg integration supports a narrow configuration with explicit S3 read prefixes.
-Unsupported authentication, storage, TLS, delegation, and runtime options use the sandbox executor.
-See [the DuckDB-Wasm Iceberg HTTP broker](./duckdb_wasm_iceberg_broker.md) for the full boundary and test procedure.
+The Iceberg integration supports explicit S3 read prefixes and Cloudflare R2 Data Catalogs. R2 uses
+a bearer token and catalog-vended credentials. Unsupported authentication, storage, TLS, delegation,
+and runtime options use the sandbox executor. See
+[the DuckDB-Wasm Iceberg HTTP broker](./duckdb_wasm_iceberg_broker.md) for the security boundary and
+test procedure.
 
 The sandbox adapter renders only the selected integration. It uses the image
 from `MARIMOHUB_DATA_PREVIEW_IMAGE` after a PyIceberg and PyArrow preflight. It

--- a/packages/config/src/duckdbHttpBroker.test.ts
+++ b/packages/config/src/duckdbHttpBroker.test.ts
@@ -1,7 +1,11 @@
 import { createServer } from 'node:http';
 import type { Server } from 'node:http';
 import type { DuckDBHttpAccess } from '@marimo-hub/core';
-import type { IcebergHttpBrokerTransportRequest } from '@marimo-hub/duckdb-wasm-runtime/node';
+import { createNodeDuckDBWasmRuntimeFactory } from '@marimo-hub/duckdb-wasm-runtime/node';
+import type {
+	IcebergHttpBrokerTransport,
+	IcebergHttpBrokerTransportRequest,
+} from '@marimo-hub/duckdb-wasm-runtime/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	createDuckDBHttpSessionFactory,
@@ -32,10 +36,23 @@ const ACCESS = {
 	},
 } as const satisfies DuckDBHttpAccess;
 
+const R2_ACCESS = {
+	kind: 'iceberg-rest',
+	catalog: {
+		url: 'https://catalog.cloudflarestorage.com/account-id/warehouse',
+		authorization: 'Bearer catalog-secret',
+	},
+	storage: {
+		kind: 'r2-catalog',
+		endpoint: 'https://account-id.r2.cloudflarestorage.com',
+		bucket: 'warehouse',
+	},
+} as const satisfies DuckDBHttpAccess;
+
 describe('createDuckDBHttpSessionFactory', () => {
 	it('injects route-specific credentials and denies sibling paths', async () => {
 		const calls: IcebergHttpBrokerTransportRequest[] = [];
-		const transport = vi.fn(async (request: IcebergHttpBrokerTransportRequest) => {
+		const transport = vi.fn<IcebergHttpBrokerTransport>(async (request) => {
 			calls.push(request);
 			return { status: 200, headers: {}, body: new Uint8Array([1, 2, 3]) };
 		});
@@ -47,11 +64,17 @@ describe('createDuckDBHttpSessionFactory', () => {
 		await session.fetch({
 			url: 'https://catalog.example.test/iceberg/v1/config',
 			method: 'HEAD',
+			headers: { authorization: 'Bearer marimohub-parent-broker' },
 		});
 		await session.fetch({
 			url: 'https://objects.example.test/warehouse/tables/data/file.parquet',
 			method: 'GET',
-			headers: { range: 'bytes=0-127' },
+			headers: {
+				authorization: 'AWS4-HMAC-SHA256 Credential=marimohub-parent-broker',
+				range: 'bytes=0-127',
+				'x-amz-content-sha256': 'dummy-hash',
+				'x-amz-date': '20260814T120000Z',
+			},
 		});
 
 		expect(calls[0].headers).toEqual({ authorization: 'Bearer catalog-secret' });
@@ -134,6 +157,220 @@ describe('createDuckDBHttpSessionFactory', () => {
 		).rejects.toMatchObject({ code: 'target_denied' });
 	});
 
+	it('confines catalog-vended R2 signatures to the catalog bucket', async () => {
+		const calls: IcebergHttpBrokerTransportRequest[] = [];
+		const transport = vi.fn(async (request: IcebergHttpBrokerTransportRequest) => {
+			calls.push(request);
+			return { status: 200, headers: {}, body: new Uint8Array([1]) };
+		});
+		const session = createDuckDBHttpSessionFactory({ transport, now: () => NOW })(R2_ACCESS, {
+			expiresAtMs: NOW + 60_000,
+		});
+
+		await session.fetch({
+			url: 'https://catalog.cloudflarestorage.com/account-id/warehouse/v1/config',
+			method: 'GET',
+			headers: { authorization: 'Bearer marimohub-parent-broker' },
+		});
+		await session.fetch({
+			url: 'https://account-id.r2.cloudflarestorage.com/warehouse/data/file.parquet',
+			method: 'GET',
+			headers: {
+				authorization: 'AWS4-HMAC-SHA256 Credential=vended',
+				'x-amz-content-sha256': 'payload-hash',
+				'x-amz-date': '20260814T120000Z',
+				'x-amz-security-token': 'session-token',
+			},
+		});
+		await session.fetch({
+			url: 'https://warehouse.account-id.r2.cloudflarestorage.com/data/file.parquet',
+			method: 'HEAD',
+			headers: {
+				authorization: 'AWS4-HMAC-SHA256 Credential=vended-vhost',
+				'x-amz-date': '20260814T120001Z',
+			},
+		});
+
+		expect(calls[0].headers).toEqual({
+			authorization: 'Bearer catalog-secret',
+			'x-iceberg-access-delegation': 'vended-credentials',
+		});
+		expect(calls[1].headers).toEqual({
+			authorization: 'AWS4-HMAC-SHA256 Credential=vended',
+			'x-amz-content-sha256': 'payload-hash',
+			'x-amz-date': '20260814T120000Z',
+			'x-amz-security-token': 'session-token',
+		});
+		expect(calls[2]).toMatchObject({
+			url: 'https://warehouse.account-id.r2.cloudflarestorage.com/data/file.parquet',
+			method: 'HEAD',
+			headers: {
+				authorization: 'AWS4-HMAC-SHA256 Credential=vended-vhost',
+				'x-amz-date': '20260814T120001Z',
+			},
+		});
+		await expect(
+			session.fetch({
+				url: 'https://account-id.r2.cloudflarestorage.com/private/data.parquet',
+				method: 'GET',
+			}),
+		).rejects.toMatchObject({ code: 'target_denied' });
+		await expect(
+			session.fetch({
+				url: 'https://private.account-id.r2.cloudflarestorage.com/data.parquet',
+				method: 'GET',
+				headers: { authorization: 'AWS4-HMAC-SHA256 Credential=vended' },
+			}),
+		).rejects.toMatchObject({ code: 'target_denied' });
+		await expect(
+			session.fetch({
+				url: 'https://catalog.cloudflarestorage.com/account-id/warehouse/v1/config',
+				method: 'GET',
+				headers: { 'x-amz-date': '20260814T120000Z' },
+			}),
+		).rejects.toMatchObject({ code: 'header_denied' });
+		expect(calls).toHaveLength(3);
+	});
+
+	it('injects delegation into an actual DuckDB-Wasm catalog request', async () => {
+		const calls: IcebergHttpBrokerTransportRequest[] = [];
+		const transport = vi.fn<IcebergHttpBrokerTransport>(async (request) => {
+			calls.push(request);
+			const url = new URL(request.url);
+			if (url.pathname.endsWith('/v1/config')) {
+				return {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+					body: new TextEncoder().encode(JSON.stringify({ defaults: {}, overrides: {} })),
+				};
+			}
+			return {
+				status: 404,
+				headers: {} as Record<string, string>,
+				body: new Uint8Array(),
+			};
+		});
+		const runtime = await createNodeDuckDBWasmRuntimeFactory(
+			'worker',
+			createDuckDBHttpSessionFactory({ transport }),
+		)();
+
+		try {
+			await runtime.initialize({ memoryLimitMb: 128 });
+			await expect(
+				runtime.execute({
+					setup: [
+						{ text: 'LOAD iceberg' },
+						{ text: 'LOAD httpfs' },
+						{
+							text:
+								`ATTACH 'account-id_warehouse' AS "r2_e2e" (` +
+								'TYPE iceberg, ENDPOINT ?, TOKEN ?, ACCESS_DELEGATION_MODE ?, READ_ONLY)',
+							params: [R2_ACCESS.catalog.url, 'marimohub-parent-broker', 'vended_credentials'],
+						},
+					],
+					query: { text: 'SELECT 1 AS value' },
+					cleanup: [{ text: 'DETACH "r2_e2e"' }],
+					requires: ['iceberg-http'],
+					httpAccess: R2_ACCESS,
+				}),
+			).resolves.toEqual({ columns: ['value'], rows: [[1]] });
+		} finally {
+			await runtime.close();
+		}
+
+		const configRequest = calls.find((request) =>
+			new URL(request.url).pathname.endsWith('/v1/config'),
+		);
+		expect(configRequest?.headers).toMatchObject({
+			authorization: 'Bearer catalog-secret',
+			'x-iceberg-access-delegation': 'vended-credentials',
+		});
+	}, 30_000);
+
+	it('keeps non-DNS R2 bucket names on the path-style route', async () => {
+		const calls: IcebergHttpBrokerTransportRequest[] = [];
+		const transport = vi.fn(async (request: IcebergHttpBrokerTransportRequest) => {
+			calls.push(request);
+			return { status: 200, headers: {}, body: new Uint8Array([1]) };
+		});
+		const session = createDuckDBHttpSessionFactory({ transport, now: () => NOW })(
+			{
+				...R2_ACCESS,
+				storage: { ...R2_ACCESS.storage, bucket: 'warehouse_name' },
+			},
+			{ expiresAtMs: NOW + 60_000 },
+		);
+
+		await session.fetch({
+			url: 'https://account-id.r2.cloudflarestorage.com/warehouse_name/data.parquet',
+			method: 'GET',
+			headers: { authorization: 'AWS4-HMAC-SHA256 Credential=vended' },
+		});
+
+		expect(calls).toHaveLength(1);
+		await expect(
+			session.fetch({
+				url: 'https://warehouse_name.account-id.r2.cloudflarestorage.com/data.parquet',
+				method: 'GET',
+				headers: { authorization: 'AWS4-HMAC-SHA256 Credential=vended' },
+			}),
+		).rejects.toMatchObject({ code: 'target_denied' });
+	});
+
+	it('routes iceberg bucket objects through storage when the catalog uses a separate host', async () => {
+		const calls: IcebergHttpBrokerTransportRequest[] = [];
+		const transport = vi.fn(async (request: IcebergHttpBrokerTransportRequest) => {
+			calls.push(request);
+			return { status: 200, headers: {}, body: new Uint8Array([1]) };
+		});
+		const session = createDuckDBHttpSessionFactory({ transport, now: () => NOW })(
+			{
+				...R2_ACCESS,
+				catalog: {
+					...R2_ACCESS.catalog,
+					url: 'https://catalog.cloudflarestorage.com/account-id/iceberg',
+				},
+				storage: { ...R2_ACCESS.storage, bucket: 'iceberg' },
+			},
+			{ expiresAtMs: NOW + 60_000 },
+		);
+
+		await session.fetch({
+			url: 'https://account-id.r2.cloudflarestorage.com/iceberg/iceberg/data.parquet',
+			method: 'GET',
+			headers: {
+				authorization: 'AWS4-HMAC-SHA256 Credential=vended',
+				'x-amz-date': '20260814T120000Z',
+			},
+		});
+
+		expect(calls[0].headers).toEqual({
+			authorization: 'AWS4-HMAC-SHA256 Credential=vended',
+			'x-amz-date': '20260814T120000Z',
+		});
+	});
+
+	it('rejects overlapping account-scoped R2 catalog and storage routes', () => {
+		const create = createDuckDBHttpSessionFactory({
+			transport: async () => ({ status: 200, headers: {}, body: new Uint8Array() }),
+		});
+
+		expect(() =>
+			create(
+				{
+					...R2_ACCESS,
+					catalog: {
+						...R2_ACCESS.catalog,
+						url: 'https://account-id.r2.cloudflarestorage.com/iceberg/iceberg',
+					},
+					storage: { ...R2_ACCESS.storage, bucket: 'iceberg' },
+				},
+				{ expiresAtMs: NOW + 60_000 },
+			),
+		).toThrow(/catalog and path-style storage routes overlap/);
+	});
+
 	it('rejects endpoints that DuckDB cannot route through an S3 secret', () => {
 		const create = createDuckDBHttpSessionFactory({
 			transport: async () => ({ status: 200, headers: {}, body: new Uint8Array() }),
@@ -194,6 +431,36 @@ describe('createDuckDBHttpSessionFactory', () => {
 				{ expiresAtMs: Date.now() + 60_000 },
 			),
 		).toThrow(/Catalog endpoint is invalid/);
+		expect(() =>
+			create(
+				{
+					...R2_ACCESS,
+					storage: { ...R2_ACCESS.storage, endpoint: `${R2_ACCESS.storage.endpoint}/base` },
+				},
+				{ expiresAtMs: Date.now() + 60_000 },
+			),
+		).toThrow(/S3 endpoint is invalid/);
+		expect(() =>
+			create(
+				{
+					...R2_ACCESS,
+					storage: { ...R2_ACCESS.storage, bucket: '../private' },
+				},
+				{ expiresAtMs: Date.now() + 60_000 },
+			),
+		).toThrow(/S3 read location is invalid/);
+		expect(() =>
+			create(
+				{
+					...ACCESS,
+					storage: {
+						...ACCESS.storage,
+						locations: [{ bucket: 'warehouse', prefix: '' }],
+					},
+				},
+				{ expiresAtMs: Date.now() + 60_000 },
+			),
+		).toThrow(/S3 read location is invalid/);
 	});
 });
 

--- a/packages/config/src/duckdbHttpBroker.ts
+++ b/packages/config/src/duckdbHttpBroker.ts
@@ -22,6 +22,12 @@ const DEFAULT_MAX_REQUESTS = 512;
 const DEFAULT_MAX_CONCURRENT_REQUESTS = 4;
 const DEFAULT_MAX_REDIRECTS = 8;
 const DEFAULT_MAX_RESPONSE_BYTES = 64 * 1024 * 1024;
+const VENDED_S3_REQUEST_HEADERS = [
+	'authorization',
+	'x-amz-content-sha256',
+	'x-amz-date',
+	'x-amz-security-token',
+] as const;
 
 export interface DuckDBHttpBrokerOptions {
 	allowPrivate?: boolean;
@@ -58,41 +64,82 @@ export function createDuckDBHttpSessionFactory(
 }
 
 function routesFor(access: Readonly<DuckDBHttpAccess>, now: () => number) {
-	if (access.kind !== 'iceberg-rest' || access.storage.kind !== 's3') {
+	if (access.kind !== 'iceberg-rest') {
 		throw new IcebergHttpBrokerError(
 			'invalid_capability',
 			'DuckDB HTTP access specification is unsupported.',
 		);
 	}
-	const endpoint = parseEndpoint(access.storage.endpoint);
-	const credentials = access.storage.credentials;
+	const catalog = {
+		kind: 'catalog' as const,
+		url: routePrefixUrl(access.catalog.url),
+		match: 'prefix' as const,
+		methods: ['GET', 'HEAD'] as const,
+		headers: access.catalog.authorization
+			? { authorization: access.catalog.authorization }
+			: undefined,
+		discardRequestHeaders: ['authorization'] as const,
+	};
+	const storage = access.storage;
+	if (storage.kind === 'r2-catalog') {
+		const endpoint = parseEndpoint(storage.endpoint);
+		const pathStorageUrl = storagePrefixUrl(endpoint, storage.bucket, '', 'path', true);
+		if (prefixRoutesOverlap(catalog.url, pathStorageUrl)) {
+			throw new IcebergHttpBrokerError(
+				'invalid_capability',
+				'R2 catalog and path-style storage routes overlap.',
+			);
+		}
+		return [
+			{
+				...catalog,
+				headers: {
+					...catalog.headers,
+					'x-iceberg-access-delegation': 'vended-credentials',
+				},
+			},
+			{
+				kind: 'storage' as const,
+				url: pathStorageUrl,
+				match: 'prefix' as const,
+				methods: ['GET', 'HEAD'] as const,
+				forwardRequestHeaders: VENDED_S3_REQUEST_HEADERS,
+			},
+			...(isDnsCompatibleS3Bucket(storage.bucket) && !isIpAddressHost(endpoint.hostname)
+				? [
+						{
+							kind: 'storage' as const,
+							url: storagePrefixUrl(endpoint, storage.bucket, '', 'vhost', true),
+							match: 'prefix' as const,
+							methods: ['GET', 'HEAD'] as const,
+							forwardRequestHeaders: VENDED_S3_REQUEST_HEADERS,
+						},
+					]
+				: []),
+		];
+	}
+	const endpoint = parseEndpoint(storage.endpoint);
+	const credentials = storage.credentials;
 	const prepareStorageHeaders =
 		credentials.method === 'static'
 			? (request: Readonly<IcebergHttpBrokerRequest>) =>
 					Promise.resolve(
 						signS3Request(request, {
 							...credentials,
-							region: access.storage.region,
+							region: storage.region,
 							now: now(),
 						}),
 					)
 			: undefined;
 	return [
-		{
-			kind: 'catalog' as const,
-			url: routePrefixUrl(access.catalog.url),
-			match: 'prefix' as const,
-			methods: ['GET', 'HEAD'] as const,
-			headers: access.catalog.authorization
-				? { authorization: access.catalog.authorization }
-				: undefined,
-		},
-		...access.storage.locations.map((location) => ({
+		catalog,
+		...storage.locations.map((location) => ({
 			kind: 'storage' as const,
-			url: storagePrefixUrl(endpoint, location.bucket, location.prefix, access.storage.urlStyle),
+			url: storagePrefixUrl(endpoint, location.bucket, location.prefix, storage.urlStyle),
 			match: 'prefix' as const,
 			methods: ['GET', 'HEAD'] as const,
 			prepareHeaders: prepareStorageHeaders,
+			discardRequestHeaders: VENDED_S3_REQUEST_HEADERS,
 		})),
 	];
 }
@@ -271,17 +318,33 @@ function routePrefixUrl(value: string): string {
 	return url.toString();
 }
 
+function prefixRoutesOverlap(left: string, right: string): boolean {
+	const leftUrl = new URL(left);
+	const rightUrl = new URL(right);
+	if (leftUrl.origin !== rightUrl.origin) return false;
+	const leftPrefix = leftUrl.pathname.replace(/\/$/, '');
+	const rightPrefix = rightUrl.pathname.replace(/\/$/, '');
+	return (
+		leftPrefix === rightPrefix ||
+		leftPrefix.startsWith(`${rightPrefix}/`) ||
+		rightPrefix.startsWith(`${leftPrefix}/`)
+	);
+}
+
 function storagePrefixUrl(
 	endpoint: URL,
 	bucket: string,
 	prefix: string,
 	urlStyle: 'path' | 'vhost',
+	allowEmptyPrefix = false,
 ): string {
 	const normalizedPrefix = prefix.replaceAll(/^\/+|\/+$/g, '');
-	const segments = normalizedPrefix.split('/');
+	const segments = normalizedPrefix ? normalizedPrefix.split('/') : [];
 	if (
-		!normalizedPrefix ||
+		(!normalizedPrefix && !allowEmptyPrefix) ||
+		!bucket ||
 		bucket.includes('/') ||
+		bucket.includes('\\') ||
 		bucket === '.' ||
 		bucket === '..' ||
 		segments.some((segment) => segment === '.' || segment === '..')

--- a/packages/core/src/services/integrations/data-preview/programs.ts
+++ b/packages/core/src/services/integrations/data-preview/programs.ts
@@ -20,21 +20,27 @@ export interface DuckDBHttpAccess {
 		url: string;
 		authorization?: string;
 	};
-	storage: {
-		kind: 's3';
-		endpoint: string;
-		region: string;
-		urlStyle: 'path' | 'vhost';
-		credentials:
-			| { method: 'anonymous' }
-			| {
-					method: 'static';
-					accessKeyId: string;
-					secretAccessKey: string;
-					sessionToken?: string;
-			  };
-		locations: readonly { bucket: string; prefix: string }[];
-	};
+	storage:
+		| {
+				kind: 's3';
+				endpoint: string;
+				region: string;
+				urlStyle: 'path' | 'vhost';
+				credentials:
+					| { method: 'anonymous' }
+					| {
+							method: 'static';
+							accessKeyId: string;
+							secretAccessKey: string;
+							sessionToken?: string;
+					  };
+				locations: readonly { bucket: string; prefix: string }[];
+		  }
+		| {
+				kind: 'r2-catalog';
+				endpoint: string;
+				bucket: string;
+		  };
 }
 
 export interface DuckDBPreviewProgram {

--- a/packages/core/src/services/integrations/kinds/icebergRest.ts
+++ b/packages/core/src/services/integrations/kinds/icebergRest.ts
@@ -291,9 +291,9 @@ export const icebergRest = defineIntegration({
 					setup: [
 						{ text: 'LOAD iceberg' },
 						{ text: 'LOAD httpfs' },
-						secret.create,
+						...(secret ? [secret.create] : []),
 						{
-							text: `ATTACH ${sqlLiteral(input.config.warehouse ?? input.integration.name)} AS ${sqlIdentifier(alias)} (${options.join(', ')})`,
+							text: `ATTACH ${sqlLiteral(duckdbWarehouse(input.config, input.integration.name))} AS ${sqlIdentifier(alias)} (${options.join(', ')})`,
 							params: attachParams,
 						},
 					],
@@ -301,7 +301,7 @@ export const icebergRest = defineIntegration({
 						text: `SELECT * FROM ${[alias, ...input.namespace, input.table].map(sqlIdentifier).join('.')} LIMIT ?`,
 						params: [input.limit],
 					},
-					cleanup: [secret.drop, { text: `DETACH ${sqlIdentifier(alias)}` }],
+					cleanup: [...(secret ? [secret.drop] : []), { text: `DETACH ${sqlIdentifier(alias)}` }],
 					requires: ['iceberg-http'],
 					httpAccess: duckdbHttpAccess(input.config),
 				},
@@ -334,13 +334,13 @@ export const icebergRest = defineIntegration({
 				setup: [
 					{ text: 'LOAD iceberg' },
 					{ text: 'LOAD httpfs' },
-					secret.create,
+					...(secret ? [secret.create] : []),
 					{
-						text: `ATTACH ${sqlLiteral(config.warehouse ?? integration.name)} AS ${alias} (${options.join(', ')})`,
+						text: `ATTACH ${sqlLiteral(duckdbWarehouse(config, integration.name))} AS ${alias} (${options.join(', ')})`,
 						params,
 					},
 				],
-				cleanup: [secret.drop, { text: `DETACH ${alias}` }],
+				cleanup: [...(secret ? [secret.drop] : []), { text: `DETACH ${alias}` }],
 				httpAccess: duckdbHttpAccess(config),
 			};
 		},
@@ -605,6 +605,79 @@ function isIpv4Address(value: string): boolean {
 	);
 }
 
+interface R2CatalogAccess {
+	endpoint: string;
+	bucket: string;
+	warehouse: string;
+}
+
+function r2CatalogAccess(config: IcebergRestConfig): R2CatalogAccess | undefined {
+	if (config.storage.scheme !== 'catalog') return undefined;
+	const url = parsedUrl(config.uri);
+	if (
+		url?.protocol !== 'https:' ||
+		url.username ||
+		url.password ||
+		url.port ||
+		url.search ||
+		url.hash
+	) {
+		return undefined;
+	}
+	let segments: string[];
+	try {
+		const pathSegments = url.pathname.split('/');
+		pathSegments.shift();
+		if (pathSegments.at(-1) === '') pathSegments.pop();
+		if (pathSegments.some((segment) => !segment)) return undefined;
+		segments = pathSegments.map((segment) => decodeURIComponent(segment));
+	} catch {
+		return undefined;
+	}
+	if (url.hostname === 'catalog.cloudflarestorage.com' && segments.length === 2) {
+		const [account, bucket] = segments;
+		if (!isR2CatalogPart(account) || !isR2Bucket(bucket)) return undefined;
+		return {
+			endpoint: `https://${account}.r2.cloudflarestorage.com`,
+			bucket,
+			warehouse: `${account}_${bucket}`,
+		};
+	}
+	const accountMatch = /^([a-z0-9-]+)\.r2\.cloudflarestorage\.com$/.exec(url.hostname);
+	if (
+		accountMatch &&
+		isR2CatalogPart(accountMatch[1]) &&
+		segments.length === 2 &&
+		segments[0] === 'iceberg'
+	) {
+		const bucket = segments[1];
+		if (!isR2Bucket(bucket)) return undefined;
+		return { endpoint: url.origin, bucket, warehouse: bucket };
+	}
+	return undefined;
+}
+
+function isR2CatalogPart(value: string): boolean {
+	return /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(value);
+}
+
+function isR2Bucket(value: string): boolean {
+	return value.length >= 3 && value.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])$/.test(value);
+}
+
+function r2CatalogRoutesOverlap(config: IcebergRestConfig, access: R2CatalogAccess): boolean {
+	const catalog = parsedUrl(config.uri);
+	const storage = parsedUrl(access.endpoint);
+	if (!catalog || !storage || catalog.origin !== storage.origin) return false;
+	const catalogPrefix = catalog.pathname.replace(/\/$/, '');
+	const storagePrefix = `/${encodeURIComponent(access.bucket)}`;
+	return (
+		catalogPrefix === storagePrefix ||
+		catalogPrefix.startsWith(`${storagePrefix}/`) ||
+		storagePrefix.startsWith(`${catalogPrefix}/`)
+	);
+}
+
 function duckdbPreviewReadiness(value: IcebergRestConfig): QueryReadinessCheck[] {
 	const config = asRecord(value) ?? {};
 	const auth = asRecord(config.auth) ?? {};
@@ -619,6 +692,8 @@ function duckdbPreviewReadiness(value: IcebergRestConfig): QueryReadinessCheck[]
 	const endpoint = parsedUrl(storage.endpoint);
 	const hasEndpoint = typeof storage.endpoint === 'string' && storage.endpoint.length > 0;
 	const storageIsS3 = storage.scheme === 's3';
+	const r2Catalog = r2CatalogAccess(value);
+	const supportedStorage = storageIsS3 || r2Catalog !== undefined;
 	const endpointOriginOnly = endpoint
 		? endpoint.pathname === '/' && endpoint.search === '' && endpoint.hash === ''
 		: false;
@@ -660,8 +735,10 @@ function duckdbPreviewReadiness(value: IcebergRestConfig): QueryReadinessCheck[]
 	return [
 		readinessCheck(
 			'catalog-auth',
-			'Use no catalog authentication or a bearer token',
-			authMethod === 'none' || authMethod === 'bearer_token',
+			r2Catalog ? 'Use a catalog bearer token' : 'Use no catalog authentication or a bearer token',
+			r2Catalog
+				? authMethod === 'bearer_token'
+				: authMethod === 'none' || authMethod === 'bearer_token',
 			'auth',
 			`${String(authMethod)} authentication is not supported by DuckDB-Wasm preview`,
 		),
@@ -702,76 +779,89 @@ function duckdbPreviewReadiness(value: IcebergRestConfig): QueryReadinessCheck[]
 		),
 		readinessCheck(
 			'no-access-delegation',
-			'Set access delegation to none',
-			config.access_delegation === 'none',
+			r2Catalog ? 'Use catalog-vended credentials' : 'Set access delegation to none',
+			r2Catalog
+				? config.access_delegation === 'vended_credentials'
+				: config.access_delegation === 'none',
 			'access_delegation',
 			'catalog access delegation is not supported by DuckDB-Wasm preview',
 		),
 		readinessCheck(
 			's3-storage',
-			'Switch Storage to the s3 scheme',
-			storageIsS3,
+			'Use explicit S3 storage or a supported R2 Data Catalog',
+			supportedStorage,
 			'storage',
-			'DuckDB-Wasm preview requires explicit S3 storage configuration',
+			'DuckDB-Wasm preview requires explicit S3 storage or a supported R2 Data Catalog',
 		),
 		readinessCheck(
-			's3-endpoint',
-			'Set an explicit S3 endpoint',
-			storageIsS3 && hasEndpoint,
-			storageIsS3 ? 'storage.endpoint' : 'storage',
-			'DuckDB-Wasm preview requires an explicit S3 endpoint',
+			'r2-route-separation',
+			'Use the catalog.cloudflarestorage.com R2 catalog URI',
+			r2Catalog === undefined || !r2CatalogRoutesOverlap(value, r2Catalog),
+			'uri',
+			'account-scoped R2 catalog and path-style storage routes overlap; use the catalog.cloudflarestorage.com catalog URI',
 		),
-		readinessCheck(
-			's3-endpoint-origin',
-			'Use an origin-only S3 endpoint',
-			storageIsS3 && endpointOriginOnly,
-			storageIsS3 ? 'storage.endpoint' : 'storage',
-			'DuckDB-Wasm preview requires an origin-only S3 endpoint',
-		),
-		readinessCheck(
-			's3-virtual-host-endpoint',
-			'Use a DNS endpoint for virtual-hosted S3',
-			storageIsS3 &&
-				(storage.force_virtual_addressing !== true ||
-					(endpoint !== undefined && !isIpAddressHost(endpoint.hostname))),
-			storageIsS3 ? 'storage.endpoint' : 'storage',
-			'virtual-hosted S3 addressing requires a DNS endpoint',
-		),
-		readinessCheck(
-			's3-basic-options',
-			'Remove advanced S3 client options',
-			storageIsS3 && advancedField === undefined,
-			storageIsS3 && advancedField ? `storage.${advancedField}` : 'storage',
-			'advanced S3 client options are not supported by DuckDB-Wasm preview',
-		),
-		readinessCheck(
-			's3-credentials',
-			'Use static S3 credentials or anonymous access',
-			supportedCredentials,
-			storageIsS3 ? 'storage.credentials' : 'storage',
-			credentialsReason,
-		),
-		readinessCheck(
-			's3-read-locations',
-			'Add at least one guarded S3 read location',
-			storageIsS3 &&
-				Array.isArray(storage.broker_read_locations) &&
-				storage.broker_read_locations.length > 0,
-			storageIsS3 ? 'storage.broker_read_locations' : 'storage',
-			'DuckDB-Wasm preview requires at least one guarded S3 read location',
-		),
-		readinessCheck(
-			's3-virtual-host-buckets',
-			'Use DNS-compatible bucket names for virtual-hosted S3',
-			storageIsS3 &&
-				(storage.force_virtual_addressing !== true ||
-					(Array.isArray(storage.broker_read_locations) &&
-						storage.broker_read_locations.every((location) =>
-							isDnsCompatibleS3Bucket(asRecord(location)?.bucket),
-						))),
-			storageIsS3 ? 'storage.broker_read_locations' : 'storage',
-			'virtual-hosted S3 addressing requires DNS-compatible bucket names',
-		),
+		...(storageIsS3
+			? [
+					readinessCheck(
+						's3-endpoint',
+						'Set an explicit S3 endpoint',
+						storageIsS3 && hasEndpoint,
+						storageIsS3 ? 'storage.endpoint' : 'storage',
+						'DuckDB-Wasm preview requires an explicit S3 endpoint',
+					),
+					readinessCheck(
+						's3-endpoint-origin',
+						'Use an origin-only S3 endpoint',
+						storageIsS3 && endpointOriginOnly,
+						storageIsS3 ? 'storage.endpoint' : 'storage',
+						'DuckDB-Wasm preview requires an origin-only S3 endpoint',
+					),
+					readinessCheck(
+						's3-virtual-host-endpoint',
+						'Use a DNS endpoint for virtual-hosted S3',
+						storageIsS3 &&
+							(storage.force_virtual_addressing !== true ||
+								(endpoint !== undefined && !isIpAddressHost(endpoint.hostname))),
+						storageIsS3 ? 'storage.endpoint' : 'storage',
+						'virtual-hosted S3 addressing requires a DNS endpoint',
+					),
+					readinessCheck(
+						's3-basic-options',
+						'Remove advanced S3 client options',
+						storageIsS3 && advancedField === undefined,
+						storageIsS3 && advancedField ? `storage.${advancedField}` : 'storage',
+						'advanced S3 client options are not supported by DuckDB-Wasm preview',
+					),
+					readinessCheck(
+						's3-credentials',
+						'Use static S3 credentials or anonymous access',
+						supportedCredentials,
+						storageIsS3 ? 'storage.credentials' : 'storage',
+						credentialsReason,
+					),
+					readinessCheck(
+						's3-read-locations',
+						'Add at least one guarded S3 read location',
+						storageIsS3 &&
+							Array.isArray(storage.broker_read_locations) &&
+							storage.broker_read_locations.length > 0,
+						storageIsS3 ? 'storage.broker_read_locations' : 'storage',
+						'DuckDB-Wasm preview requires at least one guarded S3 read location',
+					),
+					readinessCheck(
+						's3-virtual-host-buckets',
+						'Use DNS-compatible bucket names for virtual-hosted S3',
+						storageIsS3 &&
+							(storage.force_virtual_addressing !== true ||
+								(Array.isArray(storage.broker_read_locations) &&
+									storage.broker_read_locations.every((location) =>
+										isDnsCompatibleS3Bucket(asRecord(location)?.bucket),
+									))),
+						storageIsS3 ? 'storage.broker_read_locations' : 'storage',
+						'virtual-hosted S3 addressing requires DNS-compatible bucket names',
+					),
+				]
+			: []),
 		readinessCheck(
 			'default-runtime-options',
 			'Keep PyIceberg runtime options at their defaults',
@@ -815,6 +905,7 @@ function duckdbAuthOptions(
 }
 
 function duckdbS3Secret(config: IcebergRestConfig, suffix: string) {
+	if (r2CatalogAccess(config)) return;
 	if (config.storage.scheme !== 's3' || !config.storage.endpoint) {
 		throw new ValidationError('DuckDB-Wasm requires explicit S3 storage configuration.');
 	}
@@ -834,6 +925,23 @@ function duckdbS3Secret(config: IcebergRestConfig, suffix: string) {
 }
 
 function duckdbHttpAccess(config: IcebergRestConfig): DuckDBHttpAccess {
+	const r2Catalog = r2CatalogAccess(config);
+	if (r2Catalog) {
+		return {
+			kind: 'iceberg-rest',
+			catalog: {
+				url: config.uri,
+				...(config.auth.method === 'bearer_token'
+					? { authorization: `Bearer ${config.auth.token}` }
+					: {}),
+			},
+			storage: {
+				kind: 'r2-catalog',
+				endpoint: r2Catalog.endpoint,
+				bucket: r2Catalog.bucket,
+			},
+		};
+	}
 	if (config.storage.scheme !== 's3' || !config.storage.endpoint) {
 		throw new ValidationError('DuckDB-Wasm requires explicit S3 storage configuration.');
 	}
@@ -865,6 +973,10 @@ function duckdbHttpAccess(config: IcebergRestConfig): DuckDBHttpAccess {
 			locations: config.storage.broker_read_locations,
 		},
 	};
+}
+
+function duckdbWarehouse(config: IcebergRestConfig, fallback: string): string {
+	return config.warehouse ?? r2CatalogAccess(config)?.warehouse ?? fallback;
 }
 
 /**

--- a/packages/core/src/services/integrations/kinds/kinds.test.ts
+++ b/packages/core/src/services/integrations/kinds/kinds.test.ts
@@ -783,6 +783,254 @@ describe('kind renders (golden)', () => {
 		});
 	});
 
+	it('iceberg_rest supports R2 Data Catalog with a bearer token and vended credentials', () => {
+		const uri = 'https://catalog.cloudflarestorage.com/account-id/warehouse';
+		const config = icebergRest.configSchema.parse({
+			uri,
+			auth: { method: 'bearer_token', token: 'catalog-token' },
+			storage: { scheme: 'catalog' },
+		});
+		const checks = icebergRest.query?.readiness?.(config) ?? [];
+		const programs = icebergPreviewPrograms(config);
+		const integration = {
+			id: createIntegrationId(),
+			name: 'lake',
+			kind: 'iceberg_rest',
+			version: 1,
+		} as const;
+		const plan = icebergRest.query?.plan({ config, integration });
+
+		expect(checks.every((check) => check.ready)).toBe(true);
+		const ids = checks.map((check) => check.id);
+		for (const id of [
+			's3-endpoint',
+			's3-endpoint-origin',
+			's3-virtual-host-endpoint',
+			's3-basic-options',
+			's3-credentials',
+			's3-read-locations',
+			's3-virtual-host-buckets',
+		]) {
+			expect(ids).not.toContain(id);
+		}
+		expect(icebergRest.query?.available(config)).toEqual({ ok: true });
+		expect(programs?.duckdbWasm?.setup).toHaveLength(3);
+		expect(programs?.duckdbWasm?.setup[2]).toEqual({
+			text: expect.stringContaining("ATTACH 'account-id_warehouse'"),
+			params: [uri, 'marimohub-parent-broker', 'vended_credentials'],
+		});
+		expect(programs?.duckdbWasm?.cleanup).toEqual([{ text: expect.stringMatching(/^DETACH /) }]);
+		expect(programs?.duckdbWasm?.httpAccess).toEqual({
+			kind: 'iceberg-rest',
+			catalog: { url: uri, authorization: 'Bearer catalog-token' },
+			storage: {
+				kind: 'r2-catalog',
+				endpoint: 'https://account-id.r2.cloudflarestorage.com',
+				bucket: 'warehouse',
+			},
+		});
+		expect(plan).toMatchObject({
+			setup: [
+				{ text: 'LOAD iceberg' },
+				{ text: 'LOAD httpfs' },
+				{ params: [uri, 'marimohub-parent-broker', 'vended_credentials'] },
+			],
+			cleanup: [{ text: 'DETACH "lake"' }],
+			httpAccess: programs?.duckdbWasm?.httpAccess,
+		});
+	});
+
+	it('iceberg_rest supports the bucket-scoped R2 catalog URL form', () => {
+		const uri = 'https://account-id.r2.cloudflarestorage.com/iceberg/warehouse';
+		const config = icebergRest.configSchema.parse({
+			uri,
+			auth: { method: 'bearer_token', token: 'catalog-token' },
+			storage: { scheme: 'catalog' },
+		});
+		const programs = icebergPreviewPrograms(config);
+
+		expect(icebergRest.query?.available(config)).toEqual({ ok: true });
+		expect(programs?.duckdbWasm?.setup.at(-1)).toEqual({
+			text: expect.stringContaining("ATTACH 'warehouse'"),
+			params: [uri, 'marimohub-parent-broker', 'vended_credentials'],
+		});
+		expect(programs?.duckdbWasm?.httpAccess?.storage).toEqual({
+			kind: 'r2-catalog',
+			endpoint: 'https://account-id.r2.cloudflarestorage.com',
+			bucket: 'warehouse',
+		});
+	});
+
+	it('iceberg_rest rejects overlapping account-scoped R2 catalog and storage routes', () => {
+		const config = icebergRest.configSchema.parse({
+			uri: 'https://account-id.r2.cloudflarestorage.com/iceberg/iceberg',
+			auth: { method: 'bearer_token', token: 'catalog-token' },
+			storage: { scheme: 'catalog' },
+		});
+		const checks = icebergRest.query?.readiness?.(config) ?? [];
+		const failed = checks.find((check) => check.id === 'r2-route-separation');
+
+		expect(failed).toMatchObject({
+			ready: false,
+			field: 'uri',
+			label: 'Use the catalog.cloudflarestorage.com R2 catalog URI',
+		});
+		expect(icebergRest.query?.available(config)).toEqual({ ok: false, reason: failed?.reason });
+		expect(icebergRest.preview?.available(config)).toEqual({
+			ok: true,
+			programs: { python: true },
+		});
+		expect(() =>
+			icebergRest.query?.plan({
+				config,
+				integration: {
+					id: createIntegrationId(),
+					name: 'lake',
+					kind: 'iceberg_rest',
+					version: 1,
+				},
+			}),
+		).toThrow(ValidationError);
+	});
+
+	it('iceberg_rest supports an iceberg bucket through the separate catalog host', () => {
+		const config = icebergRest.configSchema.parse({
+			uri: 'https://catalog.cloudflarestorage.com/account-id/iceberg',
+			auth: { method: 'bearer_token', token: 'catalog-token' },
+			storage: { scheme: 'catalog' },
+		});
+		const programs = icebergPreviewPrograms(config);
+
+		expect(icebergRest.query?.available(config)).toEqual({ ok: true });
+		expect(programs?.duckdbWasm?.httpAccess?.storage).toEqual({
+			kind: 'r2-catalog',
+			endpoint: 'https://account-id.r2.cloudflarestorage.com',
+			bucket: 'iceberg',
+		});
+	});
+
+	it.each([
+		['a non-R2 catalog', 'https://catalog.example.com/account-id/warehouse'],
+		['an insecure catalog', 'http://catalog.cloudflarestorage.com/account-id/warehouse'],
+		['a catalog with a port', 'https://catalog.cloudflarestorage.com:8443/account-id/warehouse'],
+		['a catalog with a query', 'https://catalog.cloudflarestorage.com/account-id/warehouse?x=1'],
+		['a catalog with a fragment', 'https://catalog.cloudflarestorage.com/account-id/warehouse#x'],
+		['a missing bucket', 'https://catalog.cloudflarestorage.com/account-id'],
+		['an extra path segment', 'https://catalog.cloudflarestorage.com/account-id/warehouse/extra'],
+		['a doubled path separator', 'https://catalog.cloudflarestorage.com/account-id//warehouse'],
+		[
+			'an encoded account separator',
+			'https://catalog.cloudflarestorage.com/account%2Fid/warehouse',
+		],
+		[
+			'an encoded bucket separator',
+			'https://catalog.cloudflarestorage.com/account-id/ware%5Chouse',
+		],
+		['an uppercase bucket', 'https://catalog.cloudflarestorage.com/account-id/Warehouse'],
+		[
+			'a bucket containing a space',
+			'https://catalog.cloudflarestorage.com/account-id/ware%20house',
+		],
+		[
+			'a bucket containing a question mark',
+			'https://catalog.cloudflarestorage.com/account-id/ware%3Fhouse',
+		],
+		[
+			'a bucket with a leading hyphen',
+			'https://catalog.cloudflarestorage.com/account-id/-warehouse',
+		],
+		[
+			'a bucket with a trailing hyphen',
+			'https://catalog.cloudflarestorage.com/account-id/warehouse-',
+		],
+		[
+			'a bucket shorter than three characters',
+			'https://catalog.cloudflarestorage.com/account-id/ab',
+		],
+		[
+			'a bucket longer than 63 characters',
+			`https://catalog.cloudflarestorage.com/account-id/${'a'.repeat(64)}`,
+		],
+		[
+			'an account hostname with a leading hyphen',
+			'https://-account.r2.cloudflarestorage.com/iceberg/warehouse',
+		],
+		[
+			'an account hostname with a trailing hyphen',
+			'https://account-.r2.cloudflarestorage.com/iceberg/warehouse',
+		],
+		['a lookalike host', 'https://catalog.cloudflarestorage.com.example.test/account-id/warehouse'],
+	])('iceberg_rest does not recognize %s as an R2 Data Catalog URL', (_case, uri) => {
+		const config = icebergRest.configSchema.parse({
+			uri,
+			auth: { method: 'bearer_token', token: 'catalog-token' },
+			storage: { scheme: 'catalog' },
+		});
+		const checks = icebergRest.query?.readiness?.(config) ?? [];
+
+		expect(checks).toContainEqual(
+			expect.objectContaining({ id: 's3-storage', ready: false, field: 'storage' }),
+		);
+		expect(icebergRest.query?.available(config).ok).toBe(false);
+	});
+
+	it('iceberg_rest rejects embedded catalog credentials at the schema boundary', () => {
+		expect(() =>
+			icebergRest.configSchema.parse({
+				uri: 'https://user@catalog.cloudflarestorage.com/account-id/warehouse',
+				auth: { method: 'bearer_token', token: 'catalog-token' },
+				storage: { scheme: 'catalog' },
+			}),
+		).toThrow(/without embedded credentials/);
+	});
+
+	it.each([
+		[
+			'no catalog bearer token',
+			{ method: 'none' } as const,
+			'vended_credentials' as const,
+			'catalog-auth',
+		],
+		[
+			'no vended credentials',
+			{ method: 'bearer_token', token: 'catalog-token' } as const,
+			'none' as const,
+			'no-access-delegation',
+		],
+		[
+			'remote signing',
+			{ method: 'bearer_token', token: 'catalog-token' } as const,
+			'remote_signing' as const,
+			'no-access-delegation',
+		],
+	])(
+		'iceberg_rest rejects R2 Data Catalog configuration with %s',
+		(_case, auth, accessDelegation, id) => {
+			const config = icebergRest.configSchema.parse({
+				uri: 'https://catalog.cloudflarestorage.com/account-id/warehouse',
+				auth,
+				storage: { scheme: 'catalog' },
+				access_delegation: accessDelegation,
+			});
+			const checks = icebergRest.query?.readiness?.(config) ?? [];
+			const failed = checks.find((check) => check.id === id);
+
+			expect(failed?.ready).toBe(false);
+			expect(icebergRest.query?.available(config)).toEqual({ ok: false, reason: failed?.reason });
+			expect(() =>
+				icebergRest.query?.plan({
+					config,
+					integration: {
+						id: createIntegrationId(),
+						name: 'lake',
+						kind: 'iceberg_rest',
+						version: 1,
+					},
+				}),
+			).toThrow(ValidationError);
+		},
+	);
+
 	it('iceberg_rest plans virtual-hosted S3 through DuckDB and the guarded broker', () => {
 		const config = icebergRest.configSchema.parse({
 			uri: 'https://catalog.example.com/api',
@@ -800,7 +1048,9 @@ describe('kind renders (golden)', () => {
 
 		expect(icebergRest.query?.available(config)).toEqual({ ok: true });
 		expect(programs?.duckdbWasm?.setup[2]?.text).toContain("URL_STYLE 'vhost'");
-		expect(programs?.duckdbWasm?.httpAccess?.storage.urlStyle).toBe('vhost');
+		const storage = programs?.duckdbWasm?.httpAccess?.storage;
+		expect(storage?.kind).toBe('s3');
+		expect(storage?.kind === 's3' ? storage.urlStyle : undefined).toBe('vhost');
 	});
 
 	it('iceberg_rest does not classify out-of-range dotted bucket names as IPv4', () => {

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
@@ -460,6 +460,55 @@ describe('IcebergHttpBroker', () => {
 		expect(response).toMatchObject({ status: 200, headers: { etag: 'snapshot-1' } });
 	});
 
+	it('does not carry discarded or parent-owned headers into redirects', async () => {
+		const { broker, calls } = setup([
+			{
+				status: 307,
+				headers: {
+					Location: 'https://objects.example.test/warehouse/table/metadata.json',
+				},
+			},
+			{ status: 200, body: '{}' },
+		]);
+		const id = broker.open(
+			capability({
+				routes: [
+					{
+						kind: 'catalog',
+						url: 'https://catalog.example.test/iceberg',
+						match: 'prefix',
+						methods: ['GET'],
+						headers: { Authorization: 'Bearer catalog-secret' },
+						discardRequestHeaders: ['authorization'],
+					},
+					{
+						kind: 'storage',
+						url: 'https://objects.example.test/warehouse',
+						match: 'prefix',
+						methods: ['GET'],
+						forwardRequestHeaders: ['authorization'],
+					},
+				],
+			}),
+		);
+
+		await broker.fetch(id, {
+			url: 'https://catalog.example.test/iceberg/v1/table',
+			method: 'GET',
+			headers: {
+				authorization: 'Bearer worker-placeholder',
+				range: 'bytes=0-99',
+			},
+		});
+
+		expect(calls).toHaveLength(2);
+		expect(calls[0].headers).toEqual({
+			range: 'bytes=0-99',
+			authorization: 'Bearer catalog-secret',
+		});
+		expect(calls[1].headers).toEqual({ range: 'bytes=0-99' });
+	});
+
 	it('emits low-cardinality policy, redirect, budget, byte, and latency metrics', async () => {
 		const metrics = {
 			increment: vi.fn(),

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
@@ -95,6 +95,46 @@ describe('IcebergHttpBroker', () => {
 		expect(error).toMatchObject({ code: 'invalid_capability' });
 	});
 
+	it.each(['authorization', 'x-amz-content-sha256', 'x-amz-date', 'x-amz-security-token'])(
+		'does not allow %s to be forwarded across every route',
+		(header) => {
+			const { broker } = setup();
+
+			expect(() => broker.open(capability({ forwardRequestHeaders: ['range', header] }))).toThrow(
+				IcebergHttpBrokerError,
+			);
+		},
+	);
+
+	it.each([
+		['a non-array forwarded list', { forwardRequestHeaders: 'authorization' }],
+		['a non-string forwarded name', { forwardRequestHeaders: [42] }],
+		['an empty forwarded name', { forwardRequestHeaders: [''] }],
+		['a never-forwarded name', { forwardRequestHeaders: ['cookie'] }],
+		['a non-array discarded list', { discardRequestHeaders: 'authorization' }],
+		['a non-string discarded name', { discardRequestHeaders: [42] }],
+		['an empty discarded name', { discardRequestHeaders: [''] }],
+		['a never-forwarded discarded name', { discardRequestHeaders: ['host'] }],
+	])('rejects a route with %s', (_case, routeOptions) => {
+		const { broker } = setup();
+
+		expect(() =>
+			broker.open(
+				capability({
+					routes: [
+						{
+							kind: 'storage',
+							url: 'https://objects.example.test/warehouse',
+							match: 'prefix',
+							methods: ['GET'],
+							...routeOptions,
+						},
+					] as IcebergHttpBrokerCapability['routes'],
+				}),
+			),
+		).toThrow(IcebergHttpBrokerError);
+	});
+
 	it('keeps credentials in the parent and forwards only approved worker headers', async () => {
 		const { broker, calls } = setup([
 			{
@@ -123,6 +163,107 @@ describe('IcebergHttpBroker', () => {
 			maxResponseBytes: 4096,
 		});
 		expect(response.headers).toEqual({ 'content-range': 'bytes 0-1/20' });
+	});
+
+	it('discards worker placeholders before applying parent-owned credentials', async () => {
+		const { broker, calls } = setup();
+		const id = broker.open(
+			capability({
+				routes: [
+					{
+						kind: 'catalog',
+						url: 'https://catalog.example.test/iceberg',
+						match: 'prefix',
+						methods: ['GET'],
+						headers: { Authorization: 'Bearer catalog-secret' },
+						discardRequestHeaders: ['authorization'],
+					},
+				],
+			}),
+		);
+
+		await broker.fetch(id, {
+			url: 'https://catalog.example.test/iceberg/v1/config',
+			method: 'GET',
+			headers: { authorization: 'Bearer marimohub-parent-broker' },
+		});
+
+		expect(calls[0].headers).toEqual({ authorization: 'Bearer catalog-secret' });
+	});
+
+	it('rejects overlapping forwarded and discarded route headers', () => {
+		const { broker } = setup();
+		expect(() =>
+			broker.open(
+				capability({
+					routes: [
+						{
+							kind: 'storage',
+							url: 'https://objects.example.test/warehouse',
+							match: 'prefix',
+							methods: ['GET'],
+							forwardRequestHeaders: ['Authorization'],
+							discardRequestHeaders: ['authorization'],
+						},
+					],
+				}),
+			),
+		).toThrow(IcebergHttpBrokerError);
+	});
+
+	it('forwards vended signing headers only on the storage route that grants them', async () => {
+		const { broker, calls } = setup();
+		const id = broker.open(
+			capability({
+				routes: [
+					{
+						kind: 'catalog',
+						url: 'https://catalog.example.test/iceberg',
+						match: 'prefix',
+						methods: ['GET'],
+						headers: { Authorization: 'Bearer catalog-secret' },
+					},
+					{
+						kind: 'storage',
+						url: 'https://objects.example.test/warehouse',
+						match: 'prefix',
+						methods: ['GET'],
+						forwardRequestHeaders: [
+							'authorization',
+							'x-amz-content-sha256',
+							'x-amz-date',
+							'x-amz-security-token',
+						],
+					},
+				],
+			}),
+		);
+
+		await broker.fetch(id, {
+			url: 'https://objects.example.test/warehouse/table/data.parquet',
+			method: 'GET',
+			headers: {
+				authorization: 'AWS4-HMAC-SHA256 Credential=vended',
+				'x-amz-content-sha256': 'payload-hash',
+				'x-amz-date': '20260814T120000Z',
+				'x-amz-security-token': 'session-token',
+			},
+		});
+
+		expect(calls[0].headers).toEqual({
+			authorization: 'AWS4-HMAC-SHA256 Credential=vended',
+			'x-amz-content-sha256': 'payload-hash',
+			'x-amz-date': '20260814T120000Z',
+			'x-amz-security-token': 'session-token',
+		});
+		await expectCode(
+			broker.fetch(id, {
+				url: 'https://catalog.example.test/iceberg/v1/config',
+				method: 'GET',
+				headers: { authorization: 'AWS4-HMAC-SHA256 Credential=vended' },
+			}),
+			'header_denied',
+		);
 	});
 
 	it('allows catalog HEAD and computes parent-owned headers after authorization', async () => {

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
@@ -104,6 +104,7 @@ interface Session {
 
 interface AuthorizedRequest {
 	request: IcebergHttpBrokerRequest;
+	redirectState: IcebergHttpBrokerRequest;
 	routeKind: IcebergHttpBrokerRoute['kind'];
 }
 
@@ -280,7 +281,7 @@ export class IcebergHttpBroker {
 					session.metrics.increment('duckdb_http_broker.redirect', 1, {
 						outcome: 'followed',
 					});
-					current = redirectRequest(current, location, response.status);
+					current = redirectRequest(authorized.redirectState, location, response.status);
 				}
 			} finally {
 				session.controllers.delete(controller);
@@ -521,6 +522,7 @@ async function authorize(
 			...request,
 			headers: { ...workerHeaders, ...route.headers, ...preparedHeaders },
 		},
+		redirectState: { ...request, headers: workerHeaders },
 		routeKind: route.kind,
 	};
 }

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
@@ -14,6 +14,8 @@ export interface IcebergHttpBrokerRoute {
 	prepareHeaders?: (
 		request: Readonly<IcebergHttpBrokerRequest>,
 	) => Promise<Readonly<Record<string, string>>>;
+	forwardRequestHeaders?: readonly string[];
+	discardRequestHeaders?: readonly string[];
 }
 
 export interface IcebergHttpBrokerCapability {
@@ -81,6 +83,8 @@ interface NormalizedRoute {
 	methods: ReadonlySet<IcebergHttpBrokerMethod>;
 	headers: Readonly<Record<string, string>>;
 	prepareHeaders?: IcebergHttpBrokerRoute['prepareHeaders'];
+	forwardRequestHeaders: ReadonlySet<string>;
+	discardRequestHeaders: ReadonlySet<string>;
 }
 
 interface Session {
@@ -115,8 +119,7 @@ const DEFAULT_FORWARDED_REQUEST_HEADERS = [
 	'range',
 ] as const;
 
-const FORBIDDEN_WORKER_HEADERS = new Set([
-	'authorization',
+const NEVER_FORWARDED_WORKER_HEADERS = new Set([
 	'cookie',
 	'host',
 	'proxy-authorization',
@@ -124,6 +127,14 @@ const FORBIDDEN_WORKER_HEADERS = new Set([
 	'x-forwarded-for',
 	'x-forwarded-host',
 	'x-iceberg-access-delegation',
+]);
+
+const GLOBALLY_FORBIDDEN_WORKER_HEADERS = new Set([
+	...NEVER_FORWARDED_WORKER_HEADERS,
+	'authorization',
+	'x-amz-content-sha256',
+	'x-amz-date',
+	'x-amz-security-token',
 ]);
 
 const RESPONSE_HEADERS = new Set([
@@ -341,7 +352,7 @@ function normalizeCapability(
 		throw invalidCapability();
 	}
 	const forwarded = new Set(rawForwardedHeaders.map(normalizeHeaderName));
-	if ([...forwarded].some((header) => !header || FORBIDDEN_WORKER_HEADERS.has(header))) {
+	if ([...forwarded].some((header) => !header || GLOBALLY_FORBIDDEN_WORKER_HEADERS.has(header))) {
 		throw invalidCapability();
 	}
 	return {
@@ -382,6 +393,37 @@ function normalizeRoute(route: IcebergHttpBrokerRoute): NormalizedRoute {
 	if (route.prepareHeaders !== undefined && typeof route.prepareHeaders !== 'function') {
 		throw invalidCapability();
 	}
+	if (route.forwardRequestHeaders !== undefined && !Array.isArray(route.forwardRequestHeaders)) {
+		throw invalidCapability();
+	}
+	const rawForwardedHeaders: readonly unknown[] = route.forwardRequestHeaders ?? [];
+	if (!rawForwardedHeaders.every((header): header is string => typeof header === 'string')) {
+		throw invalidCapability();
+	}
+	const forwardRequestHeaders = new Set(rawForwardedHeaders.map(normalizeHeaderName));
+	if (
+		[...forwardRequestHeaders].some(
+			(header) => !header || NEVER_FORWARDED_WORKER_HEADERS.has(header),
+		)
+	) {
+		throw invalidCapability();
+	}
+	if (route.discardRequestHeaders !== undefined && !Array.isArray(route.discardRequestHeaders)) {
+		throw invalidCapability();
+	}
+	const rawDiscardedHeaders: readonly unknown[] = route.discardRequestHeaders ?? [];
+	if (!rawDiscardedHeaders.every((header): header is string => typeof header === 'string')) {
+		throw invalidCapability();
+	}
+	const discardRequestHeaders = new Set(rawDiscardedHeaders.map(normalizeHeaderName));
+	if (
+		[...discardRequestHeaders].some(
+			(header) => !header || NEVER_FORWARDED_WORKER_HEADERS.has(header),
+		) ||
+		[...discardRequestHeaders].some((header) => forwardRequestHeaders.has(header))
+	) {
+		throw invalidCapability();
+	}
 	if (Object.keys(headers).some((header) => header === 'host' || header === 'content-length')) {
 		throw invalidCapability();
 	}
@@ -392,6 +434,8 @@ function normalizeRoute(route: IcebergHttpBrokerRoute): NormalizedRoute {
 		methods,
 		headers,
 		prepareHeaders: route.prepareHeaders,
+		forwardRequestHeaders,
+		discardRequestHeaders,
 	};
 }
 
@@ -438,14 +482,20 @@ async function authorize(
 			'Iceberg HTTP broker method is not allowed for this target.',
 		);
 	}
-	const workerHeaders = normalizeHeaders(request.headers ?? {}, 'invalid_request');
-	for (const header of Object.keys(workerHeaders)) {
-		if (FORBIDDEN_WORKER_HEADERS.has(header) || !session.forwardRequestHeaders.has(header)) {
+	const submittedHeaders = normalizeHeaders(request.headers ?? {}, 'invalid_request');
+	const workerHeaders: Record<string, string> = {};
+	for (const [header, value] of Object.entries(submittedHeaders)) {
+		if (route.discardRequestHeaders.has(header)) continue;
+		if (
+			NEVER_FORWARDED_WORKER_HEADERS.has(header) ||
+			(!session.forwardRequestHeaders.has(header) && !route.forwardRequestHeaders.has(header))
+		) {
 			throw new IcebergHttpBrokerError(
 				'header_denied',
 				`Iceberg HTTP broker request header "${header}" is not allowed.`,
 			);
 		}
+		workerHeaders[header] = value;
 	}
 	const preparedHeaders = normalizeHeaders(
 		(await route.prepareHeaders?.(request)) ?? {},

--- a/packages/duckdb-wasm-runtime/src/syncXmlHttpRequest.test.ts
+++ b/packages/duckdb-wasm-runtime/src/syncXmlHttpRequest.test.ts
@@ -24,13 +24,15 @@ function setup() {
 }
 
 describe('synchronous DuckDB XMLHttpRequest', () => {
-	it('forwards only safe read headers and returns binary data', () => {
+	it('forwards read and vended S3 signing headers and returns binary data', () => {
 		const { XMLHttpRequest, requests } = setup();
 		const request = new XMLHttpRequest();
 		request.open('GET', 'https://objects.example.test/warehouse/data.parquet', false);
 		request.setRequestHeader('Range', 'bytes=0-1');
 		request.setRequestHeader('Authorization', 'Bearer worker-secret');
+		request.setRequestHeader('X-Amz-Content-Sha256', 'payload-hash');
 		request.setRequestHeader('X-Amz-Date', '20260814T120000Z');
+		request.setRequestHeader('X-Amz-Security-Token', 'session-token');
 		request.setRequestHeader('X-Iceberg-Access-Delegation', 'vended-credentials');
 		request.responseType = 'arraybuffer';
 		request.send(null);
@@ -38,7 +40,13 @@ describe('synchronous DuckDB XMLHttpRequest', () => {
 		expect(requests[0].request).toEqual({
 			url: 'https://objects.example.test/warehouse/data.parquet',
 			method: 'GET',
-			headers: { range: 'bytes=0-1' },
+			headers: {
+				authorization: 'Bearer worker-secret',
+				range: 'bytes=0-1',
+				'x-amz-content-sha256': 'payload-hash',
+				'x-amz-date': '20260814T120000Z',
+				'x-amz-security-token': 'session-token',
+			},
 		});
 		expect(requests[0].executionNonce).toBe('execution-nonce-1');
 		expect(request.status).toBe(206);

--- a/packages/duckdb-wasm-runtime/src/syncXmlHttpRequest.ts
+++ b/packages/duckdb-wasm-runtime/src/syncXmlHttpRequest.ts
@@ -9,12 +9,16 @@ import type { HttpBridgeRequestMessage } from './httpBridge.ts';
 
 const FORWARDED_HEADERS = new Set([
 	'accept',
+	'authorization',
 	'content-type',
 	'if-match',
 	'if-modified-since',
 	'if-none-match',
 	'if-unmodified-since',
 	'range',
+	'x-amz-content-sha256',
+	'x-amz-date',
+	'x-amz-security-token',
 ]);
 
 export interface SyncXmlHttpRequestOptions {


### PR DESCRIPTION
Adds DuckDB-Wasm support for bearer-authenticated Cloudflare R2 Data Catalogs with catalog-vended credentials. The parent broker injects the fixed access-delegation header while blocking worker-supplied authentication, and it confines vended SigV4 requests to storage routes derived from the trusted catalog URI.

This also rejects overlapping catalog and storage routes, validates R2 account and bucket names, preserves explicit S3 constraints, expands unhappy-path and edge-case coverage, and documents the supported security boundary.