### PR TITLE
Harden DuckDB broker configuration edges

### DIFF
--- a/packages/config/src/duckdbHttpBroker.live.test.ts
+++ b/packages/config/src/duckdbHttpBroker.live.test.ts
@@ -50,8 +50,20 @@ function readLiveBrokerEnvironment(
 	};
 }
 
-const liveEnvironment = readLiveBrokerEnvironment(process.env);
-const describeLive = liveEnvironment ? describe : describe.skip;
+function captureLiveBrokerEnvironment(environment: Record<string, string | undefined>): {
+	environment?: LiveBrokerEnvironment;
+	error?: Error;
+} {
+	try {
+		return { environment: readLiveBrokerEnvironment(environment) };
+	} catch (error) {
+		return { error: error instanceof Error ? error : new Error(String(error)) };
+	}
+}
+
+const liveEnvironmentResult = captureLiveBrokerEnvironment(process.env);
+const describeLive =
+	liveEnvironmentResult.environment || liveEnvironmentResult.error ? describe : describe.skip;
 
 const integration = {
 	id: createIntegrationId(),
@@ -86,10 +98,21 @@ describe('readLiveBrokerEnvironment', () => {
 				'MARIMOHUB_TEST_ICEBERG_BROKER_S3_SECRET_KEY',
 		);
 	});
+
+	it('captures partial process configuration without throwing during module evaluation', () => {
+		const result = captureLiveBrokerEnvironment({
+			MARIMOHUB_TEST_ICEBERG_BROKER_URI: 'http://127.0.0.1:18181',
+		});
+
+		expect(result.environment).toBeUndefined();
+		expect(result.error?.message).toContain('MARIMOHUB_TEST_ICEBERG_BROKER_S3_SECRET_KEY');
+	});
 });
 
 describeLive('guarded DuckDB HTTP broker live', () => {
 	it('runs production preview and query plans through the guarded broker', async () => {
+		if (liveEnvironmentResult.error) throw liveEnvironmentResult.error;
+		const liveEnvironment = liveEnvironmentResult.environment;
 		if (!liveEnvironment) throw new Error('Expected live-test configuration.');
 		const { catalogUrl: liveCatalogUrl, s3Endpoint: liveS3Endpoint } = liveEnvironment;
 		const config = icebergRest.configSchema.parse({

--- a/packages/core/src/services/integrations/kinds/common.ts
+++ b/packages/core/src/services/integrations/kinds/common.ts
@@ -86,6 +86,18 @@ export function isInsecureHttpUrl(value: string | undefined): boolean {
 	}
 }
 
+export function usesInsecureAuthenticatedS3({
+	endpoint,
+	authenticated,
+	allowInsecureTransport,
+}: {
+	endpoint: string | undefined;
+	authenticated: boolean;
+	allowInsecureTransport: boolean;
+}): boolean {
+	return authenticated && !allowInsecureTransport && isInsecureHttpUrl(endpoint);
+}
+
 export const serviceUrlField = () =>
 	z
 		.string()

--- a/packages/core/src/services/integrations/kinds/icebergRest.ts
+++ b/packages/core/src/services/integrations/kinds/icebergRest.ts
@@ -27,7 +27,12 @@ import {
 	storageProperties,
 	validateExtraProperties,
 } from './icebergShared';
-import { HTTP_HEADER_NAME_REGEX, httpUrlField, isInsecureHttpUrl } from './common';
+import {
+	HTTP_HEADER_NAME_REGEX,
+	httpUrlField,
+	isInsecureHttpUrl,
+	usesInsecureAuthenticatedS3,
+} from './common';
 
 const httpUrl = httpUrlField;
 
@@ -220,7 +225,14 @@ export const icebergRest = defineIntegration({
 						'Basic auth. Enable allow_insecure_transport to override for local development.',
 				);
 			}
-			if (usesInsecureAuthenticatedS3(config)) {
+			if (
+				config.storage.scheme === 's3' &&
+				usesInsecureAuthenticatedS3({
+					endpoint: config.storage.endpoint,
+					authenticated: !config.storage.anonymous,
+					allowInsecureTransport: config.allow_insecure_transport,
+				})
+			) {
 				throw new ValidationError(
 					'Authenticated S3 storage requires an https:// endpoint. Enable ' +
 						'allow_insecure_transport to override for local development.',
@@ -850,7 +862,11 @@ function duckdbPreviewReadiness(value: IcebergRestConfig): QueryReadinessCheck[]
 					readinessCheck(
 						's3-secure-transport',
 						'Use HTTPS for authenticated S3',
-						!usesInsecureAuthenticatedS3(value),
+						!usesInsecureAuthenticatedS3({
+							endpoint: typeof storage.endpoint === 'string' ? storage.endpoint : undefined,
+							authenticated: storage.anonymous !== true,
+							allowInsecureTransport: value.allow_insecure_transport,
+						}),
 						'storage.endpoint',
 						'authenticated S3 requires HTTPS unless insecure transport is explicitly enabled',
 					),
@@ -1029,15 +1045,6 @@ function duckdbHttpAccess(config: IcebergRestConfig): DuckDBHttpAccess {
 			locations: config.storage.broker_read_locations,
 		},
 	};
-}
-
-function usesInsecureAuthenticatedS3(config: IcebergRestConfig): boolean {
-	return (
-		config.storage.scheme === 's3' &&
-		!config.storage.anonymous &&
-		!config.allow_insecure_transport &&
-		isInsecureHttpUrl(config.storage.endpoint)
-	);
 }
 
 function duckdbWarehouse(config: IcebergRestConfig, fallback: string): string {

--- a/packages/core/src/services/integrations/kinds/objectStores.ts
+++ b/packages/core/src/services/integrations/kinds/objectStores.ts
@@ -24,6 +24,7 @@ import {
 	renderFile,
 	S3_BUCKET_REGEX,
 	s3BrokerReadLocationsSchema,
+	usesInsecureAuthenticatedS3,
 } from './common';
 
 const s3Config = z.strictObject({
@@ -260,7 +261,11 @@ function s3QueryReadiness(config: S3Config): QueryReadinessCheck[] {
 		readinessCheck(
 			's3-secure-transport',
 			'Use HTTPS for authenticated S3',
-			!usesInsecureAuthenticatedS3(config),
+			!usesInsecureAuthenticatedS3({
+				endpoint: config.endpoint_url,
+				authenticated: config.auth.method !== 'anonymous',
+				allowInsecureTransport: config.allow_insecure_transport,
+			}),
 			'endpoint_url',
 			'authenticated S3 requires HTTPS unless insecure transport is explicitly enabled',
 		),
@@ -336,16 +341,16 @@ function s3HttpAccess(config: S3Config): DuckDBHttpAccess {
 	};
 }
 
-function usesInsecureAuthenticatedS3(config: S3Config): boolean {
-	return (
-		config.auth.method !== 'anonymous' &&
-		!config.allow_insecure_transport &&
-		isInsecureHttpUrl(config.endpoint_url)
-	);
-}
-
 function assertSecureS3Transport(config: S3Config): void {
-	if (!usesInsecureAuthenticatedS3(config)) return;
+	if (
+		!usesInsecureAuthenticatedS3({
+			endpoint: config.endpoint_url,
+			authenticated: config.auth.method !== 'anonymous',
+			allowInsecureTransport: config.allow_insecure_transport,
+		})
+	) {
+		return;
+	}
 	throw new ValidationError(
 		'Authenticated S3 requires an https:// endpoint. Enable allow_insecure_transport to override ' +
 			'for local development.',

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.test.ts
@@ -499,6 +499,37 @@ describe('IcebergHttpBroker', () => {
 		expect(transport).not.toHaveBeenCalled();
 	});
 
+	it('stops waiting when a closed capability header preparer ignores its signal', async () => {
+		const { broker, transport } = setup();
+		const prepareHeaders = vi.fn(() => new Promise<Readonly<Record<string, string>>>(() => {}));
+		const id = broker.open(
+			capability({
+				routes: [
+					{
+						kind: 'catalog',
+						url: 'https://catalog.example.test/iceberg',
+						match: 'prefix',
+						methods: ['GET'],
+						prepareHeaders,
+					},
+				],
+			}),
+		);
+		const pending = broker.fetch(id, {
+			url: 'https://catalog.example.test/iceberg/v1/config',
+			method: 'GET',
+		});
+		await vi.waitFor(() => expect(prepareHeaders).toHaveBeenCalledOnce());
+
+		broker.close(id);
+
+		await expect(pending).rejects.toMatchObject({
+			name: 'AbortError',
+			message: 'The DuckDB remote-read request was canceled.',
+		});
+		expect(transport).not.toHaveBeenCalled();
+	});
+
 	it('uses an exact route before an equal-path prefix route', async () => {
 		const { broker, calls } = setup();
 		const url = 'https://objects.example.test/warehouse/table.parquet';

--- a/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
+++ b/packages/duckdb-wasm-runtime/src/icebergHttpBroker.ts
@@ -508,8 +508,11 @@ async function authorize(
 	if (signal?.aborted) throw abortError();
 	session.requests += 1;
 	const preparation = route.prepareHeaders?.(request, session.lifecycleController.signal);
+	const preparationSignal = signal
+		? AbortSignal.any([signal, session.lifecycleController.signal])
+		: session.lifecycleController.signal;
 	const preparedHeaders = normalizeHeaders(
-		preparation ? await withAbortSignal(preparation, signal, abortError) : {},
+		preparation ? await withAbortSignal(preparation, preparationSignal, abortError) : {},
 		'invalid_request',
 	);
 	session.metrics.increment('duckdb_http_broker.request', 1, {


### PR DESCRIPTION
Shares the authenticated S3 transport policy between object-store and Iceberg REST integrations. Also defers partial live-environment errors until the live test runs and ensures header preparation stops when its broker capability closes, with regression coverage for both edge cases.