### PR TITLE
fix(data): Data browser SQL editor UX: real query errors, non-blocking schema loads, editor fixes

### DIFF
--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -2324,9 +2324,29 @@ components:
             - tables
             - columns
             - bytes
+        counts:
+          type: object
+          properties:
+            tables:
+              type: integer
+              minimum: 0
+            discovered_tables:
+              type: integer
+              minimum: 0
+            columns:
+              type: integer
+              minimum: 0
+            discovery_complete:
+              type: boolean
+          required:
+            - tables
+            - discovered_tables
+            - columns
+            - discovery_complete
       required:
         - tables
         - truncated
+        - counts
     IntegrationObjectBucket:
       type: object
       properties:

--- a/packages/api/src/routes/cliAuthorizations.test.ts
+++ b/packages/api/src/routes/cliAuthorizations.test.ts
@@ -535,28 +535,33 @@ describe('CLI authorization routes', () => {
 		}
 	});
 
-	it('charges malformed device codes against the global poll budget', async () => {
-		const realNow = Date.now();
-		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-		vi.useFakeTimers({ now: realNow + 61_000 });
-		try {
-			const poll = () =>
-				app.request('/api/cli/v1/device-token', {
-					method: 'POST',
-					headers: { 'content-type': 'application/json' },
-					body: JSON.stringify({ device_code: 'malformed', code_verifier: VERIFIER }),
-				});
+	// 6k sequential requests; needs headroom when the whole suite shares the CPU.
+	it(
+		'charges malformed device codes against the global poll budget',
+		{ timeout: 15_000 },
+		async () => {
+			const realNow = Date.now();
+			const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+			vi.useFakeTimers({ now: realNow + 61_000 });
+			try {
+				const poll = () =>
+					app.request('/api/cli/v1/device-token', {
+						method: 'POST',
+						headers: { 'content-type': 'application/json' },
+						body: JSON.stringify({ device_code: 'malformed', code_verifier: VERIFIER }),
+					});
 
-			for (let attempt = 0; attempt < 6_000; attempt += 1) {
-				expect((await poll()).status).toBe(400);
+				for (let attempt = 0; attempt < 6_000; attempt += 1) {
+					expect((await poll()).status).toBe(400);
+				}
+				await expectError(await poll(), 429, 'RESOURCE_EXHAUSTED');
+			} finally {
+				log.mockRestore();
+				vi.setSystemTime(realNow);
+				vi.useRealTimers();
 			}
-			await expectError(await poll(), 429, 'RESOURCE_EXHAUSTED');
-		} finally {
-			log.mockRestore();
-			vi.setSystemTime(realNow);
-			vi.useRealTimers();
-		}
-	});
+		},
+	);
 });
 
 function testApiAuthenticator(bucket: MemoryBucket) {

--- a/packages/api/src/routes/integrationBrowse.ts
+++ b/packages/api/src/routes/integrationBrowse.ts
@@ -210,6 +210,13 @@ const QuerySchemaSchema = z
 			}),
 		),
 		truncated: z.object({ tables: z.boolean(), columns: z.boolean(), bytes: z.boolean() }),
+		counts: z.object({
+			tables: z.number().int().nonnegative(),
+			// Lower bound on catalog size: tables discovered before a limit tripped.
+			discovered_tables: z.number().int().nonnegative(),
+			columns: z.number().int().nonnegative(),
+			discovery_complete: z.boolean(),
+		}),
 	})
 	.openapi('IntegrationQuerySchema');
 
@@ -896,17 +903,24 @@ async function collectQuerySchema(
 		columnCount += columns.length;
 		if (columnCount >= QUERY_SCHEMA_MAX_COLUMNS) break;
 	}
+	const discoveryComplete = !(
+		workLimitReached ||
+		namespaceLimitReached ||
+		tableLimitReached ||
+		Date.now() >= deadline
+	);
 	return {
 		tables,
 		truncated: {
-			tables:
-				workLimitReached ||
-				namespaceLimitReached ||
-				tableLimitReached ||
-				tables.length < tableRefs.length ||
-				Date.now() >= deadline,
+			tables: !discoveryComplete || tables.length < tableRefs.length,
 			columns: columnLimitReached,
 			bytes: byteLimitReached,
+		},
+		counts: {
+			tables: tables.length,
+			discovered_tables: tableRefs.length,
+			columns: columnCount,
+			discovery_complete: discoveryComplete,
 		},
 	};
 }

--- a/packages/api/src/routes/integrationBrowse.ts
+++ b/packages/api/src/routes/integrationBrowse.ts
@@ -893,6 +893,14 @@ async function collectQuerySchema(
 				JSON.stringify({
 					tables: candidate,
 					truncated: { tables: true, columns: true, bytes: true },
+					// Worst-case envelope so appending the real counts later cannot
+					// push the response past the byte limit.
+					counts: {
+						tables: Number.MAX_SAFE_INTEGER,
+						discovered_tables: Number.MAX_SAFE_INTEGER,
+						columns: Number.MAX_SAFE_INTEGER,
+						discovery_complete: false,
+					},
 				}),
 			) > QUERY_SCHEMA_MAX_BYTES
 		) {

--- a/packages/api/src/routes/integrations.browse.test.ts
+++ b/packages/api/src/routes/integrations.browse.test.ts
@@ -86,7 +86,7 @@ const browsyKind = defineIntegration({
 					next_cursor: null,
 				};
 			}
-			if (config.token === 'repeated-table-cursor') {
+			if (config.token === 'repeated-table-cursor' || config.token === 'small-catalog') {
 				return { items: request.parent ? [] : [['sales']], next_cursor: null };
 			}
 			return {
@@ -965,7 +965,12 @@ describe('Data browser routes', () => {
 		const url = `/projects/${pid}/integrations/${created.id}/browse/query/schema`;
 
 		const [first, coalesced] = await Promise.all([query('GET', url), query('GET', url)]);
-		await expectOk(first);
+		const schema = await expectOk<{
+			tables: unknown[];
+			counts: { tables: number; discovered_tables: number };
+		}>(first);
+		expect(schema.counts.tables).toBe(schema.tables.length);
+		expect(schema.counts.discovered_tables).toBeGreaterThanOrEqual(schema.tables.length);
 		await expectOk(coalesced);
 		const callsAfterMiss = browseNamespaces.mock.calls.length;
 		expect(callsAfterMiss).toBeGreaterThan(0);
@@ -1010,12 +1015,15 @@ describe('Data browser routes', () => {
 		const browseTableSchema = vi.spyOn(queryDeps.integrations, 'browseTableSchema');
 		const query = createTestApi({ bucket, userId: ACTOR, deps: queryDeps }).request;
 
-		const schema = await expectOk<{ tables: unknown[]; truncated: { tables: boolean } }>(
-			await query('GET', `/projects/${pid}/integrations/${created.id}/browse/query/schema`),
-		);
+		const schema = await expectOk<{
+			tables: unknown[];
+			truncated: { tables: boolean };
+			counts: { tables: number; columns: number; discovery_complete: boolean };
+		}>(await query('GET', `/projects/${pid}/integrations/${created.id}/browse/query/schema`));
 
 		expect(schema.tables).toEqual([]);
 		expect(schema.truncated.tables).toBe(true);
+		expect(schema.counts).toMatchObject({ tables: 0, columns: 0, discovery_complete: false });
 		expect(browseNamespaces.mock.calls.length + browseTables.mock.calls.length).toBe(512);
 		expect(browseTableSchema).not.toHaveBeenCalled();
 	});
@@ -1034,12 +1042,51 @@ describe('Data browser routes', () => {
 		queryDeps.dataBrowser.query = true;
 		const query = createTestApi({ bucket, userId: ACTOR, deps: queryDeps }).request;
 
-		const schema = await expectOk<{ tables: unknown[]; truncated: { tables: boolean } }>(
-			await query('GET', `/projects/${pid}/integrations/${created.id}/browse/query/schema`),
-		);
+		const schema = await expectOk<{
+			tables: unknown[];
+			truncated: { tables: boolean };
+			counts: { tables: number; discovered_tables: number; discovery_complete: boolean };
+		}>(await query('GET', `/projects/${pid}/integrations/${created.id}/browse/query/schema`));
 
 		expect(schema.tables).toHaveLength(128);
 		expect(schema.truncated.tables).toBe(true);
+		expect(schema.counts.tables).toBe(128);
+		expect(schema.counts.discovered_tables).toBeGreaterThanOrEqual(128);
+		expect(schema.counts.discovery_complete).toBe(false);
+	});
+
+	it('reports complete discovery counts when the catalog fits the schema bounds', async () => {
+		const pid = await createProject();
+		const created = await expectOk<{ id: string }>(
+			await request('POST', `/projects/${pid}/integrations`, {
+				kind: 'browsy',
+				name: 'small',
+				config: { token: 'small-catalog' },
+			}),
+			201,
+		);
+		const queryDeps = browserDeps(bucket, undefined, queryService([]));
+		queryDeps.dataBrowser.query = true;
+		const query = createTestApi({ bucket, userId: ACTOR, deps: queryDeps }).request;
+
+		const schema = await expectOk<{
+			tables: { columns: unknown[] }[];
+			truncated: { tables: boolean; columns: boolean; bytes: boolean };
+			counts: {
+				tables: number;
+				discovered_tables: number;
+				columns: number;
+				discovery_complete: boolean;
+			};
+		}>(await query('GET', `/projects/${pid}/integrations/${created.id}/browse/query/schema`));
+
+		expect(schema.truncated).toEqual({ tables: false, columns: false, bytes: false });
+		expect(schema.counts).toEqual({
+			tables: schema.tables.length,
+			discovered_tables: schema.tables.length,
+			columns: schema.tables.reduce((total, table) => total + table.columns.length, 0),
+			discovery_complete: true,
+		});
 	});
 
 	it('rejects byte-oversized revise input before invoking managed AI', async () => {

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -2365,6 +2365,12 @@ export interface components {
 				columns: boolean;
 				bytes: boolean;
 			};
+			counts: {
+				tables: number;
+				discovered_tables: number;
+				columns: number;
+				discovery_complete: boolean;
+			};
 		};
 		IntegrationObjectBucket: {
 			name: string;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
 	"exports": {
 		".": "./src/index.ts",
 		"./data-query-sql": "./src/services/integrations/data-query/sql.ts",
+		"./data-query-contracts": "./src/services/integrations/data-query/contracts.ts",
 		"./ports": "./src/ports/index.ts",
 		"./url": "./src/url.ts",
 		"./testing": "./src/testing/index.ts",

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -92,6 +92,7 @@ export type { OrgIntegrationsService, ProjectIntegrationsService } from './integ
 export {
 	assertValidDataQuerySql,
 	DataQueryService,
+	DataQueryUserError,
 	MAX_DATA_QUERY_SQL_BYTES,
 } from './integrations/data-query';
 export type {

--- a/packages/core/src/services/integrations/data-query/DataQueryService.test.ts
+++ b/packages/core/src/services/integrations/data-query/DataQueryService.test.ts
@@ -9,6 +9,7 @@ import type {
 	DataQueryResult,
 	DisposableDataQueryExecutor,
 } from './contracts';
+import { DataQueryUserError } from './contracts';
 
 const user = 'user-1' as UserId;
 const connection = {
@@ -248,7 +249,7 @@ describe('DataQueryService', () => {
 		);
 
 		await expect(service.query(user, { sql: 'select 1', connection })).rejects.toThrow(
-			'not execute',
+			'not isolated',
 		);
 		expect(terminate).toHaveBeenCalledOnce();
 	});
@@ -265,6 +266,48 @@ describe('DataQueryService', () => {
 		await expect(service.query(user, { sql: 'select 1', connection })).rejects.toMatchObject({
 			message: 'The data-query runtime could not execute this query.',
 		});
+	});
+
+	it('surfaces adapter-vetted user SQL errors as redacted validation errors', async () => {
+		const secretConnection = { ...connection, vars: { TOKEN: 'hunter2-secret' } };
+		const { service } = setup(async () => {
+			throw new DataQueryUserError('Binder Error: column "foo" not found near hunter2-secret');
+		});
+
+		await expect(
+			service.query(user, { sql: 'select 1', connection: secretConnection }),
+		).rejects.toMatchObject({
+			name: 'ValidationError',
+			message: 'Binder Error: column "foo" not found near [redacted]',
+		});
+	});
+
+	it('classifies a user error by name when the adapter holds a bundled copy of the class', async () => {
+		const foreignCopy = Object.assign(new Error('Parser Error: syntax error at or near "selct"'), {
+			name: 'DataQueryUserError',
+		});
+		const { service } = setup(async () => {
+			throw foreignCopy;
+		});
+
+		await expect(service.query(user, { sql: 'select 1', connection })).rejects.toMatchObject({
+			name: 'ValidationError',
+			message: 'Parser Error: syntax error at or near "selct"',
+		});
+	});
+
+	it('keeps a redacted cause on the generic runtime error for server-side logging', async () => {
+		const secretConnection = { ...connection, vars: { TOKEN: 'hunter2-secret' } };
+		const { service } = setup(async () => {
+			throw new Error('worker exploded with token hunter2-secret');
+		});
+
+		const error = await service.query(user, { sql: 'select 1', connection: secretConnection }).then(
+			() => {},
+			(cause: unknown) => cause as Error & { cause?: Error },
+		);
+		expect(error?.message).toBe('The data-query runtime could not execute this query.');
+		expect(error?.cause?.message).toBe('worker exploded with token [redacted]');
 	});
 
 	it('ignores synchronous termination errors after preserving the query outcome', async () => {
@@ -302,7 +345,7 @@ describe('DataQueryService', () => {
 		const { service } = setup(async () => result as never);
 
 		await expect(service.query(user, { sql: 'select 1', connection })).rejects.toThrow(
-			'could not execute',
+			'invalid result',
 		);
 	});
 
@@ -316,7 +359,7 @@ describe('DataQueryService', () => {
 		}));
 
 		await expect(service.query(user, { sql: 'select 1', connection })).rejects.toThrow(
-			'could not execute',
+			'invalid result',
 		);
 	});
 
@@ -339,7 +382,7 @@ describe('DataQueryService', () => {
 			'exactly one statement',
 		);
 		await expect(service.query(user, { sql: 'select 1', connection })).rejects.toThrow(
-			'could not execute',
+			'invalid result',
 		);
 
 		const oversized = setup(
@@ -347,7 +390,7 @@ describe('DataQueryService', () => {
 			{ maxBytes: 10 },
 		).service;
 		await expect(oversized.query(user, { sql: 'select 1', connection })).rejects.toThrow(
-			'could not execute',
+			'exceeded its byte limit',
 		);
 
 		const exactBytes = 'é'.repeat(MAX_DATA_QUERY_SQL_BYTES / 2);

--- a/packages/core/src/services/integrations/data-query/DataQueryService.ts
+++ b/packages/core/src/services/integrations/data-query/DataQueryService.ts
@@ -9,6 +9,8 @@ import type {
 	DataQueryResult,
 	DisposableDataQueryExecutor,
 } from './contracts';
+import { DataQueryUserError } from './contracts';
+import { redactConnectionSecrets } from './redaction';
 import { validateTableData } from '../data-preview/previewResult';
 import { DrainableService } from '../DrainableService';
 import { singleDataQueryStatement } from './sql';
@@ -116,29 +118,41 @@ export class DataQueryService extends DrainableService {
 			() => active.stop(new UnavailableError('The data query timed out.')),
 			this.options.executionTimeoutMs,
 		);
+		// Executor rejections may quote connection secrets; classify and redact
+		// them at the boundary. The service's own errors are fixed safe strings.
+		const guarded = async <T>(operation: () => Promise<T>): Promise<T> => {
+			try {
+				return await operation();
+			} catch (error) {
+				throw toSafeExecutorError(error, input.connection);
+			}
+		};
 		try {
 			const started = performance.now();
 			const work = (async () => {
-				executor = await this.options.executorFactory.create(controller.signal);
+				const created = await guarded(() => this.options.executorFactory.create(controller.signal));
+				executor = created;
 				if (controller.signal.aborted) {
 					terminate();
 					throw new UnavailableError('The data query was cancelled.');
 				}
-				if (executor.runtime !== 'worker' && executor.runtime !== 'process') {
+				if (created.runtime !== 'worker' && created.runtime !== 'process') {
 					throw new UnavailableError('The data-query executor is not isolated.');
 				}
-				const result = await executor.execute(
-					{
-						sql: input.sql,
-						connection: input.connection,
-						accessMode: 'read-only',
-						limits: {
-							maxRows: this.options.maxRows,
-							maxBytes: this.options.maxBytes,
-							deadlineMs: Math.max(1, deadlineAtMs - Date.now()),
+				const result = await guarded(() =>
+					created.execute(
+						{
+							sql: input.sql,
+							connection: input.connection,
+							accessMode: 'read-only',
+							limits: {
+								maxRows: this.options.maxRows,
+								maxBytes: this.options.maxBytes,
+								deadlineMs: Math.max(1, deadlineAtMs - Date.now()),
+							},
 						},
-					},
-					controller.signal,
+						controller.signal,
+					),
 				);
 				return this.validateResult({
 					...result,
@@ -147,8 +161,10 @@ export class DataQueryService extends DrainableService {
 			})();
 			return await Promise.race([work, stopped]);
 		} catch (error) {
-			if (error === stopError) throw error;
-			throw new UnavailableError('The data-query runtime could not execute this query.');
+			// A requested stop (cancel/timeout/close) wins over whatever the doomed
+			// executor rejected with.
+			if (stopError !== undefined) throw stopError;
+			throw error;
 		} finally {
 			clearTimeout(timer);
 			externalSignal?.removeEventListener('abort', onAbort);
@@ -185,6 +201,28 @@ export class DataQueryService extends DrainableService {
 		}
 		return validated;
 	}
+}
+
+/**
+ * Executor failures may quote credentials the connection injected into the
+ * runtime, so only adapter-vetted user-SQL errors surface — redacted — while
+ * everything else collapses to a generic message with the redacted detail kept
+ * on `cause` for server-side logging.
+ */
+function toSafeExecutorError(error: unknown, connection: DataQueryConnection): Error {
+	const message = redactConnectionSecrets(
+		error instanceof Error ? error.message : String(error),
+		connection,
+	);
+	// The name fallback keeps classification working when the adapter holds a
+	// bundled copy of the class.
+	const isUserError =
+		error instanceof DataQueryUserError ||
+		(error instanceof Error && error.name === 'DataQueryUserError');
+	if (isUserError) return new ValidationError(message);
+	return new UnavailableError('The data-query runtime could not execute this query.', {
+		cause: new Error(message),
+	});
 }
 
 export function assertValidDataQuerySql(sql: string, integrationKind?: string): void {

--- a/packages/core/src/services/integrations/data-query/contracts.ts
+++ b/packages/core/src/services/integrations/data-query/contracts.ts
@@ -27,6 +27,18 @@ export interface DataQueryConnection {
 	readonly plan?: Readonly<DataQueryPlan>;
 }
 
+/**
+ * A query failure attributable to the user's SQL (parse, bind, catalog, or
+ * result-limit). Executors throw it only for messages vetted as safe to
+ * surface; the service still redacts connection secrets before doing so.
+ */
+export class DataQueryUserError extends Error {
+	constructor(message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = 'DataQueryUserError';
+	}
+}
+
 export interface DataQueryExecution {
 	sql: string;
 	connection: DataQueryConnection;

--- a/packages/core/src/services/integrations/data-query/index.ts
+++ b/packages/core/src/services/integrations/data-query/index.ts
@@ -4,6 +4,7 @@ export {
 	MAX_DATA_QUERY_SQL_BYTES,
 } from './DataQueryService';
 export { singleDataQueryStatement } from './sql';
+export { DataQueryUserError } from './contracts';
 export type { DataQueryInput, DataQueryServiceOptions } from './DataQueryService';
 export type {
 	DataQueryConnection,

--- a/packages/core/src/services/integrations/data-query/redaction.test.ts
+++ b/packages/core/src/services/integrations/data-query/redaction.test.ts
@@ -36,6 +36,22 @@ describe('redactConnectionSecrets', () => {
 		expect(result).toBe('both [redacted] and [redacted] appeared');
 	});
 
+	it('scrubs individual credentials quoted from inside file contents', () => {
+		const result = redactConnectionSecrets(
+			'auth failed for token inner-token-9 with cert line MIIEvQIBADANBgkq',
+			connection({
+				files: [
+					{ path: '/tmp/creds.json', content: '{"key":"k1","nested":{"token":"inner-token-9"}}' },
+					{
+						path: '/tmp/key.pem',
+						content: '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkq\n-----END PRIVATE KEY-----',
+					},
+				],
+			}),
+		);
+		expect(result).toBe('auth failed for token [redacted] with cert line [redacted]');
+	});
+
 	it('scrubs every string in the plan http access, including nested credentials', () => {
 		const result = redactConnectionSecrets(
 			'HTTP 403 from https://objects.example.test with key AKIAEXAMPLE token session-token-value',

--- a/packages/core/src/services/integrations/data-query/redaction.test.ts
+++ b/packages/core/src/services/integrations/data-query/redaction.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { IntegrationId } from '../../../ids';
+import type { DataQueryConnection } from './contracts';
+import { redactConnectionSecrets } from './redaction';
+
+function connection(overrides: Partial<DataQueryConnection> = {}): DataQueryConnection {
+	return {
+		files: [],
+		vars: {},
+		integration: { id: 'intg-1' as IntegrationId, name: 'lake', kind: 'test', version: 1 },
+		...overrides,
+	};
+}
+
+describe('redactConnectionSecrets', () => {
+	it('scrubs var values, file contents, and string plan params', () => {
+		const result = redactConnectionSecrets(
+			'failed: token=var-secret file={"key":"file-secret"} param=param-secret',
+			connection({
+				files: [{ path: '/tmp/c.json', content: '{"key":"file-secret"}' }],
+				vars: { TOKEN: 'var-secret' },
+				plan: {
+					setup: [{ text: 'SET s3_secret = ?', params: ['param-secret', 42, true, null] }],
+					cleanup: [{ text: 'RESET s3_secret' }],
+				},
+			}),
+		);
+		expect(result).toBe('failed: token=[redacted] file=[redacted] param=[redacted]');
+	});
+
+	it('redacts longer secrets before shorter ones contained within them', () => {
+		const result = redactConnectionSecrets(
+			'both abcdef and abcd appeared',
+			connection({ vars: { A: 'abcd', B: 'abcdef' } }),
+		);
+		expect(result).toBe('both [redacted] and [redacted] appeared');
+	});
+
+	it('scrubs every string in the plan http access, including nested credentials', () => {
+		const result = redactConnectionSecrets(
+			'HTTP 403 from https://objects.example.test with key AKIAEXAMPLE token session-token-value',
+			connection({
+				plan: {
+					setup: [],
+					httpAccess: {
+						kind: 'iceberg-rest',
+						catalog: { url: 'https://catalog.example.test', authorization: 'Bearer abc123' },
+						storage: {
+							kind: 's3',
+							endpoint: 'https://objects.example.test',
+							region: 'us-east-1',
+							urlStyle: 'path',
+							credentials: {
+								method: 'static',
+								accessKeyId: 'AKIAEXAMPLE',
+								secretAccessKey: 'very-secret-access-key',
+								sessionToken: 'session-token-value',
+							},
+							locations: [{ bucket: 'warehouse', prefix: 'tables' }],
+						},
+					},
+				},
+			}),
+		);
+		expect(result).not.toContain('AKIAEXAMPLE');
+		expect(result).not.toContain('session-token-value');
+		expect(result).not.toContain('objects.example.test');
+		expect(result).toContain('HTTP 403');
+	});
+
+	it('treats secrets as literal text, not regular expressions', () => {
+		const result = redactConnectionSecrets(
+			'auth a+b$1(c) failed twice: a+b$1(c)',
+			connection({ vars: { TOKEN: 'a+b$1(c)' } }),
+		);
+		expect(result).toBe('auth [redacted] failed twice: [redacted]');
+	});
+
+	it('skips values too short to be meaningful secrets', () => {
+		const result = redactConnectionSecrets(
+			'select 1 from t',
+			connection({ vars: { REGION: 'us', MODE: 'r' } }),
+		);
+		expect(result).toBe('select 1 from t');
+	});
+
+	it('caps runaway messages', () => {
+		const result = redactConnectionSecrets(`Parser Error: ${'x'.repeat(2_000)}`, connection());
+		expect(result.length).toBeLessThanOrEqual(501);
+		expect(result.endsWith('…')).toBe(true);
+	});
+});

--- a/packages/core/src/services/integrations/data-query/redaction.ts
+++ b/packages/core/src/services/integrations/data-query/redaction.ts
@@ -1,0 +1,43 @@
+import type { DataQueryConnection } from './contracts';
+
+/**
+ * Values shorter than this are skipped: they are not meaningful secrets and
+ * replacing them would shred unrelated text.
+ */
+const MIN_SECRET_LENGTH = 4;
+const MAX_MESSAGE_LENGTH = 500;
+
+/**
+ * Scrubs every connection-provided secret value from an executor error message
+ * before it can reach a log line or the API error envelope. Collection is
+ * deliberately broad — every string in the connection's secret-bearing
+ * material is treated as a secret, so a new field fails closed.
+ */
+export function redactConnectionSecrets(message: string, connection: DataQueryConnection): string {
+	const secrets = new Set<string>(Object.values(connection.vars));
+	for (const file of connection.files) secrets.add(file.content);
+	if (connection.plan) {
+		for (const statement of [...connection.plan.setup, ...(connection.plan.cleanup ?? [])]) {
+			for (const param of statement.params ?? []) {
+				if (typeof param === 'string') secrets.add(param);
+			}
+		}
+		collectStrings(connection.plan.httpAccess, secrets);
+	}
+	let redacted = message;
+	const ordered = [...secrets]
+		.filter((value) => value.length >= MIN_SECRET_LENGTH)
+		.sort((left, right) => right.length - left.length);
+	for (const secret of ordered) redacted = redacted.replaceAll(secret, '[redacted]');
+	return redacted.length > MAX_MESSAGE_LENGTH
+		? `${redacted.slice(0, MAX_MESSAGE_LENGTH)}…`
+		: redacted;
+}
+
+function collectStrings(value: unknown, into: Set<string>): void {
+	if (typeof value === 'string') into.add(value);
+	else if (Array.isArray(value)) for (const item of value) collectStrings(item, into);
+	else if (value && typeof value === 'object') {
+		for (const item of Object.values(value)) collectStrings(item, into);
+	}
+}

--- a/packages/core/src/services/integrations/data-query/redaction.ts
+++ b/packages/core/src/services/integrations/data-query/redaction.ts
@@ -15,7 +15,7 @@ const MAX_MESSAGE_LENGTH = 500;
  */
 export function redactConnectionSecrets(message: string, connection: DataQueryConnection): string {
 	const secrets = new Set<string>(Object.values(connection.vars));
-	for (const file of connection.files) secrets.add(file.content);
+	for (const file of connection.files) collectFileSecrets(file.content, secrets);
 	if (connection.plan) {
 		for (const statement of [...connection.plan.setup, ...(connection.plan.cleanup ?? [])]) {
 			for (const param of statement.params ?? []) {
@@ -39,5 +39,23 @@ function collectStrings(value: unknown, into: Set<string>): void {
 	else if (Array.isArray(value)) for (const item of value) collectStrings(item, into);
 	else if (value && typeof value === 'object') {
 		for (const item of Object.values(value)) collectStrings(item, into);
+	}
+}
+
+/**
+ * An error may quote an individual credential from inside a file, not the
+ * whole blob — collect its JSON leaf values and its lines (PEM body lines)
+ * alongside the full content.
+ */
+function collectFileSecrets(content: string, into: Set<string>): void {
+	into.add(content);
+	try {
+		collectStrings(JSON.parse(content), into);
+	} catch {
+		// Not JSON; the per-line entries below still cover it.
+	}
+	for (const line of content.split('\n')) {
+		const trimmed = line.trim();
+		if (trimmed) into.add(trimmed);
 	}
 }

--- a/packages/duckdb-wasm-runtime/src/engine.ts
+++ b/packages/duckdb-wasm-runtime/src/engine.ts
@@ -6,6 +6,9 @@ import type {
 	DuckDBPreviewProgram,
 	TablePreview,
 } from '@marimo-hub/core';
+// The worker loads TS via Node type-stripping, so only self-contained core
+// subpaths are importable here — never the root index.
+import { DataQueryUserError } from '@marimo-hub/core/data-query-contracts';
 import { singleDataQueryStatement } from '@marimo-hub/core/data-query-sql';
 import { createFailClosedNodeRuntime } from './networkPolicy.ts';
 
@@ -141,10 +144,12 @@ export class BlockingDuckDBEngine {
 				process.env[name] = value;
 			}
 			const connection = db.connect();
+			let userStatementStarted = false;
 			try {
 				for (const setup of plan?.setup ?? []) runStatement(connection, setup);
 				connection.query('BEGIN TRANSACTION READ ONLY');
 				transactionOpen = true;
+				userStatementStarted = true;
 				const result = await connection.send(
 					`SELECT * FROM (${statement}\n) AS "__marimohub_query" LIMIT ${maxRows + 1}`,
 					true,
@@ -152,7 +157,9 @@ export class BlockingDuckDBEngine {
 				result.open();
 				queryResult = normalizeQueryResultStream(result, maxRows, request.limits.maxBytes);
 			} catch (error) {
-				primaryError = error;
+				// Setup statements are server-generated and may quote secrets; only
+				// failures of the user's own statement are classified as user errors.
+				primaryError = userStatementStarted ? classifyUserStatementError(error) : error;
 			} finally {
 				try {
 					if (transactionOpen) connection.query('ROLLBACK');
@@ -259,6 +266,33 @@ function asError(value: unknown): Error {
 	return value instanceof Error ? value : new Error('DuckDB-Wasm execution failed.');
 }
 
+/**
+ * DuckDB error classes that only echo the user's SQL and catalog identifiers.
+ * IO/HTTP errors are deliberately excluded — they can quote signed URLs.
+ */
+const USER_SQL_ERROR_PREFIXES = [
+	'Parser Error',
+	'Syntax Error',
+	'Catalog Error',
+	'Binder Error',
+	'Conversion Error',
+	'Invalid Input Error',
+	'Out of Range Error',
+	'Constraint Error',
+	'Not implemented Error',
+];
+
+function classifyUserStatementError(error: unknown): unknown {
+	if (error instanceof DataQueryUserError) return error;
+	if (
+		error instanceof Error &&
+		USER_SQL_ERROR_PREFIXES.some((prefix) => error.message.startsWith(prefix))
+	) {
+		return new DataQueryUserError(error.message);
+	}
+	return error;
+}
+
 function normalizeResult(
 	result: ReturnType<ReturnType<Database['connect']>['query']>,
 ): TablePreview {
@@ -288,7 +322,9 @@ function normalizeQueryResultStream(
 	let responseBytes = queryResponseBaseBytes(columns);
 	if (responseBytes > maxBytes) {
 		result.cancel();
-		throw new Error('DuckDB-Wasm result exceeded the response limit.');
+		throw new DataQueryUserError(
+			'The query result exceeded the response limit before any rows were read. Select fewer columns.',
+		);
 	}
 	for (const batch of result) {
 		for (const row of batch) {

--- a/packages/duckdb-wasm-runtime/src/node.test.ts
+++ b/packages/duckdb-wasm-runtime/src/node.test.ts
@@ -7,6 +7,7 @@ import type {
 	IntegrationId,
 	Metrics,
 } from '@marimo-hub/core';
+import { DataQueryUserError } from '@marimo-hub/core';
 import {
 	createNodeDataQueryExecutorFactory,
 	createNodeDuckDBWasmRuntimeFactory,
@@ -494,6 +495,34 @@ describe.concurrent('DuckDB-Wasm data-query executor', () => {
 					new AbortController().signal,
 				),
 			).rejects.toThrow(/external access|disabled/i);
+		} finally {
+			executor.terminate();
+		}
+	}, 15_000);
+
+	it('carries user-SQL classification across the worker boundary', async ({ expect }) => {
+		const executor = await createNodeDataQueryExecutorFactory({ memoryLimitMb: 64 }).create(
+			new AbortController().signal,
+		);
+		const rejection = (sql: string, limits: Partial<DataQueryExecution['limits']> = {}) =>
+			executor.execute(dataQuery(sql, limits), new AbortController().signal).then(
+				() => {},
+				(cause: unknown) => cause as Error,
+			);
+		try {
+			const userError = await rejection('select * from missing_table');
+			expect(userError).toBeInstanceOf(DataQueryUserError);
+			expect(userError?.message).toMatch(/Catalog Error/);
+
+			const byteLimit = await rejection('select 1 as value', { maxBytes: 10 });
+			expect(byteLimit).toBeInstanceOf(DataQueryUserError);
+			expect(byteLimit?.message).toMatch(/response limit/);
+
+			const infraError = await rejection(
+				"select * from read_csv_auto('https://example.com/data.csv')",
+			);
+			expect(infraError).toBeDefined();
+			expect(infraError).not.toBeInstanceOf(DataQueryUserError);
 		} finally {
 			executor.terminate();
 		}

--- a/packages/duckdb-wasm-runtime/src/node.ts
+++ b/packages/duckdb-wasm-runtime/src/node.ts
@@ -13,7 +13,7 @@ import type {
 	Metrics,
 	TablePreview,
 } from '@marimo-hub/core';
-import { noopMetrics } from '@marimo-hub/core';
+import { DataQueryUserError, noopMetrics } from '@marimo-hub/core';
 import { ICEBERG_HTTP_UNAVAILABLE } from './networkPolicy';
 import { isHttpBridgeRequestMessage, rejectHttpBridge, resolveHttpBridge } from './httpBridge';
 import type { HttpBridgeRequestMessage } from './httpBridge';
@@ -267,6 +267,7 @@ class WorkerRuntime implements DuckDBWasmRuntime {
 		if (!pending) return;
 		this.pending.delete(response.id);
 		if (response.ok) pending.resolve(response.value);
+		else if (response.kind === 'user-sql') pending.reject(new DataQueryUserError(response.error));
 		else pending.reject(new Error(response.error));
 	}
 

--- a/packages/duckdb-wasm-runtime/src/protocol.ts
+++ b/packages/duckdb-wasm-runtime/src/protocol.ts
@@ -9,7 +9,7 @@ export type RuntimeRequest =
 
 export type RuntimeResponse =
 	| { id: number; ok: true; value?: unknown }
-	| { id: number; ok: false; error: string };
+	| { id: number; ok: false; error: string; kind?: 'user-sql' };
 
 export type WorkerMessage = RuntimeResponse | HttpBridgeRequestMessage;
 
@@ -24,5 +24,9 @@ export function isRuntimeResponse(value: unknown): value is RuntimeResponse {
 	const candidate = value as Partial<RuntimeResponse>;
 	if (!Number.isSafeInteger(candidate.id) || (candidate.id ?? 0) < 1) return false;
 	if (candidate.ok === true) return !('error' in candidate);
-	return candidate.ok === false && typeof candidate.error === 'string';
+	return (
+		candidate.ok === false &&
+		typeof candidate.error === 'string' &&
+		(candidate.kind === undefined || candidate.kind === 'user-sql')
+	);
 }

--- a/packages/duckdb-wasm-runtime/src/workerHandler.ts
+++ b/packages/duckdb-wasm-runtime/src/workerHandler.ts
@@ -1,4 +1,5 @@
 import { parentPort } from 'node:worker_threads';
+import { DataQueryUserError } from '@marimo-hub/core/data-query-contracts';
 import { BlockingDuckDBEngine } from './engine.ts';
 import type { RuntimeRequest, RuntimeResponse } from './protocol';
 import { createSyncXmlHttpRequest } from './syncXmlHttpRequest.ts';
@@ -59,6 +60,7 @@ async function handle(request: RuntimeRequest): Promise<void> {
 			id: request.id,
 			ok: false,
 			error: error instanceof Error ? error.message : 'DuckDB-Wasm worker failed.',
+			...(error instanceof DataQueryUserError ? { kind: 'user-sql' as const } : {}),
 		};
 	}
 	port.postMessage(response);

--- a/packages/source-control-github/src/githubGitDirectory.test.ts
+++ b/packages/source-control-github/src/githubGitDirectory.test.ts
@@ -97,7 +97,8 @@ afterEach(async () => {
 	);
 });
 
-describe('materializeGitDirectory', () => {
+// Git subprocess tests; need headroom when the whole suite shares the CPU.
+describe('materializeGitDirectory', { timeout: 15_000 }, () => {
 	it('caps the combined bytes from all smart-HTTP responses', () => {
 		const limit = new GitFetchByteLimit('owner/repo');
 		limit.record(Math.ceil(MAX_GIT_FETCH_BYTES / 2));

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -1021,6 +1021,7 @@ export function useDataQuerySchemaQuery(
 		),
 		enabled,
 		staleTime: BROWSE_SCHEMA_STALE_MS,
+		placeholderData: keepPreviousData,
 		queryFn: ({ signal }) =>
 			apiData(
 				apiClient.GET('/api/v1/projects/{pid}/integrations/{iid}/browse/query/schema', {
@@ -1041,6 +1042,8 @@ export function useDataQuerySchemaQuery(
 
 export function useRunDataQuery(projectId: string, integrationId: string) {
 	return useMutation({
+		// SqlWorkspace renders failures inline next to the results.
+		meta: { suppressErrorToast: true },
 		mutationFn: ({ sql, signal }: { sql: string; signal?: AbortSignal }) =>
 			apiData(
 				apiClient.POST('/api/v1/projects/{pid}/integrations/{iid}/browse/query', {
@@ -1054,6 +1057,8 @@ export function useRunDataQuery(projectId: string, integrationId: string) {
 
 export function useGenerateDataQuerySql(projectId: string, integrationId: string) {
 	return useMutation({
+		// SqlWorkspace renders failures inline next to the results.
+		meta: { suppressErrorToast: true },
 		mutationFn: (body: { mode: 'generate' | 'revise'; instruction: string; sql?: string }) =>
 			apiData(
 				apiClient.POST('/api/v1/projects/{pid}/integrations/{iid}/browse/query/generate', {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -141,6 +141,18 @@ describe('DataBrowserPage catalog', () => {
 		expect(table.querySelector('mark')).toHaveTextContent('ord');
 	});
 
+	it('skips highlighting when case folding shifts offsets, instead of marking wrong characters', async () => {
+		const user = userEvent.setup();
+		// 'İSTANBUL'.toLowerCase() is 'i̇stanbul' (one char longer), so lowered
+		// offsets do not map back to the original name.
+		setup(`/projects/${PID}/data/${IID}?q=stanbul`, { tables: ['İSTANBUL'] });
+
+		await user.click(await screen.findByTestId('browse-namespace'));
+		const table = await screen.findByTestId('browse-table');
+		expect(table).toHaveTextContent('İSTANBUL');
+		expect(table.querySelector('mark')).toBeNull();
+	});
+
 	it('keeps the tree filter available and populated on the Query surface', async () => {
 		const user = userEvent.setup();
 		setup(`/projects/${PID}/data/${IID}?q=ord`, {

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.test.tsx
@@ -131,6 +131,29 @@ describe('DataBrowserPage catalog', () => {
 		expect(await screen.findByTestId('browse-table')).toHaveTextContent('orders');
 	});
 
+	it('highlights the matched part of a filtered table name', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?q=ord`);
+
+		await user.click(await screen.findByTestId('browse-namespace'));
+		const table = await screen.findByTestId('browse-table');
+		expect(table).toHaveTextContent('orders');
+		expect(table.querySelector('mark')).toHaveTextContent('ord');
+	});
+
+	it('keeps the tree filter available and populated on the Query surface', async () => {
+		const user = userEvent.setup();
+		setup(`/projects/${PID}/data/${IID}?q=ord`, {
+			role: 'manager',
+			querySurface: { available: true },
+		});
+
+		await screen.findByTestId('browse-namespace');
+		await user.click(screen.getByRole('button', { name: 'Query' }));
+
+		expect(await screen.findByLabelText('Filter tables')).toHaveValue('ord');
+	});
+
 	it('filters loaded tables and says so when nothing matches', async () => {
 		const user = userEvent.setup();
 		setup(`/projects/${PID}/data/${IID}?q=zzz`);

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.testWorld.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.testWorld.tsx
@@ -2,6 +2,7 @@ import { afterEach, vi } from 'vitest';
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import DataBrowserPage from './DataBrowserPage';
 import type { IntegrationEntry, IntegrationKind } from '@/types';
+import { ThemeProvider } from '@/context/ThemeContext';
 import { installMatchMedia, renderWithClient } from '@/test/render';
 
 export const PID = 'p_1';
@@ -267,6 +268,22 @@ function makeFetch({
 				? ok({ items: ['refunds'], next_cursor: null })
 				: ok({ items: ['orders'], next_cursor: 'p2' });
 		}
+		if (url.includes('/api/v1/me')) {
+			return ok({ id: 'user_1', email: 'u@example.test', name: 'U', role: 'member' });
+		}
+		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/query/schema`)) {
+			return ok({
+				tables: [
+					{
+						namespace: ['sales'],
+						name: 'orders',
+						columns: [{ name: 'id', type: 'long', nullable: false }],
+					},
+				],
+				truncated: { tables: false, columns: false, bytes: false },
+				counts: { tables: 1, discovered_tables: 1, columns: 1, discovery_complete: true },
+			});
+		}
 		if (url.includes(`/api/v1/projects/${PID}/integrations/${IID}/browse/schema`)) {
 			return ok({
 				columns: [
@@ -359,7 +376,7 @@ export function setup(route: string | string[], fetchOpts?: Parameters<typeof ma
 	installMatchMedia();
 	const fetchImpl = makeFetch(fetchOpts);
 	renderWithClient(
-		<>
+		<ThemeProvider>
 			<Routes>
 				<Route path="/projects/:pid/data" element={<DataBrowserPage />} />
 				<Route path="/projects/:pid/data/:iid" element={<DataBrowserPage />} />
@@ -367,7 +384,7 @@ export function setup(route: string | string[], fetchOpts?: Parameters<typeof ma
 			<LocationProbe />
 			<DeepLink to={`/projects/${PID}/data/${IID}?ns=sales&table=orders`} />
 			<HistoryControls />
-		</>,
+		</ThemeProvider>,
 		{ route },
 	);
 	return fetchImpl;

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -797,7 +797,15 @@ function TableRows({
 
 /** The first case-insensitive occurrence of `query` in `text`, marked. */
 function HighlightMatch({ text, query }: { text: string; query: string }) {
-	const start = query === '' ? -1 : text.toLowerCase().indexOf(query.toLowerCase());
+	const lowered = text.toLowerCase();
+	const loweredQuery = query.toLowerCase();
+	// Case folding can change string length (e.g. İ → i̇); offsets in the
+	// lowered strings then no longer map back, so render unmarked instead of
+	// marking the wrong characters.
+	if (query === '' || lowered.length !== text.length || loweredQuery.length !== query.length) {
+		return text;
+	}
+	const start = lowered.indexOf(loweredQuery);
 	if (start === -1) return text;
 	const end = start + query.length;
 	return (

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -233,7 +233,8 @@ export default function DataBrowserPage() {
 				: ['bucket', 'prefix', 'key', 'version']) {
 				next.delete(name);
 			}
-			next.delete('q');
+			// Tables and Query share the tree filter; only Objects has no use for it.
+			if (surface === 'objects') next.delete('q');
 			return next;
 		});
 	};
@@ -336,7 +337,7 @@ export default function DataBrowserPage() {
 			) : (
 				<div className="grid min-h-0 flex-1 grid-cols-[minmax(18rem,1fr)_minmax(0,2fr)] gap-4 text-sm max-lg:grid-cols-1 max-lg:overflow-y-auto">
 					<div className="flex min-h-0 flex-col gap-2 overflow-hidden rounded-xl border bg-card p-3 max-lg:max-h-[50vh]">
-						{selectedSurface === 'tables' && (
+						{(selectedSurface === 'tables' || selectedSurface === 'query') && (
 							<SearchField
 								aria-label="Filter tables"
 								placeholder="Filter tables..."
@@ -777,7 +778,9 @@ function TableRows({
 						style={{ paddingLeft: `${depth * 16 + 26}px` }}
 					>
 						<Table2 className="size-4 shrink-0" aria-hidden />
-						<span className="truncate">{table}</span>
+						<span className="truncate">
+							<HighlightMatch text={table} query={query} />
+						</span>
 					</button>
 				);
 			})}
@@ -789,6 +792,22 @@ function TableRows({
 				/>
 			)}
 		</div>
+	);
+}
+
+/** The first case-insensitive occurrence of `query` in `text`, marked. */
+function HighlightMatch({ text, query }: { text: string; query: string }) {
+	const start = query === '' ? -1 : text.toLowerCase().indexOf(query.toLowerCase());
+	if (start === -1) return text;
+	const end = start + query.length;
+	return (
+		<>
+			{text.slice(0, start)}
+			<mark className="rounded-sm bg-amber-200/80 text-inherit dark:bg-amber-500/40">
+				{text.slice(start, end)}
+			</mark>
+			{text.slice(end)}
+		</>
 	);
 }
 

--- a/packages/web/src/components/DataBrowser/SqlWorkspace.component.test.tsx
+++ b/packages/web/src/components/DataBrowser/SqlWorkspace.component.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from '@/context/ThemeContext';
 import { installMatchMedia, renderWithClient } from '@/test/render';
@@ -53,8 +53,8 @@ function useRunDataQueryMock() {
 	};
 }
 
-function renderWorkspace() {
-	return renderWithClient(
+function workspaceElement() {
+	return (
 		<ThemeProvider>
 			<SqlWorkspace
 				projectId="project-1"
@@ -63,9 +63,12 @@ function renderWorkspace() {
 				selection={null}
 				aiAvailable={false}
 			/>
-		</ThemeProvider>,
-		{ toaster: false },
+		</ThemeProvider>
 	);
+}
+
+function renderWorkspace() {
+	return renderWithClient(workspaceElement(), { toaster: false });
 }
 
 function storeDraft(draft: string) {
@@ -158,6 +161,156 @@ describe('SqlWorkspace', () => {
 		);
 		expect(screen.queryByRole('columnheader', { name: 'value' })).not.toBeInTheDocument();
 		expect(screen.getByText('Run a query to see results.')).toBeInTheDocument();
+	});
+
+	it('renders a single fold gutter', async () => {
+		const { container } = renderWorkspace();
+
+		await waitFor(() => expect(container.querySelector('.cm-content')).toBeInTheDocument());
+		expect(container.querySelectorAll('.cm-foldGutter')).toHaveLength(1);
+	});
+
+	it('runs the current statement on Mod-Enter despite basicSetup keybindings', async () => {
+		storeDraft('SELECT 1 AS value;');
+		hookMocks.executeQuery.mockResolvedValue(RESULT);
+		const { container } = renderWorkspace();
+
+		const content = await waitFor(() => {
+			const element = container.querySelector('.cm-content');
+			expect(element).toBeInTheDocument();
+			return element as HTMLElement;
+		});
+		fireEvent.keyDown(content, { key: 'Enter', ctrlKey: true });
+
+		await waitFor(() => expect(hookMocks.executeQuery).toHaveBeenCalledOnce());
+		expect(hookMocks.executeQuery.mock.calls[0]?.[0].sql).toBe('SELECT 1 AS value');
+	});
+
+	it('keeps the editor mounted while completions refresh', async () => {
+		storeDraft('SELECT 1 AS value;');
+		hookMocks.useDataQuerySchemaQuery.mockReturnValue({
+			isPending: false,
+			isFetching: true,
+			isError: false,
+			data: { tables: [], truncated: { tables: false, columns: false, bytes: false } },
+		});
+		const { container } = renderWorkspace();
+
+		await waitFor(() => expect(container.querySelector('.cm-content')).toBeInTheDocument());
+		expect(screen.getByText('Updating completions…')).toBeInTheDocument();
+	});
+
+	it('preserves the editor instance when a table click refetches the schema', async () => {
+		storeDraft('SELECT 1 AS value;');
+		const view = renderWorkspace();
+		const content = await waitFor(() => {
+			const element = view.container.querySelector('.cm-content');
+			expect(element).toBeInTheDocument();
+			return element as HTMLElement;
+		});
+
+		hookMocks.useDataQuerySchemaQuery.mockReturnValue({
+			isPending: false,
+			isFetching: true,
+			isError: false,
+			data: {
+				tables: [{ namespace: ['sales'], name: 'orders', columns: [{ name: 'id', type: 'long' }] }],
+				truncated: { tables: false, columns: false, bytes: false },
+			},
+		});
+		view.rerender(workspaceElement());
+
+		await screen.findByText('Updating completions…');
+		expect(view.container.querySelector('.cm-content')).toBe(content);
+		expect(content).toHaveTextContent('SELECT 1 AS value;');
+	});
+
+	it('toggles fullscreen and exits on Escape', async () => {
+		const user = userEvent.setup();
+		renderWorkspace();
+
+		await user.click(await screen.findByRole('button', { name: 'Fullscreen' }));
+		expect(screen.getByRole('button', { name: 'Exit fullscreen' })).toBeInTheDocument();
+
+		fireEvent.keyDown(window, { key: 'Escape' });
+
+		expect(await screen.findByRole('button', { name: 'Fullscreen' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Exit fullscreen' })).not.toBeInTheDocument();
+	});
+
+	it('falls back to the last loaded schema when a refetch errors with no data', async () => {
+		storeDraft('SELECT 1 AS value;');
+		const view = renderWorkspace();
+		const content = await waitFor(() => {
+			const element = view.container.querySelector('.cm-content');
+			expect(element).toBeInTheDocument();
+			return element as HTMLElement;
+		});
+
+		hookMocks.useDataQuerySchemaQuery.mockReturnValue({
+			isPending: false,
+			isFetching: false,
+			isError: true,
+			error: new Error('schema fetch failed'),
+			data: undefined,
+		});
+		view.rerender(workspaceElement());
+
+		expect(view.container.querySelector('.cm-content')).toBe(content);
+		expect(screen.getByText(/Couldn’t refresh completions/)).toBeInTheDocument();
+		expect(screen.queryByText('SQL schema unavailable')).not.toBeInTheDocument();
+	});
+
+	it('keeps the editor mounted when a completions refresh fails', async () => {
+		storeDraft('SELECT 1 AS value;');
+		hookMocks.useDataQuerySchemaQuery.mockReturnValue({
+			isPending: false,
+			isFetching: false,
+			isError: true,
+			error: new Error('boom'),
+			data: { tables: [], truncated: { tables: false, columns: false, bytes: false } },
+		});
+		const { container } = renderWorkspace();
+
+		await waitFor(() => expect(container.querySelector('.cm-content')).toBeInTheDocument());
+		expect(screen.getByText(/Couldn’t refresh completions/)).toBeInTheDocument();
+		expect(screen.queryByText('SQL schema unavailable')).not.toBeInTheDocument();
+	});
+
+	it('blocks on the schema only for the very first load', () => {
+		hookMocks.useDataQuerySchemaQuery.mockReturnValue({
+			isPending: true,
+			isFetching: true,
+			isError: false,
+			data: undefined,
+		});
+		const { container } = renderWorkspace();
+
+		expect(container.querySelector('.cm-content')).not.toBeInTheDocument();
+	});
+
+	it('explains what a bounded completion schema loaded', async () => {
+		hookMocks.useDataQuerySchemaQuery.mockReturnValue({
+			isPending: false,
+			isFetching: false,
+			isError: false,
+			data: {
+				tables: [],
+				truncated: { tables: true, columns: false, bytes: false },
+				counts: { tables: 5, discovered_tables: 12, columns: 40, discovery_complete: false },
+			},
+		});
+		const user = userEvent.setup();
+		renderWorkspace();
+
+		expect(
+			screen.getByText('Completion schema is bounded; some tables or columns were omitted.'),
+		).toBeInTheDocument();
+		const trigger = screen.getByLabelText('Completion schema details');
+		await user.hover(trigger);
+		await screen.findByText(/Loaded 5 of 12\+ tables \(40 columns\)/, undefined, {
+			timeout: 2_000,
+		});
 	});
 
 	it('falls back to the default draft when persisted state is malformed', async () => {

--- a/packages/web/src/components/DataBrowser/SqlWorkspace.test.ts
+++ b/packages/web/src/components/DataBrowser/SqlWorkspace.test.ts
@@ -3,6 +3,7 @@ import { EditorSelection, EditorState } from '@codemirror/state';
 import {
 	allSqlStatements,
 	applySqlTarget,
+	completionSchemaSummary,
 	csvCell,
 	selectedOrCurrentStatement,
 	sqlTargetAtState,
@@ -79,5 +80,40 @@ describe('CSV serialization', () => {
 		['say "hi"', '"say ""hi"""'],
 	])('serializes %j safely', (value, expected) => {
 		expect(csvCell(value)).toBe(expected);
+	});
+});
+
+describe('completionSchemaSummary', () => {
+	it('reports an exact total when discovery completed', () => {
+		expect(
+			completionSchemaSummary({
+				tables: 12,
+				discovered_tables: 12,
+				columns: 40,
+				discovery_complete: true,
+			}),
+		).toMatch(/^Loaded 12 of 12 tables \(40 columns\) for autocomplete\./);
+	});
+
+	it('marks the total as a lower bound when discovery was cut short', () => {
+		expect(
+			completionSchemaSummary({
+				tables: 5,
+				discovered_tables: 12,
+				columns: 40,
+				discovery_complete: false,
+			}),
+		).toMatch(/^Loaded 5 of 12\+ tables/);
+	});
+
+	it('uses singular nouns for a fully discovered single table', () => {
+		expect(
+			completionSchemaSummary({
+				tables: 1,
+				discovered_tables: 1,
+				columns: 1,
+				discovery_complete: true,
+			}),
+		).toMatch(/^Loaded 1 of 1 table \(1 column\)/);
 	});
 });

--- a/packages/web/src/components/DataBrowser/SqlWorkspace.tsx
+++ b/packages/web/src/components/DataBrowser/SqlWorkspace.tsx
@@ -10,17 +10,13 @@ import {
 } from 'react';
 import type { Ref } from 'react';
 import { basicSetup } from 'codemirror';
-import { autocompletion, closeBrackets } from '@codemirror/autocomplete';
-import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands';
-import { bracketMatching, foldGutter, indentOnInput } from '@codemirror/language';
+import { indentWithTab } from '@codemirror/commands';
 import { lintGutter } from '@codemirror/lint';
-import { highlightSelectionMatches, searchKeymap } from '@codemirror/search';
 import type { EditorState } from '@codemirror/state';
-import { Compartment, EditorSelection } from '@codemirror/state';
-import { drawSelection, EditorView, highlightActiveLine, keymap } from '@codemirror/view';
+import { Compartment, EditorSelection, Prec } from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
 import { sql } from '@codemirror/lang-sql';
 import {
-	defaultSqlHoverTheme,
 	NodeSqlParser,
 	QueryContextAnalyzer,
 	sqlCompletion,
@@ -34,12 +30,15 @@ import {
 	Download,
 	Eraser,
 	History as HistoryIcon,
+	Info,
+	Maximize2,
+	Minimize2,
 	Play,
 	Sparkles,
 	Square,
 	WandSparkles,
 } from 'lucide-react';
-import { Button, EmptyState, Skeleton } from '@/components/ui';
+import { Button, EmptyState, Skeleton, Tooltip } from '@/components/ui';
 import {
 	useDataQuerySchemaQuery,
 	useGenerateDataQuerySql,
@@ -130,9 +129,22 @@ function SqlWorkspaceSession({
 	const [instruction, setInstruction] = useState('');
 	const [showHistory, setShowHistory] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const [lastLoadedSchema, setLastLoadedSchema] = useState<typeof schemaQuery.data>(undefined);
+	const [fullscreen, setFullscreen] = useState(false);
 	const { copy, copied } = useCopyToClipboard();
 
 	useEffect(() => () => abortRef.current?.abort(), []);
+
+	useEffect(() => {
+		if (!fullscreen) return;
+		const onKeyDown = (event: KeyboardEvent) => {
+			// defaultPrevented: Escape was consumed inside the editor (e.g. closing
+			// the completion popup) and should not also exit fullscreen.
+			if (event.key === 'Escape' && !event.defaultPrevented) setFullscreen(false);
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	}, [fullscreen]);
 
 	const persistDraft = useCallback(
 		(sqlText: string) =>
@@ -208,20 +220,31 @@ function SqlWorkspaceSession({
 		}
 	};
 
-	if (schemaQuery.isPending) return <Skeleton className="h-full min-h-96 w-full" />;
-	if (schemaQuery.isError) {
-		return (
-			<EmptyState
-				icon={<Bot />}
-				message="SQL schema unavailable"
-				description={errorMessage(schemaQuery.error)}
-			/>
-		);
+	// Retain the last loaded schema so table clicks (new query key) and refresh
+	// failures never unmount the editor and discard the user's draft.
+	if (schemaQuery.data !== undefined && schemaQuery.data !== lastLoadedSchema) {
+		setLastLoadedSchema(schemaQuery.data);
 	}
-
-	const schema = schemaQuery.data;
+	const schema = schemaQuery.data ?? lastLoadedSchema;
+	if (schema === undefined) {
+		if (schemaQuery.isError) {
+			return (
+				<EmptyState
+					icon={<Bot />}
+					message="SQL schema unavailable"
+					description={errorMessage(schemaQuery.error)}
+				/>
+			);
+		}
+		return <Skeleton className="h-full min-h-96 w-full" />;
+	}
 	return (
-		<div className="flex min-h-[34rem] flex-col overflow-hidden rounded-xl border bg-card">
+		<div
+			className={cn(
+				'flex min-h-[34rem] flex-col overflow-hidden border bg-card',
+				fullscreen ? 'fixed inset-0 z-50 rounded-none' : 'rounded-xl',
+			)}
+		>
 			<div className="flex flex-wrap items-center gap-2 border-b px-3 py-2">
 				<Button
 					size="sm"
@@ -258,6 +281,14 @@ function SqlWorkspaceSession({
 				<span className="ml-auto text-xs text-muted-foreground">
 					⌘/Ctrl+Enter runs the selection or current statement
 				</span>
+				<Button
+					size="sm"
+					variant="ghost"
+					aria-label={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+					onPress={() => setFullscreen((value) => !value)}
+				>
+					{fullscreen ? <Minimize2 className="size-3.5" /> : <Maximize2 className="size-3.5" />}
+				</Button>
 			</div>
 			{aiAvailable ? (
 				<div className="flex gap-2 border-b bg-muted/20 p-3">
@@ -306,15 +337,35 @@ function SqlWorkspaceSession({
 				onRun={() => void run(false)}
 				onChange={persistDraft}
 			/>
-			{schema.truncated.tables || schema.truncated.columns || schema.truncated.bytes ? (
+			{schemaQuery.isFetching ? (
+				<output className="block border-t px-3 py-2 text-xs text-muted-foreground">
+					Updating completions…
+				</output>
+			) : schemaQuery.isError ? (
 				<p className="border-t bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+					Couldn’t refresh completions; showing the last loaded schema.
+				</p>
+			) : null}
+			{schema.truncated.tables || schema.truncated.columns || schema.truncated.bytes ? (
+				<p className="flex items-center gap-1.5 border-t bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
 					Completion schema is bounded; some tables or columns were omitted.
+					<Tooltip content={completionSchemaSummary(schema.counts)}>
+						<button
+							type="button"
+							aria-label="Completion schema details"
+							className="inline-flex rounded-full outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						>
+							<Info className="size-3.5" />
+						</button>
+					</Tooltip>
 				</p>
 			) : null}
 			<div className="min-h-56 flex-1 overflow-auto border-t p-3">
 				{error ? <p className="mb-3 text-sm text-destructive">{error}</p> : null}
 				{query.isPending ? (
-					<Skeleton className="h-32 w-full" />
+					<output aria-label="Running query" className="block">
+						<Skeleton className="h-32 w-full" />
+					</output>
 				) : executions.length > 0 ? (
 					<QueryExecutionResults
 						executions={executions}
@@ -347,6 +398,9 @@ const SqlEditor = forwardRef(function SqlEditor(
 ) {
 	const parentRef = useRef<HTMLDivElement>(null);
 	const viewRef = useRef<EditorView>(null);
+	const analyzersRef = useRef<{ parser: NodeSqlParser; contextAnalyzer: QueryContextAnalyzer }>(
+		null,
+	);
 	const onRunRef = useRef(onRun);
 	const onChangeRef = useRef(onChange);
 	const schemaCompartment = useRef(new Compartment()).current;
@@ -408,34 +462,26 @@ const SqlEditor = forwardRef(function SqlEditor(
 			getParserOptions: () => ({ database: 'DuckDB' }),
 		});
 		const contextAnalyzer = new QueryContextAnalyzer(parser);
+		analyzersRef.current = { parser, contextAnalyzer };
 		const view = new EditorView({
 			parent: parentRef.current,
 			doc: initialSql,
 			extensions: [
 				basicSetup,
-				history(),
-				foldGutter(),
 				lintGutter(),
-				drawSelection(),
-				indentOnInput(),
-				bracketMatching(),
-				closeBrackets(),
-				autocompletion({ activateOnTyping: true }),
-				highlightActiveLine(),
-				highlightSelectionMatches(),
-				keymap.of([
-					{
-						key: 'Mod-Enter',
-						run: () => {
-							onRunRef.current();
-							return true;
+				// basicSetup's defaultKeymap binds Mod-Enter to insertBlankLine; Prec.high keeps Run first.
+				Prec.high(
+					keymap.of([
+						{
+							key: 'Mod-Enter',
+							run: () => {
+								onRunRef.current();
+								return true;
+							},
 						},
-					},
-					indentWithTab,
-					...defaultKeymap,
-					...historyKeymap,
-					...searchKeymap,
-				]),
+						indentWithTab,
+					]),
+				),
 				EditorView.updateListener.of((update) => {
 					if (update.docChanged) onChangeRef.current(update.state.doc.toString());
 				}),
@@ -452,7 +498,13 @@ const SqlEditor = forwardRef(function SqlEditor(
 
 	useEffect(() => {
 		viewRef.current?.dispatch({
-			effects: schemaCompartment.reconfigure(schemaExtensions(schema, undefined, undefined)),
+			effects: schemaCompartment.reconfigure(
+				schemaExtensions(
+					schema,
+					analyzersRef.current?.parser,
+					analyzersRef.current?.contextAnalyzer,
+				),
+			),
 		});
 	}, [schema, schemaCompartment]);
 
@@ -488,7 +540,6 @@ function schemaExtensions(
 			enableNavigation: true,
 			navigationConfig: { keymap: true },
 		}),
-		defaultSqlHoverTheme(),
 	];
 }
 
@@ -506,6 +557,24 @@ function editorTheme(theme: 'light' | 'dark') {
 			},
 		},
 		{ dark: theme === 'dark' },
+	);
+}
+
+export function completionSchemaSummary(counts: {
+	tables: number;
+	discovered_tables: number;
+	columns: number;
+	discovery_complete: boolean;
+}): string {
+	// discovered_tables is a lower bound when discovery was cut short.
+	const discovered = counts.discovery_complete
+		? `${counts.discovered_tables}`
+		: `${counts.discovered_tables}+`;
+	const tables = counts.discovered_tables === 1 && counts.discovery_complete ? 'table' : 'tables';
+	const columns = counts.columns === 1 ? 'column' : 'columns';
+	return (
+		`Loaded ${counts.tables} of ${discovered} ${tables} (${counts.columns} ${columns}) for autocomplete. ` +
+		'The selected table is always included, and queries against omitted tables still run.'
 	);
 }
 


### PR DESCRIPTION
Improves the data browser's SQL editor across error reporting, loading behavior, and editor polish.

- Removes duplicate CodeMirror extensions (`basicSetup` already provides `foldGutter` etc.), fixing the double fold-arrow column, and wraps the Run keymap in `Prec.high` — Mod-Enter was shadowed by `basicSetup`'s `insertBlankLine` binding.
- Replaces the blanket "data-query runtime could not execute this query" with real DuckDB parser/catalog/binder messages: the engine classifies a prefix allowlist of user-SQL error classes into a `DataQueryUserError` marker, carried across the worker boundary as a structured `kind`, redacted against all connection secrets (vars, files, plan params, httpAccess), and surfaced as a 422 `ValidationError`. Everything else stays generic but now carries a redacted `cause` so 5xx logs have request-correlated detail. The existing secret-leak tests pass unchanged.
- Keeps the editor mounted across table clicks: the completion-schema query uses `keepPreviousData` plus a retained last-loaded schema, so a focus change (or a failed refresh) shows an inline "Updating completions…" note instead of unmounting CodeMirror — which was silently reverting the user's typed SQL to a stale localStorage snapshot.
- Explains the "Completion schema is bounded" notice with an info tooltip fed by new additive `counts` on the schema endpoint (tables loaded / discovered / columns / discovery-complete, now also accounting for deadline expiry).
- Tree filter is available on the Query surface, persists between Tables and Query, and highlights the matched fragment; adds a fullscreen toggle for the SQL workspace (Escape exits, unless the editor consumed it).
- Suppresses the duplicate global toast for inline-rendered query/AI errors and uses semantic `<output>` elements for loading states.

Also bumps timeouts on two pre-existing load-sensitive tests (6k-request CLI poll budget, git subprocess suite) that flaked under full-suite CPU contention once core changes invalidated their cached results.