### PR TITLE
feat(projects): claim email invites into user-id rows

### DIFF
--- a/apps/server/src/cron.test.ts
+++ b/apps/server/src/cron.test.ts
@@ -66,10 +66,21 @@ describe('startMaintenance', () => {
 		expect(events[0]).toMatchObject({
 			event: 'maintenance_cycle',
 			sessions_expired: 0,
+			invite_rows_claimed: 0,
 			projects_swept: 0,
 			notebooks_swept: 0,
 			'counter.sessions_created': 1,
 		});
+	});
+
+	it('claims pending invite rows during the maintenance cycle', async () => {
+		const claimSpy = vi.spyOn(deps.services.projects, 'claimPendingInvites').mockResolvedValue(2);
+
+		stop = startMaintenance(deps, metrics);
+		await flushRun();
+
+		expect(claimSpy).toHaveBeenCalledOnce();
+		expect(parseLoggedEvents(logSpy)[0]).toMatchObject({ invite_rows_claimed: 2 });
 	});
 
 	it('sweeps projects before notebooks (a deleted project reclaims its own notebooks)', async () => {

--- a/apps/server/src/cron.ts
+++ b/apps/server/src/cron.ts
@@ -86,7 +86,8 @@ async function scheduleUnavailableAppAlerts(
  *  5. `pruneEvents()`     — drop event-day folders past retention.
  *  6. `pruneExpiredPayloads()` — delete expired proposal change bytes while
  *     retaining proposal and publication metadata.
- *  7. `sweepDeletedProjects()` / `sweepDeletedNotebooks()` — purge the storage of
+ *  7. `claimPendingInvites()` — replace resolvable email invites with user ids.
+ *  8. `sweepDeletedProjects()` / `sweepDeletedNotebooks()` — purge the storage of
  *     soft-deleted projects/notebooks past their grace period. Projects first, so
  *     a deleted project's notebooks are reclaimed by the project subtree wipe.
  *
@@ -144,6 +145,7 @@ export function startMaintenance(deps: ApiDeps, metrics: WideEventMetrics): () =
 				const eventsPruned = await maintenance.pruneEvents();
 				const idempotencyPruned = await idempotency.prune();
 				const proposalPayloadsPruned = await proposals.pruneExpiredPayloads();
+				const inviteRowsClaimed = await projects.claimPendingInvites();
 				// Projects before notebooks: a swept project wipes its whole subtree, so
 				// its soft-deleted notebooks are reclaimed without per-notebook work.
 				const projectsSwept = await projects.sweepDeletedProjects();
@@ -166,6 +168,7 @@ export function startMaintenance(deps: ApiDeps, metrics: WideEventMetrics): () =
 					events_pruned: eventsPruned,
 					idempotency_pruned: idempotencyPruned,
 					proposal_payloads_pruned: proposalPayloadsPruned,
+					invite_rows_claimed: inviteRowsClaimed,
 					projects_swept: projectsSwept,
 					notebooks_swept: notebooksSwept.purged,
 					snapshots_reaped: snapshotsReaped,

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -106,6 +106,12 @@ an invite row and an id row — adding a member is rejected (409) when any of
 their known identifiers is already on the roster, so removing a member always
 revokes their access.
 
+After an invitee signs in, the next membership write or maintenance sweep
+replaces their email invite with a user-id row while preserving their role. A
+legacy roster that contains both forms is collapsed to one user-id row with the
+higher role. Email matching remains active until that claim occurs, so access is
+continuous.
+
 The login email grants access, so OIDC requires `email_verified: true` by
 default. `trusted-issuer` permits an enterprise issuer to omit the claim,
 including when a domain allowlist is active. If the claim is present, its value

--- a/examples/cloudflare-worker/src/index.ts
+++ b/examples/cloudflare-worker/src/index.ts
@@ -229,7 +229,8 @@ export default {
 	},
 	async scheduled(_event: ScheduledController, env: Env): Promise<void> {
 		const bucket = new R2BucketAdapter(env.NOTEBOOKS_BUCKET);
-		const { sessions, maintenance, notebooks, proposals, idempotency } = createServices(bucket);
+		const { sessions, maintenance, projects, notebooks, proposals, idempotency } =
+			createServices(bucket);
 		const compute = new CloudflareSandboxProvider(env.SANDBOX);
 
 		// The Workers scheduled trigger is already a platform singleton; the lease
@@ -252,6 +253,7 @@ export default {
 			await maintenance.pruneEvents();
 			await idempotency.prune();
 			await proposals.pruneExpiredPayloads();
+			await projects.claimPendingInvites();
 		} finally {
 			await lock.release('cloudflare-scheduled');
 		}

--- a/packages/api/src/routes/projects.test.ts
+++ b/packages/api/src/routes/projects.test.ts
@@ -481,6 +481,11 @@ describe('Project member routes', () => {
 		expect((await expectOk<any>(await inviteeRequest('GET', `/projects/${pid}`))).your_role).toBe(
 			'editor',
 		);
+		const pendingMembers = await expectOk<any[]>(
+			await ownerRequest('GET', `/projects/${pid}/members`),
+		);
+		expect(pendingMembers).toContainEqual({ email, role: 'editor' });
+		expect(pendingMembers.some((member) => member.user_id === inviteeId)).toBe(false);
 
 		await expectOk(
 			await ownerRequest('POST', `/projects/${pid}/members`, {

--- a/packages/api/src/routes/projects.test.ts
+++ b/packages/api/src/routes/projects.test.ts
@@ -460,6 +460,40 @@ describe('Project member routes', () => {
 		expect(listed.map((p: any) => p.id)).toContain(pid);
 	});
 
+	it('claims an invite to the user id after sign-in and the next membership action', async () => {
+		const services = createServices(bucket);
+		const ownerRequest = createTestApi({
+			bucket,
+			deps: { services, notifier },
+		}).request;
+		const inviteeId = uid('claimed_invitee');
+		const email = `${inviteeId}@example.com`;
+
+		await expectOk(
+			await ownerRequest('POST', `/projects/${pid}/members`, { email, role: 'editor' }),
+			201,
+		);
+		const inviteeRequest = createTestApi({
+			bucket,
+			userId: inviteeId,
+			deps: { services },
+		}).request;
+		expect((await expectOk<any>(await inviteeRequest('GET', `/projects/${pid}`))).your_role).toBe(
+			'editor',
+		);
+
+		await expectOk(
+			await ownerRequest('POST', `/projects/${pid}/members`, {
+				user_id: uid('another_member'),
+				role: 'viewer',
+			}),
+			201,
+		);
+		const members = await expectOk<any[]>(await ownerRequest('GET', `/projects/${pid}/members`));
+		expect(members).toContainEqual({ user_id: inviteeId, role: 'editor' });
+		expect(members.some((member) => member.email === email)).toBe(false);
+	});
+
 	it('uses a new dedupe key after an invite is removed and added again', async () => {
 		const email = 'returning@example.com';
 		await expectOk(await owner('POST', `/projects/${pid}/members`, { email, role: 'viewer' }), 201);

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -453,13 +453,7 @@ app.openapi(updateMember, async (c) => {
 	assertNotificationMutationAllowed(deps, user.id, { delivery: 'project-alert' });
 	const body = c.req.valid('json');
 	const result = await projects.updateMemberRoleWithMutation(pid, uid, body.role, user.id);
-	const member = result.project.members.find(
-		(candidate) =>
-			(result.previousMember.user_id !== undefined &&
-				candidate.user_id === result.previousMember.user_id) ||
-			(result.previousMember.email !== undefined &&
-				candidate.email === result.previousMember.email),
-	);
+	const member = result.member;
 	if (member && member.role !== result.previousMember.role) {
 		scheduleProjectAlert(deps, pid, 'member.role_changed', { project_id: pid, user: user.id }, () =>
 			notificationRouter.render({

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -319,8 +319,8 @@ export const EmailAddressSchema = z.string().refine(
 // added before they ever logged in. Exactly one of the two identifiers is set.
 // The schema lowercases emails on parse so the authz comparison (see authz.ts)
 // can rely on the invariant even for rows written outside ProjectService. An
-// email row is not rewritten to an id when the invitee first logs in — it keeps
-// matching by email.
+// email row keeps matching during the pending window, then becomes an id row on
+// the next membership write or maintenance sweep after the invitee signs in.
 export const ProjectMemberSchema = z
 	.object({
 		user_id: UserIdSchema.optional(),

--- a/packages/core/src/services/content/ProjectService.test.ts
+++ b/packages/core/src/services/content/ProjectService.test.ts
@@ -6,8 +6,9 @@ import { paths } from '../../paths';
 import { ACTOR, setupTestEnv } from '../../testing';
 import type { MemoryBucket } from '../../testing';
 import type { CatalogService } from '../catalog/CatalogService';
+import type { IdentityService } from '../identity/IdentityService';
 import type { NotebookService } from './NotebookService';
-import type { ProjectService } from './ProjectService';
+import { claimInviteRows, ProjectService } from './ProjectService';
 import { listAllKeys } from '../catalog/storage';
 
 describe('ProjectService', () => {
@@ -15,6 +16,7 @@ describe('ProjectService', () => {
 	let projects: ProjectService;
 	let notebooks: NotebookService;
 	let catalog: CatalogService;
+	let identities: IdentityService;
 
 	beforeEach(async () => {
 		const env = await setupTestEnv();
@@ -22,6 +24,7 @@ describe('ProjectService', () => {
 		projects = env.projects;
 		notebooks = env.notebooks;
 		catalog = env.catalog;
+		identities = env.identities;
 	});
 
 	describe('createProject', () => {
@@ -220,6 +223,20 @@ describe('ProjectService', () => {
 	describe('membership', () => {
 		const MEMBER = UserId.parse('user_member');
 
+		it('does not resolve or copy an id-only roster', async () => {
+			const members = [
+				{ user_id: ACTOR, role: 'admin' as const },
+				{ user_id: MEMBER, role: 'viewer' as const },
+			];
+			const resolveByEmail = vi.fn(async () => null);
+
+			const result = await claimInviteRows(members, resolveByEmail);
+
+			expect(resolveByEmail).not.toHaveBeenCalled();
+			expect(result.members).toBe(members);
+			expect(result.claimedRows).toBe(0);
+		});
+
 		it('projects the latest roster when catalog updates finish out of order', async () => {
 			const project = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
 			const first = UserId.parse('first_member');
@@ -294,6 +311,151 @@ describe('ProjectService', () => {
 			const snap = await catalog.getCurrentSnapshot();
 			expect(mutation).toMatchObject({ project: stored, mutationId: snap.snapshot_id });
 			expect(snap.projects[0].member_emails).toEqual(['invitee@example.com']);
+		});
+
+		it('claims a known invite on the next membership write without changing its role', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			await projects.addMember(p.id, { email: 'invitee@example.com' }, 'editor', ACTOR);
+			await identities.upsert({ id: MEMBER, email: 'invitee@example.com', name: 'Invitee' });
+
+			await projects.addMember(p.id, { user_id: UserId.parse('user_other') }, 'viewer', ACTOR);
+
+			const stored = await projects.getProject(p.id);
+			expect(stored.members).toContainEqual({ user_id: MEMBER, role: 'editor' });
+			expect(stored.members.some((member) => member.email === 'invitee@example.com')).toBe(false);
+			const snapshot = await catalog.getCurrentSnapshot();
+			expect(snapshot.projects[0].member_ids).toContain(MEMBER);
+			expect(snapshot.projects[0].member_emails).toEqual([]);
+		});
+
+		it('leaves unknown invite emails pending on later membership writes', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			await projects.addMember(p.id, { email: 'unknown@example.com' }, 'viewer', ACTOR);
+
+			const updated = await projects.addMember(
+				p.id,
+				{ user_id: UserId.parse('user_other') },
+				'editor',
+				ACTOR,
+			);
+
+			expect(updated.members).toContainEqual({ email: 'unknown@example.com', role: 'viewer' });
+		});
+
+		it('does not mutate the project or catalog when invite resolution fails', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			await projects.addMember(p.id, { email: 'invitee@example.com' }, 'viewer', ACTOR);
+			const projectBefore = await projects.getProject(p.id);
+			const snapshotBefore = await catalog.getCurrentSnapshot();
+			const unavailable = new Error('identity directory unavailable');
+			const resolveByEmail = vi.fn(async () => {
+				throw unavailable;
+			});
+			const failingProjects = new ProjectService(bucket, catalog, undefined, resolveByEmail);
+
+			await expect(
+				failingProjects.addMember(p.id, { user_id: UserId.parse('user_other') }, 'editor', ACTOR),
+			).rejects.toBe(unavailable);
+
+			expect(resolveByEmail).toHaveBeenCalledWith('invitee@example.com');
+			expect(await projects.getProject(p.id)).toEqual(projectBefore);
+			expect(await catalog.getCurrentSnapshot()).toEqual(snapshotBefore);
+		});
+
+		it('collapses legacy id and email rows to the higher role', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			await projects.addMember(p.id, { email: 'legacy@example.com' }, 'manager', ACTOR);
+			const key = paths.project(p.id).meta;
+			const stored = await projects.getProject(p.id);
+			await bucket.put(
+				key,
+				JSON.stringify({
+					...stored,
+					members: [...stored.members, { user_id: MEMBER, role: 'viewer' }],
+				}),
+			);
+			await identities.upsert({ id: MEMBER, email: 'legacy@example.com', name: 'Legacy' });
+
+			const updated = await projects.addMember(
+				p.id,
+				{ user_id: UserId.parse('user_other') },
+				'viewer',
+				ACTOR,
+			);
+
+			expect(updated.members.filter((member) => member.user_id === MEMBER)).toEqual([
+				{ user_id: MEMBER, role: 'manager' },
+			]);
+			expect(updated.members.some((member) => member.email === 'legacy@example.com')).toBe(false);
+		});
+
+		it('keeps email selectors valid on the write that claims the invite', async () => {
+			const updateProject = await projects.createProject(
+				{ name: 'Update', description: 'a' },
+				ACTOR,
+			);
+			await projects.addMember(updateProject.id, { email: 'invitee@example.com' }, 'viewer', ACTOR);
+			await identities.upsert({ id: MEMBER, email: 'invitee@example.com', name: 'Invitee' });
+
+			const updated = await projects.updateMemberRole(
+				updateProject.id,
+				'invitee@example.com',
+				'editor',
+				ACTOR,
+			);
+			expect(updated.members).toContainEqual({ user_id: MEMBER, role: 'editor' });
+
+			const removeProject = await projects.createProject(
+				{ name: 'Remove', description: 'a' },
+				ACTOR,
+			);
+			await projects.addMember(removeProject.id, { email: 'remove@example.com' }, 'viewer', ACTOR);
+			await identities.upsert({ id: MEMBER, email: 'remove@example.com', name: 'Invitee' });
+
+			const removed = await projects.removeMember(removeProject.id, 'remove@example.com', ACTOR);
+			expect(removed.members.some((member) => member.user_id === MEMBER)).toBe(false);
+			expect(removed.members.some((member) => member.email === 'remove@example.com')).toBe(false);
+		});
+
+		it('claims resolvable invites during maintenance and is idempotent', async () => {
+			const known = await projects.createProject({ name: 'Known', description: 'a' }, ACTOR);
+			const unknown = await projects.createProject({ name: 'Unknown', description: 'a' }, ACTOR);
+			await projects.addMember(known.id, { email: 'known@example.com' }, 'viewer', ACTOR);
+			await projects.addMember(unknown.id, { email: 'unknown@example.com' }, 'editor', ACTOR);
+			await identities.upsert({ id: MEMBER, email: 'known@example.com', name: 'Known' });
+
+			expect(await projects.claimPendingInvites()).toBe(1);
+			expect(await projects.claimPendingInvites()).toBe(0);
+			expect((await projects.getProject(known.id)).members).toContainEqual({
+				user_id: MEMBER,
+				role: 'viewer',
+			});
+			expect((await projects.getProject(unknown.id)).members).toContainEqual({
+				email: 'unknown@example.com',
+				role: 'editor',
+			});
+		});
+
+		it('leaves a failed maintenance claim pending and recovers on the next sweep', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			await projects.addMember(p.id, { email: 'invitee@example.com' }, 'editor', ACTOR);
+			await identities.upsert({ id: MEMBER, email: 'invitee@example.com', name: 'Invitee' });
+			const projectBefore = await projects.getProject(p.id);
+			const snapshotBefore = await catalog.getCurrentSnapshot();
+			const unavailable = new Error('identity directory unavailable');
+			const failingProjects = new ProjectService(bucket, catalog, undefined, async () => {
+				throw unavailable;
+			});
+
+			await expect(failingProjects.claimPendingInvites()).rejects.toBe(unavailable);
+			expect(await projects.getProject(p.id)).toEqual(projectBefore);
+			expect(await catalog.getCurrentSnapshot()).toEqual(snapshotBefore);
+
+			expect(await projects.claimPendingInvites()).toBe(1);
+			expect((await projects.getProject(p.id)).members).toContainEqual({
+				user_id: MEMBER,
+				role: 'editor',
+			});
 		});
 
 		it('rejects an id add carrying an email that matches a pending invite (409)', async () => {

--- a/packages/core/src/services/content/ProjectService.test.ts
+++ b/packages/core/src/services/content/ProjectService.test.ts
@@ -228,7 +228,7 @@ describe('ProjectService', () => {
 				{ user_id: ACTOR, role: 'admin' as const },
 				{ user_id: MEMBER, role: 'viewer' as const },
 			];
-			const resolveByEmail = vi.fn(async () => null);
+			const resolveByEmail = vi.fn(async () => new Map());
 
 			const result = await claimInviteRows(members, resolveByEmail);
 
@@ -328,6 +328,33 @@ describe('ProjectService', () => {
 			expect(snapshot.projects[0].member_emails).toEqual([]);
 		});
 
+		it('keeps an invite by email when multiple identities match it', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			await projects.addMember(p.id, { email: 'shared@example.com' }, 'editor', ACTOR);
+			await identities.upsert({
+				id: UserId.parse('user_old'),
+				email: 'shared@example.com',
+				name: 'Old',
+			});
+			await identities.upsert({
+				id: UserId.parse('user_new'),
+				email: 'shared@example.com',
+				name: 'New',
+			});
+
+			const updated = await projects.addMember(
+				p.id,
+				{ user_id: UserId.parse('user_other') },
+				'viewer',
+				ACTOR,
+			);
+
+			expect(updated.members).toContainEqual({ email: 'shared@example.com', role: 'editor' });
+			expect(updated.members.some((member) => member.user_id === UserId.parse('user_new'))).toBe(
+				false,
+			);
+		});
+
 		it('leaves unknown invite emails pending on later membership writes', async () => {
 			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
 			await projects.addMember(p.id, { email: 'unknown@example.com' }, 'viewer', ACTOR);
@@ -357,7 +384,7 @@ describe('ProjectService', () => {
 				failingProjects.addMember(p.id, { user_id: UserId.parse('user_other') }, 'editor', ACTOR),
 			).rejects.toBe(unavailable);
 
-			expect(resolveByEmail).toHaveBeenCalledWith('invitee@example.com');
+			expect(resolveByEmail).toHaveBeenCalledWith(['invitee@example.com']);
 			expect(await projects.getProject(p.id)).toEqual(projectBefore);
 			expect(await catalog.getCurrentSnapshot()).toEqual(snapshotBefore);
 		});
@@ -423,9 +450,14 @@ describe('ProjectService', () => {
 			await projects.addMember(known.id, { email: 'known@example.com' }, 'viewer', ACTOR);
 			await projects.addMember(unknown.id, { email: 'unknown@example.com' }, 'editor', ACTOR);
 			await identities.upsert({ id: MEMBER, email: 'known@example.com', name: 'Known' });
+			const resolve = vi.spyOn(identities, 'getUniqueByEmails');
 
 			expect(await projects.claimPendingInvites()).toBe(1);
+			expect(resolve).toHaveBeenCalledOnce();
+			expect(resolve).toHaveBeenCalledWith(['known@example.com', 'unknown@example.com']);
+			const snapshotAfterClaim = await catalog.getCurrentSnapshot();
 			expect(await projects.claimPendingInvites()).toBe(0);
+			expect((await catalog.getCurrentSnapshot()).snapshot_id).toBe(snapshotAfterClaim.snapshot_id);
 			expect((await projects.getProject(known.id)).members).toContainEqual({
 				user_id: MEMBER,
 				role: 'viewer',
@@ -458,6 +490,28 @@ describe('ProjectService', () => {
 			});
 		});
 
+		it('repairs the catalog after a claim commits only to project metadata', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			await projects.addMember(p.id, { email: 'invitee@example.com' }, 'editor', ACTOR);
+			await identities.upsert({ id: MEMBER, email: 'invitee@example.com', name: 'Invitee' });
+			const projectionFailure = new Error('catalog unavailable');
+			vi.spyOn(catalog, 'updateProjectEntry').mockRejectedValueOnce(projectionFailure);
+
+			await expect(projects.claimPendingInvites()).rejects.toBe(projectionFailure);
+			expect((await projects.getProject(p.id)).members).toContainEqual({
+				user_id: MEMBER,
+				role: 'editor',
+			});
+			expect((await catalog.getCurrentSnapshot()).projects[0].member_emails).toEqual([
+				'invitee@example.com',
+			]);
+
+			expect(await projects.claimPendingInvites()).toBe(0);
+			const repaired = (await catalog.getCurrentSnapshot()).projects[0];
+			expect(repaired.member_ids).toContain(MEMBER);
+			expect(repaired.member_emails).toEqual([]);
+		});
+
 		it('rejects an id add carrying an email that matches a pending invite (409)', async () => {
 			// One person must never hold both an invite row and an id row — removing
 			// one would silently leave the other granting access.
@@ -479,6 +533,16 @@ describe('ProjectService', () => {
 			);
 			await expect(
 				projects.addMember(p.id, { email: 'DUP@example.com' }, 'editor', ACTOR),
+			).rejects.toThrow(/already a member/);
+		});
+
+		it('rejects an email re-add when the existing invite is claimed during the write', async () => {
+			const p = await projects.createProject({ name: 'A', description: 'a' }, ACTOR);
+			await projects.addMember(p.id, { email: 'invitee@example.com' }, 'viewer', ACTOR);
+			await identities.upsert({ id: MEMBER, email: 'invitee@example.com', name: 'Invitee' });
+
+			await expect(
+				projects.addMember(p.id, { email: 'invitee@example.com' }, 'editor', ACTOR),
 			).rejects.toThrow(/already a member/);
 		});
 

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -26,6 +26,7 @@ import type {
 	ProjectMember,
 	PublicProjectEntry,
 	Snapshot,
+	SnapshotProjectEntry,
 } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject, mutateObjectWithOutcome, withCasRetry } from '../catalog/cas';
@@ -76,7 +77,9 @@ export interface ProjectDeleteMutationResult {
 	mutationId: SnapshotId;
 }
 
-export type InviteIdentityResolver = (email: string) => Promise<{ id: UserId } | null>;
+export type InviteIdentityResolver = (
+	emails: readonly string[],
+) => Promise<ReadonlyMap<string, { id: UserId }>>;
 
 export interface ClaimedInviteRows {
 	members: readonly ProjectMember[];
@@ -104,9 +107,15 @@ function selectorAfterClaims(member: ProjectMember, claimed: ClaimedInviteRows):
 	return claimed.userIdsByEmail.get(normalizeEmail(email)) ?? email;
 }
 
+function sameValues(a: readonly string[] | undefined, b: readonly string[] | undefined): boolean {
+	if (a === b) return true;
+	if (a === undefined || b === undefined || a.length !== b.length) return false;
+	return a.every((value, index) => value === b[index]);
+}
+
 async function resolveInviteRows(
 	members: readonly ProjectMember[],
-	resolveByEmail: InviteIdentityResolver,
+	resolveIdentitiesByEmail: InviteIdentityResolver,
 ): Promise<ClaimedInviteRows> {
 	const emails = [
 		...new Set(
@@ -115,12 +124,11 @@ async function resolveInviteRows(
 			),
 		),
 	];
-	const resolved = await Promise.all(
-		emails.map(async (email) => [email, await resolveByEmail(email)] as const),
-	);
+	const resolved = await resolveIdentitiesByEmail(emails);
 	const userIdsByEmail = new Map<string, UserId>();
-	for (const [email, identity] of resolved) {
-		if (identity) userIdsByEmail.set(email, identity.id);
+	for (const email of emails) {
+		const identity = resolved.get(email);
+		if (identity !== undefined) userIdsByEmail.set(email, identity.id);
 	}
 
 	const directUserIds = new Set(
@@ -170,10 +178,10 @@ async function resolveInviteRows(
 
 export async function claimInviteRows(
 	members: readonly ProjectMember[],
-	resolveByEmail: InviteIdentityResolver,
+	resolveIdentitiesByEmail: InviteIdentityResolver,
 ): Promise<ClaimedInviteRows> {
 	return hasInviteRows(members)
-		? resolveInviteRows(members, resolveByEmail)
+		? resolveInviteRows(members, resolveIdentitiesByEmail)
 		: noInviteClaims(members);
 }
 
@@ -190,7 +198,7 @@ export class ProjectService {
 		private bucket: Bucket,
 		private catalog: CatalogService,
 		private metrics: Metrics = noopMetrics,
-		private resolveIdentityByEmail: InviteIdentityResolver = async () => null,
+		private resolveIdentitiesByEmail: InviteIdentityResolver = async () => new Map(),
 	) {}
 
 	/**
@@ -359,9 +367,11 @@ export class ProjectService {
 		const { project, mutationId } = await this.writeMembers(
 			id,
 			(_current, claimed) => {
+				const claimedUserId =
+					userId ?? (email === undefined ? undefined : claimed.userIdsByEmail.get(email));
 				const duplicate = claimed.members.some(
 					(m) =>
-						(userId !== undefined && m.user_id === userId) ||
+						(claimedUserId !== undefined && m.user_id === claimedUserId) ||
 						(email !== undefined && m.email === email),
 				);
 				if (duplicate) {
@@ -472,7 +482,10 @@ export class ProjectService {
 	private async mutateMemberObject(
 		id: ProjectId,
 		deriveMembers: (current: Project, claimed: ClaimedInviteRows) => ProjectMember[],
-		options: { skipIfNoClaims?: boolean } = {},
+		options: {
+			skipIfNoClaims?: boolean;
+			resolveIdentitiesByEmail?: InviteIdentityResolver;
+		} = {},
 	): Promise<{ project: Project; claimedRows: number; written: boolean }> {
 		const key = paths.project(id).meta;
 		return withCasRetry(this.bucket, async (cas) => {
@@ -481,7 +494,10 @@ export class ProjectService {
 			const current = await readStored(ProjectSchema, object, key);
 			if (current.status === 'deleted') throw new NotFoundError(`Project ${id} not found`);
 			const claimed = hasInviteRows(current.members)
-				? await resolveInviteRows(current.members, this.resolveIdentityByEmail)
+				? await resolveInviteRows(
+						current.members,
+						options.resolveIdentitiesByEmail ?? this.resolveIdentitiesByEmail,
+					)
 				: noInviteClaims(current.members);
 			if (options.skipIfNoClaims && claimed.claimedRows === 0) {
 				return { project: current, claimedRows: 0, written: false };
@@ -496,18 +512,29 @@ export class ProjectService {
 		});
 	}
 
-	private async claimProjectInvites(id: ProjectId): Promise<number> {
+	private async claimProjectInvites(
+		candidate: SnapshotProjectEntry,
+		resolveIdentitiesByEmail: InviteIdentityResolver,
+	): Promise<number> {
 		try {
 			const result = await this.mutateMemberObject(
-				id,
+				candidate.id,
 				(_current, claimed) => [...claimed.members],
 				{
 					skipIfNoClaims: true,
+					resolveIdentitiesByEmail,
 				},
 			);
-			if (!result.written) return 0;
-			await this.catalog.updateProjectEntry('project.members.claim', SYSTEM_ACTOR, id, (entry) =>
-				loadProjectCatalogPatch(this.bucket, id, entry),
+			const projection = projectCatalogPatch(result.project, candidate);
+			const projectionIsCurrent =
+				sameValues(candidate.member_ids, projection.member_ids) &&
+				sameValues(candidate.member_emails, projection.member_emails);
+			if (!result.written && projectionIsCurrent) return 0;
+			await this.catalog.updateProjectEntry(
+				result.written ? 'project.members.claim' : 'project.members.repair',
+				SYSTEM_ACTOR,
+				candidate.id,
+				(entry) => loadProjectCatalogPatch(this.bucket, candidate.id, entry),
 			);
 			return result.claimedRows;
 		} catch (error) {
@@ -521,8 +548,14 @@ export class ProjectService {
 		const candidates = snapshot.projects.filter(
 			(project) => project.status !== 'deleted' && (project.member_emails?.length ?? 0) > 0,
 		);
+		if (candidates.length === 0) return 0;
+		const candidateEmails = [
+			...new Set(candidates.flatMap((project) => project.member_emails ?? []).map(normalizeEmail)),
+		];
+		const resolved = await this.resolveIdentitiesByEmail(candidateEmails);
+		const resolveFromSweep: InviteIdentityResolver = async () => resolved;
 		const claimed = await mapWithConcurrency(candidates, BUCKET_SCAN_CONCURRENCY, (project) =>
-			this.claimProjectInvites(project.id),
+			this.claimProjectInvites(project, resolveFromSweep),
 		);
 		return claimed.reduce((total, count) => total + count, 0);
 	}

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -1,10 +1,16 @@
 import type { Bucket } from '../../ports/bucket';
-import { canAct, canSeeProjectEntry, isSuperAdmin, subjectDefaultRole } from '../../authz';
+import {
+	canAct,
+	canSeeProjectEntry,
+	isSuperAdmin,
+	roleAtLeast,
+	subjectDefaultRole,
+} from '../../authz';
 import type { AuthSubject, AuthzPolicy } from '../../authz';
 import { memberRefMatchesSelector, normalizeEmail } from '../../identityMatch';
 import { mapWithConcurrency } from '../../concurrency';
 import { BUCKET_SCAN_CONCURRENCY } from '../../constants';
-import type { AssignableRole } from '../../constants';
+import type { AssignableRole, Role } from '../../constants';
 import { Millis } from '../../duration';
 import { assertVersionMatch, ConflictError, NotFoundError, ValidationError } from '../../errors';
 import { createProjectId, SYSTEM_ACTOR } from '../../ids';
@@ -22,7 +28,7 @@ import type {
 	Snapshot,
 } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
-import { mutateObject, mutateObjectWithOutcome } from '../catalog/cas';
+import { mutateObject, mutateObjectWithOutcome, withCasRetry } from '../catalog/cas';
 import { deleteByPrefix } from '../catalog/storage';
 import { loadProjectCatalogPatch, projectCatalogPatch } from './catalogProjection';
 
@@ -61,9 +67,114 @@ export interface ExistingMemberMutationResult extends MemberMutationResult {
 	previousMember: ProjectMember;
 }
 
+export interface UpdatedMemberMutationResult extends ExistingMemberMutationResult {
+	member: ProjectMember;
+}
+
 export interface ProjectDeleteMutationResult {
 	project: Project;
 	mutationId: SnapshotId;
+}
+
+export type InviteIdentityResolver = (email: string) => Promise<{ id: UserId } | null>;
+
+export interface ClaimedInviteRows {
+	members: readonly ProjectMember[];
+	claimedRows: number;
+	userIdsByEmail: ReadonlyMap<string, UserId>;
+}
+
+const EMPTY_EMAIL_CLAIMS: ReadonlyMap<string, UserId> = new Map();
+
+function hasInviteRows(members: readonly ProjectMember[]): boolean {
+	return members.some((member) => member.email !== undefined);
+}
+
+function noInviteClaims(members: readonly ProjectMember[]): ClaimedInviteRows {
+	return { members, claimedRows: 0, userIdsByEmail: EMPTY_EMAIL_CLAIMS };
+}
+
+function higherRole(a: Role, b: Role): Role {
+	return roleAtLeast(a, b) ? a : b;
+}
+
+function selectorAfterClaims(member: ProjectMember, claimed: ClaimedInviteRows): string {
+	if (member.user_id !== undefined) return member.user_id;
+	const email = member.email as string;
+	return claimed.userIdsByEmail.get(normalizeEmail(email)) ?? email;
+}
+
+async function resolveInviteRows(
+	members: readonly ProjectMember[],
+	resolveByEmail: InviteIdentityResolver,
+): Promise<ClaimedInviteRows> {
+	const emails = [
+		...new Set(
+			members.flatMap((member) =>
+				member.email === undefined ? [] : [normalizeEmail(member.email)],
+			),
+		),
+	];
+	const resolved = await Promise.all(
+		emails.map(async (email) => [email, await resolveByEmail(email)] as const),
+	);
+	const userIdsByEmail = new Map<string, UserId>();
+	for (const [email, identity] of resolved) {
+		if (identity) userIdsByEmail.set(email, identity.id);
+	}
+
+	const directUserIds = new Set(
+		members.flatMap((member) => (member.user_id === undefined ? [] : [member.user_id])),
+	);
+	const output: ProjectMember[] = [];
+	const outputIndexByUserId = new Map<UserId, number>();
+	const pendingRoles = new Map<UserId, Role>();
+	let claimedRows = 0;
+
+	for (const member of members) {
+		if (member.user_id !== undefined) {
+			const pendingRole = pendingRoles.get(member.user_id);
+			const index = output.length;
+			output.push({
+				user_id: member.user_id,
+				role: pendingRole ? higherRole(member.role, pendingRole) : member.role,
+			});
+			if (!outputIndexByUserId.has(member.user_id)) outputIndexByUserId.set(member.user_id, index);
+			pendingRoles.delete(member.user_id);
+			continue;
+		}
+
+		const email = normalizeEmail(member.email as string);
+		const userId = userIdsByEmail.get(email);
+		if (userId === undefined) {
+			output.push(member);
+			continue;
+		}
+
+		claimedRows++;
+		const existingIndex = outputIndexByUserId.get(userId);
+		if (existingIndex !== undefined) {
+			const existing = output[existingIndex];
+			output[existingIndex] = { user_id: userId, role: higherRole(existing.role, member.role) };
+		} else if (directUserIds.has(userId)) {
+			const pendingRole = pendingRoles.get(userId);
+			pendingRoles.set(userId, pendingRole ? higherRole(pendingRole, member.role) : member.role);
+		} else {
+			outputIndexByUserId.set(userId, output.length);
+			output.push({ user_id: userId, role: member.role });
+		}
+	}
+
+	return { members: output, claimedRows, userIdsByEmail };
+}
+
+export async function claimInviteRows(
+	members: readonly ProjectMember[],
+	resolveByEmail: InviteIdentityResolver,
+): Promise<ClaimedInviteRows> {
+	return hasInviteRows(members)
+		? resolveInviteRows(members, resolveByEmail)
+		: noInviteClaims(members);
 }
 
 function normalizeProjectName(name: string): string {
@@ -79,6 +190,7 @@ export class ProjectService {
 		private bucket: Bucket,
 		private catalog: CatalogService,
 		private metrics: Metrics = noopMetrics,
+		private resolveIdentityByEmail: InviteIdentityResolver = async () => null,
 	) {}
 
 	/**
@@ -244,10 +356,10 @@ export class ProjectService {
 	): Promise<MemberMutationResult> {
 		const userId = 'user_id' in member ? member.user_id : undefined;
 		const email = member.email !== undefined ? normalizeEmail(member.email) : undefined;
-		return this.writeMembers(
+		const { project, mutationId } = await this.writeMembers(
 			id,
-			(current) => {
-				const duplicate = current.members.some(
+			(_current, claimed) => {
+				const duplicate = claimed.members.some(
 					(m) =>
 						(userId !== undefined && m.user_id === userId) ||
 						(email !== undefined && m.email === email),
@@ -257,10 +369,11 @@ export class ProjectService {
 				}
 				const row: ProjectMember =
 					userId !== undefined ? { user_id: userId, role } : { email: email as string, role };
-				return [...current.members, row];
+				return [...claimed.members, row];
 			},
 			actor,
 		);
+		return { project, mutationId };
 	}
 
 	/**
@@ -282,11 +395,12 @@ export class ProjectService {
 		selector: string,
 		role: AssignableRole,
 		actor: UserId,
-	): Promise<ExistingMemberMutationResult> {
+	): Promise<UpdatedMemberMutationResult> {
 		let previousMember: ProjectMember | undefined;
+		let member: ProjectMember | undefined;
 		const { project, mutationId } = await this.writeMembers(
 			id,
-			(current) => {
+			(current, claimed) => {
 				if (selector === current.owner) {
 					throw new ConflictError(`Cannot change the role of the project owner`);
 				}
@@ -294,13 +408,16 @@ export class ProjectService {
 				if (!previousMember) {
 					throw new NotFoundError(`${selector} is not a member of project ${id}`);
 				}
-				return current.members.map((m) =>
-					memberRefMatchesSelector(m, selector) ? { ...m, role } : m,
+				const claimedSelector = selectorAfterClaims(previousMember, claimed);
+				const members = claimed.members.map((m) =>
+					memberRefMatchesSelector(m, claimedSelector) ? { ...m, role } : m,
 				);
+				member = members.find((candidate) => memberRefMatchesSelector(candidate, claimedSelector));
+				return members;
 			},
 			actor,
 		);
-		return { project, mutationId, previousMember: previousMember! };
+		return { project, mutationId, previousMember: previousMember!, member: member! };
 	}
 
 	/**
@@ -319,7 +436,7 @@ export class ProjectService {
 		let previousMember: ProjectMember | undefined;
 		const { project, mutationId } = await this.writeMembers(
 			id,
-			(current) => {
+			(current, claimed) => {
 				if (selector === current.owner) {
 					throw new ConflictError(`Cannot remove the project owner`);
 				}
@@ -327,7 +444,8 @@ export class ProjectService {
 				if (!previousMember) {
 					throw new NotFoundError(`${selector} is not a member of project ${id}`);
 				}
-				return current.members.filter((m) => !memberRefMatchesSelector(m, selector));
+				const claimedSelector = selectorAfterClaims(previousMember, claimed);
+				return claimed.members.filter((m) => !memberRefMatchesSelector(m, claimedSelector));
 			},
 			actor,
 		);
@@ -341,30 +459,72 @@ export class ProjectService {
 	// `updated_at` and refreshes both rosters to match.
 	private async writeMembers(
 		id: ProjectId,
-		deriveMembers: (current: Project) => ProjectMember[],
+		deriveMembers: (current: Project, claimed: ClaimedInviteRows) => ProjectMember[],
 		actor: UserId,
 	): Promise<MemberMutationResult> {
-		const key = paths.project(id).meta;
-		const updated = await mutateObject(
-			this.bucket,
-			key,
-			(raw) => parseStored(ProjectSchema, raw, key),
-			(current) => {
-				if (current.status === 'deleted') {
-					throw new NotFoundError(`Project ${id} not found`);
-				}
-				return {
-					...current,
-					members: deriveMembers(current),
-					updated_at: new Date().toISOString(),
-				};
-			},
-			{ notFound: () => new NotFoundError(`Project ${id} not found`) },
-		);
+		const { project: updated } = await this.mutateMemberObject(id, deriveMembers);
 		const snapshot = await this.catalog.updateProjectEntry('project.members', actor, id, (entry) =>
 			loadProjectCatalogPatch(this.bucket, id, entry),
 		);
 		return { project: updated, mutationId: snapshot.snapshot_id };
+	}
+
+	private async mutateMemberObject(
+		id: ProjectId,
+		deriveMembers: (current: Project, claimed: ClaimedInviteRows) => ProjectMember[],
+		options: { skipIfNoClaims?: boolean } = {},
+	): Promise<{ project: Project; claimedRows: number; written: boolean }> {
+		const key = paths.project(id).meta;
+		return withCasRetry(this.bucket, async (cas) => {
+			const object = await this.bucket.get(key);
+			if (!object) throw new NotFoundError(`Project ${id} not found`);
+			const current = await readStored(ProjectSchema, object, key);
+			if (current.status === 'deleted') throw new NotFoundError(`Project ${id} not found`);
+			const claimed = hasInviteRows(current.members)
+				? await resolveInviteRows(current.members, this.resolveIdentityByEmail)
+				: noInviteClaims(current.members);
+			if (options.skipIfNoClaims && claimed.claimedRows === 0) {
+				return { project: current, claimedRows: 0, written: false };
+			}
+			const updated = {
+				...current,
+				members: deriveMembers(current, claimed),
+				updated_at: new Date().toISOString(),
+			};
+			await cas.put(key, JSON.stringify(updated), { onlyIfEtagMatches: object.etag });
+			return { project: updated, claimedRows: claimed.claimedRows, written: true };
+		});
+	}
+
+	private async claimProjectInvites(id: ProjectId): Promise<number> {
+		try {
+			const result = await this.mutateMemberObject(
+				id,
+				(_current, claimed) => [...claimed.members],
+				{
+					skipIfNoClaims: true,
+				},
+			);
+			if (!result.written) return 0;
+			await this.catalog.updateProjectEntry('project.members.claim', SYSTEM_ACTOR, id, (entry) =>
+				loadProjectCatalogPatch(this.bucket, id, entry),
+			);
+			return result.claimedRows;
+		} catch (error) {
+			if (error instanceof NotFoundError) return 0;
+			throw error;
+		}
+	}
+
+	async claimPendingInvites(): Promise<number> {
+		const snapshot = await this.catalog.getCurrentSnapshot();
+		const candidates = snapshot.projects.filter(
+			(project) => project.status !== 'deleted' && (project.member_emails?.length ?? 0) > 0,
+		);
+		const claimed = await mapWithConcurrency(candidates, BUCKET_SCAN_CONCURRENCY, (project) =>
+			this.claimProjectInvites(project.id),
+		);
+		return claimed.reduce((total, count) => total + count, 0);
 	}
 
 	/**

--- a/packages/core/src/services/identity/IdentityService.test.ts
+++ b/packages/core/src/services/identity/IdentityService.test.ts
@@ -589,6 +589,25 @@ describe('IdentityService', () => {
 				}),
 			);
 			expect((await identities.getByEmail('shared@x.io'))?.id).toBe(uid('new'));
+			expect(await identities.getUniqueByEmail('shared@x.io')).toBeNull();
+		});
+
+		it('resolves a unique email and rejects unknown or ambiguous matches', async () => {
+			await identities.upsert({ id: uid('only'), email: 'only@x.io', name: 'Only' });
+
+			expect((await identities.getUniqueByEmail('ONLY@x.io'))?.id).toBe(uid('only'));
+			expect(await identities.getUniqueByEmail('missing@x.io')).toBeNull();
+		});
+
+		it('bypasses a stale directory cache when checking uniqueness', async () => {
+			await identities.upsert({ id: uid('first'), email: 'shared@x.io', name: 'First' });
+			await identities.list();
+			const otherReplica = new IdentityService(bucket);
+			await otherReplica.upsert({ id: uid('second'), email: 'shared@x.io', name: 'Second' });
+			const list = vi.spyOn(bucket, 'list');
+
+			expect(await identities.getUniqueByEmail('shared@x.io')).toBeNull();
+			expect(list).toHaveBeenCalledOnce();
 		});
 	});
 });

--- a/packages/core/src/services/identity/IdentityService.ts
+++ b/packages/core/src/services/identity/IdentityService.ts
@@ -225,11 +225,36 @@ export class IdentityService {
 	 * record wins.
 	 */
 	async getByEmail(email: string): Promise<Identity | null> {
-		const target = normalizeEmail(email);
-		if (!target) return null;
-		const all = await this.list();
-		const matches = all.filter((u) => normalizeEmail(u.email) === target);
+		const matches = await this.findByEmail(email);
 		if (matches.length === 0) return null;
 		return matches.reduce((a, b) => (a.updated_at >= b.updated_at ? a : b));
+	}
+
+	async getUniqueByEmail(email: string): Promise<Identity | null> {
+		const target = normalizeEmail(email);
+		if (!target) return null;
+		return (await this.getUniqueByEmails([target])).get(target) ?? null;
+	}
+
+	/**
+	 * Resolve only unambiguous emails from a fresh directory scan. Claiming an
+	 * invite is destructive, so the eventually consistent search cache is unsafe.
+	 */
+	async getUniqueByEmails(emails: readonly string[]): Promise<ReadonlyMap<string, Identity>> {
+		const targets = new Set(emails.map(normalizeEmail).filter(Boolean));
+		if (targets.size === 0) return new Map();
+		const matches = new Map<string, Identity | null>();
+		for (const identity of await this.scanDirectory()) {
+			const email = normalizeEmail(identity.email);
+			if (!targets.has(email)) continue;
+			matches.set(email, matches.has(email) ? null : identity);
+		}
+		return new Map([...matches].filter((entry): entry is [string, Identity] => entry[1] !== null));
+	}
+
+	private async findByEmail(email: string): Promise<Identity[]> {
+		const target = normalizeEmail(email);
+		if (!target) return [];
+		return (await this.list()).filter((identity) => normalizeEmail(identity.email) === target);
 	}
 }

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -353,7 +353,7 @@ export function createServices(
 	});
 	const projects = wrap(
 		'ProjectService',
-		new ProjectService(bucket, catalog, metrics, (email) => identities.getByEmail(email)),
+		new ProjectService(bucket, catalog, metrics, (emails) => identities.getUniqueByEmails(emails)),
 		{
 			getProject: project,
 			updateProject: project,

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -64,7 +64,8 @@ export type {
 	SyncNotebookInput,
 	UpdateSyncedNotebookSourceInput,
 } from '../integrations/syncedSource';
-export { ProjectService } from './content/ProjectService';
+export { claimInviteRows, ProjectService } from './content/ProjectService';
+export type { ClaimedInviteRows, InviteIdentityResolver } from './content/ProjectService';
 export {
 	MAX_PROJECT_ALERT_DESTINATIONS,
 	ProjectAlertConfigSchema,
@@ -345,15 +346,25 @@ export function createServices(
 	const catalog = wrap('CatalogService', new CatalogService(bucket, metrics, events), {
 		initialize: user,
 	});
-	const projects = wrap('ProjectService', new ProjectService(bucket, catalog, metrics), {
-		getProject: project,
-		updateProject: project,
-		deleteProject: project,
-		hardDeleteProject: project,
-		addMember: project,
-		updateMemberRole: project,
-		removeMember: project,
+	const identities = wrap('IdentityService', new IdentityService(bucket), {
+		get: user,
+		isSuspended: user,
+		setSuspension: user,
 	});
+	const projects = wrap(
+		'ProjectService',
+		new ProjectService(bucket, catalog, metrics, (email) => identities.getByEmail(email)),
+		{
+			getProject: project,
+			updateProject: project,
+			deleteProject: project,
+			hardDeleteProject: project,
+			addMember: project,
+			updateMemberRole: project,
+			removeMember: project,
+			claimPendingInvites: () => ({}),
+		},
+	);
 	const sessions = wrap('SessionService', new SessionService(bucket, metrics), {
 		createSession: (input) => ({
 			...notebook(input.project_id, input.notebook_id),
@@ -405,11 +416,6 @@ export function createServices(
 		getReusableProposal: proposal,
 		publishChangeRequest: (input) => proposal(input.projectId, input.notebookId, input.proposalId),
 		pruneExpiredPayloads: () => ({}),
-	});
-	const identities = wrap('IdentityService', new IdentityService(bucket), {
-		get: user,
-		isSuspended: user,
-		setSuspension: user,
 	});
 	const tokens = wrap('TokenService', new TokenService(bucket, identities), {
 		list: user,


### PR DESCRIPTION
Resolves pending email invites to user-id member rows once the invitee signs in — on the next membership write and via a new `claimPendingInvites` maintenance sweep (wired into the Node cron and the Cloudflare scheduled worker).

- Roles are preserved through the claim.
- A roster holding both an email row and an id row for the same user collapses to a single row with the higher role.
- Email matching stays active until the claim occurs, so access is continuous.