### PR TITLE
feat(api): add project and notebook list filters

### DIFF
--- a/apps/cli/generated/cli-manifest.json
+++ b/apps/cli/generated/cli-manifest.json
@@ -2371,6 +2371,7 @@
 			"method": "GET",
 			"path": "/api/v1/projects/{pid}/notebooks",
 			"summary": "List notebooks in a project",
+			"description": "When paging a filtered list, send the same filters with each cursor.",
 			"parameters": [
 				{
 					"name": "pid",
@@ -2394,6 +2395,33 @@
 					"in": "query",
 					"required": false,
 					"value_type": "integer",
+					"repeatable": false
+				},
+				{
+					"name": "q",
+					"cli_name": "q",
+					"in": "query",
+					"required": false,
+					"description": "Case-insensitive substring to match against the name or title and description.",
+					"value_type": "string",
+					"repeatable": false
+				},
+				{
+					"name": "status",
+					"cli_name": "status",
+					"in": "query",
+					"required": false,
+					"description": "Notebook status to match. Deleted notebooks are excluded when omitted.",
+					"value_type": "string",
+					"repeatable": false
+				},
+				{
+					"name": "tag",
+					"cli_name": "tag",
+					"in": "query",
+					"required": false,
+					"description": "Exact tag to match.",
+					"value_type": "string",
 					"repeatable": false
 				}
 			],
@@ -2981,6 +3009,7 @@
 			"method": "GET",
 			"path": "/api/v1/projects",
 			"summary": "List all projects",
+			"description": "When paging a filtered list, send the same filters with each cursor.",
 			"parameters": [
 				{
 					"name": "cursor",
@@ -2996,6 +3025,33 @@
 					"in": "query",
 					"required": false,
 					"value_type": "integer",
+					"repeatable": false
+				},
+				{
+					"name": "q",
+					"cli_name": "q",
+					"in": "query",
+					"required": false,
+					"description": "Case-insensitive substring to match against the name or title and description.",
+					"value_type": "string",
+					"repeatable": false
+				},
+				{
+					"name": "status",
+					"cli_name": "status",
+					"in": "query",
+					"required": false,
+					"description": "Project status to match. Deleted projects are excluded when omitted.",
+					"value_type": "string",
+					"repeatable": false
+				},
+				{
+					"name": "tag",
+					"cli_name": "tag",
+					"in": "query",
+					"required": false,
+					"description": "Exact tag to match.",
+					"value_type": "string",
 					"repeatable": false
 				}
 			],

--- a/internal/schemas/bucket.yml
+++ b/internal/schemas/bucket.yml
@@ -1141,6 +1141,10 @@ components:
                     - last_run_at
                     - key_prefix
                   additionalProperties: {}
+              tags:
+                type: array
+                items:
+                  type: string
               member_ids:
                 type: array
                 items:

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -3117,6 +3117,7 @@ paths:
       tags:
         - Projects
       summary: List all projects
+      description: When paging a filtered list, send the same filters with each cursor.
       parameters:
         - schema:
             type: integer
@@ -3130,6 +3131,36 @@ paths:
             example: WyIyMDI1LTAzLTA1VDE0OjAwOjAwWiIsIm5iLTEiXQ
           required: false
           name: cursor
+          in: query
+        - schema:
+            type: string
+            enum:
+              - active
+              - deleted
+            description: Project status to match. Deleted projects are excluded when
+              omitted.
+            example: active
+          required: false
+          description: Project status to match. Deleted projects are excluded when omitted.
+          name: status
+          in: query
+        - schema:
+            type: string
+            description: Exact tag to match.
+            example: analytics
+          required: false
+          description: Exact tag to match.
+          name: tag
+          in: query
+        - schema:
+            type: string
+            description: Case-insensitive substring to match against the name or title and
+              description.
+            example: revenue
+          required: false
+          description: Case-insensitive substring to match against the name or title and
+            description.
+          name: q
           in: query
       responses:
         '200':
@@ -5386,6 +5417,7 @@ paths:
       tags:
         - Notebooks
       summary: List notebooks in a project
+      description: When paging a filtered list, send the same filters with each cursor.
       parameters:
         - schema:
             type: string
@@ -5406,6 +5438,39 @@ paths:
             example: WyIyMDI1LTAzLTA1VDE0OjAwOjAwWiIsIm5iLTEiXQ
           required: false
           name: cursor
+          in: query
+        - schema:
+            type: string
+            enum:
+              - draft
+              - active
+              - archived
+              - deleted
+            description: Notebook status to match. Deleted notebooks are excluded when
+              omitted.
+            example: active
+          required: false
+          description: Notebook status to match. Deleted notebooks are excluded when
+            omitted.
+          name: status
+          in: query
+        - schema:
+            type: string
+            description: Exact tag to match.
+            example: analytics
+          required: false
+          description: Exact tag to match.
+          name: tag
+          in: query
+        - schema:
+            type: string
+            description: Case-insensitive substring to match against the name or title and
+              description.
+            example: revenue
+          required: false
+          description: Case-insensitive substring to match against the name or title and
+            description.
+          name: q
           in: query
       responses:
         '200':

--- a/packages/api/src/pagination.ts
+++ b/packages/api/src/pagination.ts
@@ -1,5 +1,5 @@
 import { z } from '@hono/zod-openapi';
-import { BadRequestError } from '@marimo-hub/core';
+import { BadRequestError, NOTEBOOK_STATUSES, PROJECT_STATUSES } from '@marimo-hub/core';
 
 /**
  * Keyset (cursor) pagination for the list endpoints. List responses carry their
@@ -34,6 +34,49 @@ export const PaginationQuery = z.object({
 			param: { name: 'cursor', in: 'query' },
 			example: 'WyIyMDI1LTAzLTA1VDE0OjAwOjAwWiIsIm5iLTEiXQ',
 		}),
+});
+
+const ListFilterQuery = {
+	tag: z
+		.string()
+		.optional()
+		.openapi({
+			param: { name: 'tag', in: 'query' },
+			description: 'Exact tag to match.',
+			example: 'analytics',
+		}),
+	q: z
+		.string()
+		.optional()
+		.openapi({
+			param: { name: 'q', in: 'query' },
+			description: 'Case-insensitive substring to match against the name or title and description.',
+			example: 'revenue',
+		}),
+};
+
+export const ProjectListQuery = PaginationQuery.extend({
+	status: z
+		.enum(PROJECT_STATUSES)
+		.optional()
+		.openapi({
+			param: { name: 'status', in: 'query' },
+			description: 'Project status to match. Deleted projects are excluded when omitted.',
+			example: 'active',
+		}),
+	...ListFilterQuery,
+});
+
+export const NotebookListQuery = PaginationQuery.extend({
+	status: z
+		.enum(NOTEBOOK_STATUSES)
+		.optional()
+		.openapi({
+			param: { name: 'status', in: 'query' },
+			description: 'Notebook status to match. Deleted notebooks are excluded when omitted.',
+			example: 'active',
+		}),
+	...ListFilterQuery,
 });
 
 export interface Page<T> {

--- a/packages/api/src/routes/notebooks.test.ts
+++ b/packages/api/src/routes/notebooks.test.ts
@@ -62,6 +62,129 @@ describe('Notebook routes', () => {
 		expect(await expectPage(await request('GET', nb('')))).toEqual([]);
 	});
 
+	describe('list filters', () => {
+		const create = (title: string, description: string, tags: string[]) =>
+			request('POST', nb(''), { title, description, tags, code: 'import marimo' });
+
+		it('filters by status, exact tag, and case-insensitive title or description text', async () => {
+			const finance = await expectOk<any>(
+				await create('Revenue Review', 'Monthly totals', ['finance']),
+				201,
+			);
+			const operations = await expectOk<any>(
+				await create('Capacity', 'Quarterly PIPELINE forecast', ['finance-archive']),
+				201,
+			);
+			const deleted = await expectOk<any>(
+				await create('Retired Revenue', 'Historical totals', ['retired']),
+				201,
+			);
+			await expectOk(await request('DELETE', nb(`/${deleted.id}`)));
+
+			expect(
+				(await expectPage<any>(await request('GET', nb('?status=deleted')))).map((n) => n.id),
+			).toEqual([deleted.id]);
+			expect(
+				(await expectPage<any>(await request('GET', nb('?tag=finance')))).map((n) => n.id),
+			).toEqual([finance.id]);
+			expect(
+				(await expectPage<any>(await request('GET', nb('?q=pipeline')))).map((n) => n.id),
+			).toEqual([operations.id]);
+			expect(
+				(await expectPage<any>(await request('GET', nb('?q=REVENUE')))).map((n) => n.id),
+			).toEqual([finance.id]);
+			expect(
+				(await expectPage<any>(await request('GET', nb(''))))
+					.map((n) => n.id)
+					.sort((a, b) => a.localeCompare(b)),
+			).toEqual([finance.id, operations.id].sort((a, b) => a.localeCompare(b)));
+		});
+
+		it('ANDs filters and paginates the filtered set', async () => {
+			const matching: string[] = [];
+			for (let i = 0; i < 3; i++) {
+				const notebook = await expectOk<any>(
+					await create(`Match ${i}`, `Search target ${i}`, ['selected']),
+					201,
+				);
+				matching.push(notebook.id);
+			}
+			await create('Wrong tag', 'Search target', ['other']);
+			await create('Wrong text', 'Unrelated', ['selected']);
+
+			const first = await expectOk<any>(
+				await request('GET', nb('?status=active&tag=selected&q=TARGET&limit=2')),
+			);
+			expect(first.items).toHaveLength(2);
+			expect(first.next_cursor).toBeTruthy();
+
+			const second = await expectOk<any>(
+				await request(
+					'GET',
+					nb(
+						`?status=active&tag=selected&q=TARGET&limit=2&cursor=${encodeURIComponent(first.next_cursor)}`,
+					),
+				),
+			);
+			expect(second.items).toHaveLength(1);
+			expect(second.next_cursor).toBeNull();
+			const ids = [...first.items, ...second.items].map((notebook: any) => notebook.id);
+			expect(ids.sort((a, b) => a.localeCompare(b))).toEqual(
+				matching.sort((a, b) => a.localeCompare(b)),
+			);
+		});
+
+		it('treats empty search as unfiltered and returns a terminal empty page for misses', async () => {
+			await create('Revenue', 'Monthly totals', ['finance']);
+			await create('Capacity', 'Quarterly forecast', ['operations']);
+
+			const unfiltered = await expectOk<any>(await request('GET', nb('')));
+			const emptySearch = await expectOk<any>(await request('GET', nb('?q=')));
+			expect(emptySearch).toEqual(unfiltered);
+
+			for (const query of ['tag=Finance', 'q=missing']) {
+				const page = await expectOk<any>(await request('GET', nb(`?${query}`)));
+				expect(page).toEqual({ items: [], next_cursor: null });
+			}
+		});
+
+		it('can combine status, tag, and text filters for deleted notebooks', async () => {
+			const live = await expectOk<any>(
+				await create('Live audit', 'Compliance records', ['audit']),
+				201,
+			);
+			const deleted = await expectOk<any>(
+				await create('Retired audit', 'Compliance records', ['audit']),
+				201,
+			);
+			await expectOk(await request('DELETE', nb(`/${deleted.id}`)));
+
+			const page = await expectOk<any>(
+				await request('GET', nb('?status=deleted&tag=audit&q=COMPLIANCE')),
+			);
+			expect(page).toEqual({
+				items: [expect.objectContaining({ id: deleted.id })],
+				next_cursor: null,
+			});
+			expect(page.items.map((item: any) => item.id)).not.toContain(live.id);
+		});
+
+		it.each(['status=unknown', 'limit=0', 'limit=-1', 'limit=1.5', 'limit=nope'])(
+			'rejects invalid query parameter %s',
+			async (query) => {
+				await expectError(await request('GET', nb(`?${query}`)), 422, 'VALIDATION_ERROR');
+			},
+		);
+
+		it('rejects a malformed cursor on a filtered request', async () => {
+			await expectError(
+				await request('GET', nb('?tag=finance&cursor=not~base64')),
+				400,
+				'BAD_REQUEST',
+			);
+		});
+	});
+
 	it('POST creates a notebook', async () => {
 		const data = await expectOk<any>(
 			await request('POST', nb(''), {

--- a/packages/api/src/routes/notebooks.ts
+++ b/packages/api/src/routes/notebooks.ts
@@ -49,7 +49,7 @@ import { idempotentCreate } from '../idempotency';
 import { appendAudit } from '../log';
 import { assertPullSourceSupported, pullSourceToHead, resolveSyncTarget } from './sourcePullSync';
 import type { HonoEnv, SandboxConfig } from '../context';
-import { pageSchema, paginate, PaginationQuery } from '../pagination';
+import { NotebookListQuery, pageSchema, paginate, PaginationQuery } from '../pagination';
 import { scheduleProjectAlert } from '../notifications';
 
 // --- Request body schemas ---
@@ -206,7 +206,8 @@ const listNotebooks = createRoute({
 	operationId: 'notebooks.list',
 	tags: ['Notebooks'],
 	summary: 'List notebooks in a project',
-	request: { params: ProjectIdParam, query: PaginationQuery },
+	description: 'When paging a filtered list, send the same filters with each cursor.',
+	request: { params: ProjectIdParam, query: NotebookListQuery },
 	responses: {
 		200: jsonContent(
 			z.object({
@@ -574,9 +575,14 @@ app.openapi(listNotebooks, async (c) => {
 	const { notebooks, projects } = deps.services;
 	const user = c.get('user');
 	const { pid } = c.req.valid('param');
+	const query = c.req.valid('query');
 	await assertProjectVisible(projects, pid, user, deps.policy);
-	const all = await notebooks.listNotebooks(pid);
-	const data = paginate(all, c.req.valid('query'), {
+	const all = await notebooks.listNotebooks(pid, {
+		status: query.status,
+		tag: query.tag,
+		q: query.q,
+	});
+	const data = paginate(all, query, {
 		key: (n) => n.created_at,
 		tiebreak: (n) => n.id,
 	});

--- a/packages/api/src/routes/projects.test.ts
+++ b/packages/api/src/routes/projects.test.ts
@@ -25,6 +25,145 @@ describe('Project routes', () => {
 		expect(await expectPage(res)).toEqual([]);
 	});
 
+	describe('list filters', () => {
+		const create = (name: string, description: string, tags: string[]) =>
+			request('POST', '/projects', { name, description, tags });
+
+		it('filters by status, exact tag, and case-insensitive name or description text', async () => {
+			const finance = await expectOk<any>(
+				await create('Revenue Review', 'Monthly totals', ['finance']),
+				201,
+			);
+			const operations = await expectOk<any>(
+				await create('Capacity', 'Quarterly PIPELINE forecast', ['finance-archive']),
+				201,
+			);
+			const deleted = await expectOk<any>(
+				await create('Retired Revenue', 'Historical totals', ['retired']),
+				201,
+			);
+			await expectOk(await request('DELETE', `/projects/${deleted.id}`));
+
+			expect(
+				(await expectPage<any>(await request('GET', '/projects?status=deleted'))).map((p) => p.id),
+			).toEqual([deleted.id]);
+			const tagged = await expectPage<any>(await request('GET', '/projects?tag=finance'));
+			expect(tagged.map((p) => p.id)).toEqual([finance.id]);
+			expect(tagged[0]).not.toHaveProperty('tags');
+			expect(
+				(await expectPage<any>(await request('GET', '/projects?q=pipeline'))).map((p) => p.id),
+			).toEqual([operations.id]);
+			expect(
+				(await expectPage<any>(await request('GET', '/projects?q=REVENUE'))).map((p) => p.id),
+			).toEqual([finance.id]);
+			expect(
+				(await expectPage<any>(await request('GET', '/projects')))
+					.map((p) => p.id)
+					.sort((a, b) => a.localeCompare(b)),
+			).toEqual([finance.id, operations.id].sort((a, b) => a.localeCompare(b)));
+		});
+
+		it('ANDs filters and paginates the filtered set', async () => {
+			const matching: string[] = [];
+			for (let i = 0; i < 3; i++) {
+				const project = await expectOk<any>(
+					await create(`Match ${i}`, `Search target ${i}`, ['selected']),
+					201,
+				);
+				matching.push(project.id);
+			}
+			await create('Wrong tag', 'Search target', ['other']);
+			await create('Wrong text', 'Unrelated', ['selected']);
+
+			const first = await expectOk<any>(
+				await request('GET', '/projects?status=active&tag=selected&q=TARGET&limit=2'),
+			);
+			expect(first.items).toHaveLength(2);
+			expect(first.next_cursor).toBeTruthy();
+
+			const second = await expectOk<any>(
+				await request(
+					'GET',
+					`/projects?status=active&tag=selected&q=TARGET&limit=2&cursor=${encodeURIComponent(first.next_cursor)}`,
+				),
+			);
+			expect(second.items).toHaveLength(1);
+			expect(second.next_cursor).toBeNull();
+			const ids = [...first.items, ...second.items].map((project: any) => project.id);
+			expect(ids.sort((a, b) => a.localeCompare(b))).toEqual(
+				matching.sort((a, b) => a.localeCompare(b)),
+			);
+		});
+
+		it('falls back to project metadata when a legacy snapshot entry has no tags', async () => {
+			const project = await expectOk<any>(
+				await create('Legacy', 'Predates snapshot tags', ['legacy']),
+				201,
+			);
+			await createServices(bucket).catalog.updateProjectEntry(
+				'test.strip',
+				ACTOR,
+				project.id,
+				() => ({
+					tags: undefined,
+				}),
+			);
+
+			const items = await expectPage<any>(await request('GET', '/projects?tag=legacy'));
+			expect(items.map((item) => item.id)).toEqual([project.id]);
+		});
+
+		it('treats empty search as unfiltered and returns a terminal empty page for misses', async () => {
+			await create('Revenue', 'Monthly totals', ['finance']);
+			await create('Capacity', 'Quarterly forecast', ['operations']);
+
+			const unfiltered = await expectOk<any>(await request('GET', '/projects'));
+			const emptySearch = await expectOk<any>(await request('GET', '/projects?q='));
+			expect(emptySearch).toEqual(unfiltered);
+
+			for (const query of ['tag=Finance', 'q=missing']) {
+				const page = await expectOk<any>(await request('GET', `/projects?${query}`));
+				expect(page).toEqual({ items: [], next_cursor: null });
+			}
+		});
+
+		it('can combine status, tag, and text filters for deleted projects', async () => {
+			const live = await expectOk<any>(
+				await create('Live audit', 'Compliance records', ['audit']),
+				201,
+			);
+			const deleted = await expectOk<any>(
+				await create('Retired audit', 'Compliance records', ['audit']),
+				201,
+			);
+			await expectOk(await request('DELETE', `/projects/${deleted.id}`));
+
+			const page = await expectOk<any>(
+				await request('GET', '/projects?status=deleted&tag=audit&q=COMPLIANCE'),
+			);
+			expect(page).toEqual({
+				items: [expect.objectContaining({ id: deleted.id })],
+				next_cursor: null,
+			});
+			expect(page.items.map((item: any) => item.id)).not.toContain(live.id);
+		});
+
+		it.each(['status=unknown', 'limit=0', 'limit=-1', 'limit=1.5', 'limit=nope'])(
+			'rejects invalid query parameter %s',
+			async (query) => {
+				await expectError(await request('GET', `/projects?${query}`), 422, 'VALIDATION_ERROR');
+			},
+		);
+
+		it('rejects a malformed cursor on a filtered request', async () => {
+			await expectError(
+				await request('GET', '/projects?tag=finance&cursor=not~base64'),
+				400,
+				'BAD_REQUEST',
+			);
+		});
+	});
+
 	it('POST /projects creates a project', async () => {
 		const res = await request('POST', '/projects', {
 			name: 'ML Pipeline',

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -37,7 +37,7 @@ import {
 	SuccessResponseSchema,
 } from '../shared';
 import { idempotentCreate } from '../idempotency';
-import { pageSchema, paginate, PaginationQuery } from '../pagination';
+import { pageSchema, paginate, ProjectListQuery } from '../pagination';
 import {
 	assertNotificationMutationAllowed,
 	scheduleNotification,
@@ -139,7 +139,8 @@ const listProjects = createRoute({
 	operationId: 'projects.list',
 	tags: ['Projects'],
 	summary: 'List all projects',
-	request: { query: PaginationQuery },
+	description: 'When paging a filtered list, send the same filters with each cursor.',
+	request: { query: ProjectListQuery },
 	responses: {
 		200: jsonContent(
 			z.object({
@@ -297,11 +298,15 @@ const app = createApp();
 app.openapi(listProjects, async (c) => {
 	const deps = c.get('deps');
 	const user = c.get('user');
+	const query = c.req.valid('query');
 	const all = await deps.services.projects.listProjects({
 		subject: user,
 		policy: deps.policy,
+		status: query.status,
+		tag: query.tag,
+		q: query.q,
 	});
-	const data = paginate(all, c.req.valid('query'), {
+	const data = paginate(all, query, {
 		key: (p) => p.created_at,
 		tiebreak: (p) => p.id,
 	});

--- a/packages/api/src/schema-conformance.test.ts
+++ b/packages/api/src/schema-conformance.test.ts
@@ -109,14 +109,13 @@ describe('schema conformance: api response shapes vs core public shapes', () => 
 	});
 
 	// The project-list response drops the nested `notebooks` roster (unbounded,
-	// defeats the page cursor) and the denormalized `member_ids`/`member_emails`
-	// (server-side visibility-filter aids, not part of the public contract).
+	// defeats the page cursor) and the denormalized filtering aids.
 	// `notebook_count` stays for the summary; clients page
 	// `GET /projects/{pid}/notebooks`.
-	it('SnapshotProjectEntry omits `notebooks` and the member rosters from the core entry', () => {
+	it('SnapshotProjectEntry omits internal list-filter fields from the core entry', () => {
 		const coreKeys = shapeKeys(CoreSnapshotProjectEntrySchema);
 		const apiKeys = shapeKeys(SnapshotProjectEntrySchema);
-		const internal = ['notebooks', 'member_ids', 'member_emails'];
+		const internal = ['notebooks', 'tags', 'member_ids', 'member_emails'];
 		expect(coreKeys.filter((k) => !internal.includes(k))).toEqual(apiKeys);
 		expect(coreKeys).toEqual(expect.arrayContaining(internal));
 	});

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -125,7 +125,10 @@ export interface paths {
 			path?: never;
 			cookie?: never;
 		};
-		/** List all projects */
+		/**
+		 * List all projects
+		 * @description When paging a filtered list, send the same filters with each cursor.
+		 */
 		get: operations['projects.list'];
 		put?: never;
 		/** Create a project */
@@ -387,7 +390,10 @@ export interface paths {
 			path?: never;
 			cookie?: never;
 		};
-		/** List notebooks in a project */
+		/**
+		 * List notebooks in a project
+		 * @description When paging a filtered list, send the same filters with each cursor.
+		 */
 		get: operations['notebooks.list'];
 		put?: never;
 		/** Create a notebook */
@@ -2909,6 +2915,12 @@ export interface operations {
 			query?: {
 				limit?: number;
 				cursor?: string;
+				/** @description Project status to match. Deleted projects are excluded when omitted. */
+				status?: 'active' | 'deleted';
+				/** @description Exact tag to match. */
+				tag?: string;
+				/** @description Case-insensitive substring to match against the name or title and description. */
+				q?: string;
 			};
 			header?: never;
 			path?: never;
@@ -5142,6 +5154,12 @@ export interface operations {
 			query?: {
 				limit?: number;
 				cursor?: string;
+				/** @description Notebook status to match. Deleted notebooks are excluded when omitted. */
+				status?: 'draft' | 'active' | 'archived' | 'deleted';
+				/** @description Exact tag to match. */
+				tag?: string;
+				/** @description Case-insensitive substring to match against the name or title and description. */
+				q?: string;
 			};
 			header?: never;
 			path: {

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -194,6 +194,9 @@ export const SnapshotProjectEntrySchema = z.looseObject({
 	updated_at: z.iso.datetime(),
 	notebook_count: z.number().int().nonnegative(),
 	notebooks: z.array(SnapshotNotebookEntrySchema),
+	// Filtering aid added after the v1 snapshot shape shipped. Legacy entries
+	// omit it; ProjectService falls back to project.json for those entries.
+	tags: z.array(z.string()).optional(),
 	// Denormalized roster (user ids of `owner` + every member) so the project
 	// list can be filtered to a caller's visible projects in-memory, without an
 	// extra `project.json` read per entry — see ProjectService.listProjects and
@@ -231,9 +234,9 @@ export type PublicNotebookEntry = Pick<
 // unbounded (a project can hold thousands of notebooks) and would let one row
 // blow up a page that is otherwise bounded by the cursor. Clients use
 // `notebook_count` for the summary and page `GET /projects/{pid}/notebooks` for
-// the list. `member_ids`/`member_emails` are server-side filtering aids, not
-// part of the public contract, so they are stripped too. The bytes stay in the
-// persisted snapshot — the GC sweep and the list filter read them.
+// the list. `tags`, `member_ids`, and `member_emails` are server-side filtering
+// aids, not part of the public contract, so they are stripped too. The bytes
+// stay in the persisted snapshot — the GC sweep and list filters read them.
 export type PublicProjectEntry = Pick<
 	SnapshotProjectEntry,
 	| 'id'

--- a/packages/core/src/services/content/NotebookService.ts
+++ b/packages/core/src/services/content/NotebookService.ts
@@ -27,6 +27,7 @@ import type {
 	PublicNotebookEntry,
 	Snapshot,
 	SnapshotDescriptor,
+	SnapshotNotebookEntry,
 	Source,
 	Version,
 } from '../../schema';
@@ -42,6 +43,8 @@ import {
 import { SyncedNotebookService } from './SyncedNotebookService';
 import { deleteByPrefix, listAllKeys, listAllObjects, listAllPrefixes } from '../catalog/storage';
 import { loadNotebookCatalogPatch } from './catalogProjection';
+import { createListFilter } from './listFilters';
+import type { ListFilters } from './listFilters';
 
 /**
  * Maximum number of immutable version folders to retain per notebook. Older
@@ -141,13 +144,23 @@ export class NotebookService {
 		});
 	}
 
-	async listNotebooks(projectId: ProjectId): Promise<PublicNotebookEntry[]> {
+	async listNotebooks(
+		projectId: ProjectId,
+		filter?: ListFilters<NotebookMeta['status']>,
+	): Promise<PublicNotebookEntry[]> {
 		const snapshot = await this.catalog.getCurrentSnapshot();
 		const project = snapshot.projects.find((p) => p.id === projectId);
 		if (!project) {
 			throw new NotFoundError(`Project ${projectId} not found`);
 		}
-		return project.notebooks.filter((n) => n.status !== 'deleted').map(toPublicNotebookEntry);
+		return project.notebooks
+			.filter(
+				createListFilter<SnapshotNotebookEntry>(filter, (notebook) => [
+					notebook.title,
+					notebook.description,
+				]),
+			)
+			.map(toPublicNotebookEntry);
 	}
 
 	async getNotebook(projectId: ProjectId, notebookId: NotebookId): Promise<NotebookDetail> {

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -113,7 +113,7 @@ export class ProjectService {
 				matching,
 				BUCKET_SCAN_CONCURRENCY,
 				async (project) =>
-					project.tags !== undefined || (await this.getProject(project.id)).tags.includes(tag),
+					project.tags?.includes(tag) ?? (await this.getProject(project.id)).tags.includes(tag),
 			);
 			matching = matching.filter((_, index) => tagMatches[index]);
 		}

--- a/packages/core/src/services/content/ProjectService.ts
+++ b/packages/core/src/services/content/ProjectService.ts
@@ -20,11 +20,14 @@ import type {
 	ProjectMember,
 	PublicProjectEntry,
 	Snapshot,
+	SnapshotProjectEntry,
 } from '../../schema';
 import type { CatalogService } from '../catalog/CatalogService';
 import { mutateObject, mutateObjectWithOutcome } from '../catalog/cas';
 import { deleteByPrefix } from '../catalog/storage';
 import { loadProjectCatalogPatch, projectCatalogPatch } from './catalogProjection';
+import { createListFilter } from './listFilters';
+import type { ListFilters } from './listFilters';
 
 /** Grace period before a soft-deleted project's storage is purged by the GC sweep. */
 export const DEFAULT_DELETED_PROJECT_RETENTION_MS = Millis.days(30);
@@ -83,32 +86,55 @@ export class ProjectService {
 
 	/**
 	 * List projects, newest-first paging applied by the caller. Soft-deleted
-	 * projects are always hidden. When `filter` is passed with a null/undefined
-	 * `policy.defaultRole` (deployment `MARIMOHUB_DEFAULT_ROLE=none`), the list
+	 * projects are hidden unless explicitly requested by status. When `filter` is
+	 * passed with a null/undefined `policy.defaultRole` (deployment
+	 * `MARIMOHUB_DEFAULT_ROLE=none`), the list
 	 * is restricted to projects the caller can see (owner or member); with a
 	 * `defaultRole` set — or when the caller is a super admin — every project
 	 * is visible, so nothing is hidden.
 	 */
-	async listProjects(filter?: {
-		subject: AuthSubject;
-		policy?: AuthzPolicy;
-	}): Promise<PublicProjectEntry[]> {
+	async listProjects(
+		filter?: ListFilters<Project['status']> & {
+			subject: AuthSubject;
+			policy?: AuthzPolicy;
+		},
+	): Promise<PublicProjectEntry[]> {
 		const snapshot = await this.catalog.getCurrentSnapshot();
-		const live = snapshot.projects.filter((p) => p.status !== 'deleted');
+		let matching = snapshot.projects.filter(
+			createListFilter<SnapshotProjectEntry>(
+				filter,
+				(project) => [project.name, project.description],
+				{ allowUnknownTags: true },
+			),
+		);
+		if (filter?.tag !== undefined) {
+			const tag = filter.tag;
+			const tagMatches = await mapWithConcurrency(
+				matching,
+				BUCKET_SCAN_CONCURRENCY,
+				async (project) =>
+					project.tags !== undefined || (await this.getProject(project.id)).tags.includes(tag),
+			);
+			matching = matching.filter((_, index) => tagMatches[index]);
+		}
 		if (
 			!filter ||
 			subjectDefaultRole(filter.subject, filter.policy) != null ||
 			isSuperAdmin(filter.subject, filter.policy?.superAdmins)
 		) {
-			return live.map(toPublicProjectEntry);
+			return matching.map(toPublicProjectEntry);
 		}
-		const visibility = await mapWithConcurrency(live, BUCKET_SCAN_CONCURRENCY, async (entry) => {
-			const seen = canSeeProjectEntry(entry, filter.subject, filter.policy);
-			// `null` = the entry predates `member_ids`, so visibility can't be decided
-			// from the snapshot alone; fall back to the authoritative project.json.
-			return seen ?? (await this.canSeeProject(entry.id, filter.subject));
-		});
-		return live.filter((_, i) => visibility[i]).map(toPublicProjectEntry);
+		const visibility = await mapWithConcurrency(
+			matching,
+			BUCKET_SCAN_CONCURRENCY,
+			async (entry) => {
+				const seen = canSeeProjectEntry(entry, filter.subject, filter.policy);
+				// `null` = the entry predates `member_ids`, so visibility can't be decided
+				// from the snapshot alone; fall back to the authoritative project.json.
+				return seen ?? (await this.canSeeProject(entry.id, filter.subject));
+			},
+		);
+		return matching.filter((_, i) => visibility[i]).map(toPublicProjectEntry);
 	}
 
 	// Only reached when the fast path above didn't return, i.e. the caller is
@@ -170,6 +196,7 @@ export class ProjectService {
 								updated_at: now,
 								notebook_count: 0,
 								notebooks: [],
+								tags: project.tags,
 								member_ids: project.members.flatMap((m) =>
 									m.user_id !== undefined ? [m.user_id] : [],
 								),

--- a/packages/core/src/services/content/catalogProjection.ts
+++ b/packages/core/src/services/content/catalogProjection.ts
@@ -42,6 +42,7 @@ export function projectCatalogPatch(
 		name: project.name,
 		description: project.description,
 		status: project.status,
+		tags: project.tags,
 		updated_at: entry.updated_at >= project.updated_at ? entry.updated_at : project.updated_at,
 		member_ids: project.members.flatMap((member) =>
 			member.user_id !== undefined ? [member.user_id] : [],

--- a/packages/core/src/services/content/listFilters.test.ts
+++ b/packages/core/src/services/content/listFilters.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { createListFilter } from './listFilters';
+
+interface Entry {
+	status: string;
+	tags?: string[];
+	name: string;
+	description: string;
+}
+
+const entries: Entry[] = [
+	{ status: 'active', tags: ['finance'], name: 'Revenue', description: 'Monthly totals' },
+	{ status: 'archived', tags: ['finance'], name: 'Capacity', description: 'Annual forecast' },
+	{ status: 'deleted', tags: ['finance'], name: 'Retired', description: 'Annual forecast' },
+];
+
+describe('createListFilter', () => {
+	it('ANDs status, exact tag, and case-insensitive text filters', () => {
+		const matches = createListFilter<Entry>(
+			{ status: 'archived', tag: 'finance', q: 'FORECAST' },
+			(entry) => [entry.name, entry.description],
+		);
+
+		expect(entries.filter(matches)).toEqual([entries[1]]);
+	});
+
+	it('excludes deleted entries by default and leaves missing tags for legacy resolution', () => {
+		const legacy = { ...entries[0], tags: undefined };
+		const strict = createListFilter<Entry>({ tag: 'finance' }, (entry) => [entry.name]);
+		const allowLegacy = createListFilter<Entry>({ tag: 'finance' }, (entry) => [entry.name], {
+			allowUnknownTags: true,
+		});
+
+		expect([...entries, legacy].filter(strict)).toEqual([entries[0], entries[1]]);
+		expect([...entries, legacy].filter(allowLegacy)).toEqual([entries[0], entries[1], legacy]);
+	});
+});

--- a/packages/core/src/services/content/listFilters.ts
+++ b/packages/core/src/services/content/listFilters.ts
@@ -1,0 +1,25 @@
+export interface ListFilters<Status extends string> {
+	status?: Status;
+	tag?: string;
+	q?: string;
+}
+
+interface ListFilterEntry {
+	status: string;
+	tags?: readonly string[];
+}
+
+export function createListFilter<Entry extends ListFilterEntry>(
+	filter: ListFilters<Entry['status']> | undefined,
+	searchableFields: (entry: Entry) => readonly string[],
+	options: { allowUnknownTags?: boolean } = {},
+): (entry: Entry) => boolean {
+	const query = filter?.q?.toLowerCase();
+	return (entry) =>
+		(filter?.status ? entry.status === filter.status : entry.status !== 'deleted') &&
+		(filter?.tag === undefined ||
+			entry.tags?.includes(filter.tag) ||
+			(entry.tags === undefined && options.allowUnknownTags === true)) &&
+		(query === undefined ||
+			searchableFields(entry).some((value) => value.toLowerCase().includes(query)));
+}

--- a/packages/core/src/testing/fixtures.ts
+++ b/packages/core/src/testing/fixtures.ts
@@ -105,6 +105,7 @@ export function makeSnapshotProjectEntry(
 		updated_at: NOW,
 		notebook_count: 0,
 		notebooks: [],
+		tags: ['test'],
 		...overrides,
 	};
 }

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -32,6 +32,8 @@ import type {
 	ResolvedUser,
 	ProjectFederation,
 	ProjectAlertKind,
+	ProjectListFilters,
+	NotebookListFilters,
 	SandboxStartupReport,
 } from '../types';
 
@@ -256,10 +258,19 @@ export function useRunSandboxStartupTest(startupTimeoutSeconds = 120) {
 }
 
 // Projects
-export function useProjectsQuery() {
-	return useSuspenseQuery({
-		queryKey: projectKeys.list(),
-		queryFn: async () => (await apiData(apiClient.GET('/api/v1/projects'))).items,
+export function useProjectsQuery(filters: ProjectListFilters = {}) {
+	return useQuery({
+		queryKey: projectKeys.filteredList(filters),
+		queryFn: async () =>
+			(
+				await apiData(
+					apiClient.GET('/api/v1/projects', {
+						params: { query: filters },
+					}),
+				)
+			).items,
+		placeholderData: keepPreviousData,
+		throwOnError: true,
 	});
 }
 
@@ -1241,17 +1252,19 @@ export function objectContentUrl(input: {
 
 // Notebooks
 
-export function useNotebooksQuery(projectId: string) {
-	return useSuspenseQuery({
-		queryKey: notebookKeys.list(projectId),
+export function useNotebooksQuery(projectId: string, filters: NotebookListFilters = {}) {
+	return useQuery({
+		queryKey: notebookKeys.filteredList(projectId, filters),
 		queryFn: async () =>
 			(
 				await apiData(
 					apiClient.GET('/api/v1/projects/{pid}/notebooks', {
-						params: { path: { pid: projectId } },
+						params: { path: { pid: projectId }, query: filters },
 					}),
 				)
 			).items,
+		placeholderData: keepPreviousData,
+		throwOnError: true,
 	});
 }
 

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -1,3 +1,9 @@
+interface ListQueryFilters {
+	q?: string;
+	status?: string;
+	tag?: string;
+}
+
 export const userKeys = {
 	all: ['user'] as const,
 	me: () => [...userKeys.all, 'me'] as const,
@@ -11,6 +17,7 @@ export const userKeys = {
 export const projectKeys = {
 	all: ['projects'] as const,
 	list: () => [...projectKeys.all, 'list'] as const,
+	filteredList: (filters: ListQueryFilters) => [...projectKeys.list(), filters] as const,
 	/** Full multi-page roster for pickers; distinct from the first-page `list`. */
 	pickerList: () => [...projectKeys.all, 'list', 'all'] as const,
 	detail: (projectId: string) => [...projectKeys.all, 'detail', projectId] as const,
@@ -90,6 +97,8 @@ export const integrationKeys = {
 export const notebookKeys = {
 	all: ['notebooks'] as const,
 	list: (projectId: string) => [...notebookKeys.all, 'list', { projectId }] as const,
+	filteredList: (projectId: string, filters: ListQueryFilters) =>
+		[...notebookKeys.list(projectId), filters] as const,
 	detail: (projectId: string, notebookId: string) =>
 		[...notebookKeys.all, 'detail', { projectId, notebookId }] as const,
 	sourceDrift: (projectId: string, notebookId: string) =>

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.test.tsx
@@ -20,8 +20,11 @@ vi.mock('./VersionDiffView', () => ({
 const PID = 'proj-1';
 const NID = 'nb-1';
 
-const notebook = (sourceType: 'local' | 'git' = 'local'): NotebookEntry =>
-	({ id: NID, title: 'my_analysis', source_type: sourceType }) as NotebookEntry;
+const notebook = (
+	sourceType: 'local' | 'git' = 'local',
+	status: NotebookEntry['status'] = 'active',
+): NotebookEntry =>
+	({ id: NID, title: 'my_analysis', source_type: sourceType, status }) as NotebookEntry;
 
 function version(id: string, savedAt: string, message: string): NotebookVersion {
 	return {
@@ -117,7 +120,12 @@ const GIT_SOURCE = {
 function renderDialog({
 	sourceType = 'local' as const,
 	canRestore = true,
-}: { sourceType?: 'local' | 'git'; canRestore?: boolean } = {}) {
+	status = 'active' as const,
+}: {
+	sourceType?: 'local' | 'git';
+	canRestore?: boolean;
+	status?: NotebookEntry['status'];
+} = {}) {
 	const client = createTestQueryClient();
 	const onClose = vi.fn();
 	const wrapper = ({ children }: { children: ReactNode }) => (
@@ -133,7 +141,7 @@ function renderDialog({
 			isOpen
 			onClose={onClose}
 			projectId={PID}
-			notebook={notebook(sourceType)}
+			notebook={notebook(sourceType, status)}
 			canRestore={canRestore}
 		/>,
 		{ wrapper },
@@ -288,6 +296,13 @@ describe('VersionHistoryDialog', () => {
 	it('hides Restore when the viewer cannot restore', async () => {
 		makeFetch();
 		renderDialog({ canRestore: false });
+		await screen.findAllByTestId('version-row');
+		expect(screen.queryByRole('button', { name: 'Restore' })).not.toBeInTheDocument();
+	});
+
+	it('hides Restore for deleted notebooks', async () => {
+		makeFetch();
+		renderDialog({ status: 'deleted' });
 		await screen.findAllByTestId('version-row');
 		expect(screen.queryByRole('button', { name: 'Restore' })).not.toBeInTheDocument();
 	});

--- a/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
+++ b/packages/web/src/components/Notebook/VersionHistoryDialog.tsx
@@ -214,8 +214,7 @@ export function VersionHistoryDialog({
 	const { data: users, isLoading: usersLoading } = useUsersQuery(versions.map((v) => v.author));
 
 	const restoreVersion = useRestoreVersion(projectId, notebook.id);
-	// Git-synced content is owned by the sync; the API rejects restoring it.
-	const restorable = canRestore && notebook.source_type !== 'git';
+	const restorable = canRestore && notebook.status !== 'deleted' && notebook.source_type !== 'git';
 
 	const handleRestore = () => {
 		const target = confirmRestore.target;

--- a/packages/web/src/components/Project/Project.actions.test.tsx
+++ b/packages/web/src/components/Project/Project.actions.test.tsx
@@ -16,7 +16,7 @@ describe('Project — Notebook Actions: configuration', () => {
 		makeFetch();
 		await renderProject();
 
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		const menu = await screen.findByRole('menu');
 
 		expect(within(menu).getAllByRole('separator')).toHaveLength(4);
@@ -93,7 +93,7 @@ describe('Project — Notebook Actions: configuration', () => {
 		});
 		await renderProject();
 
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(await screen.findByText('Rename')).toBeInTheDocument();
 		expect(screen.queryByText('Change base image')).not.toBeInTheDocument();
 	});
@@ -264,7 +264,7 @@ describe('Project — Notebook Actions: configuration', () => {
 		});
 		await renderProject();
 
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(await screen.findByText('Rename')).toBeInTheDocument();
 		expect(screen.queryByText('Change compute…')).not.toBeInTheDocument();
 	});

--- a/packages/web/src/components/Project/Project.sessions.test.tsx
+++ b/packages/web/src/components/Project/Project.sessions.test.tsx
@@ -71,7 +71,7 @@ describe('Project — Notebook Actions: files and sessions', () => {
 		makeFetch({ notebooks: [{ ...notebook(), source_type: 'git' }] });
 		await renderProject();
 
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(await screen.findByText('Sync settings')).toBeInTheDocument();
 		expect(screen.queryByText('Sync keys')).not.toBeInTheDocument();
 		expect(screen.queryByText('Rotate sync token')).not.toBeInTheDocument();
@@ -176,7 +176,7 @@ describe('Project — Notebook Actions: files and sessions', () => {
 		});
 		await renderProject();
 
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(await screen.findByText('Open app')).toBeInTheDocument();
 		expect(screen.queryByText('Stop app')).toBeNull();
 	});
@@ -193,7 +193,7 @@ describe('Project — Notebook Actions: files and sessions', () => {
 		});
 		await renderProject();
 
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(await screen.findByText('Run as app')).toBeInTheDocument();
 	});
 
@@ -217,7 +217,7 @@ describe('Project — Notebook Actions: files and sessions', () => {
 		});
 		await renderProject();
 
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(await screen.findByText('Rename')).toBeInTheDocument();
 		expect(screen.queryByText('Open app')).toBeNull();
 		expect(screen.queryByText('Run as app')).toBeNull();
@@ -239,7 +239,7 @@ describe('Project — Notebook Actions: files and sessions', () => {
 		});
 		await renderProject();
 
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(await screen.findByText('Open app')).toBeInTheDocument();
 		expect(screen.getByText('Stop app')).toBeInTheDocument();
 	});
@@ -284,7 +284,7 @@ describe('Project — Notebook Actions: files and sessions', () => {
 		await renderProject();
 
 		expect(screen.queryByRole('button', { name: 'Shut down kernel' })).not.toBeInTheDocument();
-		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(screen.queryByRole('menuitem', { name: 'Shut down kernel' })).not.toBeInTheDocument();
 	});
 });

--- a/packages/web/src/components/Project/Project.test.tsx
+++ b/packages/web/src/components/Project/Project.test.tsx
@@ -1,7 +1,142 @@
 import { describe, expect, it } from 'vitest';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { PID, makeFetch, renderProject } from './Project.testWorld';
+import { PID, makeFetch, notebook, renderProject, stoppableSession } from './Project.testWorld';
+
+describe('notebook filters', () => {
+	it('provides labeled controls and announces the result count', async () => {
+		makeFetch();
+		await renderProject();
+
+		expect(screen.getByRole('search', { name: 'Filter notebooks' })).toBeInTheDocument();
+		expect(screen.getByRole('searchbox', { name: 'Search' })).toBeInTheDocument();
+		expect(screen.getByRole('textbox', { name: 'Tag (exact)' })).toBeInTheDocument();
+		const status = screen.getByRole('combobox', { name: 'Status' });
+		expect(status).toBeInTheDocument();
+		expect(within(status).getByRole('option', { name: 'Draft' })).toHaveValue('draft');
+		await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('1 notebook'));
+	});
+
+	it('ANDs text, exact-tag, and status filters through the API', async () => {
+		const user = userEvent.setup();
+		const calls = makeFetch({
+			notebooks: [
+				{ ...notebook(), title: 'Current forecast', tags: ['finance'] },
+				{
+					...notebook(),
+					id: 'nb-archived',
+					title: 'Archived forecast',
+					description: 'Annual planning',
+					tags: ['finance'],
+					status: 'archived',
+				},
+				{
+					...notebook(),
+					id: 'nb-marketing',
+					title: 'Archived campaign',
+					description: 'Annual planning',
+					tags: ['marketing'],
+					status: 'archived',
+				},
+			],
+		});
+		await renderProject();
+
+		await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'annual');
+		await user.type(screen.getByRole('textbox', { name: 'Tag (exact)' }), 'finance');
+		await user.selectOptions(screen.getByRole('combobox', { name: 'Status' }), 'archived');
+		await user.click(screen.getByRole('button', { name: 'Apply Filters' }));
+
+		expect(await screen.findByText('Archived forecast')).toBeInTheDocument();
+		expect(screen.queryByText('Current forecast')).not.toBeInTheDocument();
+		expect(screen.queryByText('Archived campaign')).not.toBeInTheDocument();
+		const request = [...calls]
+			.reverse()
+			.find((call) => call.method === 'GET' && call.url.includes(`/projects/${PID}/notebooks?`));
+		const params = new URL(request?.url ?? '', 'http://localhost').searchParams;
+		expect(Object.fromEntries(params)).toEqual({ q: 'annual', tag: 'finance', status: 'archived' });
+	});
+
+	it('loads draft notebooks through the status picker', async () => {
+		const user = userEvent.setup();
+		const calls = makeFetch({
+			notebooks: [
+				notebook(),
+				{
+					...notebook(),
+					id: 'nb-draft',
+					title: 'Import retry',
+					status: 'draft',
+				},
+			],
+		});
+		await renderProject();
+
+		await user.selectOptions(screen.getByRole('combobox', { name: 'Status' }), 'draft');
+		await user.click(screen.getByRole('button', { name: 'Apply Filters' }));
+
+		expect(await screen.findByText('Import retry')).toBeInTheDocument();
+		expect(screen.queryByText('Forecast')).not.toBeInTheDocument();
+		const request = [...calls]
+			.reverse()
+			.find((call) => call.method === 'GET' && call.url.includes(`/projects/${PID}/notebooks?`));
+		expect(new URL(request?.url ?? '', 'http://localhost').searchParams.get('status')).toBe(
+			'draft',
+		);
+	});
+
+	it('offers a reset path when filters have no results', async () => {
+		const user = userEvent.setup();
+		makeFetch();
+		await renderProject(`/projects/${PID}?q=missing`);
+
+		expect(await screen.findByText('No notebooks match these filters')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Reset filters' }));
+		expect(await screen.findByText('Forecast')).toBeInTheDocument();
+		expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('');
+	});
+});
+
+describe('deleted notebook tombstones', () => {
+	it('removes live actions and keeps only read-only history and exports', async () => {
+		const user = userEvent.setup();
+		makeFetch({
+			notebooks: [
+				{
+					...notebook(),
+					status: 'deleted',
+					source_type: 'git',
+				},
+			],
+			sessions: [stoppableSession()],
+		});
+		await renderProject(`/projects/${PID}?status=deleted`);
+
+		const row = await screen.findByTestId('notebook-row');
+		expect(within(row).getByText('Forecast')).toBeInTheDocument();
+		expect(within(row).getByText('deleted')).toBeInTheDocument();
+		expect(within(row).queryByRole('link', { name: 'Forecast' })).not.toBeInTheDocument();
+		expect(within(row).queryByRole('button', { name: 'Shut down kernel' })).not.toBeInTheDocument();
+
+		await user.click(within(row).getByRole('button', { name: 'Historical actions for Forecast' }));
+		const menu = await screen.findByRole('menu');
+		for (const label of [
+			'View static outputs',
+			'Version history',
+			'Download notebook file',
+			'Download outputs (HTML)',
+			'Download workspace',
+		]) {
+			expect(within(menu).getByRole('menuitem', { name: label })).toBeInTheDocument();
+		}
+		for (const label of ['Rename', 'Duplicate', 'Run as app', 'Sync settings', 'Delete']) {
+			expect(within(menu).queryByRole('menuitem', { name: label })).not.toBeInTheDocument();
+		}
+
+		await user.click(within(menu).getByRole('menuitem', { name: 'View static outputs' }));
+		expect(await screen.findByText('snapshot page')).toBeInTheDocument();
+	});
+});
 
 describe('environment and access', () => {
 	it('is always visible and opens the unified overview', async () => {

--- a/packages/web/src/components/Project/Project.testWorld.tsx
+++ b/packages/web/src/components/Project/Project.testWorld.tsx
@@ -63,6 +63,7 @@ export function makeFetch(
 	const calls: { url: string; method: string; body: unknown }[] = [];
 	const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = String(input);
+		const parsedUrl = new URL(url, 'http://localhost');
 		const method = init?.method ?? 'GET';
 		const body = init?.body
 			? (JSON.parse(init.body as string) as Record<string, unknown>)
@@ -122,8 +123,18 @@ export function makeFetch(
 				headers: { 'content-type': 'text/html' },
 			});
 
-		if (url.includes(`/projects/${PID}/notebooks`))
-			return jsonOk({ items: notebooks, next_cursor: null });
+		if (method === 'GET' && parsedUrl.pathname.endsWith(`/projects/${PID}/notebooks`)) {
+			const q = parsedUrl.searchParams.get('q')?.toLocaleLowerCase();
+			const tag = parsedUrl.searchParams.get('tag');
+			const status = parsedUrl.searchParams.get('status');
+			const items = notebooks.filter(
+				(entry) =>
+					(status ? entry.status === status : entry.status !== 'deleted') &&
+					(!tag || entry.tags.includes(tag)) &&
+					(!q || `${entry.title} ${entry.description}`.toLocaleLowerCase().includes(q)),
+			);
+			return jsonOk({ items, next_cursor: null });
+		}
 		if (url.includes(`/projects/${PID}/sessions`))
 			return jsonOk({ items: sessions, next_cursor: null });
 		if (url.includes('/capabilities')) return jsonOk(capabilities);
@@ -135,23 +146,24 @@ export function makeFetch(
 	return calls;
 }
 
-export async function renderProject() {
+export async function renderProject(route = `/projects/${PID}`) {
 	renderWithClient(
 		<Routes>
 			<Route path="/projects/:pid" element={<Project />} />
 			<Route path="/projects/:pid/notebooks/:nid/snapshot" element={<div>snapshot page</div>} />
 			<Route path="/" element={<div>home</div>} />
 		</Routes>,
-		{ route: `/projects/${PID}`, suspenseFallback: <div>loading</div> },
+		{ route, suspenseFallback: <div>loading</div> },
 	);
 	await waitFor(() => expect(screen.getByRole('heading', { name: 'Sales' })).toBeInTheDocument());
+	await waitFor(() => expect(screen.getByRole('status')).not.toHaveTextContent('Loading'));
 }
 
 export async function chooseNotebookAction(
 	user: ReturnType<typeof userEvent.setup>,
 	label: string,
 ) {
-	await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+	await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 	await user.click(await screen.findByText(label));
 }
 

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -25,7 +25,6 @@ import {
 	Plus,
 	Power,
 	RefreshCw,
-	SearchX,
 	Settings2,
 	Trash2,
 	Upload,
@@ -40,10 +39,10 @@ import {
 	IconLink,
 	LinkButton,
 	RowLink,
-	SearchField,
 	ConfirmDialog,
 	EmptyState,
-	ListContainer,
+	ListFilters,
+	ListResults,
 	PageContainer,
 	PageHeader,
 	SessionStatusDot,
@@ -98,26 +97,127 @@ import { SyncSettingsDialog } from '@/components/Notebook/SyncSettingsDialog';
 import { VersionHistoryDialog } from '@/components/Notebook/VersionHistoryDialog';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { useDisclosure } from '@/hooks/useDisclosure';
-import { useSearchField } from '@/hooks/useSearchField';
-import { filterBySearch } from '@/lib/search';
+import { useListFilters } from '@/hooks/useListFilters';
 import { formatRelative } from '@/lib/time';
 import { syncUrl } from '@/lib/links';
 import { sessionConnectionHint, sessionsByNotebook } from '@/lib/sessions';
 import { canManageProject } from '@/lib/roles';
 import type { DropdownMenuOption } from '@/components/ui';
-import type { NotebookEntry, Session } from '@/types';
+import type { NotebookEntry, ResolvedUser, Session } from '@/types';
 
-/**
- * The tag/status chips for a notebook row: its tags if any, otherwise a
- * noteworthy lifecycle status. The unremarkable `active` (nearly every notebook)
- * is hidden, and a tagless `active` notebook shows nothing.
- */
+/** Keep non-active lifecycle state visible even when the notebook has user tags. */
 function notebookBadges(nb: NotebookEntry): string[] {
-	if (nb.tags.length > 0) return nb.tags;
-	return nb.status === 'active' ? [] : [nb.status];
+	const badges = [...nb.tags];
+	if (nb.status !== 'active' && !badges.includes(nb.status)) badges.push(nb.status);
+	return badges;
 }
 
 const MAX_UPLOAD_BYTES = 1_000_000;
+
+const NOTEBOOK_STATUS_FILTERS = [
+	{ value: 'active', label: 'Active' },
+	{ value: 'draft', label: 'Draft' },
+	{ value: 'archived', label: 'Archived' },
+	{ value: 'deleted', label: 'Deleted' },
+] as const;
+
+const NOTEBOOK_HISTORY_ACTIONS: DropdownMenuOption[] = [
+	{ id: 'view-snapshot', label: 'View static outputs', icon: <Camera className="size-4" /> },
+	{ id: 'history', label: 'Version history', icon: <History className="size-4" /> },
+];
+
+const NOTEBOOK_EXPORT_ACTIONS: DropdownMenuOption[] = [
+	{
+		id: 'download-file',
+		label: 'Download notebook file',
+		icon: <Download className="size-4" />,
+	},
+	{
+		id: 'download-outputs',
+		label: 'Download outputs (HTML)',
+		icon: <FileDown className="size-4" />,
+	},
+	{
+		id: 'download-workspace',
+		label: 'Download workspace',
+		icon: <FolderArchive className="size-4" />,
+	},
+];
+
+function groupedMenuOptions(groups: DropdownMenuOption[][]): DropdownMenuOption[] {
+	return groups
+		.filter((group) => group.length > 0)
+		.flatMap((group, index) =>
+			index === 0 ? group : [{ ...group[0], separatorBefore: true }, ...group.slice(1)],
+		);
+}
+
+const DELETED_NOTEBOOK_ACTIONS = groupedMenuOptions([
+	NOTEBOOK_HISTORY_ACTIONS,
+	NOTEBOOK_EXPORT_ACTIONS,
+]);
+
+interface DeletedNotebookRowProps {
+	notebook: NotebookEntry;
+	user: ResolvedUser | undefined;
+	usersLoading: boolean;
+	onAction: (key: string) => void;
+}
+
+function DeletedNotebookRow({ notebook, user, usersLoading, onAction }: DeletedNotebookRowProps) {
+	return (
+		<div
+			data-testid="notebook-row"
+			className="flex items-center border-b border-l-2 border-l-transparent bg-muted/20 last:border-b-0"
+		>
+			<div className="flex min-w-0 flex-1 items-center justify-between gap-3 px-4 py-3.5">
+				<div className="flex min-w-0 items-center gap-3">
+					<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+						{notebook.source_type === 'git' ? (
+							<GitBranch className="size-4" aria-hidden="true" />
+						) : (
+							<FileText className="size-4" aria-hidden="true" />
+						)}
+					</span>
+					<span className="truncate text-sm font-medium" title={notebook.title}>
+						{notebook.title}
+					</span>
+					{notebookBadges(notebook).map((badge) => (
+						<Chip key={badge} className={badge === 'deleted' ? undefined : 'max-md:hidden'}>
+							{badge}
+						</Chip>
+					))}
+				</div>
+				<div className="flex shrink-0 items-center gap-3">
+					<span className="hidden items-center gap-1 text-xs text-muted-foreground sm:flex">
+						<span className="text-muted-foreground/70">by</span>
+						<UserLabel
+							user={user}
+							fallbackId={notebook.author}
+							loading={usersLoading}
+							className="max-w-[8rem]"
+						/>
+					</span>
+					<time
+						dateTime={notebook.updated_at}
+						title={new Date(notebook.updated_at).toLocaleString()}
+						className="text-xs tabular-nums text-muted-foreground"
+					>
+						{formatRelative(notebook.updated_at)}
+					</time>
+				</div>
+			</div>
+			<div className="relative flex shrink-0 items-center pr-2">
+				<DropdownMenu
+					label={`Historical actions for ${notebook.title}`}
+					icon={<MoreHorizontal className="size-4" />}
+					options={DELETED_NOTEBOOK_ACTIONS}
+					onAction={onAction}
+				/>
+			</div>
+		</div>
+	);
+}
 
 const projectSchema = z.object({
 	name: requiredText('Project name'),
@@ -137,7 +237,7 @@ const NEW_NOTEBOOK_CODE = (name: string) => {
 export function Project() {
 	const { pid } = useParams<{ pid: string }>();
 	const navigate = useNavigate();
-	const search = useSearchField();
+	const { filters, setFilters, filtersActive } = useListFilters(NOTEBOOK_STATUS_FILTERS);
 
 	// Dialogs acting on a row use useDialogTarget; plain ones use useDisclosure.
 	const uploadModal = useDisclosure();
@@ -166,7 +266,11 @@ export function Project() {
 	const membersModal = useDisclosure();
 	const alertsModal = useDisclosure();
 
-	const { data: notebooks } = useNotebooksQuery(pid!);
+	const {
+		data: notebooks = [],
+		isPending: notebooksLoading,
+		isFetching: notebooksFetching,
+	} = useNotebooksQuery(pid!, filters);
 	const { data: project } = useProjectQuery(pid!);
 	const { data: sessions, isLoading: sessionsLoading } = useProjectSessionsQuery(pid!);
 	const createNotebook = useCreateNotebook(pid!);
@@ -435,6 +539,32 @@ export function Project() {
 		}
 	};
 
+	const handleNotebookAction = (nb: NotebookEntry, key: string, stoppableEdit?: Session) => {
+		if (key === 'rename') renameModal.open(nb);
+		else if (key === 'duplicate') handleDuplicate(nb);
+		else if (key === 'stop-kernel' && stoppableEdit)
+			stopModal.open({ notebook: nb, session: stoppableEdit });
+		else if (key === 'run-app' || key === 'open-app')
+			void navigate(`/projects/${pid}/notebooks/${nb.id}/app`, {
+				state: { title: nb.title },
+			});
+		else if (key === 'stop-app') {
+			const app = sessionByNotebook.get(nb.id)?.app;
+			if (app) appModal.open({ action: 'stop', notebook: nb, session: app });
+		} else if (key === 'view-snapshot')
+			void navigate(`/projects/${pid}/notebooks/${nb.id}/snapshot`, {
+				state: { title: nb.title },
+			});
+		else if (key === 'change-image') baseImageModal.open(nb);
+		else if (key === 'change-compute') computeProfileModal.open(nb);
+		else if (key === 'history') historyModal.open(nb);
+		else if (key === 'sync-settings') syncSettings.open({ notebookId: nb.id, title: nb.title });
+		else if (key === 'download-file') handleDownloadFile(nb);
+		else if (key === 'download-outputs') handleDownloadOutputs(nb);
+		else if (key === 'download-workspace') handleDownloadWorkspace(nb);
+		else if (key === 'delete') deleteModal.open(nb);
+	};
+
 	const notebookActions = (nb: NotebookEntry): DropdownMenuOption[] => {
 		const live = sessionByNotebook.get(nb.id);
 		const app = live?.app;
@@ -506,37 +636,14 @@ export function Project() {
 							},
 						]
 					: []),
-				{ id: 'view-snapshot', label: 'View static outputs', icon: <Camera className="size-4" /> },
-				{ id: 'history', label: 'Version history', icon: <History className="size-4" /> },
+				...NOTEBOOK_HISTORY_ACTIONS,
 			],
-			[
-				{
-					id: 'download-file',
-					label: 'Download notebook file',
-					icon: <Download className="size-4" />,
-				},
-				{
-					id: 'download-outputs',
-					label: 'Download outputs (HTML)',
-					icon: <FileDown className="size-4" />,
-				},
-				{
-					id: 'download-workspace',
-					label: 'Download workspace',
-					icon: <FolderArchive className="size-4" />,
-				},
-			],
+			NOTEBOOK_EXPORT_ACTIONS,
 			[{ id: 'delete', label: 'Delete', icon: <Trash2 className="size-4" />, danger: true }],
 		];
 
-		return groups
-			.filter((group) => group.length > 0)
-			.flatMap((group, index) =>
-				index === 0 ? group : [{ ...group[0], separatorBefore: true }, ...group.slice(1)],
-			);
+		return groupedMenuOptions(groups);
 	};
-
-	const filteredNotebooks = filterBySearch(notebooks, search.query, (nb) => nb.title);
 
 	return (
 		<PageContainer>
@@ -628,24 +735,21 @@ export function Project() {
 				</div>
 			</PageHeader>
 
-			<div className="mb-4">
-				<SearchField
-					aria-label="Search notebooks"
-					placeholder="Search notebooks..."
-					value={search.query}
-					onChange={search.setQuery}
-					inputRef={search.inputRef}
-				/>
-			</div>
+			<ListFilters
+				label="Filter notebooks"
+				itemName="notebook"
+				values={filters}
+				statuses={NOTEBOOK_STATUS_FILTERS}
+				resultCount={notebooks.length}
+				resultsId="notebook-results"
+				isLoading={notebooksLoading}
+				isFetching={notebooksFetching}
+				onChange={setFilters}
+			/>
 
-			{filteredNotebooks.length === 0 ? (
-				search.query ? (
-					<EmptyState
-						icon={<SearchX />}
-						message={`No notebooks matching "${search.query}"`}
-						description="Try a different search term."
-					/>
-				) : (
+			<ListResults
+				count={notebooks.length}
+				emptyState={
 					<EmptyState
 						icon={<FileText />}
 						message="No notebooks yet"
@@ -657,146 +761,136 @@ export function Project() {
 							</Button>
 						}
 					/>
-				)
-			) : (
-				<ListContainer>
-					{filteredNotebooks.map((nb) => {
-						const badges = notebookBadges(nb);
-						const live = sessionByNotebook.get(nb.id);
-						const stoppableEdit = live?.edit?.can?.stop ? live.edit : undefined;
+				}
+				isFetching={notebooksFetching}
+				isFiltered={filtersActive}
+				isLoading={notebooksLoading}
+				itemName="notebook"
+				onReset={() => setFilters({})}
+				resultsId="notebook-results"
+			>
+				{notebooks.map((nb) => {
+					if (nb.status === 'deleted') {
 						return (
-							<RowLink
+							<DeletedNotebookRow
 								key={nb.id}
-								testId="notebook-row"
-								to={`/projects/${pid}/notebooks/${nb.id}`}
-								state={{ title: nb.title }}
-								label={nb.title}
-								contentClassName="items-center justify-between gap-3 py-3.5"
-								leading={
-									nb.source_type === 'git' ? (
-										<GitSourcePopover
-											projectId={pid!}
-											notebookId={nb.id}
-											canSync={project.your_role !== 'viewer'}
-											triggerClassName="shrink-0 cursor-pointer rounded-lg"
-											trigger={
-												<span className="flex size-9 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
-													<GitBranch className="size-4" />
-												</span>
-											}
-										/>
-									) : undefined
-								}
-								actions={
-									<>
-										{/* Primary shutdown stays edit-only: the inline Power button
-										    never targets the shared app (dropdown/popover do). */}
-										{stoppableEdit && (
-											<IconButton
-												label="Shut down kernel"
-												tooltip="Shut down kernel"
-												tone="danger"
-												onPress={() => stopModal.open({ notebook: nb, session: stoppableEdit })}
-											>
-												<Power className="size-4" />
-											</IconButton>
-										)}
-										<DropdownMenu
-											label="Notebook actions"
-											icon={<MoreHorizontal className="size-4" />}
-											triggerClassName="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-100"
-											options={notebookActions(nb)}
-											onAction={(key) => {
-												if (key === 'rename') renameModal.open(nb);
-												else if (key === 'duplicate') handleDuplicate(nb);
-												else if (key === 'stop-kernel' && stoppableEdit)
-													stopModal.open({ notebook: nb, session: stoppableEdit });
-												else if (key === 'run-app' || key === 'open-app')
-													void navigate(`/projects/${pid}/notebooks/${nb.id}/app`, {
-														state: { title: nb.title },
-													});
-												else if (key === 'stop-app') {
-													const app = sessionByNotebook.get(nb.id)?.app;
-													if (app) appModal.open({ action: 'stop', notebook: nb, session: app });
-												} else if (key === 'view-snapshot')
-													void navigate(`/projects/${pid}/notebooks/${nb.id}/snapshot`, {
-														state: { title: nb.title },
-													});
-												else if (key === 'change-image') baseImageModal.open(nb);
-												else if (key === 'change-compute') computeProfileModal.open(nb);
-												else if (key === 'history') historyModal.open(nb);
-												else if (key === 'sync-settings')
-													syncSettings.open({ notebookId: nb.id, title: nb.title });
-												else if (key === 'download-file') handleDownloadFile(nb);
-												else if (key === 'download-outputs') handleDownloadOutputs(nb);
-												else if (key === 'download-workspace') handleDownloadWorkspace(nb);
-												else if (key === 'delete') deleteModal.open(nb);
-											}}
-										/>
-									</>
-								}
-							>
-								<div className="flex min-w-0 items-center gap-3">
-									{nb.source_type !== 'git' && (
-										<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
-											<FileText className="size-4" />
-										</span>
-									)}
-									<span className="truncate text-sm font-medium">{nb.title}</span>
-									{badges.map((badge) => (
-										<Chip key={badge} className="max-md:hidden">
-											{badge}
-										</Chip>
-									))}
-								</div>
-								<div className="flex shrink-0 items-center gap-3">
-									{live?.app && (
-										<AppSessionIndicator
-											session={live.app}
-											canControl={!!live.app.can?.stop}
-											canOpen={!!live.app.can?.attach}
-											editActive={!!live.persistentEdit}
-											profiles={computeProfiles}
-											allowComputeOverride={capabilities?.compute_profile_override === 'editors'}
-											selectedProfileName={nb.compute_profile}
-											onStop={() =>
-												appModal.open({ action: 'stop', notebook: nb, session: live.app! })
-											}
-											onRestart={() =>
-												appModal.open({ action: 'restart', notebook: nb, session: live.app! })
-											}
-										/>
-									)}
-									<SessionStatusDot
-										session={live?.edit}
-										loading={sessionsLoading}
-										profiles={computeProfiles}
-										selectedProfileName={
-											canChooseComputeProfile ? nb.compute_profile : computeProfiles[0]?.name
+								notebook={nb}
+								user={users?.[nb.author]}
+								usersLoading={usersLoading}
+								onAction={(key) => handleNotebookAction(nb, key)}
+							/>
+						);
+					}
+
+					const badges = notebookBadges(nb);
+					const live = sessionByNotebook.get(nb.id);
+					const stoppableEdit = live?.edit?.can?.stop ? live.edit : undefined;
+					return (
+						<RowLink
+							key={nb.id}
+							testId="notebook-row"
+							to={`/projects/${pid}/notebooks/${nb.id}`}
+							state={{ title: nb.title }}
+							label={nb.title}
+							contentClassName="items-center justify-between gap-3 py-3.5"
+							leading={
+								nb.source_type === 'git' ? (
+									<GitSourcePopover
+										projectId={pid!}
+										notebookId={nb.id}
+										canSync={project.your_role !== 'viewer'}
+										triggerClassName="shrink-0 cursor-pointer rounded-lg"
+										trigger={
+											<span className="flex size-9 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
+												<GitBranch className="size-4" />
+											</span>
 										}
 									/>
-									<span className="hidden items-center gap-1 text-xs text-muted-foreground sm:flex">
-										<span className="text-muted-foreground/70">by</span>
-										<UserLabel
-											user={users?.[nb.author]}
-											fallbackId={nb.author}
-											loading={usersLoading}
-											className="max-w-[8rem]"
-										/>
+								) : undefined
+							}
+							actions={
+								<>
+									{/* Inline shutdown is edit-only; app controls live in the menu. */}
+									{stoppableEdit && (
+										<IconButton
+											label="Shut down kernel"
+											tooltip="Shut down kernel"
+											tone="danger"
+											onPress={() => stopModal.open({ notebook: nb, session: stoppableEdit })}
+										>
+											<Power className="size-4" />
+										</IconButton>
+									)}
+									<DropdownMenu
+										label={`Notebook actions for ${nb.title}`}
+										icon={<MoreHorizontal className="size-4" />}
+										triggerClassName="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-100"
+										options={notebookActions(nb)}
+										onAction={(key) => handleNotebookAction(nb, key, stoppableEdit)}
+									/>
+								</>
+							}
+						>
+							<div className="flex min-w-0 items-center gap-3">
+								{nb.source_type !== 'git' && (
+									<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors group-hover:bg-primary/10 group-hover:text-primary">
+										<FileText className="size-4" />
 									</span>
-									<time
-										dateTime={nb.updated_at}
-										title={new Date(nb.updated_at).toLocaleString()}
-										className="text-xs tabular-nums text-muted-foreground"
-									>
-										{formatRelative(nb.updated_at)}
-									</time>
-								</div>
-							</RowLink>
-						);
-					})}
-				</ListContainer>
-			)}
+								)}
+								<span className="truncate text-sm font-medium">{nb.title}</span>
+								{badges.map((badge) => (
+									<Chip key={badge} className="max-md:hidden">
+										{badge}
+									</Chip>
+								))}
+							</div>
+							<div className="flex shrink-0 items-center gap-3">
+								{live?.app && (
+									<AppSessionIndicator
+										session={live.app}
+										canControl={!!live.app.can?.stop}
+										canOpen={!!live.app.can?.attach}
+										editActive={!!live.persistentEdit}
+										profiles={computeProfiles}
+										allowComputeOverride={capabilities?.compute_profile_override === 'editors'}
+										selectedProfileName={nb.compute_profile}
+										onStop={() =>
+											appModal.open({ action: 'stop', notebook: nb, session: live.app! })
+										}
+										onRestart={() =>
+											appModal.open({ action: 'restart', notebook: nb, session: live.app! })
+										}
+									/>
+								)}
+								<SessionStatusDot
+									session={live?.edit}
+									loading={sessionsLoading}
+									profiles={computeProfiles}
+									selectedProfileName={
+										canChooseComputeProfile ? nb.compute_profile : computeProfiles[0]?.name
+									}
+								/>
+								<span className="hidden items-center gap-1 text-xs text-muted-foreground sm:flex">
+									<span className="text-muted-foreground/70">by</span>
+									<UserLabel
+										user={users?.[nb.author]}
+										fallbackId={nb.author}
+										loading={usersLoading}
+										className="max-w-[8rem]"
+									/>
+								</span>
+								<time
+									dateTime={nb.updated_at}
+									title={new Date(nb.updated_at).toLocaleString()}
+									className="text-xs tabular-nums text-muted-foreground"
+								>
+									{formatRelative(nb.updated_at)}
+								</time>
+							</div>
+						</RowLink>
+					);
+				})}
+			</ListResults>
 
 			<FormDialog
 				form={createNotebookForm}

--- a/packages/web/src/components/ProjectList/ProjectList.test.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.test.tsx
@@ -1,53 +1,60 @@
 import type { ReactNode } from 'react';
-import { Suspense } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ProjectSummary } from '@/types';
 import { ProjectList } from './ProjectList';
 
-function project(name: string, description = ''): ProjectSummary {
+type TestProject = ProjectSummary & { tags: string[] };
+
+function project(
+	name: string,
+	description = '',
+	options: { status?: ProjectSummary['status']; tags?: string[] } = {},
+): TestProject {
 	return {
 		id: `proj-${name.toLowerCase()}`,
 		name,
 		description,
 		owner: 'me',
-		status: 'active',
+		status: options.status ?? 'active',
+		tags: options.tags ?? [],
 		created_at: '2025-03-05T14:00:00Z',
 		updated_at: '2025-03-05T14:00:00Z',
 		notebook_count: 0,
-	} as ProjectSummary;
+	} as TestProject;
 }
 
-/** Mount ProjectList with a router, query client, and a fetch returning `projects`. */
-function renderList(projects: ProjectSummary[]) {
-	vi.stubGlobal(
-		'fetch',
-		vi.fn(
-			async () =>
-				new Response(
-					JSON.stringify({ success: true, data: { items: projects, next_cursor: null } }),
-					{
-						headers: { 'content-type': 'application/json' },
-					},
-				),
-		),
-	);
+function renderList(projects: TestProject[], route = '/') {
+	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+		const url = new URL(String(input), 'http://localhost');
+		const q = url.searchParams.get('q')?.toLocaleLowerCase();
+		const tag = url.searchParams.get('tag');
+		const status = url.searchParams.get('status');
+		const items = projects.filter(
+			(entry) =>
+				(status ? entry.status === status : entry.status !== 'deleted') &&
+				(!tag || entry.tags.includes(tag)) &&
+				(!q || `${entry.name} ${entry.description}`.toLocaleLowerCase().includes(q)),
+		);
+		return new Response(JSON.stringify({ success: true, data: { items, next_cursor: null } }), {
+			headers: { 'content-type': 'application/json' },
+		});
+	});
+	vi.stubGlobal('fetch', fetchMock);
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 	const wrapper = ({ children }: { children: ReactNode }) => (
-		<MemoryRouter>
-			<QueryClientProvider client={client}>
-				<Suspense fallback={<div>loading</div>}>{children}</Suspense>
-			</QueryClientProvider>
+		<MemoryRouter initialEntries={[route]}>
+			<QueryClientProvider client={client}>{children}</QueryClientProvider>
 		</MemoryRouter>
 	);
-	return render(<ProjectList />, { wrapper });
+	return { ...render(<ProjectList />, { wrapper }), fetchMock };
 }
 
 async function waitForLoaded() {
-	await waitForElementToBeRemoved(() => screen.queryByText('loading'));
+	await waitFor(() => expect(screen.getByRole('status')).not.toHaveTextContent('Loading'));
 }
 
 afterEach(() => {
@@ -82,25 +89,79 @@ describe('ProjectList', () => {
 		expect(screen.getByRole('button', { name: 'Create your first project' })).toBeInTheDocument();
 	});
 
-	it('filters the list by the search box (name or description)', async () => {
+	it('filters the list by name or description after submission', async () => {
 		const user = userEvent.setup();
 		renderList([project('Sales', 'revenue'), project('Marketing', 'campaign analysis')]);
 		await waitForLoaded();
 
-		await user.type(screen.getByPlaceholderText('Search projects...'), 'analysis');
+		await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'analysis{Enter}');
 
-		expect(screen.getByText('Marketing')).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByText('Marketing')).toBeInTheDocument());
 		expect(screen.queryByText('Sales')).not.toBeInTheDocument();
 	});
 
-	it('shows a "no matches" empty state when the search excludes everything', async () => {
+	it('shows a reset action when filters exclude everything', async () => {
 		const user = userEvent.setup();
 		renderList([project('Sales')]);
 		await waitForLoaded();
 
-		await user.type(screen.getByPlaceholderText('Search projects...'), 'zzz');
+		await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'zzz');
+		await user.click(screen.getByRole('button', { name: 'Apply Filters' }));
 
-		expect(screen.getByText('No projects matching "zzz"')).toBeInTheDocument();
+		expect(await screen.findByText('No projects match these filters')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Reset filters' }));
+		expect(await screen.findByText('Sales')).toBeInTheDocument();
+	});
+
+	it('provides labeled controls and announces the result count', async () => {
+		renderList([project('Sales')]);
+		await waitForLoaded();
+
+		expect(screen.getByRole('search', { name: 'Filter projects' })).toBeInTheDocument();
+		expect(screen.getByRole('searchbox', { name: 'Search' })).toBeInTheDocument();
+		expect(screen.getByRole('textbox', { name: 'Tag (exact)' })).toBeInTheDocument();
+		expect(screen.getByRole('combobox', { name: 'Status' })).toBeInTheDocument();
+		expect(screen.getByRole('status')).toHaveTextContent('1 project');
+	});
+
+	it('loads combined filters from the URL and sends them to the API', async () => {
+		const { fetchMock } = renderList(
+			[
+				project('Sales', 'annual analysis', { tags: ['finance'] }),
+				project('Marketing', 'annual analysis', { tags: ['campaigns'] }),
+			],
+			'/?q=analysis&tag=finance&status=active',
+		);
+		await waitForLoaded();
+
+		expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('analysis');
+		expect(screen.getByRole('textbox', { name: 'Tag (exact)' })).toHaveValue('finance');
+		expect(screen.getByRole('combobox', { name: 'Status' })).toHaveValue('active');
+		expect(screen.getByText('Sales')).toBeInTheDocument();
+		expect(screen.queryByText('Marketing')).not.toBeInTheDocument();
+		const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]), 'http://localhost');
+		expect(Object.fromEntries(requestUrl.searchParams)).toEqual({
+			q: 'analysis',
+			tag: 'finance',
+			status: 'active',
+		});
+	});
+
+	it('ignores an invalid status from a copied URL', async () => {
+		const { fetchMock } = renderList([project('Sales')], '/?status=unknown&q=sales');
+		await waitForLoaded();
+
+		expect(screen.getByRole('combobox', { name: 'Status' })).toHaveValue('');
+		expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain('status=');
+		expect(screen.getByText('Sales')).toBeInTheDocument();
+	});
+
+	it('shows deleted projects without a link to an unavailable detail page', async () => {
+		renderList([project('Old Sales', '', { status: 'deleted' })], '/?status=deleted');
+		await waitForLoaded();
+
+		expect(screen.getByTestId('project-row')).toHaveTextContent('Deleted');
+		expect(screen.queryByRole('link', { name: /Old Sales/ })).not.toBeInTheDocument();
 	});
 
 	it('opens the create-project dialog from the header button', async () => {

--- a/packages/web/src/components/ProjectList/ProjectList.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.tsx
@@ -1,12 +1,13 @@
 import { toast } from 'sonner';
 import { z } from 'zod';
-import { ChevronRight, Folder, FolderPlus, Plus, SearchX } from 'lucide-react';
+import { ChevronRight, Folder, FolderPlus, Plus } from 'lucide-react';
 import {
 	Button,
-	SearchField,
+	Chip,
 	RowLink,
 	EmptyState,
-	ListContainer,
+	ListFilters,
+	ListResults,
 	PageContainer,
 	PageHeader,
 } from '@/components/ui';
@@ -20,8 +21,13 @@ import {
 } from '@/components/form';
 import { useProjectsQuery, useCreateProject } from '@/api/hooks';
 import { useDisclosure } from '@/hooks/useDisclosure';
-import { useSearchField } from '@/hooks/useSearchField';
-import { filterBySearch } from '@/lib/search';
+import { useListFilters } from '@/hooks/useListFilters';
+import type { ProjectSummary } from '@/types';
+
+const PROJECT_STATUS_FILTERS = [
+	{ value: 'active', label: 'Active' },
+	{ value: 'deleted', label: 'Deleted' },
+] as const;
 
 const projectSchema = z.object({
 	name: requiredText('Project name'),
@@ -31,10 +37,10 @@ const projectSchema = z.object({
 const EMPTY_PROJECT = { name: '', description: '' };
 
 export function ProjectList() {
-	const search = useSearchField();
+	const { filters, setFilters, filtersActive } = useListFilters(PROJECT_STATUS_FILTERS);
 	const createModal = useDisclosure();
 
-	const { data: projects } = useProjectsQuery();
+	const { data: projects = [], isPending, isFetching } = useProjectsQuery(filters);
 	const createProject = useCreateProject();
 
 	const createForm = useAppForm({
@@ -54,12 +60,6 @@ export function ProjectList() {
 	});
 	useSeedOnOpen(createForm, createModal.isOpen, EMPTY_PROJECT);
 
-	const filteredProjects = filterBySearch(
-		projects,
-		search.query,
-		(p) => `${p.name} ${p.description}`,
-	);
-
 	return (
 		<PageContainer>
 			<title>Projects · marimohub</title>
@@ -73,31 +73,25 @@ export function ProjectList() {
 			>
 				<div className="flex min-w-0 flex-col gap-0.5">
 					<h1 className="text-2xl font-semibold tracking-tight">Projects</h1>
-					<p className="text-sm text-muted-foreground">
-						{projects.length} project{projects.length !== 1 ? 's' : ''} · shared workspaces for your
-						notebooks
-					</p>
+					<p className="text-sm text-muted-foreground">Shared workspaces for your notebooks</p>
 				</div>
 			</PageHeader>
 
-			<div className="mb-4">
-				<SearchField
-					aria-label="Search projects"
-					placeholder="Search projects..."
-					value={search.query}
-					onChange={search.setQuery}
-					inputRef={search.inputRef}
-				/>
-			</div>
+			<ListFilters
+				label="Filter projects"
+				itemName="project"
+				values={filters}
+				statuses={PROJECT_STATUS_FILTERS}
+				resultCount={projects.length}
+				resultsId="project-results"
+				isLoading={isPending}
+				isFetching={isFetching}
+				onChange={setFilters}
+			/>
 
-			{filteredProjects.length === 0 ? (
-				search.query ? (
-					<EmptyState
-						icon={<SearchX />}
-						message={`No projects matching "${search.query}"`}
-						description="Try a different search term."
-					/>
-				) : (
+			<ListResults
+				count={projects.length}
+				emptyState={
 					<EmptyState
 						icon={<FolderPlus />}
 						message="No projects yet"
@@ -109,34 +103,18 @@ export function ProjectList() {
 							</Button>
 						}
 					/>
-				)
-			) : (
-				<ListContainer>
-					{filteredProjects.map((project) => (
-						<RowLink
-							key={project.id}
-							to={`/projects/${project.id}`}
-							testId="project-row"
-							contentClassName="items-center gap-3 py-3.5"
-						>
-							<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
-								<Folder className="size-4" />
-							</span>
-							<span className="flex min-w-0 flex-1 flex-col gap-0.5">
-								<span className="truncate text-sm font-medium">{project.name}</span>
-								<span className="truncate text-xs text-muted-foreground">
-									{project.description}
-								</span>
-							</span>
-							<span className="shrink-0 rounded-full border bg-muted/60 px-2.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
-								{project.notebook_count} notebook
-								{project.notebook_count !== 1 ? 's' : ''}
-							</span>
-							<ChevronRight className="size-4 shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground" />
-						</RowLink>
-					))}
-				</ListContainer>
-			)}
+				}
+				isFetching={isFetching}
+				isFiltered={filtersActive}
+				isLoading={isPending}
+				itemName="project"
+				onReset={() => setFilters({})}
+				resultsId="project-results"
+			>
+				{projects.map((project) => (
+					<ProjectRow key={project.id} project={project} />
+				))}
+			</ListResults>
 
 			<FormDialog
 				form={createForm}
@@ -155,5 +133,52 @@ export function ProjectList() {
 				</createForm.AppField>
 			</FormDialog>
 		</PageContainer>
+	);
+}
+
+function ProjectRow({ project }: { project: ProjectSummary }) {
+	const content = (
+		<>
+			<span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary transition-colors group-hover:bg-primary/15">
+				<Folder className="size-4" aria-hidden="true" />
+			</span>
+			<span className="flex min-w-0 flex-1 flex-col gap-0.5">
+				<span className="truncate text-sm font-medium" title={project.name}>
+					{project.name}
+				</span>
+				<span className="truncate text-xs text-muted-foreground" title={project.description}>
+					{project.description}
+				</span>
+			</span>
+			{project.status === 'deleted' ? <Chip>Deleted</Chip> : null}
+			<span className="shrink-0 rounded-full border bg-muted/60 px-2.5 py-0.5 text-[11px] font-medium tabular-nums text-muted-foreground">
+				{project.notebook_count} notebook{project.notebook_count !== 1 ? 's' : ''}
+			</span>
+		</>
+	);
+
+	if (project.status === 'deleted') {
+		return (
+			<div
+				data-testid="project-row"
+				className="flex items-center gap-3 border-b border-l-2 border-l-transparent bg-muted/20 px-4 py-3.5 last:border-b-0"
+			>
+				{content}
+			</div>
+		);
+	}
+
+	return (
+		<RowLink
+			to={`/projects/${project.id}`}
+			testId="project-row"
+			contentClassName="items-center gap-3 py-3.5"
+		>
+			{content}
+			<ChevronRight
+				className="size-4 shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground"
+				aria-hidden="true"
+			/>
+		</RowLink>
 	);
 }

--- a/packages/web/src/components/ui/ListFilters.tsx
+++ b/packages/web/src/components/ui/ListFilters.tsx
@@ -66,7 +66,6 @@ export function ListFilters<Status extends string>({
 		>
 			<div className="grid grid-cols-[minmax(0,2fr)_minmax(8rem,1fr)_minmax(9rem,1fr)_auto] items-end gap-3 max-md:grid-cols-1">
 				<SearchField
-					aria-label="Search"
 					label="Search"
 					name="q"
 					defaultValue={values.q ?? ''}

--- a/packages/web/src/components/ui/ListFilters.tsx
+++ b/packages/web/src/components/ui/ListFilters.tsx
@@ -1,0 +1,128 @@
+/* oxlint-disable jsx-a11y/prefer-tag-over-role -- React does not recognize the HTML search element. */
+import { useId, useRef } from 'react';
+import { Filter, RotateCcw } from 'lucide-react';
+import { Button } from './Button';
+import { SearchField } from './SearchField';
+import { TextField } from './TextField';
+import { useSearchHotkey } from '@/hooks/useSearchHotkey';
+import { hasListFilters } from '@/lib/listFilters';
+import type { ListFilterStatus, ListFilterValues } from '@/lib/listFilters';
+
+interface ListFiltersProps<Status extends string> {
+	label: string;
+	itemName: string;
+	values: ListFilterValues<Status>;
+	statuses: readonly ListFilterStatus<Status>[];
+	resultCount: number;
+	resultsId: string;
+	isLoading: boolean;
+	isFetching: boolean;
+	onChange: (values: ListFilterValues<Status>) => void;
+}
+
+function formValue(data: FormData, name: string): string | undefined {
+	const value = data.get(name);
+	if (typeof value !== 'string') return undefined;
+	return value.trim() || undefined;
+}
+
+export function ListFilters<Status extends string>({
+	label,
+	itemName,
+	values,
+	statuses,
+	resultCount,
+	resultsId,
+	isLoading,
+	isFetching,
+	onChange,
+}: ListFiltersProps<Status>) {
+	const statusId = useId();
+	const searchRef = useRef<HTMLInputElement>(null);
+	useSearchHotkey(searchRef);
+	const active = hasListFilters(values);
+	const pluralName = `${itemName}${resultCount === 1 ? '' : 's'}`;
+	const announcement = isLoading
+		? `Loading ${itemName}s…`
+		: isFetching
+			? `Updating ${itemName}s…`
+			: `${resultCount} ${pluralName}`;
+
+	return (
+		<form
+			key={`${values.q ?? ''}\0${values.tag ?? ''}\0${values.status ?? ''}`}
+			role="search"
+			aria-label={label}
+			onSubmit={(event) => {
+				event.preventDefault();
+				const data = new FormData(event.currentTarget);
+				onChange({
+					q: formValue(data, 'q'),
+					tag: formValue(data, 'tag'),
+					status: formValue(data, 'status') as Status | undefined,
+				});
+			}}
+			className="mb-4 rounded-xl border bg-card p-3 shadow-xs"
+		>
+			<div className="grid grid-cols-[minmax(0,2fr)_minmax(8rem,1fr)_minmax(9rem,1fr)_auto] items-end gap-3 max-md:grid-cols-1">
+				<SearchField
+					aria-label="Search"
+					label="Search"
+					name="q"
+					defaultValue={values.q ?? ''}
+					placeholder="Name or description…"
+					inputRef={searchRef}
+				/>
+				<TextField
+					label="Tag (exact)"
+					name="tag"
+					defaultValue={values.tag ?? ''}
+					placeholder="analytics…"
+					autoComplete="off"
+					className="[&_input]:max-md:h-11"
+				/>
+				<div className="flex flex-col gap-1.5">
+					<label htmlFor={statusId} className="text-xs font-medium text-muted-foreground">
+						Status
+					</label>
+					<select
+						id={statusId}
+						name="status"
+						defaultValue={values.status ?? ''}
+						className="h-9 cursor-pointer rounded-md border border-input bg-background px-3 text-sm text-foreground shadow-sm transition-colors [color-scheme:light] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:h-11 dark:[color-scheme:dark]"
+					>
+						<option value="">All current statuses</option>
+						{statuses.map((status) => (
+							<option key={status.value} value={status.value}>
+								{status.label}
+							</option>
+						))}
+					</select>
+				</div>
+				<div className="flex gap-2 max-md:grid max-md:grid-cols-2">
+					<Button type="submit" aria-controls={resultsId}>
+						<Filter className="size-4" aria-hidden="true" />
+						Apply Filters
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						isDisabled={!active}
+						aria-controls={resultsId}
+						onPress={() => onChange({})}
+					>
+						<RotateCcw className="size-4" aria-hidden="true" />
+						Reset
+					</Button>
+				</div>
+			</div>
+			<output
+				aria-live="polite"
+				aria-atomic="true"
+				className="mt-2 block min-h-4 text-xs tabular-nums text-muted-foreground"
+			>
+				{announcement}
+			</output>
+		</form>
+	);
+}

--- a/packages/web/src/components/ui/ListResults.test.tsx
+++ b/packages/web/src/components/ui/ListResults.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ListResults } from './ListResults';
+
+interface RenderOptions {
+	count?: number;
+	isFiltered?: boolean;
+	isLoading?: boolean;
+}
+
+function renderResults({ count = 1, isFiltered = false, isLoading = false }: RenderOptions = {}) {
+	const onReset = vi.fn();
+	const result = render(
+		<ListResults
+			count={count}
+			emptyState={<p>No notebooks yet</p>}
+			isFetching={false}
+			isFiltered={isFiltered}
+			isLoading={isLoading}
+			itemName="notebook"
+			onReset={onReset}
+			resultsId="notebook-results"
+		>
+			<p>Notebook row</p>
+		</ListResults>,
+	);
+	return { ...result, onReset };
+}
+
+describe('ListResults', () => {
+	it('shows skeleton rows while loading', () => {
+		renderResults({ isLoading: true });
+
+		expect(screen.getAllByTestId('list-skeleton-row')).toHaveLength(3);
+		expect(screen.queryByText('Notebook row')).not.toBeInTheDocument();
+		expect(screen.queryByText('No notebooks yet')).not.toBeInTheDocument();
+	});
+
+	it('shows the filtered empty state and resets filters', async () => {
+		const user = userEvent.setup();
+		const { onReset } = renderResults({ count: 0, isFiltered: true });
+
+		expect(screen.getByText('No notebooks match these filters')).toBeInTheDocument();
+		await user.click(screen.getByRole('button', { name: 'Reset filters' }));
+		expect(onReset).toHaveBeenCalledOnce();
+	});
+
+	it('renders the caller-provided empty state when no filters are active', () => {
+		renderResults({ count: 0 });
+
+		expect(screen.getByText('No notebooks yet')).toBeInTheDocument();
+		expect(screen.queryByText('No notebooks match these filters')).not.toBeInTheDocument();
+	});
+});

--- a/packages/web/src/components/ui/ListResults.tsx
+++ b/packages/web/src/components/ui/ListResults.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from 'react';
+import { SearchX } from 'lucide-react';
+import { Button } from './Button';
+import { EmptyState } from './EmptyState';
+import { ListContainer } from './PageLayout';
+import { Skeleton } from './Skeleton';
+
+interface ListResultsProps {
+	children: ReactNode;
+	count: number;
+	emptyState: ReactNode;
+	isFetching: boolean;
+	isFiltered: boolean;
+	isLoading: boolean;
+	itemName: string;
+	onReset: () => void;
+	resultsId: string;
+}
+
+const SKELETON_ROWS = [0, 1, 2];
+
+export function ListResults({
+	children,
+	count,
+	emptyState,
+	isFetching,
+	isFiltered,
+	isLoading,
+	itemName,
+	onReset,
+	resultsId,
+}: ListResultsProps) {
+	let content: ReactNode = <ListContainer>{children}</ListContainer>;
+	if (isLoading) {
+		content = <ListSkeleton />;
+	} else if (count === 0) {
+		content = isFiltered ? (
+			<EmptyState
+				icon={<SearchX />}
+				message={`No ${itemName}s match these filters`}
+				description={`Adjust the filters or reset them to see all current ${itemName}s.`}
+				action={
+					<Button variant="default" onPress={onReset}>
+						Reset filters
+					</Button>
+				}
+			/>
+		) : (
+			emptyState
+		);
+	}
+
+	return (
+		<div id={resultsId} aria-busy={isFetching}>
+			{content}
+		</div>
+	);
+}
+
+function ListSkeleton() {
+	return (
+		<ListContainer>
+			{SKELETON_ROWS.map((row) => (
+				<div
+					key={row}
+					aria-hidden="true"
+					className="flex items-center gap-3 border-b p-4 last:border-b-0"
+				>
+					<Skeleton className="size-9 rounded-lg" />
+					<div className="flex flex-1 flex-col gap-2">
+						<Skeleton className="h-4 w-36" />
+						<Skeleton className="h-3 w-52 max-w-full" />
+					</div>
+				</div>
+			))}
+		</ListContainer>
+	);
+}

--- a/packages/web/src/components/ui/ListResults.tsx
+++ b/packages/web/src/components/ui/ListResults.tsx
@@ -63,6 +63,7 @@ function ListSkeleton() {
 			{SKELETON_ROWS.map((row) => (
 				<div
 					key={row}
+					data-testid="list-skeleton-row"
 					aria-hidden="true"
 					className="flex items-center gap-3 border-b p-4 last:border-b-0"
 				>

--- a/packages/web/src/components/ui/SearchField.test.tsx
+++ b/packages/web/src/components/ui/SearchField.test.tsx
@@ -16,6 +16,11 @@ function Harness() {
 }
 
 describe('SearchField', () => {
+	it('uses a visible label as its accessible name without requiring aria-label', () => {
+		render(<SearchField label="Search notebooks" />);
+		expect(screen.getByRole('searchbox', { name: 'Search notebooks' })).toBeInTheDocument();
+	});
+
 	it('is announced as a searchbox with its label and reports typing via onChange', async () => {
 		const user = userEvent.setup();
 		render(<Harness />);

--- a/packages/web/src/components/ui/SearchField.tsx
+++ b/packages/web/src/components/ui/SearchField.tsx
@@ -3,19 +3,22 @@ import { SearchField as AriaSearchField, Input, Button, Label } from 'react-aria
 import { Search, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-export interface SearchFieldProps {
+interface SearchFieldBaseProps {
 	value?: string;
 	defaultValue?: string;
 	onChange?: (value: string) => void;
 	name?: string;
-	label?: string;
 	placeholder?: string;
-	/** Accessible name used when no visible label is provided. */
-	'aria-label': string;
 	/** Forwarded to the input so a page-level hotkey can focus it. */
 	inputRef?: Ref<HTMLInputElement>;
 	className?: string;
 }
+
+type SearchFieldAccessibleName =
+	| { label: string; 'aria-label'?: never }
+	| { label?: never; 'aria-label': string };
+
+export type SearchFieldProps = SearchFieldBaseProps & SearchFieldAccessibleName;
 
 /** Search input with clear and Escape-to-clear behavior from React Aria. */
 export function SearchField({

--- a/packages/web/src/components/ui/SearchField.tsx
+++ b/packages/web/src/components/ui/SearchField.tsx
@@ -1,26 +1,29 @@
 import type { Ref } from 'react';
-import { SearchField as AriaSearchField, Input, Button } from 'react-aria-components';
+import { SearchField as AriaSearchField, Input, Button, Label } from 'react-aria-components';
 import { Search, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 export interface SearchFieldProps {
-	value: string;
-	onChange: (value: string) => void;
+	value?: string;
+	defaultValue?: string;
+	onChange?: (value: string) => void;
+	name?: string;
+	label?: string;
 	placeholder?: string;
-	/** Accessible name — required, since a search box has no visible label. */
+	/** Accessible name used when no visible label is provided. */
 	'aria-label': string;
-	/** Forwarded to the underlying input so a hotkey can focus it. */
+	/** Forwarded to the input so a page-level hotkey can focus it. */
 	inputRef?: Ref<HTMLInputElement>;
 	className?: string;
 }
 
-/**
- * A labeled search box on react-aria `SearchField`, which provides the clear (✕)
- * button, Escape-to-clear, and `searchbox` role.
- */
+/** Search input with clear and Escape-to-clear behavior from React Aria. */
 export function SearchField({
 	value,
+	defaultValue,
 	onChange,
+	name,
+	label,
 	placeholder,
 	inputRef,
 	className,
@@ -28,41 +31,47 @@ export function SearchField({
 }: SearchFieldProps) {
 	return (
 		<AriaSearchField
-			aria-label={props['aria-label']}
+			aria-label={label ? undefined : props['aria-label']}
 			value={value}
+			defaultValue={defaultValue}
 			onChange={onChange}
-			className={cn('group relative', className)}
+			name={name}
+			className={cn('group flex flex-col gap-1.5', className)}
 		>
-			<Search
-				className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
-				aria-hidden
-			/>
-			<Input
-				ref={inputRef}
-				placeholder={placeholder}
-				className={cn(
-					'h-10 w-full rounded-lg border border-input bg-card pl-9 pr-9 text-sm text-foreground shadow-xs transition-[border-color,box-shadow]',
-					'placeholder:text-muted-foreground hover:border-ring/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-					'[&::-webkit-search-cancel-button]:appearance-none',
-				)}
-			/>
-			{/* The `/` focus hotkey (useSearchHotkey); swaps for the clear button once there's a query. */}
-			<kbd
-				aria-hidden
-				className="pointer-events-none absolute right-2.5 top-1/2 hidden h-5 -translate-y-1/2 items-center rounded border bg-muted px-1.5 font-mono text-[11px] text-muted-foreground group-data-[empty]:flex"
-			>
-				/
-			</kbd>
-			<Button
-				aria-label="Clear search"
-				className={cn(
-					'absolute right-1 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded text-muted-foreground outline-none transition-colors',
-					'hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring',
-					'group-data-[empty]:hidden',
-				)}
-			>
-				<X className="size-4" aria-hidden />
-			</Button>
+			{label ? <Label className="text-xs font-medium text-muted-foreground">{label}</Label> : null}
+			<div className="relative">
+				<Search
+					className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+					aria-hidden
+				/>
+				<Input
+					ref={inputRef}
+					placeholder={placeholder}
+					autoComplete="off"
+					className={cn(
+						'h-10 w-full rounded-lg border border-input bg-card pl-9 pr-10 text-sm text-foreground shadow-xs transition-[border-color,box-shadow] max-md:h-11',
+						'placeholder:text-muted-foreground hover:border-ring/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+						'[&::-webkit-search-cancel-button]:appearance-none',
+					)}
+				/>
+				{/* The `/` focus hotkey swaps for the clear button once the input has a value. */}
+				<kbd
+					aria-hidden
+					className="pointer-events-none absolute right-2.5 top-1/2 hidden h-5 -translate-y-1/2 items-center rounded border bg-muted px-1.5 font-mono text-[11px] text-muted-foreground group-data-[empty]:flex"
+				>
+					/
+				</kbd>
+				<Button
+					aria-label="Clear search"
+					className={cn(
+						'absolute right-1 top-1/2 flex size-8 -translate-y-1/2 items-center justify-center rounded text-muted-foreground outline-none transition-colors max-md:size-10',
+						'hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring',
+						'group-data-[empty]:hidden',
+					)}
+				>
+					<X className="size-4" aria-hidden />
+				</Button>
+			</div>
 		</AriaSearchField>
 	);
 }

--- a/packages/web/src/components/ui/index.ts
+++ b/packages/web/src/components/ui/index.ts
@@ -21,6 +21,10 @@ export type { TextFieldProps } from './TextField';
 export { SearchField } from './SearchField';
 export type { SearchFieldProps } from './SearchField';
 
+export { ListFilters } from './ListFilters';
+
+export { ListResults } from './ListResults';
+
 export { ComboBox } from './ComboBox';
 export type { ComboBoxProps, ComboBoxOption } from './ComboBox';
 

--- a/packages/web/src/hooks/useListFilters.ts
+++ b/packages/web/src/hooks/useListFilters.ts
@@ -1,0 +1,14 @@
+import { useSearchParams } from 'react-router-dom';
+import { hasListFilters, readListFilters, updateListFilterParams } from '@/lib/listFilters';
+import type { ListFilterStatus, ListFilterValues } from '@/lib/listFilters';
+
+export function useListFilters<Status extends string>(
+	statuses: readonly ListFilterStatus<Status>[],
+) {
+	const [searchParams, setSearchParams] = useSearchParams();
+	const filters = readListFilters(searchParams, statuses);
+	const setFilters = (values: ListFilterValues<Status>) =>
+		setSearchParams(updateListFilterParams(searchParams, values));
+
+	return { filters, setFilters, filtersActive: hasListFilters(filters) };
+}

--- a/packages/web/src/lib/listFilters.test.ts
+++ b/packages/web/src/lib/listFilters.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { hasListFilters, readListFilters, updateListFilterParams } from './listFilters';
+
+const STATUSES = [
+	{ value: 'active', label: 'Active' },
+	{ value: 'deleted', label: 'Deleted' },
+] as const;
+
+describe('list filter URL state', () => {
+	it('trims values and ignores invalid statuses', () => {
+		const filters = readListFilters(
+			new URLSearchParams('q=%20revenue%20&tag=%20finance%20&status=unknown'),
+			STATUSES,
+		);
+
+		expect(filters).toEqual({ q: 'revenue', tag: 'finance', status: undefined });
+		expect(hasListFilters(filters)).toBe(true);
+	});
+
+	it('replaces only filter parameters', () => {
+		const params = updateListFilterParams(new URLSearchParams('q=old&view=grid'), {
+			status: 'deleted',
+		});
+
+		expect(Object.fromEntries(params)).toEqual({ view: 'grid', status: 'deleted' });
+	});
+});

--- a/packages/web/src/lib/listFilters.ts
+++ b/packages/web/src/lib/listFilters.ts
@@ -1,0 +1,39 @@
+export interface ListFilterValues<Status extends string = string> {
+	q?: string;
+	status?: Status;
+	tag?: string;
+}
+
+export interface ListFilterStatus<Status extends string> {
+	value: Status;
+	label: string;
+}
+
+export function readListFilters<Status extends string>(
+	params: URLSearchParams,
+	statuses: readonly ListFilterStatus<Status>[],
+): ListFilterValues<Status> {
+	const readParam = (name: string) => params.get(name)?.trim() || undefined;
+	const status = readParam('status');
+	return {
+		q: readParam('q'),
+		tag: readParam('tag'),
+		status: statuses.some((option) => option.value === status) ? (status as Status) : undefined,
+	};
+}
+
+export function updateListFilterParams(
+	current: URLSearchParams,
+	values: ListFilterValues,
+): URLSearchParams {
+	const next = new URLSearchParams(current);
+	for (const name of ['q', 'status', 'tag'] as const) {
+		next.delete(name);
+		if (values[name]) next.set(name, values[name]);
+	}
+	return next;
+}
+
+export function hasListFilters(values: ListFilterValues): boolean {
+	return values.q !== undefined || values.status !== undefined || values.tag !== undefined;
+}

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -49,6 +49,8 @@ import type {
 // Aliases onto the generated client types. Names kept stable so existing web
 // imports (`ProjectSummary`, `NotebookEntry`, ...) continue to work.
 export type ProjectSummary = SnapshotProjectEntry;
+type ProjectListQuery = NonNullable<paths['/api/v1/projects']['get']['parameters']['query']>;
+export type ProjectListFilters = Pick<ProjectListQuery, 'q' | 'status' | 'tag'>;
 /** The full project meta returned by `GET /api/v1/projects/:id` (includes `federation`). */
 export type ProjectDetail = ClientProject;
 /** Per-project workload-identity federation opt-in. */
@@ -65,6 +67,10 @@ type CreateProjectAlertDestinationBody =
 	paths['/api/v1/projects/{pid}/alert-destinations']['post']['requestBody']['content']['application/json'];
 export type ProjectAlertKind = NonNullable<CreateProjectAlertDestinationBody['kinds']>[number];
 export type NotebookEntry = SnapshotNotebookEntry;
+type NotebookListQuery = NonNullable<
+	paths['/api/v1/projects/{pid}/notebooks']['get']['parameters']['query']
+>;
+export type NotebookListFilters = Pick<NotebookListQuery, 'q' | 'status' | 'tag'>;
 export type NotebookMeta = ClientNotebookMeta;
 export type NotebookDetail = ClientNotebookDetail;
 /** A saved notebook revision from `GET .../versions`. */


### PR DESCRIPTION
- Add validated status, tag, and text filters to project and notebook list APIs before cursor pagination.
- Add shared accessible filter controls, Draft selection, and deleted-notebook tombstones limited to historical actions.
- Regenerate the OpenAPI schema and typed client while preserving unfiltered behavior and legacy catalog compatibility.