### PR TITLE
feat(web): make list filters collapsible

### DIFF
--- a/packages/web/src/components/Project/Project.test.tsx
+++ b/packages/web/src/components/Project/Project.test.tsx
@@ -5,12 +5,18 @@ import { PID, makeFetch, notebook, renderProject, stoppableSession } from './Pro
 
 describe('notebook filters', () => {
 	it('provides labeled controls and announces the result count', async () => {
+		const user = userEvent.setup();
 		makeFetch();
 		await renderProject();
 
+		const toggle = screen.getByRole('button', { name: 'Filters' });
+		expect(toggle).toHaveAttribute('aria-expanded', 'false');
+		expect(screen.queryByRole('search', { name: 'Filter notebooks' })).not.toBeInTheDocument();
+
+		await user.click(toggle);
 		expect(screen.getByRole('search', { name: 'Filter notebooks' })).toBeInTheDocument();
 		expect(screen.getByRole('searchbox', { name: 'Search' })).toBeInTheDocument();
-		expect(screen.getByRole('textbox', { name: 'Tag (exact)' })).toBeInTheDocument();
+		expect(screen.getByRole('textbox', { name: 'Exact tag' })).toBeInTheDocument();
 		const status = screen.getByRole('combobox', { name: 'Status' });
 		expect(status).toBeInTheDocument();
 		expect(within(status).getByRole('option', { name: 'Draft' })).toHaveValue('draft');
@@ -42,10 +48,11 @@ describe('notebook filters', () => {
 		});
 		await renderProject();
 
+		await user.click(screen.getByRole('button', { name: 'Filters' }));
 		await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'annual');
-		await user.type(screen.getByRole('textbox', { name: 'Tag (exact)' }), 'finance');
+		await user.type(screen.getByRole('textbox', { name: 'Exact tag' }), 'finance');
 		await user.selectOptions(screen.getByRole('combobox', { name: 'Status' }), 'archived');
-		await user.click(screen.getByRole('button', { name: 'Apply Filters' }));
+		await user.click(screen.getByRole('button', { name: 'Apply' }));
 
 		expect(await screen.findByText('Archived forecast')).toBeInTheDocument();
 		expect(screen.queryByText('Current forecast')).not.toBeInTheDocument();
@@ -72,8 +79,9 @@ describe('notebook filters', () => {
 		});
 		await renderProject();
 
+		await user.click(screen.getByRole('button', { name: 'Filters' }));
 		await user.selectOptions(screen.getByRole('combobox', { name: 'Status' }), 'draft');
-		await user.click(screen.getByRole('button', { name: 'Apply Filters' }));
+		await user.click(screen.getByRole('button', { name: 'Apply' }));
 
 		expect(await screen.findByText('Import retry')).toBeInTheDocument();
 		expect(screen.queryByText('Forecast')).not.toBeInTheDocument();
@@ -90,6 +98,10 @@ describe('notebook filters', () => {
 		makeFetch();
 		await renderProject(`/projects/${PID}?q=missing`);
 
+		expect(screen.getByRole('button', { name: 'Filters' })).toHaveAttribute(
+			'aria-expanded',
+			'true',
+		);
 		expect(await screen.findByText('No notebooks match these filters')).toBeInTheDocument();
 		await user.click(screen.getByRole('button', { name: 'Reset filters' }));
 		expect(await screen.findByText('Forecast')).toBeInTheDocument();

--- a/packages/web/src/components/ProjectList/ProjectList.test.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.test.tsx
@@ -94,6 +94,7 @@ describe('ProjectList', () => {
 		renderList([project('Sales', 'revenue'), project('Marketing', 'campaign analysis')]);
 		await waitForLoaded();
 
+		await user.click(screen.getByRole('button', { name: 'Filters' }));
 		await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'analysis{Enter}');
 
 		await waitFor(() => expect(screen.getByText('Marketing')).toBeInTheDocument());
@@ -105,23 +106,43 @@ describe('ProjectList', () => {
 		renderList([project('Sales')]);
 		await waitForLoaded();
 
+		await user.click(screen.getByRole('button', { name: 'Filters' }));
 		await user.type(screen.getByRole('searchbox', { name: 'Search' }), 'zzz');
-		await user.click(screen.getByRole('button', { name: 'Apply Filters' }));
+		await user.click(screen.getByRole('button', { name: 'Apply' }));
 
 		expect(await screen.findByText('No projects match these filters')).toBeInTheDocument();
 		await user.click(screen.getByRole('button', { name: 'Reset filters' }));
 		expect(await screen.findByText('Sales')).toBeInTheDocument();
 	});
 
-	it('provides labeled controls and announces the result count', async () => {
+	it('opens the filters and focuses search with the search shortcut', async () => {
+		const user = userEvent.setup();
 		renderList([project('Sales')]);
 		await waitForLoaded();
 
+		await user.keyboard('/');
+
+		await waitFor(() => expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveFocus());
+	});
+
+	it('provides labeled controls and announces the result count', async () => {
+		const user = userEvent.setup();
+		renderList([project('Sales')]);
+		await waitForLoaded();
+
+		const toggle = screen.getByRole('button', { name: 'Filters' });
+		expect(toggle).toHaveAttribute('aria-expanded', 'false');
+		expect(screen.queryByRole('search', { name: 'Filter projects' })).not.toBeInTheDocument();
+		expect(screen.getByRole('status')).toHaveTextContent('1 project');
+
+		await user.click(toggle);
 		expect(screen.getByRole('search', { name: 'Filter projects' })).toBeInTheDocument();
 		expect(screen.getByRole('searchbox', { name: 'Search' })).toBeInTheDocument();
-		expect(screen.getByRole('textbox', { name: 'Tag (exact)' })).toBeInTheDocument();
+		expect(screen.getByRole('textbox', { name: 'Exact tag' })).toBeInTheDocument();
 		expect(screen.getByRole('combobox', { name: 'Status' })).toBeInTheDocument();
-		expect(screen.getByRole('status')).toHaveTextContent('1 project');
+
+		await user.click(toggle);
+		expect(screen.queryByRole('search', { name: 'Filter projects' })).not.toBeInTheDocument();
 	});
 
 	it('loads combined filters from the URL and sends them to the API', async () => {
@@ -134,8 +155,12 @@ describe('ProjectList', () => {
 		);
 		await waitForLoaded();
 
+		expect(screen.getByRole('button', { name: 'Filters' })).toHaveAttribute(
+			'aria-expanded',
+			'true',
+		);
 		expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('analysis');
-		expect(screen.getByRole('textbox', { name: 'Tag (exact)' })).toHaveValue('finance');
+		expect(screen.getByRole('textbox', { name: 'Exact tag' })).toHaveValue('finance');
 		expect(screen.getByRole('combobox', { name: 'Status' })).toHaveValue('active');
 		expect(screen.getByText('Sales')).toBeInTheDocument();
 		expect(screen.queryByText('Marketing')).not.toBeInTheDocument();

--- a/packages/web/src/components/ui/ListFilters.test.tsx
+++ b/packages/web/src/components/ui/ListFilters.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ListFilters } from './ListFilters';
+import type { ListFilterValues } from '@/lib/listFilters';
+
+const STATUSES = [
+	{ value: 'active', label: 'Active' },
+	{ value: 'deleted', label: 'Deleted' },
+] as const;
+const onChange = vi.fn();
+
+function filters(values: ListFilterValues<'active' | 'deleted'> = {}) {
+	return (
+		<ListFilters
+			label="Filter projects"
+			itemName="project"
+			values={values}
+			statuses={STATUSES}
+			resultCount={1}
+			resultsId="project-results"
+			isLoading={false}
+			isFetching={false}
+			onChange={onChange}
+		/>
+	);
+}
+
+describe('ListFilters', () => {
+	it('opens when URL-backed filters become active after mount', async () => {
+		const { rerender } = render(filters());
+		const toggle = screen.getByRole('button', { name: 'Filters' });
+		expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+		rerender(filters({ q: 'sales' }));
+
+		await waitFor(() => expect(toggle).toHaveAttribute('aria-expanded', 'true'));
+		expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveValue('sales');
+	});
+
+	it('describes the blank status as current statuses', async () => {
+		const user = userEvent.setup();
+		render(filters());
+
+		await user.click(screen.getByRole('button', { name: 'Filters' }));
+
+		expect(screen.getByRole('option', { name: 'All current statuses' })).toHaveValue('');
+	});
+
+	it('focuses search after the shortcut mounts the filter panel', async () => {
+		render(filters());
+
+		fireEvent.keyDown(document, { key: '/' });
+
+		await waitFor(() => expect(screen.getByRole('searchbox', { name: 'Search' })).toHaveFocus());
+	});
+});

--- a/packages/web/src/components/ui/ListFilters.tsx
+++ b/packages/web/src/components/ui/ListFilters.tsx
@@ -1,6 +1,6 @@
 /* oxlint-disable jsx-a11y/prefer-tag-over-role -- React does not recognize the HTML search element. */
-import { useId, useRef } from 'react';
-import { Filter, RotateCcw } from 'lucide-react';
+import { useCallback, useId, useRef, useState } from 'react';
+import { ChevronDown, Filter } from 'lucide-react';
 import { Button } from './Button';
 import { SearchField } from './SearchField';
 import { TextField } from './TextField';
@@ -38,9 +38,12 @@ export function ListFilters<Status extends string>({
 	onChange,
 }: ListFiltersProps<Status>) {
 	const statusId = useId();
+	const panelId = useId();
 	const searchRef = useRef<HTMLInputElement>(null);
-	useSearchHotkey(searchRef);
 	const active = hasListFilters(values);
+	const [isOpen, setIsOpen] = useState(active);
+	const openFilters = useCallback(() => setIsOpen(true), []);
+	useSearchHotkey(searchRef, openFilters);
 	const pluralName = `${itemName}${resultCount === 1 ? '' : 's'}`;
 	const announcement = isLoading
 		? `Loading ${itemName}s…`
@@ -49,79 +52,101 @@ export function ListFilters<Status extends string>({
 			: `${resultCount} ${pluralName}`;
 
 	return (
-		<form
-			key={`${values.q ?? ''}\0${values.tag ?? ''}\0${values.status ?? ''}`}
-			role="search"
-			aria-label={label}
-			onSubmit={(event) => {
-				event.preventDefault();
-				const data = new FormData(event.currentTarget);
-				onChange({
-					q: formValue(data, 'q'),
-					tag: formValue(data, 'tag'),
-					status: formValue(data, 'status') as Status | undefined,
-				});
-			}}
-			className="mb-4 rounded-xl border bg-card p-3 shadow-xs"
-		>
-			<div className="grid grid-cols-[minmax(0,2fr)_minmax(8rem,1fr)_minmax(9rem,1fr)_auto] items-end gap-3 max-md:grid-cols-1">
-				<SearchField
-					label="Search"
-					name="q"
-					defaultValue={values.q ?? ''}
-					placeholder="Name or description…"
-					inputRef={searchRef}
-				/>
-				<TextField
-					label="Tag (exact)"
-					name="tag"
-					defaultValue={values.tag ?? ''}
-					placeholder="analytics…"
-					autoComplete="off"
-					className="[&_input]:max-md:h-11"
-				/>
-				<div className="flex flex-col gap-1.5">
-					<label htmlFor={statusId} className="text-xs font-medium text-muted-foreground">
-						Status
-					</label>
-					<select
-						id={statusId}
-						name="status"
-						defaultValue={values.status ?? ''}
-						className="h-9 cursor-pointer rounded-md border border-input bg-background px-3 text-sm text-foreground shadow-sm transition-colors [color-scheme:light] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:h-11 dark:[color-scheme:dark]"
-					>
-						<option value="">All current statuses</option>
-						{statuses.map((status) => (
-							<option key={status.value} value={status.value}>
-								{status.label}
-							</option>
-						))}
-					</select>
-				</div>
-				<div className="flex gap-2 max-md:grid max-md:grid-cols-2">
-					<Button type="submit" aria-controls={resultsId}>
-						<Filter className="size-4" aria-hidden="true" />
-						Apply Filters
-					</Button>
-					<Button
-						type="button"
-						variant="ghost"
-						isDisabled={!active}
-						aria-controls={resultsId}
-						onPress={() => onChange({})}
-					>
-						<RotateCcw className="size-4" aria-hidden="true" />
-						Reset
-					</Button>
-				</div>
+		<div className="mb-3">
+			<div className="flex items-center gap-2">
+				<Button
+					type="button"
+					size="sm"
+					aria-expanded={isOpen}
+					aria-controls={panelId}
+					onPress={() => setIsOpen((open) => !open)}
+				>
+					<Filter className="size-3.5" aria-hidden="true" />
+					Filters
+					{active ? <span className="size-1.5 rounded-full bg-primary" aria-hidden="true" /> : null}
+					<ChevronDown
+						className={`size-3.5 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+						aria-hidden="true"
+					/>
+				</Button>
+				<output
+					aria-live="polite"
+					aria-atomic="true"
+					className="text-xs tabular-nums text-muted-foreground"
+				>
+					{announcement}
+				</output>
 			</div>
-			<output
-				aria-live="polite"
-				aria-atomic="true"
-				className="mt-2 block min-h-4 text-xs tabular-nums text-muted-foreground"
-			>
-				{announcement}
-			</output>
-		</form>
+			{isOpen ? (
+				<form
+					id={panelId}
+					key={`${values.q ?? ''}\0${values.tag ?? ''}\0${values.status ?? ''}`}
+					role="search"
+					aria-label={label}
+					onSubmit={(event) => {
+						event.preventDefault();
+						const data = new FormData(event.currentTarget);
+						onChange({
+							q: formValue(data, 'q'),
+							tag: formValue(data, 'tag'),
+							status: formValue(data, 'status') as Status | undefined,
+						});
+					}}
+					className="mt-2 rounded-lg border bg-card p-2 shadow-xs"
+				>
+					<div className="grid grid-cols-[minmax(0,2fr)_minmax(7rem,1fr)_minmax(8.5rem,1fr)_auto] items-end gap-2 max-md:grid-cols-1">
+						<SearchField
+							label="Search"
+							name="q"
+							defaultValue={values.q ?? ''}
+							placeholder="Name or description…"
+							inputRef={searchRef}
+							className="gap-1 [&_input]:h-8 [&_input]:rounded-md [&_input]:pl-8 [&_input]:pr-8 [&_input]:text-xs"
+						/>
+						<TextField
+							label="Exact tag"
+							name="tag"
+							defaultValue={values.tag ?? ''}
+							placeholder="analytics…"
+							autoComplete="off"
+							className="gap-1 [&_input]:h-8 [&_input]:text-xs [&_input]:max-md:h-11"
+						/>
+						<div className="flex flex-col gap-1">
+							<label htmlFor={statusId} className="text-xs font-medium text-muted-foreground">
+								Status
+							</label>
+							<select
+								id={statusId}
+								name="status"
+								defaultValue={values.status ?? ''}
+								className="h-8 cursor-pointer rounded-md border border-input bg-background px-2.5 text-xs text-foreground shadow-sm transition-colors [color-scheme:light] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:h-11 dark:[color-scheme:dark]"
+							>
+								<option value="">All statuses</option>
+								{statuses.map((status) => (
+									<option key={status.value} value={status.value}>
+										{status.label}
+									</option>
+								))}
+							</select>
+						</div>
+						<div className="flex gap-1 max-md:grid max-md:grid-cols-2">
+							<Button type="submit" size="sm" aria-controls={resultsId}>
+								Apply
+							</Button>
+							<Button
+								type="button"
+								size="sm"
+								variant="ghost"
+								isDisabled={!active}
+								aria-controls={resultsId}
+								onPress={() => onChange({})}
+							>
+								Reset
+							</Button>
+						</div>
+					</div>
+				</form>
+			) : null}
+		</div>
 	);
 }

--- a/packages/web/src/components/ui/ListFilters.tsx
+++ b/packages/web/src/components/ui/ListFilters.tsx
@@ -1,5 +1,5 @@
 /* oxlint-disable jsx-a11y/prefer-tag-over-role -- React does not recognize the HTML search element. */
-import { useCallback, useId, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { ChevronDown, Filter } from 'lucide-react';
 import { Button } from './Button';
 import { SearchField } from './SearchField';
@@ -42,8 +42,22 @@ export function ListFilters<Status extends string>({
 	const searchRef = useRef<HTMLInputElement>(null);
 	const active = hasListFilters(values);
 	const [isOpen, setIsOpen] = useState(active);
-	const openFilters = useCallback(() => setIsOpen(true), []);
+	const focusSearchOnOpen = useRef(false);
+	const openFilters = useCallback(() => {
+		if (searchRef.current) return;
+		focusSearchOnOpen.current = true;
+		setIsOpen(true);
+	}, []);
 	useSearchHotkey(searchRef, openFilters);
+	useEffect(() => {
+		if (active) setIsOpen(true);
+	}, [active]);
+	useEffect(() => {
+		const input = searchRef.current;
+		if (!isOpen || !focusSearchOnOpen.current || !input) return;
+		focusSearchOnOpen.current = false;
+		input.focus();
+	}, [isOpen]);
 	const pluralName = `${itemName}${resultCount === 1 ? '' : 's'}`;
 	const announcement = isLoading
 		? `Loading ${itemName}s…`
@@ -121,7 +135,7 @@ export function ListFilters<Status extends string>({
 								defaultValue={values.status ?? ''}
 								className="h-8 cursor-pointer rounded-md border border-input bg-background px-2.5 text-xs text-foreground shadow-sm transition-colors [color-scheme:light] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:h-11 dark:[color-scheme:dark]"
 							>
-								<option value="">All statuses</option>
+								<option value="">All current statuses</option>
 								{statuses.map((status) => (
 									<option key={status.value} value={status.value}>
 										{status.label}

--- a/packages/web/src/hooks/useSearchHotkey.ts
+++ b/packages/web/src/hooks/useSearchHotkey.ts
@@ -21,11 +21,7 @@ export function useSearchHotkey(
 
 			event.preventDefault();
 			onActivate?.();
-			if (ref.current) {
-				ref.current.focus();
-			} else {
-				requestAnimationFrame(() => ref.current?.focus());
-			}
+			ref.current?.focus();
 		}
 
 		document.addEventListener('keydown', onKeyDown);

--- a/packages/web/src/hooks/useSearchHotkey.ts
+++ b/packages/web/src/hooks/useSearchHotkey.ts
@@ -6,7 +6,10 @@ import type { RefObject } from 'react';
  * while the user is already typing in a field, and ignores the key when a
  * modifier is held so it never hijacks browser/OS shortcuts.
  */
-export function useSearchHotkey(ref: RefObject<HTMLInputElement | null>): void {
+export function useSearchHotkey(
+	ref: RefObject<HTMLInputElement | null>,
+	onActivate?: () => void,
+): void {
 	useEffect(() => {
 		function onKeyDown(event: KeyboardEvent) {
 			if (event.key !== '/' || event.metaKey || event.ctrlKey || event.altKey) return;
@@ -17,10 +20,15 @@ export function useSearchHotkey(ref: RefObject<HTMLInputElement | null>): void {
 			if (isTyping) return;
 
 			event.preventDefault();
-			ref.current?.focus();
+			onActivate?.();
+			if (ref.current) {
+				ref.current.focus();
+			} else {
+				requestAnimationFrame(() => ref.current?.focus());
+			}
 		}
 
 		document.addEventListener('keydown', onKeyDown);
 		return () => document.removeEventListener('keydown', onKeyDown);
-	}, [ref]);
+	}, [ref, onActivate]);
 }


### PR DESCRIPTION
Makes project and notebook filters collapsed by default, compact when expanded, and automatically open for URL-backed filters.