### PR TITLE
fix(cli): update manifest operation count

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -795,7 +795,7 @@ mod tests {
     #[test]
     fn embedded_manifest_covers_the_api() {
         let manifest = manifest::load();
-        assert_eq!(manifest.operations.len(), 82);
+        assert_eq!(manifest.operations.len(), 89);
         assert_eq!(manifest.api_version, "1.0.0");
         assert_eq!(
             manifest


### PR DESCRIPTION
Updates the Rust CLI manifest invariant to account for the seven workspace-browser operations added on main.