### PR TITLE
feat(surfaces): Add OpenCode session surfaces

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -33,6 +33,23 @@ jobs:
       - name: helm lint
         run: helm lint --strict charts/marimohub
 
+      - name: Verify surface image upgrade compatibility
+        run: |
+          legacy_image=ghcr.io/example/sandbox:legacy-vscode
+          current_image=ghcr.io/example/sandbox:tools
+          legacy_render=$(helm template test charts/marimohub \
+            --set surfaces.vscode.enabled=true \
+            --set surfaces.vscode.sandboxImage=$legacy_image)
+          grep -Fq "MARIMOHUB_COMPUTE_IMAGE: \"$legacy_image\"" <<< "$legacy_render"
+          current_render=$(helm template test charts/marimohub \
+            --set surfaces.vscode.enabled=true \
+            --set surfaces.vscode.sandboxImage=$legacy_image \
+            --set surfaces.sandboxImage=$current_image)
+          grep -Fq "MARIMOHUB_COMPUTE_IMAGE: \"$current_image\"" <<< "$current_render"
+          if grep -Fq "MARIMOHUB_COMPUTE_IMAGE: \"$legacy_image\"" <<< "$current_render"; then
+            exit 1
+          fi
+
       - name: Install kubeconform
         run: |
           curl -sSfL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \

--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -61,6 +61,8 @@ jobs:
       - name: Verify OpenCode variant
         run: |
           docker run --rm marimo-sandbox:opencode-ci opencode --version | grep -F '1.18.17'
+          docker run --rm marimo-sandbox:opencode-ci jq --version
+          docker run --rm marimo-sandbox:opencode-ci test -f /home/appuser/.agents/skills/marimo-pair/SKILL.md
           docker run --rm marimo-sandbox:opencode-ci sh -ec '
             opencode web --hostname 127.0.0.1 --port 4096 >/tmp/opencode.log 2>&1 &
             pid=$!
@@ -74,6 +76,8 @@ jobs:
               fi
               sleep 1
             done
+            curl -fsS -H "x-opencode-directory: /workspace" http://127.0.0.1:4096/skill \
+              | jq -e ".[] | select(.name == \"marimo-pair\")" >/dev/null
           '
 
       - name: Build and verify combined tools variant
@@ -81,6 +85,8 @@ jobs:
           docker build --target tools -t marimo-sandbox:tools-ci images/marimo-sandbox
           docker run --rm marimo-sandbox:tools-ci code-server --version
           docker run --rm marimo-sandbox:tools-ci opencode --version | grep -F '1.18.17'
+          docker run --rm marimo-sandbox:tools-ci jq --version
+          docker run --rm marimo-sandbox:tools-ci test -f /home/appuser/.agents/skills/marimo-pair/SKILL.md
           docker run --rm marimo-sandbox:tools-ci sh -ec '
             opencode web --hostname 127.0.0.1 --port 4096 >/tmp/opencode.log 2>&1 &
             pid=$!
@@ -94,6 +100,8 @@ jobs:
               fi
               sleep 1
             done
+            curl -fsS -H "x-opencode-directory: /workspace" http://127.0.0.1:4096/skill \
+              | jq -e ".[] | select(.name == \"marimo-pair\")" >/dev/null
           '
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -5,9 +5,11 @@ on:
     branches: [main]
     paths:
       - 'images/marimo-sandbox/Dockerfile'
+      - '.github/workflows/publish-sandbox-image.yml'
   pull_request:
     paths:
       - 'images/marimo-sandbox/Dockerfile'
+      - '.github/workflows/publish-sandbox-image.yml'
 
 permissions:
   contents: read
@@ -53,6 +55,47 @@ jobs:
             done
           '
 
+      - name: Build OpenCode variant
+        run: docker build --target opencode -t marimo-sandbox:opencode-ci images/marimo-sandbox
+
+      - name: Verify OpenCode variant
+        run: |
+          docker run --rm marimo-sandbox:opencode-ci opencode --version | grep -F '1.18.17'
+          docker run --rm marimo-sandbox:opencode-ci sh -ec '
+            opencode web --hostname 127.0.0.1 --port 4096 >/tmp/opencode.log 2>&1 &
+            pid=$!
+            trap "kill $pid 2>/dev/null || true" EXIT
+            attempts=0
+            until curl -fsS http://127.0.0.1:4096/global/health; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 30 ]; then
+                cat /tmp/opencode.log
+                exit 1
+              fi
+              sleep 1
+            done
+          '
+
+      - name: Build and verify combined tools variant
+        run: |
+          docker build --target tools -t marimo-sandbox:tools-ci images/marimo-sandbox
+          docker run --rm marimo-sandbox:tools-ci code-server --version
+          docker run --rm marimo-sandbox:tools-ci opencode --version | grep -F '1.18.17'
+          docker run --rm marimo-sandbox:tools-ci sh -ec '
+            opencode web --hostname 127.0.0.1 --port 4096 >/tmp/opencode.log 2>&1 &
+            pid=$!
+            trap "kill $pid 2>/dev/null || true" EXIT
+            attempts=0
+            until curl -fsS http://127.0.0.1:4096/global/health; do
+              attempts=$((attempts + 1))
+              if [ "$attempts" -ge 30 ]; then
+                cat /tmp/opencode.log
+                exit 1
+              fi
+              sleep 1
+            done
+          '
+
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         if: github.event_name == 'push'
 
@@ -88,3 +131,29 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/marimo-sandbox:latest-vscode
             ghcr.io/${{ github.repository_owner }}/marimo-sandbox:py3.13-marimo${{ steps.version.outputs.marimo }}-vscode
             ghcr.io/${{ github.repository_owner }}/marimo-sandbox:sha-${{ github.sha }}-vscode
+
+      - name: Publish OpenCode variant
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: images/marimo-sandbox
+          target: opencode
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:latest-opencode
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:py3.13-marimo${{ steps.version.outputs.marimo }}-opencode
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:sha-${{ github.sha }}-opencode
+
+      - name: Publish combined tools variant
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: images/marimo-sandbox
+          target: tools
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:latest-tools
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:py3.13-marimo${{ steps.version.outputs.marimo }}-tools
+            ghcr.io/${{ github.repository_owner }}/marimo-sandbox:sha-${{ github.sha }}-tools

--- a/apps/cli/generated/cli-manifest.json
+++ b/apps/cli/generated/cli-manifest.json
@@ -3628,6 +3628,13 @@
 						"required": false,
 						"value_type": "string",
 						"repeatable": false
+					},
+					{
+						"name": "surfaces",
+						"cli_name": "surfaces",
+						"required": false,
+						"value_type": "string",
+						"repeatable": true
 					}
 				]
 			},
@@ -3891,6 +3898,7 @@
 						"name": "open",
 						"cli_name": "open",
 						"required": false,
+						"description": "Workspace-relative file to open. Supported only by the VS Code surface.",
 						"value_type": "string",
 						"repeatable": false
 					}

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -67,6 +67,23 @@ MARIMOHUB_SANDBOX_EXPOSURE=subdomain         # subdomain (direct, isolated domai
 # MARIMOHUB_SANDBOX_PROXY_ACK_UNTRUSTED=true  # required to enable proxy mode (fails closed)
 # MARIMOHUB_APP_BASE_URL=https://hub.example.com  # optional; else derived from the request
 
+# --- Secondary edit surfaces (disabled unless listed) ---
+# Use the `-vscode`, `-opencode`, or `-tools` sandbox image that matches this list.
+# OpenCode requires subdomain exposure. Ports must be unique and cannot use 2718.
+# MARIMOHUB_SURFACES=marimo,vscode,opencode
+# MARIMOHUB_SURFACE_VSCODE_FLAVOR=code-server        # code-server | openvscode
+# MARIMOHUB_SURFACE_VSCODE_START=on-demand          # on-demand | eager
+# MARIMOHUB_SURFACE_VSCODE_PORT=8443
+# MARIMOHUB_SURFACE_VSCODE_EXTENSION_GALLERY=openvsx # openvsx | none | mirror URL
+# MARIMOHUB_SURFACE_VSCODE_SETTINGS_JSON={}
+# MARIMOHUB_SURFACE_VSCODE_EMBED=tab                 # tab | iframe
+# MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH=true
+# MARIMOHUB_SURFACE_OPENCODE_START=on-demand         # on-demand | eager
+# MARIMOHUB_SURFACE_OPENCODE_PORT=4096
+# MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB=1024
+# MARIMOHUB_SURFACE_OPENCODE_EMBED=tab               # tab | iframe
+# MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH=true
+
 # --- Authentication (app-native OIDC) ---
 MARIMOHUB_AUTH_BACKEND=oidc                  # oidc | dev
 MARIMOHUB_AUTH_OIDC_ISSUER=https://accounts.example.com

--- a/charts/marimohub/README.md
+++ b/charts/marimohub/README.md
@@ -66,6 +66,9 @@ Updater](https://argocd-image-updater.readthedocs.io/) or
 | `serviceAccount.automountServiceAccountToken` | `true` | Mount the Kubernetes API token in API and maintenance pods |
 | `compute.profiles` | `""` | Ordered sandbox CPU/memory profiles; first is the default |
 | `compute.profileOverride` | `none` | Set to `editors` to allow per-notebook profile selection |
+| `surfaces.sandboxImage` | `""` | Sandbox image with the enabled surface tools |
+| `surfaces.vscode.enabled` | `false` | Enable the VS Code surface |
+| `surfaces.opencode.enabled` | `false` | Enable the subdomain-only OpenCode surface |
 | `maintenance.enabled` | `true` | Singleton session reaper |
 | `config` | see `values.yaml` | Non-secret `MARIMOHUB_*` → ConfigMap |
 | `secrets.existingSecret` | `""` | Secret you create with the secret vars (recommended) |

--- a/charts/marimohub/README.md
+++ b/charts/marimohub/README.md
@@ -67,6 +67,7 @@ Updater](https://argocd-image-updater.readthedocs.io/) or
 | `compute.profiles` | `""` | Ordered sandbox CPU/memory profiles; first is the default |
 | `compute.profileOverride` | `none` | Set to `editors` to allow per-notebook profile selection |
 | `surfaces.sandboxImage` | `""` | Sandbox image with the enabled surface tools |
+| `surfaces.vscode.sandboxImage` | `""` | Deprecated fallback for `surfaces.sandboxImage` |
 | `surfaces.vscode.enabled` | `false` | Enable the VS Code surface |
 | `surfaces.opencode.enabled` | `false` | Enable the subdomain-only OpenCode surface |
 | `maintenance.enabled` | `true` | Singleton session reaper |

--- a/charts/marimohub/templates/_helpers.tpl
+++ b/charts/marimohub/templates/_helpers.tpl
@@ -61,7 +61,7 @@ Call with: (dict "root" $ "maintenance" true|false)
 {{- define "marimohub.podTemplate" -}}
 {{- $root := .root -}}
 {{- $v := $root.Values -}}
-{{- $hasConfigMap := or $v.config $v.compute.profiles (ne $v.compute.profileOverride "none") $v.surfaces.vscode.enabled -}}
+{{- $hasConfigMap := or $v.config $v.compute.profiles (ne $v.compute.profileOverride "none") $v.surfaces.vscode.enabled $v.surfaces.opencode.enabled -}}
 {{- $res := $v.resources -}}
 {{- if .maintenance -}}{{- $res = $v.maintenance.resources -}}{{- end }}
 metadata:

--- a/charts/marimohub/templates/configmap.yaml
+++ b/charts/marimohub/templates/configmap.yaml
@@ -1,4 +1,12 @@
-{{- if or .Values.config .Values.compute.profiles (ne .Values.compute.profileOverride "none") .Values.surfaces.vscode.enabled }}
+{{- $secondarySurfaces := list -}}
+{{- if .Values.surfaces.vscode.enabled -}}
+{{- $secondarySurfaces = append $secondarySurfaces "vscode" -}}
+{{- end -}}
+{{- if .Values.surfaces.opencode.enabled -}}
+{{- $secondarySurfaces = append $secondarySurfaces "opencode" -}}
+{{- end -}}
+{{- $surfacesEnabled := gt (len $secondarySurfaces) 0 -}}
+{{- if or .Values.config .Values.compute.profiles (ne .Values.compute.profileOverride "none") $surfacesEnabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,8 +18,8 @@ data:
   {{- if not (or
     (and $.Values.compute.profiles (eq $k "MARIMOHUB_COMPUTE_PROFILES"))
     (and (ne $.Values.compute.profileOverride "none") (eq $k "MARIMOHUB_COMPUTE_PROFILE_OVERRIDE"))
-    (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACES"))
-    (and $.Values.surfaces.vscode.sandboxImage (eq $k "MARIMOHUB_COMPUTE_IMAGE"))
+    (and $surfacesEnabled (eq $k "MARIMOHUB_SURFACES"))
+    (and $surfacesEnabled $.Values.surfaces.sandboxImage (eq $k "MARIMOHUB_COMPUTE_IMAGE"))
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_FLAVOR"))
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_START"))
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_PORT"))
@@ -19,6 +27,11 @@ data:
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_SETTINGS_JSON"))
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_EMBED"))
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH"))
+    (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_START"))
+    (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_PORT"))
+    (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB"))
+    (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_EMBED"))
+    (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH"))
   ) }}
   {{ $k }}: {{ $v | quote }}
   {{- end }}
@@ -29,8 +42,13 @@ data:
   {{- if ne .Values.compute.profileOverride "none" }}
   MARIMOHUB_COMPUTE_PROFILE_OVERRIDE: {{ .Values.compute.profileOverride | quote }}
   {{- end }}
+  {{- if $surfacesEnabled }}
+  MARIMOHUB_SURFACES: {{ prepend $secondarySurfaces "marimo" | join "," | quote }}
+  {{- with .Values.surfaces.sandboxImage }}
+  MARIMOHUB_COMPUTE_IMAGE: {{ . | quote }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.surfaces.vscode.enabled }}
-  MARIMOHUB_SURFACES: "marimo,vscode"
   MARIMOHUB_SURFACE_VSCODE_FLAVOR: {{ .Values.surfaces.vscode.flavor | quote }}
   MARIMOHUB_SURFACE_VSCODE_START: {{ .Values.surfaces.vscode.start | quote }}
   MARIMOHUB_SURFACE_VSCODE_PORT: {{ .Values.surfaces.vscode.port | quote }}
@@ -38,8 +56,12 @@ data:
   MARIMOHUB_SURFACE_VSCODE_SETTINGS_JSON: {{ .Values.surfaces.vscode.settingsJson | quote }}
   MARIMOHUB_SURFACE_VSCODE_EMBED: {{ .Values.surfaces.vscode.embed | quote }}
   MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH: {{ .Values.surfaces.vscode.marimoWatch | quote }}
-  {{- with .Values.surfaces.vscode.sandboxImage }}
-  MARIMOHUB_COMPUTE_IMAGE: {{ . | quote }}
   {{- end }}
+  {{- if .Values.surfaces.opencode.enabled }}
+  MARIMOHUB_SURFACE_OPENCODE_START: {{ .Values.surfaces.opencode.start | quote }}
+  MARIMOHUB_SURFACE_OPENCODE_PORT: {{ .Values.surfaces.opencode.port | quote }}
+  MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: {{ .Values.surfaces.opencode.memoryMb | quote }}
+  MARIMOHUB_SURFACE_OPENCODE_EMBED: {{ .Values.surfaces.opencode.embed | quote }}
+  MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH: {{ .Values.surfaces.opencode.marimoWatch | quote }}
   {{- end }}
 {{- end }}

--- a/charts/marimohub/templates/configmap.yaml
+++ b/charts/marimohub/templates/configmap.yaml
@@ -6,6 +6,7 @@
 {{- $secondarySurfaces = append $secondarySurfaces "opencode" -}}
 {{- end -}}
 {{- $surfacesEnabled := gt (len $secondarySurfaces) 0 -}}
+{{- $surfaceSandboxImage := .Values.surfaces.sandboxImage | default .Values.surfaces.vscode.sandboxImage -}}
 {{- if or .Values.config .Values.compute.profiles (ne .Values.compute.profileOverride "none") $surfacesEnabled }}
 apiVersion: v1
 kind: ConfigMap
@@ -19,7 +20,7 @@ data:
     (and $.Values.compute.profiles (eq $k "MARIMOHUB_COMPUTE_PROFILES"))
     (and (ne $.Values.compute.profileOverride "none") (eq $k "MARIMOHUB_COMPUTE_PROFILE_OVERRIDE"))
     (and $surfacesEnabled (eq $k "MARIMOHUB_SURFACES"))
-    (and $surfacesEnabled $.Values.surfaces.sandboxImage (eq $k "MARIMOHUB_COMPUTE_IMAGE"))
+    (and $surfacesEnabled $surfaceSandboxImage (eq $k "MARIMOHUB_COMPUTE_IMAGE"))
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_FLAVOR"))
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_START"))
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_PORT"))
@@ -29,7 +30,6 @@ data:
     (and $.Values.surfaces.vscode.enabled (eq $k "MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH"))
     (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_START"))
     (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_PORT"))
-    (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB"))
     (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_EMBED"))
     (and $.Values.surfaces.opencode.enabled (eq $k "MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH"))
   ) }}
@@ -44,7 +44,7 @@ data:
   {{- end }}
   {{- if $surfacesEnabled }}
   MARIMOHUB_SURFACES: {{ prepend $secondarySurfaces "marimo" | join "," | quote }}
-  {{- with .Values.surfaces.sandboxImage }}
+  {{- with $surfaceSandboxImage }}
   MARIMOHUB_COMPUTE_IMAGE: {{ . | quote }}
   {{- end }}
   {{- end }}
@@ -60,7 +60,6 @@ data:
   {{- if .Values.surfaces.opencode.enabled }}
   MARIMOHUB_SURFACE_OPENCODE_START: {{ .Values.surfaces.opencode.start | quote }}
   MARIMOHUB_SURFACE_OPENCODE_PORT: {{ .Values.surfaces.opencode.port | quote }}
-  MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: {{ .Values.surfaces.opencode.memoryMb | quote }}
   MARIMOHUB_SURFACE_OPENCODE_EMBED: {{ .Values.surfaces.opencode.embed | quote }}
   MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH: {{ .Values.surfaces.opencode.marimoWatch | quote }}
   {{- end }}

--- a/charts/marimohub/values.yaml
+++ b/charts/marimohub/values.yaml
@@ -44,6 +44,8 @@ surfaces:
   sandboxImage: ''
   vscode:
     enabled: false
+    # Deprecated: use surfaces.sandboxImage. This remains an upgrade fallback.
+    sandboxImage: ''
     flavor: code-server
     start: on-demand
     port: 8443
@@ -55,7 +57,6 @@ surfaces:
     enabled: false
     start: on-demand
     port: 4096
-    memoryMb: 1024
     embed: tab
     marimoWatch: true
 

--- a/charts/marimohub/values.yaml
+++ b/charts/marimohub/values.yaml
@@ -40,15 +40,22 @@ compute:
   profileOverride: none
 
 surfaces:
+  # Use a published `-vscode`, `-opencode`, or `-tools` sandbox image tag.
+  sandboxImage: ''
   vscode:
     enabled: false
-    # Use a published `-vscode` sandbox image tag when enabled.
-    sandboxImage: ''
     flavor: code-server
     start: on-demand
     port: 8443
     extensionGallery: openvsx
     settingsJson: '{}'
+    embed: tab
+    marimoWatch: true
+  opencode:
+    enabled: false
+    start: on-demand
+    port: 4096
+    memoryMb: 1024
     embed: tab
     marimoWatch: true
 

--- a/development_docs/architecture.md
+++ b/development_docs/architecture.md
@@ -162,8 +162,10 @@ An edit sandbox can also expose secondary **surfaces**. `SurfaceRegistry` owns
 the provider-neutral process specification, and `SurfaceManager` probes,
 prepares, starts, and exposes the process. Surface state lives on the session
 record and every transition goes through `SessionService` CAS mutation. The
-`vscode` surface runs beside the primary `marimo` process and shares its
-workspace; it is not a second session mode or sandbox.
+The `vscode` and `opencode` surfaces run beside `marimo` and share its workspace.
+Each surface has independent CAS-fenced lifecycle state. A surface is not a
+session mode or sandbox. OpenCode supports only subdomain exposure because its
+client uses root-relative paths.
 
 **Lifecycle (provider-independent):**
 
@@ -237,8 +239,8 @@ from one pure evaluator in core (`sessionCan`/`canStartSessionMode` in
 `services/runtime/sessionAuthz.ts`, over the `VIEWER_SESSION_MODES` admission
 table in `constants.ts`): the API's throwing gates (`assertSessionControl`,
 `assertSessionAccess`), the `sandbox_url` projection, and the per-caller
-`can: { attach, stop, surfaces: { vscode } }` grants shipped on every session response are the same
-function applied to the same facts — and the web renders from `session.can`
+`can: { attach, stop, surfaces: { vscode, opencode } }` grants in each session response use the same
+function and facts. The web renders from `session.can`
 and `capabilities.viewer_session_modes` instead of re-deriving policy, so
 client and server cannot disagree. Apps skip
 managed-AI injection (no editor surface). They are excluded from the per-user

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -103,3 +103,8 @@ The injected config sits at the user-config tier, so a user who explicitly sets
 `[tool.marimo.ai]` in their own `pyproject.toml` still overrides it — a deliberate
 bring-your-own-key escape hatch. With managed AI **off** (`MARIMOHUB_AI_BACKEND=none`),
 the assistant only works for users who supply their own key in marimo's settings.
+
+[OpenCode](./surfaces.md#opencode-ai-providers) uses the same proxy through a
+temporary `marimohub` provider. Project `opencode.json` files and `/connect`
+providers can override it. The token expires at the configured TTL. Restart
+OpenCode to get a new token.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,10 @@ Persistent edit sandboxes use a per-notebook editor claim. See
    ways, set by `MARIMOHUB_SANDBOX_EXPOSURE`: **directly** on a separate domain
    (`subdomain`, the default), or **through the app** at `/proxy/<token>/`
    (`proxy`). See [Security → Kernel exposure](/security#kernel-exposure).
-5. On teardown, source (and optionally the whole workspace) is persisted back to
+5. An authorized edit session can start [VS Code or OpenCode](/surfaces) in its
+   sandbox. Each surface shares the workspace and has an independent lifecycle.
+   OpenCode supports only subdomain exposure.
+6. On teardown, source (and optionally the whole workspace) is persisted back to
    storage. A single background maintenance loop reaps idle sessions and orphaned
    sandboxes.
 

--- a/docs/compute.md
+++ b/docs/compute.md
@@ -10,8 +10,8 @@ on-demand sandbox created by the selected compute backend.
 See [Editor sessions](./editor-sessions.md) to choose shared or exclusive access
 to persistent editor sandboxes.
 
-See [VS Code surface](./surfaces.md) to attach a browser editor to the existing
-edit sandbox.
+See [Session surfaces](./surfaces.md) to attach VS Code or OpenCode to the
+existing edit sandbox.
 
 Selector: `MARIMOHUB_COMPUTE_BACKEND`. Full variables:
 [Configuration -> Compute](./configuration.md#compute).
@@ -59,7 +59,8 @@ stop the sandbox. For Modal, the adapter sets the provider-side idle timeout to
 - `proxy`: kernel traffic is forwarded through the app origin.
 
 See [Security -> Kernel exposure](./security.md#kernel-exposure) for the trust
-model.
+OpenCode supports only `subdomain` exposure. Configuration fails when OpenCode
+and `proxy` mode are both enabled.
 
 ## Compute profiles
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -127,7 +127,6 @@ Read regardless of the selected compute backend.
 | `MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH` | Pass `--watch` to marimo edit when the VS Code surface is enabled. | — | `true` | — |
 | `MARIMOHUB_SURFACE_OPENCODE_START` | Start OpenCode on demand or with every authorized edit session. | — | `on-demand` | — |
 | `MARIMOHUB_SURFACE_OPENCODE_PORT` | Logical sandbox port used by OpenCode. Must differ from marimo port 2718 and all other enabled surface ports. | — | `4096` | — |
-| `MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB` | Memory requirement declared for the OpenCode surface. | — | `1024` | — |
 | `MARIMOHUB_SURFACE_OPENCODE_EMBED` | Open OpenCode in an application tab or split view (`tab` or `iframe`). | — | `tab` | — |
 | `MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH` | Pass `--watch` to marimo edit when OpenCode is enabled. | — | `true` | — |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,14 +117,19 @@ Read regardless of the selected compute backend.
 | `MARIMOHUB_COMPUTE_WORKDIR` | Working directory inside the sandbox where notebook files land and marimo runs. | — | `/workspace` | — |
 | `MARIMOHUB_COMPUTE_ASSET_URL` | Base URL for marimo frontend assets (e.g. a CDN). Omit to use the bundled assets. | — | — | `https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist` |
 | `MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS` | How long a session start waits for the marimo kernel to come up before failing. Generous by default because a cold sandbox may resolve + download the notebook environment on first boot. Served on `/api/v1/capabilities` so the client bounds its own startup wait with the same value. | — | `120` | — |
-| `MARIMOHUB_SURFACES` | Comma-separated editor surfaces enabled in notebook sandboxes. `marimo` is always available; add `vscode` to enable browser VS Code. | — | `marimo` | `marimo,vscode` |
+| `MARIMOHUB_SURFACES` | Comma-separated editor surfaces enabled in notebook sandboxes. `marimo` is always available; add `vscode`, `opencode`, or both. | — | `marimo` | `marimo,vscode,opencode` |
 | `MARIMOHUB_SURFACE_VSCODE_FLAVOR` | Browser editor implementation (`code-server` or `openvscode`). | — | `code-server` | — |
 | `MARIMOHUB_SURFACE_VSCODE_START` | Start VS Code on demand or with every edit session. | — | `on-demand` | — |
 | `MARIMOHUB_SURFACE_VSCODE_PORT` | Logical sandbox port used by the VS Code surface. Must differ from marimo port 2718. | — | `8443` | — |
 | `MARIMOHUB_SURFACE_VSCODE_EXTENSION_GALLERY` | Extension gallery (`openvsx`, `none`, or the HTTP(S) service URL of a mirror). | — | `openvsx` | — |
 | `MARIMOHUB_SURFACE_VSCODE_SETTINGS_JSON` | JSON object merged over the safe browser-editor defaults. | — | `{}` | `{"editor.fontSize":14}` |
-| `MARIMOHUB_SURFACE_VSCODE_EMBED` | Open VS Code in a new tab or an iframe (`tab` or `iframe`). | — | `tab` | — |
+| `MARIMOHUB_SURFACE_VSCODE_EMBED` | Open VS Code in an application tab or split view (`tab` or `iframe`). | — | `tab` | — |
 | `MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH` | Pass `--watch` to marimo edit when the VS Code surface is enabled. | — | `true` | — |
+| `MARIMOHUB_SURFACE_OPENCODE_START` | Start OpenCode on demand or with every authorized edit session. | — | `on-demand` | — |
+| `MARIMOHUB_SURFACE_OPENCODE_PORT` | Logical sandbox port used by OpenCode. Must differ from marimo port 2718 and all other enabled surface ports. | — | `4096` | — |
+| `MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB` | Memory requirement declared for the OpenCode surface. | — | `1024` | — |
+| `MARIMOHUB_SURFACE_OPENCODE_EMBED` | Open OpenCode in an application tab or split view (`tab` or `iframe`). | — | `tab` | — |
+| `MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH` | Pass `--watch` to marimo edit when OpenCode is enabled. | — | `true` | — |
 
 ### CoreWeave Sandbox
 

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -19,6 +19,18 @@ Every container-based backend reads this same variable. (`local` runs `uv` on th
 host and needs no image; `e2b` uses an E2B template instead — see
 [Compute](./compute.md).)
 
+The repository image also publishes optional [session surface](./surfaces.md)
+targets:
+
+| Target     | Published tag suffix | Included tools                    |
+| ---------- | -------------------- | --------------------------------- |
+| `vscode`   | `-vscode`            | code-server and pinned extensions |
+| `opencode` | `-opencode`          | OpenCode and ripgrep              |
+| `tools`    | `-tools`             | VS Code, OpenCode, and ripgrep    |
+
+OpenCode is pinned to 1.18.17 with separate SHA-256 checksums for Linux x64 and
+arm64 builds.
+
 ## Multiple images
 
 To offer more than one image — say a lean default plus a GPU or heavy-ML

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -22,11 +22,11 @@ host and needs no image; `e2b` uses an E2B template instead — see
 The repository image also publishes optional [session surface](./surfaces.md)
 targets:
 
-| Target     | Published tag suffix | Included tools                    |
-| ---------- | -------------------- | --------------------------------- |
-| `vscode`   | `-vscode`            | code-server and pinned extensions |
-| `opencode` | `-opencode`          | OpenCode and ripgrep              |
-| `tools`    | `-tools`             | VS Code, OpenCode, and ripgrep    |
+| Target     | Published tag suffix | Included tools                         |
+| ---------- | -------------------- | -------------------------------------- |
+| `vscode`   | `-vscode`            | code-server and pinned extensions      |
+| `opencode` | `-opencode`          | OpenCode, ripgrep, jq, and marimo-pair |
+| `tools`    | `-tools`             | VS Code plus the OpenCode tools        |
 
 OpenCode is pinned to 1.18.17 with separate SHA-256 checksums for Linux x64 and
 arm64 builds.

--- a/docs/security.md
+++ b/docs/security.md
@@ -87,13 +87,18 @@ the `kubernetes`/`coreweave` backends) in front.
 
 ## Secondary editor surfaces
 
-The optional VS Code surface runs in the existing edit sandbox. Its terminal
-can read the same session credentials and project integrations as the marimo
-kernel, so only an editor who can attach to that edit session may start or reach
-it. App sessions and viewer-owned ephemeral sessions are denied. Proxy exposure
-rechecks this grant on every HTTP request and WebSocket upgrade; subdomain
-exposure treats the returned URL as a capability and withholds it from other
-callers.
+VS Code and OpenCode run in the edit sandbox. Their terminals and agents can run
+shell commands and read the notebook credentials. Only users who can attach to
+the edit session can use these surfaces. App sessions and viewer-owned ephemeral
+sessions cannot use them.
+
+VS Code proxy exposure authorizes each HTTP request and WebSocket upgrade.
+OpenCode supports only subdomain exposure because its client requires root
+paths. Each subdomain URL is an access capability. Do not publish these URLs.
+
+OpenCode stores `/connect` credentials and state in its temporary surface
+directory. Managed AI stores an expiring session token there, not the upstream
+API key. Project configuration and bring-your-own-key providers can override it.
 
 ## Authentication fails closed
 

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -75,6 +75,9 @@ Project `opencode.json` files can override the provider or initial model. Users
 can also add bring-your-own-key providers through `/connect`. These credentials
 stay in the temporary surface directory.
 
+The published OpenCode images include the `marimo-pair` skill and its shell
+dependencies. OpenCode can use it to work directly with the running marimo kernel.
+
 The managed token expires after `MARIMOHUB_AI_TOKEN_TTL_SECONDS`, even while
 OpenCode is open. Restart OpenCode to get a new token. A bring-your-own-key
 provider uses its own credential.

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -1,62 +1,101 @@
 ---
-description: Open a notebook workspace in browser-based VS Code on its existing edit sandbox.
+description: Run VS Code or OpenCode beside marimo in an existing edit sandbox.
 ---
 
-# VS Code surface
+# Session surfaces
 
-marimohub can run code-server or OpenVSCode Server beside marimo in the same
-notebook edit sandbox. Both editors use the same workspace, credentials, Python
-environment, and lifecycle. Stopping the session saves the workspace through
-the normal version-capture path.
+marimohub can run VS Code, OpenCode, or both in an edit sandbox. Each surface
+shares marimo's workspace, Python environment, credentials, authorization, and
+session lifetime. A surface does not create another sandbox.
 
-VS Code is disabled by default. Enable it with a sandbox image built from the
-`vscode` target in `images/marimo-sandbox/Dockerfile`:
+Secondary surfaces are disabled by default. Select an image and enable the
+matching surface:
 
 ```bash
+# VS Code only
 MARIMOHUB_SURFACES=marimo,vscode
 MARIMOHUB_COMPUTE_IMAGE=ghcr.io/marimo-team/marimo-sandbox:latest-vscode
+
+# OpenCode only
+MARIMOHUB_SURFACES=marimo,opencode
+MARIMOHUB_COMPUTE_IMAGE=ghcr.io/marimo-team/marimo-sandbox:latest-opencode
+
+# Both
+MARIMOHUB_SURFACES=marimo,vscode,opencode
+MARIMOHUB_COMPUTE_IMAGE=ghcr.io/marimo-team/marimo-sandbox:latest-tools
 ```
 
-The notebook toolbar then shows **Open in VS Code** for editors who can attach
-to the edit session. The server starts VS Code on demand and opens it in a new
-tab. Set `MARIMOHUB_SURFACE_VSCODE_START=eager` to start it with each new edit
-session. Set `MARIMOHUB_SURFACE_VSCODE_EMBED=iframe` to show marimo and VS Code
-side by side instead.
+The toolbar has a **Surfaces** menu, even when only one surface is enabled. The
+menu has a start action for each surface. It has a stop action when that surface
+is running.
+
+By default, a surface opens in the notebook's application tabs. Set its `EMBED`
+variable to `iframe` to open it beside marimo in a split view. The most recently
+opened split replaces the previous split, while the previous surface remains
+available as a background tab. Use a surface tab's pop-out control to open its
+iframe in a separate browser tab.
+
+Set a surface's `START` variable to `eager` to start it with each authorized edit
+session. The default is `on-demand`. A surface failure does not stop marimo or
+another surface.
 
 ## Availability
 
-The compute adapter must expose more than one port from one sandbox. The current
-implementation enables this for `local`, `e2b`, and `cloudflare`. Configuration
-fails at startup on an adapter that cannot provide the second port. Docker,
-Podman, Kubernetes, Modal, and CoreWeave require their create-time port manifests
-to reserve the configured VS Code port before they can enable this feature.
+The compute adapter must expose multiple ports from one sandbox. The `local`,
+`e2b`, and `cloudflare` adapters support this feature. Configuration fails for
+other adapters. Docker, Podman, Kubernetes, Modal, CoreWeave, and W&B need
+create-time port reservation support.
 
-If the selected image does not contain the configured server binary, the
-surface is marked unavailable and the marimo session continues to run.
+Port 2718 belongs to marimo. Each secondary surface must use a unique port. If
+an image lacks a required binary, only that surface becomes unavailable.
 
-## Editing behavior
+## Editing and state
 
-- marimo starts with file watching when VS Code is enabled. A saved VS Code edit
-  reloads in marimo. Set `MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH=false` to opt out.
-- VS Code autosaves after one second by default. Concurrent writes remain
-  last-writer-wins; v1 does not merge editor buffers.
-- Temporary edit sessions may use VS Code, but their changes are discarded with
+- marimo watches files when either surface requests this behavior. A saved file
+  then reloads in marimo.
+- VS Code opens the notebook entry path. OpenCode starts in the workspace without
+  a notebook path.
+- VS Code autosaves after one second. Concurrent writes use last-writer-wins.
+- Surfaces start and stop independently. Session teardown stops all surfaces,
+  captures eligible workspace changes, and destroys the sandbox.
+- Surface configuration, caches, credentials, databases, and UI state stay
+  under `/tmp/.marimohub/surfaces/<session-id>/<surface-id>`. They survive a
+  stop and restart in the same sandbox. They are not versioned and do not
+  survive session teardown.
+- Temporary edit sessions can use surfaces. Their changes are discarded with
   the sandbox.
-- App sessions and viewer-owned ephemeral sessions cannot start VS Code. Its
-  terminal has the same credential access as the notebook kernel and remains
-  inside the editor trust boundary.
-- VS Code user data stays under `/tmp/.marimohub`, outside the versioned
-  workspace. Unsaved hot-exit buffers do not survive a sandbox restart.
-- The extension gallery defaults to Open VSX. Set
-  `MARIMOHUB_SURFACE_VSCODE_EXTENSION_GALLERY=none` for an air-gapped deployment,
-  or provide the HTTP(S) service URL of a mirror.
 
-## Exposure
+## OpenCode AI providers
 
-In `proxy` mode, HTTP and WebSocket traffic uses a signed
-`/surface-proxy/<token>/vscode/` prefix. The hub authenticates and authorizes
-each new request or upgrade. In `subdomain` mode, the compute adapter returns the
-second port's direct URL. The same origin-isolation requirements as the marimo
-kernel apply.
+When [managed AI](./ai.md) is enabled, marimohub adds a temporary `marimohub`
+provider when OpenCode starts. This OpenAI-compatible provider uses the configured
+model and a session token. The upstream API key stays on the server.
 
-See [Configuration](./configuration.md#compute) for all VS Code settings.
+Project `opencode.json` files can override the provider or initial model. Users
+can also add bring-your-own-key providers through `/connect`. These credentials
+stay in the temporary surface directory.
+
+The managed token expires after `MARIMOHUB_AI_TOKEN_TTL_SECONDS`, even while
+OpenCode is open. Restart OpenCode to get a new token. A bring-your-own-key
+provider uses its own credential.
+
+## Security and exposure
+
+Only users who can attach to an edit session can use its surfaces. App sessions
+and viewer-owned ephemeral sessions cannot use them. VS Code terminals and
+OpenCode agents can run shell commands and read the notebook credentials.
+
+VS Code supports both exposure modes. In `proxy` mode, traffic uses a signed
+`/surface-proxy/<token>/vscode/` path. The hub authorizes each HTTP request and
+WebSocket upgrade.
+
+OpenCode supports only `subdomain` mode because its client uses root-relative
+paths. Configuration fails when OpenCode and
+`MARIMOHUB_SANDBOX_EXPOSURE=proxy` are both enabled.
+
+In `subdomain` mode, each surface has a direct, high-entropy URL. The URL is an
+access capability, so the hub returns it only to authorized editors. Keep the
+sandbox domain isolated. Do not publish these URLs.
+
+See [Configuration](./configuration.md#compute) for all surface configuration and
+[Security](./security.md#secondary-editor-surfaces) for the trust boundary.

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -104,4 +104,37 @@ RUN code-server --extensions-dir /opt/marimohub/vscode-extensions --install-exte
  && code-server --extensions-dir /opt/marimohub/vscode-extensions --install-extension charliermarsh.ruff@2026.74.0 \
  && code-server --extensions-dir /opt/marimohub/vscode-extensions --install-extension tamasfe.even-better-toml@0.21.2
 
+FROM base AS opencode
+
+USER root
+ARG OPENCODE_VERSION=1.18.17
+ARG OPENCODE_AMD64_SHA256=3f14a4c61c7f6b0d3b6d933d1d212e64e19683eba6fa453ad98e46303afe144a
+ARG OPENCODE_ARM64_SHA256=7531c1a110546aaf04b465d98a3bf54018e1740f769077c2526fec6add5fc230
+ARG TARGETARCH
+RUN case "${TARGETARCH:-amd64}" in \
+      amd64) arch=x64; checksum="${OPENCODE_AMD64_SHA256}" ;; \
+      arm64) arch=arm64; checksum="${OPENCODE_ARM64_SHA256}" ;; \
+      *) exit 1 ;; \
+    esac \
+ && archive=/tmp/opencode.tar.gz \
+ && curl -fsSL -o "${archive}" "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-${arch}.tar.gz" \
+ && printf '%s  %s\n' "${checksum}" "${archive}" | sha256sum -c - \
+ && tar -xzf "${archive}" -C /usr/local/bin opencode \
+ && rm "${archive}" \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends ripgrep \
+ && rm -rf /var/lib/apt/lists/*
+
+USER appuser
+
+FROM vscode AS tools
+
+USER root
+COPY --from=opencode /usr/local/bin/opencode /usr/local/bin/opencode
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ripgrep \
+ && rm -rf /var/lib/apt/lists/*
+
+USER appuser
+
 FROM base AS release

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -122,17 +122,25 @@ RUN case "${TARGETARCH:-amd64}" in \
  && tar -xzf "${archive}" -C /usr/local/bin opencode \
  && rm "${archive}" \
  && apt-get update \
- && apt-get install -y --no-install-recommends ripgrep \
+ && apt-get install -y --no-install-recommends jq ripgrep \
  && rm -rf /var/lib/apt/lists/*
 
 USER appuser
+ARG SKILLS_CLI_VERSION=1.5.23
+RUN UV_CACHE_DIR=/tmp/marimo-pair-uv-cache \
+    DENO_DIR=/tmp/marimo-pair-deno-cache \
+    uvx deno -A "npm:skills@${SKILLS_CLI_VERSION}" add marimo-team/marimo-pair \
+      --global --agent opencode --skill marimo-pair --yes --copy \
+ && test -f /home/appuser/.agents/skills/marimo-pair/SKILL.md \
+ && rm -rf /tmp/marimo-pair-uv-cache /tmp/marimo-pair-deno-cache
 
 FROM vscode AS tools
 
 USER root
 COPY --from=opencode /usr/local/bin/opencode /usr/local/bin/opencode
+COPY --from=opencode --chown=appuser:appuser /home/appuser/.agents/skills /home/appuser/.agents/skills
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ripgrep \
+ && apt-get install -y --no-install-recommends jq ripgrep \
  && rm -rf /var/lib/apt/lists/*
 
 USER appuser

--- a/internal/schemas/allowed-breaking/api.md
+++ b/internal/schemas/allowed-breaking/api.md
@@ -18,6 +18,13 @@ GET /api/v1/version removed the required property `data/started_at` from the res
 GET /api/v1/projects/{pid}/notebooks/{nid} the response property `data/source/oneOf[subschema #2]/provider` became nullable for the status `200`
 PATCH /api/v1/projects/{pid}/notebooks/{nid}/source the response property `data/source/provider` became nullable for the status `200`
 
+Capabilities now return independent schemas for each supported secondary
+surface. Existing VS Code responses are unchanged.
+
+```text
+GET /api/v1/capabilities added `subschema #1, subschema #2` to the `data/surfaces/items/` response property `oneOf` list for the response status `200`
+```
+
 GET /api/v1/projects/{pid}/alert-destinations the `data` response's property `type` changed from `array<any>` to `object` for status `200`
 POST /api/v1/projects/{pid}/alert-destinations removed `subschema #1, subschema #2` from the request body `oneOf` list
 POST /api/v1/projects/{pid}/alert-destinations added `subschema #1, subschema #2` to the `data` response property `oneOf` list for the response status `201`

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -326,32 +326,56 @@ components:
         surfaces:
           type: array
           items:
-            type: object
-            properties:
-              id:
-                type: string
-                enum:
-                  - vscode
-              flavor:
-                type: string
-                enum:
-                  - code-server
-                  - openvscode
-              start:
-                type: string
-                enum:
-                  - on-demand
-                  - eager
-              embed:
-                type: string
-                enum:
-                  - tab
-                  - iframe
-            required:
-              - id
-              - flavor
-              - start
-              - embed
+            oneOf:
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - vscode
+                  flavor:
+                    type: string
+                    enum:
+                      - code-server
+                      - openvscode
+                  start:
+                    type: string
+                    enum:
+                      - on-demand
+                      - eager
+                  embed:
+                    type: string
+                    enum:
+                      - tab
+                      - iframe
+                required:
+                  - id
+                  - flavor
+                  - start
+                  - embed
+              - type: object
+                properties:
+                  id:
+                    type: string
+                    enum:
+                      - opencode
+                  start:
+                    type: string
+                    enum:
+                      - on-demand
+                      - eager
+                  embed:
+                    type: string
+                    enum:
+                      - tab
+                      - iframe
+                  managed_ai:
+                    type: boolean
+                required:
+                  - id
+                  - start
+                  - embed
+                  - managed_ai
       required:
         - federation
         - integrations
@@ -1658,8 +1682,11 @@ components:
               properties:
                 vscode:
                   type: boolean
+                opencode:
+                  type: boolean
               required:
                 - vscode
+                - opencode
           required:
             - attach
             - stop
@@ -1884,6 +1911,14 @@ components:
           type: string
           enum:
             - temporary
+        surfaces:
+          type: array
+          items:
+            type: string
+            enum:
+              - vscode
+              - opencode
+          maxItems: 2
       additionalProperties: false
     SurfaceStartBody:
       type: object
@@ -1891,6 +1926,8 @@ components:
         open:
           type: string
           maxLength: 4096
+          description: Workspace-relative file to open. Supported only by the VS Code
+            surface.
     IntegrationKind:
       type: object
       properties:
@@ -9371,6 +9408,7 @@ paths:
             type: string
             enum:
               - vscode
+              - opencode
           required: true
           name: surface
           in: path
@@ -9401,6 +9439,7 @@ paths:
                             type: string
                             enum:
                               - vscode
+                              - opencode
                         required:
                           - id
                 required:
@@ -9426,6 +9465,7 @@ paths:
                             type: string
                             enum:
                               - vscode
+                              - opencode
                         required:
                           - id
                 required:
@@ -9524,6 +9564,7 @@ paths:
             type: string
             enum:
               - vscode
+              - opencode
           required: true
           name: surface
           in: path
@@ -9548,6 +9589,7 @@ paths:
                             type: string
                             enum:
                               - vscode
+                              - opencode
                         required:
                           - id
                 required:
@@ -9634,6 +9676,7 @@ paths:
             type: string
             enum:
               - vscode
+              - opencode
           required: true
           name: surface
           in: path

--- a/packages/api/src/capabilities.test.ts
+++ b/packages/api/src/capabilities.test.ts
@@ -230,7 +230,6 @@ describe('GET /api/v1/capabilities', () => {
 			opencode: {
 				start: 'eager',
 				port: 4096,
-				memoryMb: 1024,
 				embed: 'iframe',
 				marimoWatch: true,
 			},

--- a/packages/api/src/capabilities.test.ts
+++ b/packages/api/src/capabilities.test.ts
@@ -215,6 +215,41 @@ describe('GET /api/v1/capabilities', () => {
 		});
 	});
 
+	it('reports VS Code and managed OpenCode independently', async () => {
+		const deps = makeTestDeps(new MemoryBucket(), { authenticator: authed });
+		deps.sandbox.surfaces = {
+			vscode: {
+				flavor: 'openvscode',
+				start: 'on-demand',
+				port: 8443,
+				settings: {},
+				extensionGallery: 'openvsx',
+				embed: 'tab',
+				marimoWatch: true,
+			},
+			opencode: {
+				start: 'eager',
+				port: 4096,
+				memoryMb: 1024,
+				embed: 'iframe',
+				marimoWatch: true,
+			},
+		};
+		deps.ai = {
+			upstreamBaseUrl: 'https://provider.example/v1',
+			upstreamApiKey: 'secret',
+			model: 'gpt-test',
+			signingSecret: 'signing-secret',
+		};
+
+		expect(await expectOk(await createApi(deps).request('/api/v1/capabilities'))).toMatchObject({
+			surfaces: [
+				{ id: 'vscode', flavor: 'openvscode', start: 'on-demand', embed: 'tab' },
+				{ id: 'opencode', start: 'eager', embed: 'iframe', managed_ai: true },
+			],
+		});
+	});
+
 	it('requires authentication (not a public endpoint)', async () => {
 		const deps = makeTestDeps(new MemoryBucket(), { wif: stubWif });
 		const res = await createApi(deps).request('/api/v1/capabilities');

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -156,7 +156,6 @@ export interface SandboxConfig {
 		opencode?: {
 			start: 'on-demand' | 'eager';
 			port: number;
-			memoryMb: number;
 			embed: 'tab' | 'iframe';
 			marimoWatch: boolean;
 		};

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -153,6 +153,13 @@ export interface SandboxConfig {
 			embed: 'tab' | 'iframe';
 			marimoWatch: boolean;
 		};
+		opencode?: {
+			start: 'on-demand' | 'eager';
+			port: number;
+			memoryMb: number;
+			embed: 'tab' | 'iframe';
+			marimoWatch: boolean;
+		};
 	};
 }
 

--- a/packages/api/src/routes/sessionSurfaces.ts
+++ b/packages/api/src/routes/sessionSurfaces.ts
@@ -87,7 +87,6 @@ async function createSurfaceManager(
 		specs.push(
 			opencodeSurface({
 				port: openCodeConfig.port,
-				memoryMb: openCodeConfig.memoryMb,
 				managedAi,
 			}),
 		);

--- a/packages/api/src/routes/sessionSurfaces.ts
+++ b/packages/api/src/routes/sessionSurfaces.ts
@@ -1,0 +1,225 @@
+import type {
+	AuthUser,
+	ProjectId,
+	SandboxExposure,
+	SecondarySurfaceId,
+	Session,
+	SessionId,
+	SurfaceSpec,
+} from '@marimo-hub/core';
+import {
+	joinUrlPath,
+	marimoSurface,
+	mintAiSessionToken,
+	NotFoundError,
+	opencodeSurface,
+	ProxyExposure,
+	signProxyToken,
+	SurfaceManager,
+	SurfaceNotEnabledError,
+	SurfaceRegistry,
+	SurfaceUnsupportedProviderError,
+	vscodeSurface,
+} from '@marimo-hub/core';
+import type { ApiDeps } from '../context';
+import { errorMetadata, logEvent } from '../log';
+import { assertSessionControl, assertSessionSurfaceAccess, loadVisibleProject } from '../shared';
+
+export function surfaceConfig(deps: ApiDeps, id: SecondarySurfaceId) {
+	const config = deps.sandbox.surfaces?.[id];
+	if (!config) throw new SurfaceNotEnabledError(`The ${id} surface is not enabled`);
+	return config;
+}
+
+async function createSurfaceManager(
+	deps: ApiDeps,
+	startingId: SecondarySurfaceId,
+	context: { user: AuthUser; session: Session; appBaseUrl: string },
+): Promise<SurfaceManager> {
+	if (deps.compute.capabilities?.multiPort !== true) {
+		throw new SurfaceUnsupportedProviderError(
+			'The compute backend cannot expose a second sandbox port',
+		);
+	}
+	const specs: SurfaceSpec[] = [marimoSurface];
+	const vscodeConfig = deps.sandbox.surfaces?.vscode;
+	if (vscodeConfig) {
+		specs.push(
+			vscodeSurface({
+				flavor: vscodeConfig.flavor,
+				port: vscodeConfig.port,
+				settings: vscodeConfig.settings,
+				extensionGallery: vscodeConfig.extensionGallery,
+			}),
+		);
+	}
+	const openCodeConfig = deps.sandbox.surfaces?.opencode;
+	if (openCodeConfig) {
+		let managedAi;
+		if (deps.ai && startingId === 'opencode') {
+			try {
+				managedAi = {
+					baseUrl: joinUrlPath(context.appBaseUrl, '/api/ai/v1'),
+					apiKey: await mintAiSessionToken(
+						deps.ai.signingSecret,
+						{
+							projectId: context.session.project_id,
+							notebookId: context.session.notebook_id,
+							sessionId: context.session.session_id,
+							userId: context.user.id,
+						},
+						{ ttlSeconds: deps.ai.tokenTtlSeconds },
+					),
+					model: deps.ai.model,
+				};
+			} catch (error) {
+				logEvent({
+					level: 'warn',
+					event: 'surface_ai_inject_failed',
+					project_id: context.session.project_id,
+					notebook_id: context.session.notebook_id,
+					session_id: context.session.session_id,
+					surface: 'opencode',
+					error: errorMetadata(error),
+				});
+			}
+		}
+		specs.push(
+			opencodeSurface({
+				port: openCodeConfig.port,
+				memoryMb: openCodeConfig.memoryMb,
+				managedAi,
+			}),
+		);
+	}
+	return new SurfaceManager(deps.compute, deps.services.sessions, new SurfaceRegistry(specs));
+}
+
+export function surfaceStopManager(deps: ApiDeps): SurfaceManager {
+	return new SurfaceManager(
+		deps.compute,
+		deps.services.sessions,
+		new SurfaceRegistry([marimoSurface, vscodeSurface(), opencodeSurface()]),
+	);
+}
+
+interface SurfaceStartContext {
+	projectId: string;
+	notebookId: string;
+	sessionId: string;
+	surface: SecondarySurfaceId;
+}
+
+function logSurfaceStartFailure(context: SurfaceStartContext, error: unknown): void {
+	logEvent({
+		level: 'warn',
+		event: 'surface_start_failed',
+		project_id: context.projectId,
+		notebook_id: context.notebookId,
+		session_id: context.sessionId,
+		surface: context.surface,
+		error: errorMetadata(error),
+	});
+}
+
+function deferSurfaceCompletion(
+	deps: ApiDeps,
+	completion: Promise<unknown> | undefined,
+	context: SurfaceStartContext,
+): void {
+	if (!completion) return;
+	const task = completion.catch((error) => logSurfaceStartFailure(context, error));
+	if (deps.backgroundTasks) deps.backgroundTasks.defer(task);
+	else void task;
+}
+
+interface BeginSurfaceInput {
+	deps: ApiDeps;
+	session: Session;
+	user: AuthUser;
+	id: SecondarySurfaceId;
+	workspaceDir: string;
+	exposure: SandboxExposure;
+	hostname: string;
+	appBaseUrl: string;
+	open?: string;
+}
+
+export async function beginSessionSurface(input: BeginSurfaceInput) {
+	const { deps, session, user, id, workspaceDir, exposure, hostname, appBaseUrl, open } = input;
+	const config = surfaceConfig(deps, id);
+	let basePath: string | undefined;
+	let clientBaseUrl: string | undefined;
+	if (exposure instanceof ProxyExposure) {
+		const token = await signProxyToken(
+			session.project_id,
+			session.session_id,
+			exposure.signingSecret,
+		);
+		basePath = `/surface-proxy/${token}/${id}`;
+		clientBaseUrl = `${joinUrlPath(appBaseUrl, basePath)}/`;
+	}
+	const manager = await createSurfaceManager(deps, id, { user, session, appBaseUrl });
+	const begun = await manager.begin(session, id, {
+		user,
+		workspaceDir,
+		port: config.port,
+		exposure: exposure.mode,
+		hostname,
+		clientBaseUrl,
+		basePath,
+		open,
+	});
+	deferSurfaceCompletion(deps, begun.completion, {
+		projectId: session.project_id,
+		notebookId: session.notebook_id,
+		sessionId: session.session_id,
+		surface: id,
+	});
+	return begun;
+}
+
+export async function beginSessionSurfaces(
+	input: Omit<BeginSurfaceInput, 'id' | 'open'> & {
+		ids: readonly SecondarySurfaceId[];
+	},
+): Promise<Session> {
+	const { ids, ...shared } = input;
+	await Promise.all(
+		ids.map(async (id) => {
+			try {
+				await beginSessionSurface({ ...shared, id });
+			} catch (error) {
+				logSurfaceStartFailure(
+					{
+						projectId: input.session.project_id,
+						notebookId: input.session.notebook_id,
+						sessionId: input.session.session_id,
+						surface: id,
+					},
+					error,
+				);
+			}
+		}),
+	);
+	return input.deps.services.sessions.getSession(
+		input.session.project_id,
+		input.session.session_id,
+	);
+}
+
+export async function loadSurfaceSession(
+	deps: ApiDeps,
+	user: AuthUser,
+	params: { pid: ProjectId; nid: string; sid: SessionId },
+	permission: 'attach' | 'control' = 'attach',
+) {
+	const project = await loadVisibleProject(deps.services.projects, params.pid, user, deps.policy);
+	const session = await deps.services.sessions.getSession(params.pid, params.sid);
+	if (session.notebook_id !== params.nid) {
+		throw new NotFoundError(`Session ${params.sid} not found`);
+	}
+	if (permission === 'control') assertSessionControl(project, session, user, deps.policy);
+	else assertSessionSurfaceAccess(project, session, user, deps.policy);
+	return session;
+}

--- a/packages/api/src/routes/sessions.appMode.test.ts
+++ b/packages/api/src/routes/sessions.appMode.test.ts
@@ -381,7 +381,11 @@ describe('Session routes (app mode)', () => {
 
 		it('a viewer attaches to the app an editor started, with viewer-shaped grants', async () => {
 			const app = await expectOk<any>(await owner('POST', sessionsPath(), { mode: 'app' }));
-			expect(app.can).toEqual({ attach: true, stop: true, surfaces: { vscode: false } });
+			expect(app.can).toEqual({
+				attach: true,
+				stop: true,
+				surfaces: { vscode: false, opencode: false },
+			});
 
 			const attached = await expectOk<any>(
 				await viewerApi('applications')('POST', sessionsPath(), { mode: 'app' }),
@@ -389,7 +393,11 @@ describe('Session routes (app mode)', () => {
 			expect(attached.session_id).toBe(app.session_id);
 			expect(attached.reused).toBe(true);
 			// The response carries the CALLER's evaluated grants, not the starter's.
-			expect(attached.can).toEqual({ attach: true, stop: false, surfaces: { vscode: false } });
+			expect(attached.can).toEqual({
+				attach: true,
+				stop: false,
+				surfaces: { vscode: false, opencode: false },
+			});
 		});
 
 		it('a viewer may heartbeat the shared app under `applications`, not under `static`', async () => {

--- a/packages/api/src/routes/sessions.surfaces.test.ts
+++ b/packages/api/src/routes/sessions.surfaces.test.ts
@@ -384,6 +384,10 @@ describe('Session surface routes', () => {
 		});
 		expect(calls.exposePort.at(-1)?.port).toBe(4096);
 		expect(calls.startProcess.at(-1)?.cmd).toContain("'opencode' 'web'");
+		expect(calls.startProcess.at(-1)?.cmd).toContain(
+			`'OPENCODE_CONFIG=/tmp/.marimohub/surfaces/${session.session_id}/opencode/config/opencode/opencode.json'`,
+		);
+		expect(calls.startProcess.at(-1)?.options?.env).toBeUndefined();
 		const configWrite = calls.writeFile.find((file) =>
 			file.path.endsWith('/config/opencode/opencode.json'),
 		);

--- a/packages/api/src/routes/sessions.surfaces.test.ts
+++ b/packages/api/src/routes/sessions.surfaces.test.ts
@@ -386,10 +386,13 @@ describe('Session surface routes', () => {
 		});
 		expect(calls.exposePort.at(-1)?.port).toBe(4096);
 		expect(calls.startProcess.at(-1)?.cmd).toContain("'opencode' 'web'");
-		const configWrite = calls.writeFile.find((file) => file.path.endsWith('/config/opencode.json'));
+		const configWrite = calls.writeFile.find((file) =>
+			file.path.endsWith('/config/opencode/opencode.json'),
+		);
 		const config = JSON.parse(String(configWrite?.content));
 		expect(config).toMatchObject({
 			model: 'marimohub/gpt-test',
+			small_model: 'marimohub/gpt-test',
 			provider: {
 				marimohub: {
 					options: {
@@ -418,7 +421,7 @@ describe('Session surface routes', () => {
 			const { instance, calls } = makeFakeSandbox();
 			const writeFiles = instance.writeFiles.bind(instance);
 			instance.writeFiles = async (files) => {
-				if (files.some((file) => file.path.endsWith('/opencode/config/opencode.json'))) {
+				if (files.some((file) => file.path.endsWith('/config/opencode/opencode.json'))) {
 					throw new Error('private sandbox path and credential details');
 				}
 				return writeFiles(files);

--- a/packages/api/src/routes/sessions.surfaces.test.ts
+++ b/packages/api/src/routes/sessions.surfaces.test.ts
@@ -322,7 +322,6 @@ describe('Session surface routes', () => {
 						opencode: {
 							start: 'on-demand',
 							port: 4096,
-							memoryMb: 1024,
 							embed: 'tab',
 							marimoWatch: true,
 						},
@@ -366,7 +365,6 @@ describe('Session surface routes', () => {
 						opencode: {
 							start: 'on-demand',
 							port: 4096,
-							memoryMb: 1024,
 							embed: 'tab',
 							marimoWatch: true,
 						},
@@ -438,7 +436,6 @@ describe('Session surface routes', () => {
 							opencode: {
 								start: 'on-demand',
 								port: 4096,
-								memoryMb: 1024,
 								embed: 'tab',
 								marimoWatch: true,
 							},
@@ -498,7 +495,6 @@ describe('Session surface routes', () => {
 						opencode: {
 							start: 'on-demand',
 							port: 4096,
-							memoryMb: 1024,
 							embed: 'tab',
 							marimoWatch: true,
 						},
@@ -587,7 +583,6 @@ describe('Session surface routes', () => {
 						opencode: {
 							start: 'eager',
 							port: 4096,
-							memoryMb: 1024,
 							embed: 'tab',
 							marimoWatch: true,
 						},

--- a/packages/api/src/routes/sessions.surfaces.test.ts
+++ b/packages/api/src/routes/sessions.surfaces.test.ts
@@ -1,0 +1,657 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createServices, ProxyExposure } from '@marimo-hub/core';
+import type { NotebookId, ProjectId, Session } from '@marimo-hub/core';
+import {
+	ACTOR,
+	fakeComputeFrom,
+	makeFakeCompute,
+	makeFakeSandbox,
+	uid,
+} from '@marimo-hub/core/testing';
+import type { MemoryBucket } from '@marimo-hub/core/testing';
+import type { ApiDeps } from '../context';
+import { createInitializedBucket, createTestApi, expectError, expectOk } from '../testing';
+
+const STRANGER = uid('user_stranger');
+const MANAGER = uid('user_manager');
+
+type ApiSession = Session & {
+	can: { attach: boolean; stop: boolean; surfaces?: { vscode: boolean; opencode: boolean } };
+	reused?: boolean;
+};
+
+describe('Session surface routes', () => {
+	let bucket: MemoryBucket;
+	let owner: ReturnType<typeof createTestApi>['request'];
+	let pid: ProjectId;
+	let nid: NotebookId;
+
+	beforeEach(async () => {
+		bucket = await createInitializedBucket();
+		const services = createServices(bucket);
+		const project = await services.projects.createProject(
+			{ name: 'Owned', description: 'd' },
+			ACTOR,
+		);
+		pid = project.id as ProjectId;
+		const notebook = await services.notebooks.createNotebook(
+			pid,
+			{ title: 'NB', description: 'd', code: 'import marimo as mo' },
+			ACTOR,
+		);
+		nid = notebook.id as NotebookId;
+		owner = createTestApi({ bucket, userId: ACTOR, compute: makeFakeCompute() }).request;
+	});
+
+	const sessionsPath = (suffix = '') => `/projects/${pid}/notebooks/${nid}/sessions${suffix}`;
+	const sandboxConfig = (overrides: Partial<ApiDeps['sandbox']> = {}): ApiDeps['sandbox'] => ({
+		bucket: { name: 'test', endpoint: '' },
+		hostname: 'localhost',
+		workdir: '/workspace',
+		persistWorkspace: 'source',
+		...overrides,
+	});
+
+	it('starts, reports, and stops a VS Code surface on an edit sandbox', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const compute = Object.assign(fakeComputeFrom(instance), {
+			capabilities: { multiPort: true } as const,
+		});
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute,
+			deps: {
+				sandbox: sandboxConfig({
+					surfaces: {
+						vscode: {
+							flavor: 'code-server',
+							start: 'on-demand',
+							port: 8443,
+							settings: {},
+							extensionGallery: 'openvsx',
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+			},
+		}).request;
+		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+		const path = sessionsPath(`/${session.session_id}/surfaces/vscode`);
+
+		const surface = await expectOk<{ status: string; url?: string }>(
+			await request('POST', path, { open: 'notebook.py' }),
+			202,
+		);
+		expect(surface).toMatchObject({ status: 'starting' });
+		await vi.waitFor(async () => {
+			expect(await expectOk(await request('GET', path))).toMatchObject({
+				status: 'ready',
+				url: expect.stringContaining('folder='),
+			});
+		});
+		expect(calls.exposePort.at(-1)?.port).toBe(8443);
+		expect(calls.startProcess.at(-1)?.cmd).toContain('code-server');
+
+		const exec = instance.exec.bind(instance);
+		instance.exec = async (cmd, execOptions) =>
+			cmd.includes('kill -TERM')
+				? {
+						success: false,
+						stdout: '',
+						stderr: 'permission denied',
+						error: { code: 'COMMAND_FAILED' },
+					}
+				: exec(cmd, execOptions);
+		await expectError(await request('DELETE', path), 503, 'SERVICE_UNAVAILABLE');
+		expect(await expectOk(await request('GET', path))).toMatchObject({
+			status: 'failed',
+			last_error: 'Failed to stop vscode',
+		});
+		instance.exec = exec;
+		await expectOk(await request('DELETE', path));
+		expect(calls.exec.at(-1)).toContain('/vscode/surface.pid');
+	});
+
+	it('returns 202 without waiting for VS Code readiness', async () => {
+		const { instance } = makeFakeSandbox();
+		let finishReadiness!: () => void;
+		const readiness = new Promise<void>((resolve) => {
+			finishReadiness = resolve;
+		});
+		const deferred: Promise<unknown>[] = [];
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: Object.assign(fakeComputeFrom(instance), {
+				capabilities: { multiPort: true } as const,
+			}),
+			deps: {
+				backgroundTasks: { defer: (task) => deferred.push(task) },
+				sandbox: sandboxConfig({
+					surfaces: {
+						vscode: {
+							flavor: 'code-server',
+							start: 'on-demand',
+							port: 8443,
+							settings: {},
+							extensionGallery: 'openvsx',
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+			},
+		}).request;
+		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+		instance.startProcess = vi.fn(async () => ({
+			id: 'surface-vscode',
+			command: 'code-server',
+			kill: async () => {},
+			waitForPort: async () => readiness,
+			getLogs: async () => ({ stdout: '', stderr: '' }),
+		}));
+		const path = sessionsPath(`/${session.session_id}/surfaces/vscode`);
+
+		const starting = await expectOk<{ status: string }>(await request('POST', path), 202);
+
+		expect(starting.status).toBe('starting');
+		expect(deferred).toHaveLength(1);
+		expect(await expectOk(await request('GET', path))).toMatchObject({ status: 'starting' });
+		finishReadiness();
+		await Promise.all(deferred);
+		expect(await expectOk(await request('GET', path))).toMatchObject({ status: 'ready' });
+	});
+
+	it('reports a deferred startup failure through the surface status', async () => {
+		const { instance } = makeFakeSandbox();
+		const deferred: Promise<unknown>[] = [];
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: Object.assign(fakeComputeFrom(instance), {
+				capabilities: { multiPort: true } as const,
+			}),
+			deps: {
+				backgroundTasks: { defer: (task) => deferred.push(task) },
+				sandbox: sandboxConfig({
+					surfaces: {
+						vscode: {
+							flavor: 'code-server',
+							start: 'on-demand',
+							port: 8443,
+							settings: {},
+							extensionGallery: 'openvsx',
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+			},
+		}).request;
+		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+		instance.startProcess = vi.fn(async () => ({
+			id: 'surface-vscode',
+			command: 'code-server',
+			kill: async () => {},
+			waitForPort: async () => {
+				throw new Error('readiness failed');
+			},
+			getLogs: async () => ({ stdout: '', stderr: '' }),
+		}));
+		const path = sessionsPath(`/${session.session_id}/surfaces/vscode`);
+
+		await expectOk(await request('POST', path), 202);
+		await Promise.all(deferred);
+
+		expect(await expectOk(await request('GET', path))).toMatchObject({
+			status: 'failed',
+			last_error: 'Failed to start vscode (Error)',
+		});
+	});
+
+	it('lets a manager stop an exclusive surface after VS Code is disabled', async () => {
+		await createServices(bucket).projects.addMember(pid, { user_id: MANAGER }, 'manager', ACTOR);
+		const { instance, calls } = makeFakeSandbox();
+		const compute = Object.assign(fakeComputeFrom(instance), {
+			capabilities: { multiPort: true } as const,
+		});
+		const ownerRequest = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute,
+			deps: {
+				policy: { editorSandboxSharing: 'exclusive' },
+				sandbox: sandboxConfig({
+					surfaces: {
+						vscode: {
+							flavor: 'code-server',
+							start: 'on-demand',
+							port: 8443,
+							settings: {},
+							extensionGallery: 'openvsx',
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+			},
+		}).request;
+		const session = await expectOk<ApiSession>(await ownerRequest('POST', sessionsPath()));
+		const path = sessionsPath(`/${session.session_id}/surfaces/vscode`);
+		await expectOk(await ownerRequest('POST', path), 202);
+		await vi.waitFor(async () => {
+			expect(
+				(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces?.vscode
+					?.status,
+			).toBe('ready');
+		});
+		const managerRequest = createTestApi({
+			bucket,
+			userId: MANAGER,
+			compute,
+			deps: { policy: { editorSandboxSharing: 'exclusive' } },
+		}).request;
+
+		await expectOk(await managerRequest('DELETE', path));
+
+		expect(calls.exec.at(-1)).toContain('/vscode/surface.pid');
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces?.vscode,
+		).toEqual({ status: 'stopped' });
+	});
+
+	it('rejects disabled and duplicate requested surfaces without provisioning', async () => {
+		await expectError(
+			await owner('POST', sessionsPath(), { surfaces: ['vscode'] }),
+			409,
+			'SURFACE_NOT_ENABLED',
+		);
+		await expectError(
+			await owner('POST', sessionsPath(), { surfaces: ['vscode', 'vscode'] }),
+			422,
+			'VALIDATION_ERROR',
+		);
+		expect(await createServices(bucket).sessions.listSessions(nid)).toHaveLength(0);
+	});
+
+	it('rejects unknown surfaces and surfaces on app sessions before provisioning', async () => {
+		await expectError(
+			await owner('POST', sessionsPath(), { surfaces: ['terminal'] }),
+			422,
+			'VALIDATION_ERROR',
+		);
+		await expectError(
+			await owner('POST', sessionsPath(), { mode: 'app', surfaces: ['opencode'] }),
+			400,
+			'BAD_REQUEST',
+		);
+		expect(await createServices(bucket).sessions.listSessions(nid)).toHaveLength(0);
+	});
+
+	it.each(['GET', 'POST', 'DELETE'] as const)(
+		'rejects a %s surface request when the session belongs to another notebook',
+		async (method) => {
+			const services = createServices(bucket);
+			const other = await services.notebooks.createNotebook(
+				pid,
+				{ title: 'Other', description: 'd', code: 'import marimo as mo' },
+				ACTOR,
+			);
+			const session = await expectOk<ApiSession>(await owner('POST', sessionsPath()));
+			const wrongPath = `/projects/${pid}/notebooks/${other.id}/sessions/${session.session_id}/surfaces/vscode`;
+
+			await expectError(await owner(method, wrongPath), 404, 'NOT_FOUND');
+		},
+	);
+
+	it('rejects OpenCode proxy exposure before starting the process', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: Object.assign(fakeComputeFrom(instance), {
+				capabilities: { multiPort: true } as const,
+			}),
+			deps: {
+				sandbox: sandboxConfig({
+					appBaseUrl: 'https://hub.example',
+					exposure: new ProxyExposure('test-signing-secret'),
+					surfaces: {
+						opencode: {
+							start: 'on-demand',
+							port: 4096,
+							memoryMb: 1024,
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+			},
+		}).request;
+		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+		const processCount = calls.startProcess.length;
+
+		await expectError(
+			await request('POST', sessionsPath(`/${session.session_id}/surfaces/opencode`)),
+			409,
+			'SURFACE_UNAVAILABLE',
+		);
+		expect(calls.startProcess).toHaveLength(processCount);
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces
+				?.opencode,
+		).toBeUndefined();
+	});
+
+	it('starts requested OpenCode with managed AI and rejects its open path', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const compute = Object.assign(fakeComputeFrom(instance), {
+			capabilities: { multiPort: true } as const,
+		});
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute,
+			deps: {
+				ai: {
+					upstreamBaseUrl: 'https://provider.example/v1',
+					upstreamApiKey: 'real-upstream-key',
+					model: 'gpt-test',
+					signingSecret: 'test-signing-secret',
+				},
+				sandbox: sandboxConfig({
+					surfaces: {
+						opencode: {
+							start: 'on-demand',
+							port: 4096,
+							memoryMb: 1024,
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+			},
+		}).request;
+
+		const session = await expectOk<ApiSession>(
+			await request('POST', sessionsPath(), { surfaces: ['opencode'] }),
+		);
+		await vi.waitFor(async () => {
+			expect(
+				(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces
+					?.opencode?.status,
+			).toBe('ready');
+		});
+		expect(calls.exposePort.at(-1)?.port).toBe(4096);
+		expect(calls.startProcess.at(-1)?.cmd).toContain("'opencode' 'web'");
+		const configWrite = calls.writeFile.find((file) => file.path.endsWith('/config/opencode.json'));
+		const config = JSON.parse(String(configWrite?.content));
+		expect(config).toMatchObject({
+			model: 'marimohub/gpt-test',
+			provider: {
+				marimohub: {
+					options: {
+						baseURL: 'http://localhost/api/ai/v1',
+						apiKey: expect.any(String),
+					},
+				},
+			},
+		});
+		expect(JSON.stringify(config)).not.toContain('real-upstream-key');
+
+		const processCount = calls.startProcess.length;
+		await expectError(
+			await request('POST', sessionsPath(`/${session.session_id}/surfaces/opencode`), {
+				open: 'notebook.py',
+			}),
+			400,
+			'SURFACE_OPEN_INVALID',
+		);
+		expect(calls.startProcess).toHaveLength(processCount);
+	});
+
+	it('sanitizes an OpenCode preparation failure and leaves marimo running', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			const { instance, calls } = makeFakeSandbox();
+			const writeFiles = instance.writeFiles.bind(instance);
+			instance.writeFiles = async (files) => {
+				if (files.some((file) => file.path.endsWith('/opencode/config/opencode.json'))) {
+					throw new Error('private sandbox path and credential details');
+				}
+				return writeFiles(files);
+			};
+			const request = createTestApi({
+				bucket,
+				userId: ACTOR,
+				compute: Object.assign(fakeComputeFrom(instance), {
+					capabilities: { multiPort: true } as const,
+				}),
+				deps: {
+					sandbox: sandboxConfig({
+						surfaces: {
+							opencode: {
+								start: 'on-demand',
+								port: 4096,
+								memoryMb: 1024,
+								embed: 'tab',
+								marimoWatch: true,
+							},
+						},
+					}),
+				},
+			}).request;
+
+			const session = await expectOk<ApiSession>(
+				await request('POST', sessionsPath(), { surfaces: ['opencode'] }),
+			);
+			await vi.waitFor(async () => {
+				const stored = await createServices(bucket).sessions.getSession(pid, session.session_id);
+				expect(stored.status).toBe('running');
+				expect(stored.surfaces?.opencode).toEqual({
+					status: 'failed',
+					last_error: 'Failed to start opencode (Error)',
+				});
+			});
+			expect(calls.startProcess.some(({ cmd }) => cmd.includes("'opencode' 'web'"))).toBe(false);
+			expect(JSON.stringify(log.mock.calls)).not.toContain('private sandbox path');
+		} finally {
+			log.mockRestore();
+		}
+	});
+
+	it('starts requested surfaces concurrently and isolates an unavailable OpenCode binary', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const originalExec = instance.exec.bind(instance);
+		instance.exec = async (cmd, options) =>
+			cmd.includes('command -v opencode')
+				? {
+						success: false,
+						stdout: '',
+						stderr: 'not found',
+						error: { code: 'COMMAND_FAILED' },
+					}
+				: originalExec(cmd, options);
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: Object.assign(fakeComputeFrom(instance), {
+				capabilities: { multiPort: true } as const,
+			}),
+			deps: {
+				sandbox: sandboxConfig({
+					surfaces: {
+						vscode: {
+							flavor: 'code-server',
+							start: 'on-demand',
+							port: 8443,
+							settings: {},
+							extensionGallery: 'openvsx',
+							embed: 'tab',
+							marimoWatch: true,
+						},
+						opencode: {
+							start: 'on-demand',
+							port: 4096,
+							memoryMb: 1024,
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+			},
+		}).request;
+
+		const session = await expectOk<ApiSession>(
+			await request('POST', sessionsPath(), { surfaces: ['vscode', 'opencode'] }),
+		);
+		await vi.waitFor(async () => {
+			const stored = await createServices(bucket).sessions.getSession(pid, session.session_id);
+			expect(stored.surfaces?.vscode?.status).toBe('ready');
+			expect(stored.surfaces?.opencode).toMatchObject({
+				status: 'unavailable',
+				last_error: 'The sandbox image does not include opencode',
+			});
+		});
+		expect(calls.startProcess.some(({ cmd }) => cmd.includes('code-server'))).toBe(true);
+		expect(calls.startProcess.some(({ cmd }) => cmd.includes("'opencode' 'web'"))).toBe(false);
+	});
+
+	it('rejects an unsafe VS Code open path without starting the surface', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const compute = Object.assign(fakeComputeFrom(instance), {
+			capabilities: { multiPort: true } as const,
+		});
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute,
+			deps: {
+				sandbox: sandboxConfig({
+					surfaces: {
+						vscode: {
+							flavor: 'code-server',
+							start: 'on-demand',
+							port: 8443,
+							settings: {},
+							extensionGallery: 'openvsx',
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+			},
+		}).request;
+		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+		const processCount = calls.startProcess.length;
+
+		await expectError(
+			await request('POST', sessionsPath(`/${session.session_id}/surfaces/vscode`), {
+				open: '../secret.py',
+			}),
+			400,
+			'SURFACE_OPEN_INVALID',
+		);
+		expect(calls.startProcess).toHaveLength(processCount);
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces?.vscode,
+		).toBeUndefined();
+	});
+
+	it('does not eagerly start secondary surfaces for a viewer-owned ephemeral session', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const compute = Object.assign(fakeComputeFrom(instance), {
+			capabilities: { multiPort: true } as const,
+		});
+		const request = createTestApi({
+			bucket,
+			userId: STRANGER,
+			compute,
+			deps: {
+				sandbox: sandboxConfig({
+					surfaces: {
+						vscode: {
+							flavor: 'code-server',
+							start: 'eager',
+							port: 8443,
+							settings: {},
+							extensionGallery: 'openvsx',
+							embed: 'tab',
+							marimoWatch: true,
+						},
+						opencode: {
+							start: 'eager',
+							port: 4096,
+							memoryMb: 1024,
+							embed: 'tab',
+							marimoWatch: true,
+						},
+					},
+				}),
+				policy: { defaultRole: 'viewer', viewerMode: 'ephemeral-sandbox' },
+			},
+		}).request;
+
+		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+		expect(session.ephemeral).toBe(true);
+		expect(session.can.surfaces?.vscode).toBe(false);
+		expect(session.can.surfaces?.opencode).toBe(false);
+		expect(calls.startProcess.some(({ cmd }) => cmd.includes('code-server'))).toBe(false);
+		expect(calls.startProcess.some(({ cmd }) => cmd.includes('opencode'))).toBe(false);
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces?.vscode,
+		).toBeUndefined();
+		expect(
+			(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces
+				?.opencode,
+		).toBeUndefined();
+		await expectError(
+			await request('POST', sessionsPath(`/${session.session_id}/surfaces/vscode`)),
+			403,
+			'SURFACE_FORBIDDEN',
+		);
+		await expectError(
+			await request('POST', sessionsPath(`/${session.session_id}/surfaces/opencode`)),
+			403,
+			'SURFACE_FORBIDDEN',
+		);
+	});
+
+	it('keeps session creation successful when configured eager startup is unsupported', async () => {
+		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+		try {
+			const request = createTestApi({
+				bucket,
+				userId: ACTOR,
+				compute: makeFakeCompute(),
+				deps: {
+					sandbox: sandboxConfig({
+						surfaces: {
+							vscode: {
+								flavor: 'code-server',
+								start: 'eager',
+								port: 8443,
+								settings: {},
+								extensionGallery: 'openvsx',
+								embed: 'tab',
+								marimoWatch: true,
+							},
+						},
+					}),
+				},
+			}).request;
+
+			const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+
+			expect(session.status).toBe('running');
+			expect(session.surfaces?.vscode).toBeUndefined();
+			expect(log.mock.calls.some(([line]) => String(line).includes('surface_start_failed'))).toBe(
+				true,
+			);
+		} finally {
+			log.mockRestore();
+		}
+	});
+});

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -30,7 +30,7 @@ import {
 const STRANGER = uid('user_stranger');
 const MANAGER = uid('user_manager');
 type ApiSession = Session & {
-	can: { attach: boolean; stop: boolean; surfaces?: { vscode: boolean } };
+	can: { attach: boolean; stop: boolean; surfaces?: { vscode: boolean; opencode: boolean } };
 	reused?: boolean;
 };
 
@@ -1477,343 +1477,6 @@ describe('Session routes', () => {
 		await expectError(await stranger('POST', sessionsPath()), 403, 'FORBIDDEN');
 	});
 
-	it('starts, reports, and stops a VS Code surface on an edit sandbox', async () => {
-		const { instance, calls } = makeFakeSandbox();
-		const compute = Object.assign(fakeComputeFrom(instance), {
-			capabilities: { multiPort: true } as const,
-		});
-		const request = createTestApi({
-			bucket,
-			userId: ACTOR,
-			compute,
-			deps: {
-				sandbox: sandboxConfig({
-					surfaces: {
-						vscode: {
-							flavor: 'code-server',
-							start: 'on-demand',
-							port: 8443,
-							settings: {},
-							extensionGallery: 'openvsx',
-							embed: 'tab',
-							marimoWatch: true,
-						},
-					},
-				}),
-			},
-		}).request;
-		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
-		const path = sessionsPath(`/${session.session_id}/surfaces/vscode`);
-
-		const surface = await expectOk<{ status: string; url?: string }>(
-			await request('POST', path, { open: 'notebook.py' }),
-			202,
-		);
-		expect(surface).toMatchObject({ status: 'starting' });
-		await vi.waitFor(async () => {
-			expect(await expectOk(await request('GET', path))).toMatchObject({
-				status: 'ready',
-				url: expect.stringContaining('folder='),
-			});
-		});
-		expect(calls.exposePort.at(-1)?.port).toBe(8443);
-		expect(calls.startProcess.at(-1)?.cmd).toContain('code-server');
-
-		const exec = instance.exec.bind(instance);
-		instance.exec = async (cmd, execOptions) =>
-			cmd.includes('kill -TERM')
-				? {
-						success: false,
-						stdout: '',
-						stderr: 'permission denied',
-						error: { code: 'COMMAND_FAILED' },
-					}
-				: exec(cmd, execOptions);
-		await expectError(await request('DELETE', path), 503, 'SERVICE_UNAVAILABLE');
-		expect(await expectOk(await request('GET', path))).toMatchObject({
-			status: 'failed',
-			last_error: 'Failed to stop vscode',
-		});
-		instance.exec = exec;
-		await expectOk(await request('DELETE', path));
-		expect(calls.exec.at(-1)).toContain('/vscode/surface.pid');
-	});
-
-	it('returns 202 without waiting for VS Code readiness', async () => {
-		const { instance } = makeFakeSandbox();
-		let finishReadiness!: () => void;
-		const readiness = new Promise<void>((resolve) => {
-			finishReadiness = resolve;
-		});
-		const deferred: Promise<unknown>[] = [];
-		const request = createTestApi({
-			bucket,
-			userId: ACTOR,
-			compute: Object.assign(fakeComputeFrom(instance), {
-				capabilities: { multiPort: true } as const,
-			}),
-			deps: {
-				backgroundTasks: { defer: (task) => deferred.push(task) },
-				sandbox: sandboxConfig({
-					surfaces: {
-						vscode: {
-							flavor: 'code-server',
-							start: 'on-demand',
-							port: 8443,
-							settings: {},
-							extensionGallery: 'openvsx',
-							embed: 'tab',
-							marimoWatch: true,
-						},
-					},
-				}),
-			},
-		}).request;
-		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
-		instance.startProcess = vi.fn(async () => ({
-			id: 'surface-vscode',
-			command: 'code-server',
-			kill: async () => {},
-			waitForPort: async () => readiness,
-			getLogs: async () => ({ stdout: '', stderr: '' }),
-		}));
-		const path = sessionsPath(`/${session.session_id}/surfaces/vscode`);
-
-		const starting = await expectOk<{ status: string }>(await request('POST', path), 202);
-
-		expect(starting.status).toBe('starting');
-		expect(deferred).toHaveLength(1);
-		expect(await expectOk(await request('GET', path))).toMatchObject({ status: 'starting' });
-		finishReadiness();
-		await Promise.all(deferred);
-		expect(await expectOk(await request('GET', path))).toMatchObject({ status: 'ready' });
-	});
-
-	it('reports a deferred startup failure through the surface status', async () => {
-		const { instance } = makeFakeSandbox();
-		const deferred: Promise<unknown>[] = [];
-		const request = createTestApi({
-			bucket,
-			userId: ACTOR,
-			compute: Object.assign(fakeComputeFrom(instance), {
-				capabilities: { multiPort: true } as const,
-			}),
-			deps: {
-				backgroundTasks: { defer: (task) => deferred.push(task) },
-				sandbox: sandboxConfig({
-					surfaces: {
-						vscode: {
-							flavor: 'code-server',
-							start: 'on-demand',
-							port: 8443,
-							settings: {},
-							extensionGallery: 'openvsx',
-							embed: 'tab',
-							marimoWatch: true,
-						},
-					},
-				}),
-			},
-		}).request;
-		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
-		instance.startProcess = vi.fn(async () => ({
-			id: 'surface-vscode',
-			command: 'code-server',
-			kill: async () => {},
-			waitForPort: async () => {
-				throw new Error('readiness failed');
-			},
-			getLogs: async () => ({ stdout: '', stderr: '' }),
-		}));
-		const path = sessionsPath(`/${session.session_id}/surfaces/vscode`);
-
-		await expectOk(await request('POST', path), 202);
-		await Promise.all(deferred);
-
-		expect(await expectOk(await request('GET', path))).toMatchObject({
-			status: 'failed',
-			last_error: 'Failed to start vscode (Error)',
-		});
-	});
-
-	it('lets a manager stop an exclusive surface after VS Code is disabled', async () => {
-		await createServices(bucket).projects.addMember(pid, { user_id: MANAGER }, 'manager', ACTOR);
-		const { instance, calls } = makeFakeSandbox();
-		const compute = Object.assign(fakeComputeFrom(instance), {
-			capabilities: { multiPort: true } as const,
-		});
-		const ownerRequest = createTestApi({
-			bucket,
-			userId: ACTOR,
-			compute,
-			deps: {
-				policy: { editorSandboxSharing: 'exclusive' },
-				sandbox: sandboxConfig({
-					surfaces: {
-						vscode: {
-							flavor: 'code-server',
-							start: 'on-demand',
-							port: 8443,
-							settings: {},
-							extensionGallery: 'openvsx',
-							embed: 'tab',
-							marimoWatch: true,
-						},
-					},
-				}),
-			},
-		}).request;
-		const session = await expectOk<ApiSession>(await ownerRequest('POST', sessionsPath()));
-		const path = sessionsPath(`/${session.session_id}/surfaces/vscode`);
-		await expectOk(await ownerRequest('POST', path), 202);
-		await vi.waitFor(async () => {
-			expect(
-				(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces?.vscode
-					?.status,
-			).toBe('ready');
-		});
-		const managerRequest = createTestApi({
-			bucket,
-			userId: MANAGER,
-			compute,
-			deps: { policy: { editorSandboxSharing: 'exclusive' } },
-		}).request;
-
-		await expectOk(await managerRequest('DELETE', path));
-
-		expect(calls.exec.at(-1)).toContain('/vscode/surface.pid');
-		expect(
-			(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces?.vscode,
-		).toEqual({ status: 'stopped' });
-	});
-
-	it('rejects the removed create-session surface field without provisioning', async () => {
-		await expectError(
-			await owner('POST', sessionsPath(), { surfaces: ['vscode'] }),
-			422,
-			'VALIDATION_ERROR',
-		);
-		expect(await createServices(bucket).sessions.listSessions(nid)).toHaveLength(0);
-	});
-
-	it('rejects an unsafe VS Code open path without starting the surface', async () => {
-		const { instance, calls } = makeFakeSandbox();
-		const compute = Object.assign(fakeComputeFrom(instance), {
-			capabilities: { multiPort: true } as const,
-		});
-		const request = createTestApi({
-			bucket,
-			userId: ACTOR,
-			compute,
-			deps: {
-				sandbox: sandboxConfig({
-					surfaces: {
-						vscode: {
-							flavor: 'code-server',
-							start: 'on-demand',
-							port: 8443,
-							settings: {},
-							extensionGallery: 'openvsx',
-							embed: 'tab',
-							marimoWatch: true,
-						},
-					},
-				}),
-			},
-		}).request;
-		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
-		const processCount = calls.startProcess.length;
-
-		await expectError(
-			await request('POST', sessionsPath(`/${session.session_id}/surfaces/vscode`), {
-				open: '../secret.py',
-			}),
-			400,
-			'SURFACE_OPEN_INVALID',
-		);
-		expect(calls.startProcess).toHaveLength(processCount);
-		expect(
-			(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces?.vscode,
-		).toBeUndefined();
-	});
-
-	it('does not eagerly start VS Code for a viewer-owned ephemeral session', async () => {
-		const { instance, calls } = makeFakeSandbox();
-		const compute = Object.assign(fakeComputeFrom(instance), {
-			capabilities: { multiPort: true } as const,
-		});
-		const request = createTestApi({
-			bucket,
-			userId: STRANGER,
-			compute,
-			deps: {
-				sandbox: sandboxConfig({
-					surfaces: {
-						vscode: {
-							flavor: 'code-server',
-							start: 'eager',
-							port: 8443,
-							settings: {},
-							extensionGallery: 'openvsx',
-							embed: 'tab',
-							marimoWatch: true,
-						},
-					},
-				}),
-				policy: { defaultRole: 'viewer', viewerMode: 'ephemeral-sandbox' },
-			},
-		}).request;
-
-		const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
-		expect(session.ephemeral).toBe(true);
-		expect(session.can.surfaces?.vscode).toBe(false);
-		expect(calls.startProcess.some(({ cmd }) => cmd.includes('code-server'))).toBe(false);
-		expect(
-			(await createServices(bucket).sessions.getSession(pid, session.session_id)).surfaces?.vscode,
-		).toBeUndefined();
-		await expectError(
-			await request('POST', sessionsPath(`/${session.session_id}/surfaces/vscode`)),
-			403,
-			'SURFACE_FORBIDDEN',
-		);
-	});
-
-	it('keeps session creation successful when configured eager startup is unsupported', async () => {
-		const log = vi.spyOn(console, 'log').mockImplementation(() => {});
-		try {
-			const request = createTestApi({
-				bucket,
-				userId: ACTOR,
-				compute: makeFakeCompute(),
-				deps: {
-					sandbox: sandboxConfig({
-						surfaces: {
-							vscode: {
-								flavor: 'code-server',
-								start: 'eager',
-								port: 8443,
-								settings: {},
-								extensionGallery: 'openvsx',
-								embed: 'tab',
-								marimoWatch: true,
-							},
-						},
-					}),
-				},
-			}).request;
-
-			const session = await expectOk<ApiSession>(await request('POST', sessionsPath()));
-
-			expect(session.status).toBe('running');
-			expect(session.surfaces?.vscode).toBeUndefined();
-			expect(log.mock.calls.some(([line]) => String(line).includes('surface_start_failed'))).toBe(
-				true,
-			);
-		} finally {
-			log.mockRestore();
-		}
-	});
-
 	it("a non-member super admin can start, heartbeat, and stop another user's session", async () => {
 		const god = createTestApi({
 			bucket,
@@ -1824,7 +1487,11 @@ describe('Session routes', () => {
 
 		const sid = await startSession(); // started by ACTOR
 		const session = await expectOk<ApiSession>(await god('GET', sessionsPath(`/${sid}`)));
-		expect(session.can).toEqual({ attach: true, stop: true, surfaces: { vscode: true } });
+		expect(session.can).toEqual({
+			attach: true,
+			stop: true,
+			surfaces: { vscode: true, opencode: true },
+		});
 		await expectOk(await god('POST', sessionsPath(`/${sid}/heartbeat`)));
 		await expectOk(await god('DELETE', sessionsPath(`/${sid}`)));
 	});
@@ -1838,7 +1505,11 @@ describe('Session routes', () => {
 		const visible = await expectOk<ApiSession>(
 			await manager('GET', sessionsPath(`/${session.session_id}`)),
 		);
-		expect(visible.can).toEqual({ attach: false, stop: true, surfaces: { vscode: false } });
+		expect(visible.can).toEqual({
+			attach: false,
+			stop: true,
+			surfaces: { vscode: false, opencode: false },
+		});
 		await expectOk(await manager('DELETE', sessionsPath(`/${session.session_id}`)));
 	});
 

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -52,14 +52,8 @@ import {
 	kernelActiveConnections,
 	joinUrlPath,
 	ValidationError,
-	SurfaceManager,
-	SurfaceRegistry,
-	marimoSurface,
-	vscodeSurface,
-	signProxyToken,
-	ProxyExposure,
-	SurfaceNotEnabledError,
-	SurfaceUnsupportedProviderError,
+	SECONDARY_SURFACE_IDS,
+	SurfaceForbiddenError,
 	workspaceSourcePolicy,
 } from '@marimo-hub/core';
 import { logObserver } from '../saga';
@@ -73,7 +67,6 @@ import type { ApiDeps, PolicyConfig, SandboxConfig } from '../context';
 import {
 	assertSessionAccess,
 	assertSessionControl,
-	assertSessionSurfaceAccess,
 	commonErrors,
 	createApp,
 	errorResponses,
@@ -92,6 +85,13 @@ import {
 	toComputeResourcesResponse,
 } from '../shared';
 import { pageSchema, paginate, PaginationQuery } from '../pagination';
+import {
+	beginSessionSurface,
+	beginSessionSurfaces,
+	loadSurfaceSession,
+	surfaceConfig,
+	surfaceStopManager,
+} from './sessionSurfaces';
 
 function mergeSessionEnv(base: SessionEnv | undefined, add: SessionEnv): SessionEnv {
 	return {
@@ -157,6 +157,14 @@ const SessionCreateBodySchema = z
 		compute_profile: z.literal('default').optional(),
 		/** Request a discard-only editor sandbox. Valid only with exclusive sharing. */
 		edit_intent: z.literal('temporary').optional(),
+		/** Secondary editor surfaces to start with this edit session. */
+		surfaces: z
+			.array(z.enum(SECONDARY_SURFACE_IDS))
+			.max(SECONDARY_SURFACE_IDS.length)
+			.refine((surfaces) => new Set(surfaces).size === surfaces.length, {
+				message: 'Duplicate session surfaces are not allowed',
+			})
+			.optional(),
 	})
 	.openapi('SessionCreateBody');
 
@@ -240,15 +248,21 @@ const heartbeatSession = createRoute({
 });
 
 const SurfaceParam = SessionIdParam.extend({
-	surface: z.literal('vscode').openapi({ param: { name: 'surface', in: 'path' } }),
+	surface: z.enum(SECONDARY_SURFACE_IDS).openapi({ param: { name: 'surface', in: 'path' } }),
 });
 
 const SurfaceStartBodySchema = z
-	.object({ open: z.string().max(4096).optional() })
+	.object({
+		open: z
+			.string()
+			.max(4096)
+			.optional()
+			.describe('Workspace-relative file to open. Supported only by the VS Code surface.'),
+	})
 	.openapi('SurfaceStartBody');
 
 const SurfaceResultSchema = SurfaceResponseSchema.extend({
-	id: z.literal('vscode'),
+	id: z.enum(SECONDARY_SURFACE_IDS),
 });
 
 const ensureSurfaceRoute = createRoute({
@@ -419,7 +433,11 @@ function toSessionResponse(s: Session, can: { attach: boolean; stop: boolean; su
 		user_id: s.user_id,
 		status: s.status,
 		sandbox_url: can.attach ? s.sandbox_url : undefined,
-		can: { attach: can.attach, stop: can.stop, surfaces: { vscode: can.surface } },
+		can: {
+			attach: can.attach,
+			stop: can.stop,
+			surfaces: { vscode: can.surface, opencode: can.surface },
+		},
 		surfaces: publicSurfaces(s, can),
 		started_at: s.started_at,
 		last_heartbeat: s.last_heartbeat,
@@ -441,78 +459,6 @@ function toSessionResponse(s: Session, can: { attach: boolean; stop: boolean; su
 		// withholding `sandbox_url` protects — so it rides the same grant.
 		error: can.attach ? s.error : undefined,
 	};
-}
-
-function surfaceManager(deps: ApiDeps): SurfaceManager {
-	const config = deps.sandbox.surfaces?.vscode;
-	if (!config) throw new SurfaceNotEnabledError('The VS Code surface is not enabled');
-	if (deps.compute.capabilities?.multiPort !== true) {
-		throw new SurfaceUnsupportedProviderError(
-			'The compute backend cannot expose a second sandbox port',
-		);
-	}
-	return new SurfaceManager(
-		deps.compute,
-		deps.services.sessions,
-		new SurfaceRegistry([
-			marimoSurface,
-			vscodeSurface({
-				flavor: config.flavor,
-				port: config.port,
-				settings: config.settings,
-				extensionGallery: config.extensionGallery,
-			}),
-		]),
-	);
-}
-
-function surfaceStopManager(deps: ApiDeps): SurfaceManager {
-	return new SurfaceManager(
-		deps.compute,
-		deps.services.sessions,
-		new SurfaceRegistry([marimoSurface, vscodeSurface()]),
-	);
-}
-
-function deferSurfaceCompletion(
-	deps: ApiDeps,
-	completion: Promise<unknown> | undefined,
-	context: { projectId: string; notebookId: string; sessionId: string },
-): void {
-	if (!completion) return;
-	const task = completion.catch((error) => logSurfaceStartFailure(context, error));
-	if (deps.backgroundTasks) deps.backgroundTasks.defer(task);
-	else void task;
-}
-
-function logSurfaceStartFailure(
-	context: { projectId: string; notebookId: string; sessionId: string },
-	error: unknown,
-): void {
-	logEvent({
-		level: 'warn',
-		event: 'surface_start_failed',
-		project_id: context.projectId,
-		notebook_id: context.notebookId,
-		session_id: context.sessionId,
-		surface: 'vscode',
-		error: errorMetadata(error),
-	});
-}
-
-async function loadSurfaceSession(
-	deps: ApiDeps,
-	user: AuthUser,
-	params: { pid: ProjectId; nid: string; sid: SessionId },
-	permission: 'attach' | 'control' = 'attach',
-) {
-	const project = await loadVisibleProject(deps.services.projects, params.pid, user, deps.policy);
-	const session = await deps.services.sessions.getSession(params.pid, params.sid);
-	if (session.notebook_id !== params.nid)
-		throw new NotFoundError(`Session ${params.sid} not found`);
-	if (permission === 'control') assertSessionControl(project, session, user, deps.policy);
-	else assertSessionSurfaceAccess(project, session, user, deps.policy);
-	return session;
 }
 
 /**
@@ -1068,6 +1014,16 @@ app.openapi(createSession, async (c) => {
 		},
 		deps.policy,
 	).surface;
+	const requestedSurfaces = body?.surfaces ?? [];
+	if (requestedSurfaces.length > 0 && mode !== 'edit') {
+		throw new BadRequestError('Session surfaces are only valid for edit sessions');
+	}
+	if (requestedSurfaces.length > 0 && !surfaceGrant) {
+		throw new SurfaceForbiddenError();
+	}
+	for (const id of requestedSurfaces) {
+		surfaceConfig(deps, id);
+	}
 	const userHome =
 		mode === 'edit' && sharing === 'exclusive' && roleAtLeast(authorization.role, 'editor')
 			? deps.sandbox.userHome?.resolve(user)
@@ -1131,6 +1087,9 @@ app.openapi(createSession, async (c) => {
 		});
 
 	const { compute, bucket: bucketHandle, sandbox } = deps;
+	const sandboxExposure = sandbox.exposure ?? new SubdomainExposure();
+	const hostname = sandbox.hostname || new URL(c.req.url).hostname;
+	const appBaseUrl = resolvePublicBaseUrl(c, sandbox.appBaseUrl);
 	const image = resolveBaseImage(notebook.meta.base_image, sandbox.images ?? [], () =>
 		logStoredConfigFallback('base_image'),
 	);
@@ -1160,7 +1119,7 @@ app.openapi(createSession, async (c) => {
 	const reusableCandidate =
 		mode === 'edit' ? editorReuse?.session : await sessions.findReusable(pid, nid, user.id, mode);
 	if (reusableCandidate) {
-		const reusable = await tightenAuthorizationDeadline(reusableCandidate);
+		let reusable = await tightenAuthorizationDeadline(reusableCandidate);
 		const authorizationExpired =
 			reusable.authorization_expires_at !== undefined &&
 			Date.now() >= Date.parse(reusable.authorization_expires_at);
@@ -1183,6 +1142,18 @@ app.openapi(createSession, async (c) => {
 		const dead =
 			!!kernelUrl && !!deps.kernelProbe && (await deps.kernelProbe(kernelUrl)) === 'dead';
 		if (!authorizationExpired && (!mayRetire || (!dead && !classMismatch))) {
+			if (reusable.status === 'running' && requestedSurfaces.length > 0) {
+				reusable = await beginSessionSurfaces({
+					deps,
+					session: reusable,
+					user,
+					ids: requestedSurfaces,
+					workspaceDir: sandbox.workdir,
+					exposure: sandboxExposure,
+					hostname,
+					appBaseUrl,
+				});
+			}
 			return c.json(
 				{
 					success: true,
@@ -1225,8 +1196,6 @@ app.openapi(createSession, async (c) => {
 
 	const sandboxId = createSandboxId();
 
-	// createApi defaults this; the fallback satisfies the type for direct callers.
-	const sandboxExposure = sandbox.exposure ?? new SubdomainExposure();
 	const restoreFilesystemSnapshot =
 		!ephemeral && workspacePolicy.restoreFilesystemSnapshot
 			? await resolveRestoreSnapshot(compute, notebooks, pid, nid, {
@@ -1243,9 +1212,6 @@ app.openapi(createSession, async (c) => {
 				name: requestedComputeProfile.name,
 				resources: toComputeResourcesResponse(requestedComputeProfile.resources),
 			};
-
-	const hostname = sandbox.hostname || new URL(c.req.url).hostname;
-	const appBaseUrl = resolvePublicBaseUrl(c, sandbox.appBaseUrl);
 
 	// Provision as a saga: if a later step fails, completed steps compensate in
 	// reverse — the session record is terminated (so it does not linger in
@@ -1489,7 +1455,9 @@ app.openapi(createSession, async (c) => {
 						assetUrl: sandbox.assetUrl,
 						startupTimeoutMs: sandbox.startupTimeoutMs,
 						baseUrl,
-						marimoWatch: mode === 'edit' && Boolean(sandbox.surfaces?.vscode?.marimoWatch),
+						marimoWatch:
+							mode === 'edit' &&
+							Object.values(sandbox.surfaces ?? {}).some((surface) => surface.marimoWatch),
 						restoreFilesystemSnapshotId: restoreFilesystemSnapshot?.snapshot_id,
 						image,
 						resources: requestedComputeProfile.resources,
@@ -1701,40 +1669,21 @@ app.openapi(createSession, async (c) => {
 		});
 	}
 
-	const eagerVscode =
-		mode === 'edit' &&
-		Boolean(sandbox.surfaces?.vscode) &&
-		surfaceGrant &&
-		sandbox.surfaces?.vscode?.start === 'eager';
-	if (eagerVscode && updated) {
-		const surfaceContext = {
-			projectId: pid,
-			notebookId: nid,
-			sessionId: updated.session_id,
-		};
-		try {
-			const config = sandbox.surfaces!.vscode!;
-			let surfaceBasePath: string | undefined;
-			let surfaceClientUrl: string | undefined;
-			if (sandboxExposure instanceof ProxyExposure) {
-				const token = await signProxyToken(pid, updated.session_id, sandboxExposure.signingSecret);
-				surfaceBasePath = `/surface-proxy/${token}/vscode`;
-				surfaceClientUrl = `${joinUrlPath(appBaseUrl, surfaceBasePath)}/`;
-			}
-			const begun = await surfaceManager(deps).begin(updated, 'vscode', {
-				user,
-				workspaceDir: sandbox.workdir,
-				port: config.port,
-				exposure: sandboxExposure.mode,
-				hostname,
-				clientBaseUrl: surfaceClientUrl,
-				basePath: surfaceBasePath,
-			});
-			deferSurfaceCompletion(deps, begun.completion, surfaceContext);
-			updated = await sessions.getSession(pid, updated.session_id);
-		} catch (error) {
-			logSurfaceStartFailure(surfaceContext, error);
-		}
+	const eagerSurfaces = SECONDARY_SURFACE_IDS.filter((id) => {
+		const config = sandbox.surfaces?.[id];
+		return config && (config.start === 'eager' || requestedSurfaces.includes(id));
+	});
+	if (mode === 'edit' && surfaceGrant && eagerSurfaces.length > 0 && updated) {
+		updated = await beginSessionSurfaces({
+			deps,
+			session: updated,
+			user,
+			ids: eagerSurfaces,
+			workspaceDir: sandbox.workdir,
+			exposure: sandboxExposure,
+			hostname,
+			appBaseUrl,
+		});
 	}
 
 	// An app start can put integration secrets and WIF credentials in front of the
@@ -1849,31 +1798,18 @@ app.openapi(ensureSurfaceRoute, async (c) => {
 	const user = c.get('user');
 	const { pid, nid, sid, surface } = c.req.valid('param');
 	const session = await loadSurfaceSession(deps, user, { pid, nid, sid });
-	const config = deps.sandbox.surfaces?.vscode;
-	if (!config) throw new SurfaceNotEnabledError('The VS Code surface is not enabled');
-
-	const exposure = deps.sandbox.exposure;
-	let basePath: string | undefined;
-	let clientBaseUrl: string | undefined;
-	if (exposure instanceof ProxyExposure) {
-		const token = await signProxyToken(pid, sid, exposure.signingSecret);
-		basePath = `/surface-proxy/${token}/${surface}`;
-		clientBaseUrl = `${joinUrlPath(resolvePublicBaseUrl(c, deps.sandbox.appBaseUrl), basePath)}/`;
-	}
-	const begun = await surfaceManager(deps).begin(session, surface, {
+	const exposure = deps.sandbox.exposure ?? new SubdomainExposure();
+	const appBaseUrl = resolvePublicBaseUrl(c, deps.sandbox.appBaseUrl);
+	const begun = await beginSessionSurface({
+		deps,
+		session,
 		user,
+		id: surface,
 		workspaceDir: deps.sandbox.workdir,
-		port: config.port,
-		exposure: exposure?.mode ?? 'subdomain',
+		exposure,
 		hostname: deps.sandbox.hostname,
-		clientBaseUrl,
-		basePath,
+		appBaseUrl,
 		open: c.req.valid('json')?.open,
-	});
-	deferSurfaceCompletion(deps, begun.completion, {
-		projectId: pid,
-		notebookId: nid,
-		sessionId: sid,
 	});
 	const result = begun.result;
 	if (result.status === 'starting') c.header('Retry-After', '1');

--- a/packages/api/src/routes/system.ts
+++ b/packages/api/src/routes/system.ts
@@ -142,16 +142,28 @@ app.openapi(capabilitiesRoute, (c) => {
 			...toComputeResourcesResponse(profile.resources),
 		})),
 		compute_profile_override: deps.sandbox.computeProfileOverride ?? 'none',
-		surfaces: deps.sandbox.surfaces?.vscode
-			? [
-					{
-						id: 'vscode' as const,
-						flavor: deps.sandbox.surfaces.vscode.flavor,
-						start: deps.sandbox.surfaces.vscode.start,
-						embed: deps.sandbox.surfaces.vscode.embed,
-					},
-				]
-			: [],
+		surfaces: [
+			...(deps.sandbox.surfaces?.vscode
+				? [
+						{
+							id: 'vscode' as const,
+							flavor: deps.sandbox.surfaces.vscode.flavor,
+							start: deps.sandbox.surfaces.vscode.start,
+							embed: deps.sandbox.surfaces.vscode.embed,
+						},
+					]
+				: []),
+			...(deps.sandbox.surfaces?.opencode
+				? [
+						{
+							id: 'opencode' as const,
+							start: deps.sandbox.surfaces.opencode.start,
+							embed: deps.sandbox.surfaces.opencode.embed,
+							managed_ai: Boolean(deps.ai),
+						},
+					]
+				: []),
+		],
 	});
 });
 

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -875,13 +875,13 @@ export const SessionResponseSchema = z
 		 * The caller's grants on this session, evaluated server-side (the same
 		 * `sessionCan` the gates enforce): `attach` — may reach the kernel (open,
 		 * heartbeat; `sandbox_url` is present iff true), `stop` — may stop or
-		 * restart it, `surfaces.vscode` — may use the secondary editor. Clients
+		 * restart it, `surfaces` — may use each secondary editor. Clients
 		 * render from these instead of re-deriving policy.
 		 */
 		can: z.object({
 			attach: z.boolean(),
 			stop: z.boolean(),
-			surfaces: z.object({ vscode: z.boolean() }).optional(),
+			surfaces: z.object({ vscode: z.boolean(), opencode: z.boolean() }).optional(),
 		}),
 		surfaces: z.record(z.string(), SurfaceResponseSchema).optional(),
 		/**
@@ -1122,12 +1122,20 @@ export const CapabilitiesResponseSchema = z
 		),
 		compute_profile_override: z.enum(['none', 'editors']),
 		surfaces: z.array(
-			z.object({
-				id: z.literal('vscode'),
-				flavor: z.enum(['code-server', 'openvscode']),
-				start: z.enum(['on-demand', 'eager']),
-				embed: z.enum(['tab', 'iframe']),
-			}),
+			z.discriminatedUnion('id', [
+				z.object({
+					id: z.literal('vscode'),
+					flavor: z.enum(['code-server', 'openvscode']),
+					start: z.enum(['on-demand', 'eager']),
+					embed: z.enum(['tab', 'iframe']),
+				}),
+				z.object({
+					id: z.literal('opencode'),
+					start: z.enum(['on-demand', 'eager']),
+					embed: z.enum(['tab', 'iframe']),
+					managed_ai: z.boolean(),
+				}),
+			]),
 		),
 	})
 	.openapi('Capabilities');

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -1646,16 +1646,27 @@ export interface components {
 			})[];
 			/** @enum {string} */
 			compute_profile_override: 'none' | 'editors';
-			surfaces: {
-				/** @enum {string} */
-				id: 'vscode';
-				/** @enum {string} */
-				flavor: 'code-server' | 'openvscode';
-				/** @enum {string} */
-				start: 'on-demand' | 'eager';
-				/** @enum {string} */
-				embed: 'tab' | 'iframe';
-			}[];
+			surfaces: (
+				| {
+						/** @enum {string} */
+						id: 'vscode';
+						/** @enum {string} */
+						flavor: 'code-server' | 'openvscode';
+						/** @enum {string} */
+						start: 'on-demand' | 'eager';
+						/** @enum {string} */
+						embed: 'tab' | 'iframe';
+				  }
+				| {
+						/** @enum {string} */
+						id: 'opencode';
+						/** @enum {string} */
+						start: 'on-demand' | 'eager';
+						/** @enum {string} */
+						embed: 'tab' | 'iframe';
+						managed_ai: boolean;
+				  }
+			)[];
 		};
 		ComputeResources: {
 			cpu?: number;
@@ -2260,6 +2271,7 @@ export interface components {
 				stop: boolean;
 				surfaces?: {
 					vscode: boolean;
+					opencode: boolean;
 				};
 			};
 			surfaces?: {
@@ -2348,8 +2360,10 @@ export interface components {
 			compute_profile?: 'default';
 			/** @enum {string} */
 			edit_intent?: 'temporary';
+			surfaces?: ('vscode' | 'opencode')[];
 		};
 		SurfaceStartBody: {
+			/** @description Workspace-relative file to open. Supported only by the VS Code surface. */
 			open?: string;
 		};
 		IntegrationKind: {
@@ -9033,7 +9047,7 @@ export interface operations {
 				pid: string;
 				nid: string;
 				sid: string;
-				surface: 'vscode';
+				surface: 'vscode' | 'opencode';
 			};
 			cookie?: never;
 		};
@@ -9050,7 +9064,7 @@ export interface operations {
 						success: true;
 						data: components['schemas']['Surface'] & {
 							/** @enum {string} */
-							id: 'vscode';
+							id: 'vscode' | 'opencode';
 						};
 					};
 				};
@@ -9130,7 +9144,7 @@ export interface operations {
 				pid: string;
 				nid: string;
 				sid: string;
-				surface: 'vscode';
+				surface: 'vscode' | 'opencode';
 			};
 			cookie?: never;
 		};
@@ -9151,7 +9165,7 @@ export interface operations {
 						success: true;
 						data: components['schemas']['Surface'] & {
 							/** @enum {string} */
-							id: 'vscode';
+							id: 'vscode' | 'opencode';
 						};
 					};
 				};
@@ -9167,7 +9181,7 @@ export interface operations {
 						success: true;
 						data: components['schemas']['Surface'] & {
 							/** @enum {string} */
-							id: 'vscode';
+							id: 'vscode' | 'opencode';
 						};
 					};
 				};
@@ -9265,7 +9279,7 @@ export interface operations {
 				pid: string;
 				nid: string;
 				sid: string;
-				surface: 'vscode';
+				surface: 'vscode' | 'opencode';
 			};
 			cookie?: never;
 		};

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -767,6 +767,37 @@ describe('CoreWeaveCompute', () => {
 		});
 	});
 
+	describe('extra surface ports', () => {
+		it('advertises multiPort exactly when extra ports are configured', () => {
+			const world = makeWorld();
+			expect(makeCompute(world, baseConfig).capabilities).toEqual({ multiPort: false });
+			expect(makeCompute(world, { ...baseConfig, extraPorts: [8443] }).capabilities).toEqual({
+				multiPort: true,
+			});
+		});
+
+		it('reserves extra ports as create-time services beside the kernel', async () => {
+			const world = makeWorld();
+			await makeCompute(world, { ...baseConfig, extraPorts: [8443], kernelVisibility: 'custom' })
+				.create(SANDBOX_ID)
+				.exec('true');
+			const opts = world.created[0];
+			expect(opts.services).toEqual([
+				{ name: 'kernel', port: 2718, protocol: 'tcp', visibility: 'custom' },
+				{ name: 'port-8443', port: 8443, protocol: 'tcp', visibility: 'custom' },
+			]);
+		});
+
+		it('reserves extra ports on the template overlay too', async () => {
+			const world = makeWorld();
+			await makeCompute(world, { ...baseConfig, extraPorts: [8443], templateId: 'tmpl-marimohub' })
+				.create(SANDBOX_ID)
+				.exec('true');
+			const { options } = world.createdFromTemplate[0];
+			expect(options.services?.map((s) => s.port)).toEqual([2718, 8443]);
+		});
+	});
+
 	describe('provider surface', () => {
 		it('proxy() is a no-op (kernel reached via public ingress)', async () => {
 			const world = makeWorld();

--- a/packages/compute-coreweave/src/index.ts
+++ b/packages/compute-coreweave/src/index.ts
@@ -224,6 +224,8 @@ export interface CoreWeaveConfig {
 	kernelVisibility?: 'public' | 'custom';
 	/** Publishes each kernel's hostname (an Ingress in the sandbox namespace). */
 	kernelIngress?: KernelIngressPublisher;
+	/** Secondary-surface ports reserved when the sandbox is created. */
+	extraPorts?: readonly number[];
 	/**
 	 * Org-scoped sandbox template every sandbox is created from (custom specs:
 	 * GPU placement, egress rules, pod shape). Omit to use the runner's
@@ -457,13 +459,16 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 	 * there is no per-create egress knob.
 	 */
 	private kernelServices(): readonly Service[] {
+		const visibility = this.config.kernelVisibility ?? 'public';
 		return [
-			{
-				name: 'kernel',
-				port: this.kernelPort,
-				protocol: 'tcp',
-				visibility: this.config.kernelVisibility ?? 'public',
-			},
+			{ name: 'kernel', port: this.kernelPort, protocol: 'tcp', visibility },
+			...(this.config.extraPorts ?? []).map((port) => ({
+				// Names reach pod container-port names; keep them unique + DNS-safe.
+				name: `port-${port}`,
+				port,
+				protocol: 'tcp' as const,
+				visibility,
+			})),
 		];
 	}
 
@@ -934,7 +939,11 @@ class CoreWeaveSandboxInstance implements SandboxInstance {
 }
 
 export class CoreWeaveCompute implements SandboxProvider {
-	readonly capabilities = { multiPort: false } as const;
+	/**
+	 * v1 sandbox ports are create-time only, so a second port (the VS Code
+	 * surface) works exactly when it was pre-declared via `extraPorts`.
+	 */
+	readonly capabilities: { multiPort: boolean };
 	private client?: CoreWeaveClient;
 
 	constructor(
@@ -942,6 +951,7 @@ export class CoreWeaveCompute implements SandboxProvider {
 		client?: CoreWeaveClient,
 	) {
 		this.client = client;
+		this.capabilities = { multiPort: (config.extraPorts?.length ?? 0) > 0 };
 	}
 
 	private getClient(): CoreWeaveClient {

--- a/packages/compute-coreweave/src/kernelIngress.test.ts
+++ b/packages/compute-coreweave/src/kernelIngress.test.ts
@@ -45,7 +45,7 @@ describe('createKernelIngressPublisher', () => {
 		expect(post?.path).toBe('/apis/networking.k8s.io/v1/namespaces/org-ns/ingresses');
 		expect(post?.body).toMatchObject({
 			metadata: {
-				name: 'kernel-abc-123',
+				name: 'kernel-abc-123-2718',
 				ownerReferences: [{ kind: 'Service', name: 'sabc-123-service', uid: 'uid-1' }],
 			},
 			spec: {
@@ -127,6 +127,31 @@ describe('createKernelIngressPublisher', () => {
 			api,
 		});
 		await expect(publisher.publish(target)).rejects.toThrow(/expected one Service/);
+	});
+
+	it('publishes one Ingress per port and removes them by label', async () => {
+		const { api, calls } = fakeApi({
+			services: () => ({ items: [{ metadata: { name: 'svc', uid: 'u' } }] }),
+		});
+		const publisher = createKernelIngressPublisher({
+			namespace: 'org-ns',
+			ingressClassName: 'traefik',
+			api,
+		});
+		await publisher.publish({ ...target, port: 2718, host: 'abc-123-2718.sandbox.example.com' });
+		await publisher.publish({ ...target, port: 8443, host: 'abc-123-8443.sandbox.example.com' });
+		const posts = calls.filter((c) => c.method === 'POST');
+		expect(posts.map((c) => (c.body as { metadata: { name: string } }).metadata.name)).toEqual([
+			'kernel-abc-123-2718',
+			'kernel-abc-123-8443',
+		]);
+		await publisher.remove('abc-123');
+		const del = calls.find((c) => c.method === 'DELETE');
+		expect(del?.path).toBe(
+			`/apis/networking.k8s.io/v1/namespaces/org-ns/ingresses?labelSelector=${encodeURIComponent(
+				'sandbox.coreweave.com/sandbox-id=abc-123',
+			)}`,
+		);
 	});
 
 	it('treats an existing Ingress as published and a missing one as removed', async () => {

--- a/packages/compute-coreweave/src/kernelIngress.ts
+++ b/packages/compute-coreweave/src/kernelIngress.ts
@@ -126,7 +126,8 @@ export function createKernelIngressPublisher(
 	const ns = options.namespace;
 	const retries = options.retries ?? 10;
 	const retryDelayMs = options.retryDelayMs ?? 1000;
-	const ingressName = (sandboxId: string) => `kernel-${sandboxId}`;
+	// Cleanup by label also removes the port-less names created by older deployments.
+	const ingressName = (sandboxId: string, port: number) => `kernel-${sandboxId}-${port}`;
 
 	async function findService(sandboxId: string): Promise<{ name: string; uid: string }> {
 		const selector = encodeURIComponent(`${SANDBOX_ID_LABEL}=${sandboxId}`);
@@ -166,7 +167,7 @@ export function createKernelIngressPublisher(
 					apiVersion: 'networking.k8s.io/v1',
 					kind: 'Ingress',
 					metadata: {
-						name: ingressName(sandboxId),
+						name: ingressName(sandboxId, port),
 						namespace: ns,
 						labels: { 'app.kubernetes.io/managed-by': 'marimohub', [SANDBOX_ID_LABEL]: sandboxId },
 						ownerReferences: [{ apiVersion: 'v1', kind: 'Service', name: svc.name, uid: svc.uid }],
@@ -200,9 +201,10 @@ export function createKernelIngressPublisher(
 		},
 		async remove(sandboxId) {
 			assertSandboxId(sandboxId);
+			const selector = encodeURIComponent(`${SANDBOX_ID_LABEL}=${sandboxId}`);
 			const res = await api.request(
 				'DELETE',
-				`/apis/networking.k8s.io/v1/namespaces/${ns}/ingresses/${ingressName(sandboxId)}`,
+				`/apis/networking.k8s.io/v1/namespaces/${ns}/ingresses?labelSelector=${selector}`,
 			);
 			if (res.status === 404) return;
 			if (res.status < 200 || res.status >= 300) {

--- a/packages/config/src/compute.ts
+++ b/packages/config/src/compute.ts
@@ -18,6 +18,7 @@ import type { Env } from './env';
 import { ConfigError } from './errors';
 import type { LoadedAdapterLibraries } from './library';
 import { CONFIG_SPEC } from './spec';
+import { surfacesFromEnv } from './surfaces';
 
 const COMPUTE_BACKEND_VALUES = [
 	...(CONFIG_SPEC.find((g) => g.selector === 'MARIMOHUB_COMPUTE_BACKEND')?.backends ?? [])
@@ -204,6 +205,19 @@ export function usesSandboxNativeObjectStorage(env: Env): boolean {
 }
 
 /**
+ * Surface ports the CoreWeave create must reserve up front (v1 ports are
+ * create-time only). Deriving them here keeps `multiPort` honest: it is
+ * advertised exactly when the configured surfaces' ports are on every sandbox.
+ */
+function coreWeaveExtraPorts(env: Env): readonly number[] | undefined {
+	const surfaces = surfacesFromEnv(env);
+	const ports = [surfaces?.vscode?.port, surfaces?.opencode?.port].filter(
+		(port): port is number => port !== undefined,
+	);
+	return ports.length > 0 ? ports : undefined;
+}
+
+/**
  * Sandbox v1 has no per-create profile selection or network modes; the SDK
  * rejects those options client-side. Fail at boot with the replacement rather
  * than at the first provision with a cryptic validation error. (The user-home
@@ -311,6 +325,7 @@ export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 			}
 			return new CoreWeaveCompute({
 				apiKey: computeVar(env, 'MARIMOHUB_COMPUTE_COREWEAVE_API_KEY', 'coreweave'),
+				extraPorts: coreWeaveExtraPorts(env),
 				baseUrl: env.MARIMOHUB_COMPUTE_COREWEAVE_BASE_URL,
 				image: defaultImage,
 				ownerTag: env.MARIMOHUB_COMPUTE_COREWEAVE_OWNER_TAG,

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -737,7 +737,6 @@ describe('createFromEnv sandbox exposure mode', () => {
 		expect((deps.sandbox.exposure as ProxyExposure).signingSecret).toBe('x'.repeat(48));
 		expect(deps.sandbox.appBaseUrl).toBe('https://hub.example.com');
 	});
-
 	it('passes proxy exposure to the kubernetes compute adapter', () => {
 		const deps = createFromEnv({
 			...baseEnv,
@@ -751,6 +750,27 @@ describe('createFromEnv sandbox exposure mode', () => {
 		const config = (deps.compute as unknown as { config: { exposureMode?: string } }).config;
 
 		expect(config.exposureMode).toBe('proxy');
+	});
+
+	it('rejects OpenCode in proxy exposure mode', () => {
+		expect(() =>
+			createFromEnv({
+				...baseEnv,
+				MARIMOHUB_SURFACES: 'marimo,opencode',
+				MARIMOHUB_SANDBOX_EXPOSURE: 'proxy',
+				MARIMOHUB_SANDBOX_PROXY_ACK_UNTRUSTED: 'true',
+				MARIMOHUB_AUTH_SESSION_SECRET: 'x'.repeat(48),
+			}),
+		).toThrow(/OpenCode does not support proxy/);
+	});
+
+	it('rejects OpenCode when the compute backend cannot expose another port', () => {
+		expect(() =>
+			createFromEnv({
+				...baseEnv,
+				MARIMOHUB_SURFACES: 'marimo,opencode',
+			}),
+		).toThrow(/none compute backend cannot expose secondary sandbox surfaces/);
 	});
 });
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -547,9 +547,14 @@ export function createFromEnv(
 		libraries: options?.libraries,
 	});
 	const surfaces = surfacesFromEnv(env);
-	if (surfaces?.vscode && compute.capabilities?.multiPort !== true) {
+	if (surfaces?.opencode && exposure.mode === 'proxy') {
+		throw new ConfigError('OpenCode does not support proxy sandbox exposure', {
+			variable: 'MARIMOHUB_SURFACES',
+		});
+	}
+	if (surfaces && compute.capabilities?.multiPort !== true) {
 		throw new ConfigError(
-			`The ${computeBackendValue} compute backend cannot expose a second sandbox port for VS Code`,
+			`The ${computeBackendValue} compute backend cannot expose secondary sandbox surfaces`,
 			{ variable: 'MARIMOHUB_SURFACES' },
 		);
 	}

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -307,9 +307,9 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						id: 'MARIMOHUB_SURFACES',
 						name: 'Sandbox surfaces',
 						description:
-							'Comma-separated editor surfaces enabled in notebook sandboxes. `marimo` is always available; add `vscode` to enable browser VS Code.',
+							'Comma-separated editor surfaces enabled in notebook sandboxes. `marimo` is always available; add `vscode`, `opencode`, or both.',
 						default: 'marimo',
-						example: 'marimo,vscode',
+						example: 'marimo,vscode,opencode',
 						optIn: true,
 					},
 					{
@@ -353,7 +353,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 					{
 						id: 'MARIMOHUB_SURFACE_VSCODE_EMBED',
 						name: 'VS Code presentation',
-						description: 'Open VS Code in a new tab or an iframe (`tab` or `iframe`).',
+						description: 'Open VS Code in an application tab or split view (`tab` or `iframe`).',
 						default: 'tab',
 						optIn: true,
 					},
@@ -361,6 +361,42 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						id: 'MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH',
 						name: 'Watch VS Code edits in marimo',
 						description: 'Pass `--watch` to marimo edit when the VS Code surface is enabled.',
+						default: 'true',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_SURFACE_OPENCODE_START',
+						name: 'OpenCode start policy',
+						description: 'Start OpenCode on demand or with every authorized edit session.',
+						default: 'on-demand',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_SURFACE_OPENCODE_PORT',
+						name: 'OpenCode port',
+						description:
+							'Logical sandbox port used by OpenCode. Must differ from marimo port 2718 and all other enabled surface ports.',
+						default: '4096',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB',
+						name: 'OpenCode memory (MiB)',
+						description: 'Memory requirement declared for the OpenCode surface.',
+						default: '1024',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_SURFACE_OPENCODE_EMBED',
+						name: 'OpenCode presentation',
+						description: 'Open OpenCode in an application tab or split view (`tab` or `iframe`).',
+						default: 'tab',
+						optIn: true,
+					},
+					{
+						id: 'MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH',
+						name: 'Watch OpenCode edits in marimo',
+						description: 'Pass `--watch` to marimo edit when OpenCode is enabled.',
 						default: 'true',
 						optIn: true,
 					},

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -380,13 +380,6 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						optIn: true,
 					},
 					{
-						id: 'MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB',
-						name: 'OpenCode memory (MiB)',
-						description: 'Memory requirement declared for the OpenCode surface.',
-						default: '1024',
-						optIn: true,
-					},
-					{
 						id: 'MARIMOHUB_SURFACE_OPENCODE_EMBED',
 						name: 'OpenCode presentation',
 						description: 'Open OpenCode in an application tab or split view (`tab` or `iframe`).',

--- a/packages/config/src/surfaces.test.ts
+++ b/packages/config/src/surfaces.test.ts
@@ -33,7 +33,6 @@ describe('surfacesFromEnv', () => {
 				MARIMOHUB_SURFACES: 'marimo,vscode,opencode',
 				MARIMOHUB_SURFACE_OPENCODE_START: 'eager',
 				MARIMOHUB_SURFACE_OPENCODE_PORT: '5096',
-				MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: '1536',
 				MARIMOHUB_SURFACE_OPENCODE_EMBED: 'iframe',
 				MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH: 'false',
 			}),
@@ -42,7 +41,6 @@ describe('surfacesFromEnv', () => {
 			opencode: {
 				start: 'eager',
 				port: 5096,
-				memoryMb: 1536,
 				embed: 'iframe',
 				marimoWatch: false,
 			},
@@ -54,7 +52,6 @@ describe('surfacesFromEnv', () => {
 			opencode: {
 				start: 'on-demand',
 				port: 4096,
-				memoryMb: 1024,
 				embed: 'tab',
 				marimoWatch: true,
 			},
@@ -88,19 +85,13 @@ describe('surfacesFromEnv', () => {
 		).toThrow(new RegExp(variable));
 	});
 
-	it('rejects a shared secondary port and invalid OpenCode memory', () => {
+	it('rejects a shared secondary port', () => {
 		expect(() =>
 			surfacesFromEnv({
 				MARIMOHUB_SURFACES: 'marimo,vscode,opencode',
 				MARIMOHUB_SURFACE_VSCODE_PORT: '4096',
 			}),
 		).toThrow(/cannot share sandbox port/);
-		expect(() =>
-			surfacesFromEnv({
-				MARIMOHUB_SURFACES: 'marimo,opencode',
-				MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: '0',
-			}),
-		).toThrow(/MEMORY_MB/);
 	});
 
 	it.each([
@@ -109,8 +100,6 @@ describe('surfacesFromEnv', () => {
 		['MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH', 'yes'],
 		['MARIMOHUB_SURFACE_OPENCODE_PORT', '4096.5'],
 		['MARIMOHUB_SURFACE_OPENCODE_PORT', '65536'],
-		['MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB', '1.5'],
-		['MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB', '9007199254740992'],
 	] as const)('rejects invalid OpenCode value %s=%s', (variable, value) => {
 		expect(() =>
 			surfacesFromEnv({
@@ -134,7 +123,7 @@ describe('surfacesFromEnv', () => {
 		expect(
 			surfacesFromEnv({
 				MARIMOHUB_SURFACES: 'marimo,vscode',
-				MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: '0',
+				MARIMOHUB_SURFACE_OPENCODE_PORT: '0',
 			}),
 		).toHaveProperty('vscode');
 		expect(

--- a/packages/config/src/surfaces.test.ts
+++ b/packages/config/src/surfaces.test.ts
@@ -27,6 +27,40 @@ describe('surfacesFromEnv', () => {
 		});
 	});
 
+	it('parses OpenCode and both secondary surfaces', () => {
+		expect(
+			surfacesFromEnv({
+				MARIMOHUB_SURFACES: 'marimo,vscode,opencode',
+				MARIMOHUB_SURFACE_OPENCODE_START: 'eager',
+				MARIMOHUB_SURFACE_OPENCODE_PORT: '5096',
+				MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: '1536',
+				MARIMOHUB_SURFACE_OPENCODE_EMBED: 'iframe',
+				MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH: 'false',
+			}),
+		).toEqual({
+			vscode: expect.objectContaining({ port: 8443 }),
+			opencode: {
+				start: 'eager',
+				port: 5096,
+				memoryMb: 1536,
+				embed: 'iframe',
+				marimoWatch: false,
+			},
+		});
+	});
+
+	it('uses the OpenCode defaults', () => {
+		expect(surfacesFromEnv({ MARIMOHUB_SURFACES: 'marimo,opencode' })).toEqual({
+			opencode: {
+				start: 'on-demand',
+				port: 4096,
+				memoryMb: 1024,
+				embed: 'tab',
+				marimoWatch: true,
+			},
+		});
+	});
+
 	it('rejects unknown surfaces and invalid settings JSON', () => {
 		expect(() => surfacesFromEnv({ MARIMOHUB_SURFACES: 'jupyter' })).toThrow(/MARIMOHUB_SURFACES/);
 		expect(() =>
@@ -43,12 +77,71 @@ describe('surfacesFromEnv', () => {
 		).toThrow(/EXTENSION_GALLERY/);
 	});
 
-	it('rejects the primary marimo port for VS Code', () => {
+	it.each(['vscode', 'opencode'] as const)('rejects the primary marimo port for %s', (surface) => {
+		const variable =
+			surface === 'vscode' ? 'MARIMOHUB_SURFACE_VSCODE_PORT' : 'MARIMOHUB_SURFACE_OPENCODE_PORT';
 		expect(() =>
 			surfacesFromEnv({
-				MARIMOHUB_SURFACES: 'marimo,vscode',
-				MARIMOHUB_SURFACE_VSCODE_PORT: '2718',
+				MARIMOHUB_SURFACES: `marimo,${surface}`,
+				[variable]: '2718',
 			}),
-		).toThrow(/MARIMOHUB_SURFACE_VSCODE_PORT/);
+		).toThrow(new RegExp(variable));
+	});
+
+	it('rejects a shared secondary port and invalid OpenCode memory', () => {
+		expect(() =>
+			surfacesFromEnv({
+				MARIMOHUB_SURFACES: 'marimo,vscode,opencode',
+				MARIMOHUB_SURFACE_VSCODE_PORT: '4096',
+			}),
+		).toThrow(/cannot share sandbox port/);
+		expect(() =>
+			surfacesFromEnv({
+				MARIMOHUB_SURFACES: 'marimo,opencode',
+				MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: '0',
+			}),
+		).toThrow(/MEMORY_MB/);
+	});
+
+	it.each([
+		['MARIMOHUB_SURFACE_OPENCODE_START', 'sometimes'],
+		['MARIMOHUB_SURFACE_OPENCODE_EMBED', 'window'],
+		['MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH', 'yes'],
+		['MARIMOHUB_SURFACE_OPENCODE_PORT', '4096.5'],
+		['MARIMOHUB_SURFACE_OPENCODE_PORT', '65536'],
+		['MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB', '1.5'],
+		['MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB', '9007199254740992'],
+	] as const)('rejects invalid OpenCode value %s=%s', (variable, value) => {
+		expect(() =>
+			surfacesFromEnv({
+				MARIMOHUB_SURFACES: 'marimo,opencode',
+				[variable]: value,
+			}),
+		).toThrow(new RegExp(variable));
+	});
+
+	it('trims surface names without enabling empty entries', () => {
+		expect(
+			surfacesFromEnv({
+				MARIMOHUB_SURFACES: ' marimo, , opencode, ',
+			}),
+		).toEqual({
+			opencode: expect.objectContaining({ port: 4096 }),
+		});
+	});
+
+	it('ignores configuration for disabled surfaces', () => {
+		expect(
+			surfacesFromEnv({
+				MARIMOHUB_SURFACES: 'marimo,vscode',
+				MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: '0',
+			}),
+		).toHaveProperty('vscode');
+		expect(
+			surfacesFromEnv({
+				MARIMOHUB_SURFACES: 'marimo,opencode',
+				MARIMOHUB_SURFACE_VSCODE_SETTINGS_JSON: '[]',
+			}),
+		).toHaveProperty('opencode');
 	});
 });

--- a/packages/config/src/surfaces.ts
+++ b/packages/config/src/surfaces.ts
@@ -1,28 +1,23 @@
 import type { SandboxConfig } from '@marimo-hub/api';
-import { MARIMO_PORT } from '@marimo-hub/core';
+import { MARIMO_PORT, SECONDARY_SURFACE_IDS } from '@marimo-hub/core';
 import { parseBool, parseEnumOr, parseIntEnv, parseList } from './env';
 import type { Env } from './env';
 import { ConfigError } from './errors';
 
-const SURFACE_IDS = ['marimo', 'vscode'] as const;
+const SURFACE_IDS = ['marimo', ...SECONDARY_SURFACE_IDS] as const;
 
-export function surfacesFromEnv(env: Env): SandboxConfig['surfaces'] {
-	const enabled = new Set(parseList(env.MARIMOHUB_SURFACES) ?? ['marimo']);
-	for (const id of enabled) {
-		if (!(SURFACE_IDS as readonly string[]).includes(id)) {
-			throw new ConfigError(`Invalid MARIMOHUB_SURFACES entry: ${id}`, {
-				variable: 'MARIMOHUB_SURFACES',
-			});
-		}
-	}
-	if (!enabled.has('vscode')) return undefined;
+type VscodeConfig = NonNullable<NonNullable<SandboxConfig['surfaces']>['vscode']>;
+type OpenCodeConfig = NonNullable<NonNullable<SandboxConfig['surfaces']>['opencode']>;
 
-	const port = parseIntEnv(env, 'MARIMOHUB_SURFACE_VSCODE_PORT') ?? 8443;
+function surfacePort(env: Env, variable: string, defaultPort: number): number {
+	const port = parseIntEnv(env, variable) ?? defaultPort;
 	if (port < 1 || port > 65_535 || port === MARIMO_PORT) {
-		throw new ConfigError(`Invalid MARIMOHUB_SURFACE_VSCODE_PORT: ${port}`, {
-			variable: 'MARIMOHUB_SURFACE_VSCODE_PORT',
-		});
+		throw new ConfigError(`Invalid ${variable}: ${port}`, { variable });
 	}
+	return port;
+}
+
+function vscodeFromEnv(env: Env, port: number): VscodeConfig {
 	let settings: Record<string, unknown> = {};
 	if (env.MARIMOHUB_SURFACE_VSCODE_SETTINGS_JSON) {
 		try {
@@ -41,8 +36,9 @@ export function surfacesFromEnv(env: Env): SandboxConfig['surfaces'] {
 	if (extensionGallery !== 'openvsx' && extensionGallery !== 'none') {
 		try {
 			const url = new URL(extensionGallery);
-			if (url.protocol !== 'http:' && url.protocol !== 'https:')
+			if (url.protocol !== 'http:' && url.protocol !== 'https:') {
 				throw new Error('Unsupported scheme');
+			}
 		} catch {
 			throw new ConfigError(
 				'Invalid MARIMOHUB_SURFACE_VSCODE_EXTENSION_GALLERY: expected openvsx, none, or an HTTP(S) URL',
@@ -52,27 +48,75 @@ export function surfacesFromEnv(env: Env): SandboxConfig['surfaces'] {
 	}
 
 	return {
-		vscode: {
-			flavor: parseEnumOr(
-				env,
-				'MARIMOHUB_SURFACE_VSCODE_FLAVOR',
-				['code-server', 'openvscode'],
-				'code-server',
-			),
-			start: parseEnumOr(
-				env,
-				'MARIMOHUB_SURFACE_VSCODE_START',
-				['on-demand', 'eager'],
-				'on-demand',
-			),
-			port,
-			settings,
-			extensionGallery,
-			embed: parseEnumOr(env, 'MARIMOHUB_SURFACE_VSCODE_EMBED', ['tab', 'iframe'], 'tab'),
-			marimoWatch:
-				env.MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH === undefined
-					? true
-					: parseBool(env, 'MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH'),
-		},
+		flavor: parseEnumOr(
+			env,
+			'MARIMOHUB_SURFACE_VSCODE_FLAVOR',
+			['code-server', 'openvscode'],
+			'code-server',
+		),
+		start: parseEnumOr(env, 'MARIMOHUB_SURFACE_VSCODE_START', ['on-demand', 'eager'], 'on-demand'),
+		port,
+		settings,
+		extensionGallery,
+		embed: parseEnumOr(env, 'MARIMOHUB_SURFACE_VSCODE_EMBED', ['tab', 'iframe'], 'tab'),
+		marimoWatch:
+			env.MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH === undefined
+				? true
+				: parseBool(env, 'MARIMOHUB_SURFACE_VSCODE_MARIMO_WATCH'),
+	};
+}
+
+function openCodeFromEnv(env: Env, port: number): OpenCodeConfig {
+	const memoryMb = parseIntEnv(env, 'MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB') ?? 1024;
+	if (!Number.isSafeInteger(memoryMb) || memoryMb < 1) {
+		throw new ConfigError(`Invalid MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: ${memoryMb}`, {
+			variable: 'MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB',
+		});
+	}
+	return {
+		start: parseEnumOr(
+			env,
+			'MARIMOHUB_SURFACE_OPENCODE_START',
+			['on-demand', 'eager'],
+			'on-demand',
+		),
+		port,
+		memoryMb,
+		embed: parseEnumOr(env, 'MARIMOHUB_SURFACE_OPENCODE_EMBED', ['tab', 'iframe'], 'tab'),
+		marimoWatch:
+			env.MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH === undefined
+				? true
+				: parseBool(env, 'MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH'),
+	};
+}
+
+export function surfacesFromEnv(env: Env): SandboxConfig['surfaces'] {
+	const enabled = new Set(parseList(env.MARIMOHUB_SURFACES) ?? ['marimo']);
+	for (const id of enabled) {
+		if (!(SURFACE_IDS as readonly string[]).includes(id)) {
+			throw new ConfigError(`Invalid MARIMOHUB_SURFACES entry: ${id}`, {
+				variable: 'MARIMOHUB_SURFACES',
+			});
+		}
+	}
+	if (!SECONDARY_SURFACE_IDS.some((id) => enabled.has(id))) return undefined;
+
+	const vscodePort = enabled.has('vscode')
+		? surfacePort(env, 'MARIMOHUB_SURFACE_VSCODE_PORT', 8443)
+		: undefined;
+	const openCodePort = enabled.has('opencode')
+		? surfacePort(env, 'MARIMOHUB_SURFACE_OPENCODE_PORT', 4096)
+		: undefined;
+	if (vscodePort !== undefined && vscodePort === openCodePort) {
+		throw new ConfigError(`VS Code and OpenCode cannot share sandbox port ${vscodePort}`, {
+			variable: 'MARIMOHUB_SURFACES',
+		});
+	}
+	const vscode = vscodePort === undefined ? undefined : vscodeFromEnv(env, vscodePort);
+	const opencode = openCodePort === undefined ? undefined : openCodeFromEnv(env, openCodePort);
+
+	return {
+		...(vscode ? { vscode } : {}),
+		...(opencode ? { opencode } : {}),
 	};
 }

--- a/packages/config/src/surfaces.ts
+++ b/packages/config/src/surfaces.ts
@@ -67,12 +67,6 @@ function vscodeFromEnv(env: Env, port: number): VscodeConfig {
 }
 
 function openCodeFromEnv(env: Env, port: number): OpenCodeConfig {
-	const memoryMb = parseIntEnv(env, 'MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB') ?? 1024;
-	if (!Number.isSafeInteger(memoryMb) || memoryMb < 1) {
-		throw new ConfigError(`Invalid MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB: ${memoryMb}`, {
-			variable: 'MARIMOHUB_SURFACE_OPENCODE_MEMORY_MB',
-		});
-	}
 	return {
 		start: parseEnumOr(
 			env,
@@ -81,7 +75,6 @@ function openCodeFromEnv(env: Env, port: number): OpenCodeConfig {
 			'on-demand',
 		),
 		port,
-		memoryMb,
 		embed: parseEnumOr(env, 'MARIMOHUB_SURFACE_OPENCODE_EMBED', ['tab', 'iframe'], 'tab'),
 		marimoWatch:
 			env.MARIMOHUB_SURFACE_OPENCODE_MARIMO_WATCH === undefined

--- a/packages/core/src/services/runtime/SessionRetirer.test.ts
+++ b/packages/core/src/services/runtime/SessionRetirer.test.ts
@@ -135,6 +135,24 @@ describe('SessionRetirer', () => {
 		});
 	});
 
+	it('stops VS Code and OpenCode before destroying their shared sandbox', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const session = await persistentSession({
+			surfaces: {
+				vscode: { status: 'ready', port: 8443, url: 'https://vscode.example/' },
+				opencode: { status: 'ready', port: 4096, url: 'https://opencode.example/' },
+			},
+		});
+		await sessions.beginTerminating(projectId, session.session_id);
+
+		await retirer(fakeComputeFrom(instance)).retire(session);
+
+		const stopCommands = calls.exec.filter((command) => command.includes('/surface.pid'));
+		expect(stopCommands.some((command) => command.includes('/vscode/surface.pid'))).toBe(true);
+		expect(stopCommands.some((command) => command.includes('/opencode/surface.pid'))).toBe(true);
+		expect(calls.destroy).toBe(1);
+	});
+
 	it('does not snapshot or advance the restore pointer when the capture fails', async () => {
 		const { instance } = makeFakeSandbox();
 		const compute = snapshotProvider(instance);

--- a/packages/core/src/services/runtime/surfaces/SurfaceManager.test.ts
+++ b/packages/core/src/services/runtime/surfaces/SurfaceManager.test.ts
@@ -4,6 +4,7 @@ import { createNotebookId, createProjectId, createSandboxId } from '../../../ids
 import { MemoryBucket, ACTOR, fakeComputeFrom, makeFakeSandbox } from '../../../testing';
 import { SessionService } from '../SessionService';
 import { marimoSurface } from './marimo';
+import { opencodeSurface } from './opencode';
 import { SurfaceManager } from './SurfaceManager';
 import { SurfaceRegistry } from './registry';
 import { vscodeSurface } from './vscode';
@@ -44,6 +45,23 @@ function options() {
 }
 
 describe('SurfaceManager', () => {
+	it('rejects unsupported exposure and open-path combinations before sandbox work', async () => {
+		const { calls, instance, session, sessions } = await setup();
+		const manager = new SurfaceManager(
+			fakeComputeFrom(instance),
+			sessions,
+			new SurfaceRegistry([marimoSurface, opencodeSurface()]),
+		);
+
+		await expect(
+			manager.begin(session, 'opencode', { ...options(), exposure: 'proxy', open: undefined }),
+		).rejects.toThrow('does not support proxy exposure');
+		await expect(manager.begin(session, 'opencode', options())).rejects.toThrow(
+			'does not support an open path',
+		);
+		expect(calls.exec).toHaveLength(0);
+	});
+
 	it('prepares, starts, exposes, and persists a secondary surface once', async () => {
 		const { calls, manager, session, sessions } = await setup();
 

--- a/packages/core/src/services/runtime/surfaces/SurfaceManager.test.ts
+++ b/packages/core/src/services/runtime/surfaces/SurfaceManager.test.ts
@@ -98,6 +98,31 @@ describe('SurfaceManager', () => {
 		]);
 	});
 
+	it('lets a ready surface resolve its application URL from sandbox state', async () => {
+		const resolveOpenUrl = vi.fn(async (_instance: unknown, base: URL) => {
+			const url = new URL(base);
+			url.pathname = '/workspace/session/ses_test';
+			return url;
+		});
+		const { manager, session, sessions } = await setup(undefined, {
+			...vscodeSurface(),
+			resolveOpenUrl,
+		});
+
+		const result = await manager.ensure(session, 'vscode', { ...options(), open: undefined });
+
+		expect(result.state.url).toBe('https://sandbox.example/workspace/session/ses_test');
+		expect(resolveOpenUrl).toHaveBeenCalledWith(
+			expect.anything(),
+			new URL('https://sandbox.example/kernel'),
+			expect.objectContaining({ processWorkspaceDir: '/workspace' }),
+			{ open: undefined, port: 8443 },
+		);
+		expect(
+			(await sessions.getSession(session.project_id, session.session_id)).surfaces?.vscode?.url,
+		).toBe('https://sandbox.example/workspace/session/ses_test');
+	});
+
 	it.each([
 		'/secrets.txt',
 		'../secrets.txt',

--- a/packages/core/src/services/runtime/surfaces/SurfaceManager.ts
+++ b/packages/core/src/services/runtime/surfaces/SurfaceManager.ts
@@ -131,6 +131,14 @@ export class SurfaceManager {
 			throw new ConflictError('The sandbox must be running before a surface can start');
 		}
 		const spec = this.secondary(id);
+		if (!spec.supportedExposures.includes(options.exposure)) {
+			throw new SurfaceUnavailableError(
+				`Surface ${id} does not support ${options.exposure} exposure`,
+			);
+		}
+		if (options.open && !spec.supportsOpenPath) {
+			throw new SurfaceOpenInvalidError(`Surface ${id} does not support an open path`);
+		}
 		validateOpenPath(options.open);
 		const instance = this.provider.create(session.sandbox_id);
 		const context: SurfaceContext = {

--- a/packages/core/src/services/runtime/surfaces/SurfaceManager.ts
+++ b/packages/core/src/services/runtime/surfaces/SurfaceManager.ts
@@ -290,7 +290,12 @@ export class SurfaceManager {
 				name: id,
 			});
 			const publicBase = options.clientBaseUrl ?? exposed.url;
-			const url = spec.openUrl(new URL(publicBase), context, { open: options.open }).toString();
+			const openOptions = { open: options.open, port };
+			const url = (
+				spec.resolveOpenUrl
+					? await spec.resolveOpenUrl(instance, new URL(publicBase), context, openOptions)
+					: spec.openUrl(new URL(publicBase), context, openOptions)
+			).toString();
 			const state = {
 				status: 'ready' as const,
 				port,

--- a/packages/core/src/services/runtime/surfaces/index.ts
+++ b/packages/core/src/services/runtime/surfaces/index.ts
@@ -2,4 +2,5 @@ export * from './types';
 export * from './registry';
 export * from './marimo';
 export * from './vscode';
+export * from './opencode';
 export * from './SurfaceManager';

--- a/packages/core/src/services/runtime/surfaces/marimo.ts
+++ b/packages/core/src/services/runtime/surfaces/marimo.ts
@@ -4,6 +4,7 @@ export const marimoSurface: SurfaceSpec = {
 	id: 'marimo',
 	primary: true,
 	defaultPort: 2718,
+	supportedExposures: ['proxy', 'subdomain'],
 	proxyPath: 'preserve-prefix',
 	async probe() {
 		return { available: true };

--- a/packages/core/src/services/runtime/surfaces/opencode.test.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.test.ts
@@ -27,7 +27,7 @@ describe('opencodeSurface', () => {
 		expect(surface.supportedExposures).toEqual(['subdomain']);
 		expect(surface.resources).toEqual({ memoryMb: 1024 });
 		expect(surface.readiness.path).toBe('/global/health');
-		expect(calls.writeFile[0].path).toBe(`${context.userDataDir}/config/opencode.json`);
+		expect(calls.writeFile[0].path).toBe(`${context.userDataDir}/config/opencode/opencode.json`);
 		expect(JSON.parse(String(calls.writeFile[0].content))).toEqual({
 			$schema: 'https://opencode.ai/config.json',
 		});
@@ -38,12 +38,12 @@ describe('opencodeSurface', () => {
 				XDG_DATA_HOME: `${context.userDataDir}/data`,
 				XDG_CACHE_HOME: `${context.userDataDir}/cache`,
 				XDG_STATE_HOME: `${context.userDataDir}/state`,
-				OPENCODE_CONFIG: `${context.userDataDir}/config/opencode.json`,
+				OPENCODE_CONFIG: `${context.userDataDir}/config/opencode/opencode.json`,
 				OPENCODE_DISABLE_AUTOUPDATE: 'true',
 			},
 		});
 		expect(surface.openUrl(new URL('https://surface.example/'), context, {})).toEqual(
-			new URL('https://surface.example/'),
+			new URL('https://surface.example/L3dvcmtzcGFjZQ/session'),
 		);
 	});
 
@@ -77,8 +77,10 @@ describe('opencodeSurface', () => {
 
 		expect(JSON.parse(String(calls.writeFile[0].content))).toMatchObject({
 			model: 'marimohub/gpt-test',
+			small_model: 'marimohub/gpt-test',
 			provider: {
 				marimohub: {
+					name: 'marimo Hub',
 					npm: '@ai-sdk/openai-compatible',
 					options: {
 						baseURL: 'https://hub.example/api/ai/v1',
@@ -88,6 +90,43 @@ describe('opencodeSurface', () => {
 				},
 			},
 		});
+	});
+
+	it('opens the most recent workspace chat session', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		instance.exec = async (cmd) => {
+			calls.exec.push(cmd);
+			return { success: true, stdout: 'ses_existing123\n', stderr: '' };
+		};
+		const surface = opencodeSurface();
+
+		const url = await surface.resolveOpenUrl?.(
+			instance,
+			new URL('https://surface.example/'),
+			context,
+			{ port: 4096 },
+		);
+
+		expect(url).toEqual(new URL('https://surface.example/L3dvcmtzcGFjZQ/session/ses_existing123'));
+		expect(calls.exec[0]).toContain('127.0.0.1:4096');
+		expect(calls.exec[0]).toContain("'/workspace'");
+	});
+
+	it('falls back to the workspace composer when chat bootstrap fails', async () => {
+		const { instance } = makeFakeSandbox();
+		instance.exec = async () => ({
+			success: false,
+			stdout: '',
+			stderr: 'private failure',
+			error: { code: 'COMMAND_FAILED' },
+		});
+		const surface = opencodeSurface();
+
+		await expect(
+			surface.resolveOpenUrl?.(instance, new URL('https://surface.example/'), context, {
+				port: 4096,
+			}),
+		).resolves.toEqual(new URL('https://surface.example/L3dvcmtzcGFjZQ/session'));
 	});
 
 	it('reports a missing binary without exposing command output', async () => {
@@ -133,10 +172,11 @@ describe('opencodeSurface', () => {
 		expect(config).toEqual({
 			$schema: 'https://opencode.ai/config.json',
 			model: `marimohub/${model}`,
+			small_model: `marimohub/${model}`,
 			provider: {
 				marimohub: {
 					npm: '@ai-sdk/openai-compatible',
-					name: 'marimohub',
+					name: 'marimo Hub',
 					models: { [model]: { name: model } },
 					options: {
 						baseURL: 'https://hub.example/api/ai/v1?tenant="one"',

--- a/packages/core/src/services/runtime/surfaces/opencode.test.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.test.ts
@@ -25,7 +25,6 @@ describe('opencodeSurface', () => {
 		await surface.prepare?.(instance, context);
 
 		expect(surface.supportedExposures).toEqual(['subdomain']);
-		expect(surface.resources).toEqual({ memoryMb: 1024 });
 		expect(surface.readiness.path).toBe('/global/health');
 		expect(calls.writeFile[0].path).toBe(`${context.userDataDir}/config/opencode/opencode.json`);
 		expect(JSON.parse(String(calls.writeFile[0].content))).toEqual({
@@ -47,20 +46,19 @@ describe('opencodeSurface', () => {
 		);
 	});
 
-	it('reports the installed version and configured memory', async () => {
+	it('reports the installed version', async () => {
 		const { instance } = makeFakeSandbox();
 		instance.exec = async () => ({
 			success: true,
 			stdout: '1.18.17\n',
 			stderr: '',
 		});
-		const surface = opencodeSurface({ memoryMb: 1536 });
+		const surface = opencodeSurface();
 
 		await expect(surface.probe(instance)).resolves.toEqual({
 			available: true,
 			version: '1.18.17',
 		});
-		expect(surface.resources).toEqual({ memoryMb: 1536 });
 	});
 
 	it('writes managed AI as an overridable custom provider', async () => {

--- a/packages/core/src/services/runtime/surfaces/opencode.test.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.test.ts
@@ -84,7 +84,7 @@ describe('opencodeSurface', () => {
 			small_model: 'marimohub/gpt-test',
 			provider: {
 				marimohub: {
-					name: 'marimo Hub',
+					name: 'marimohub',
 					npm: '@ai-sdk/openai-compatible',
 					options: {
 						baseURL: 'https://hub.example/api/ai/v1',
@@ -114,6 +114,32 @@ describe('opencodeSurface', () => {
 		expect(url).toEqual(new URL('https://surface.example/L3dvcmtzcGFjZQ/session/ses_existing123'));
 		expect(calls.exec[0]).toContain('127.0.0.1:4096');
 		expect(calls.exec[0]).toContain("'/workspace'");
+	});
+
+	it('creates a managed-AI chat with the configured model', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		instance.exec = async (cmd) => {
+			calls.exec.push(cmd);
+			return { success: true, stdout: 'ses_managed123\n', stderr: '' };
+		};
+		const surface = opencodeSurface({
+			managedAi: {
+				baseUrl: 'https://hub.example/api/ai/v1',
+				apiKey: 'session-token',
+				model: 'gpt-test',
+			},
+		});
+
+		const url = await surface.resolveOpenUrl?.(
+			instance,
+			new URL('https://surface.example/'),
+			context,
+			{ port: 4096 },
+		);
+
+		expect(url).toEqual(new URL('https://surface.example/L3dvcmtzcGFjZQ/session/ses_managed123'));
+		expect(calls.exec[0]).not.toContain('?limit=1');
+		expect(calls.exec[0]).toContain(`'{"model":{"id":"gpt-test","providerID":"marimohub"}}'`);
 	});
 
 	it('falls back to the workspace composer when chat bootstrap fails', async () => {
@@ -180,7 +206,7 @@ describe('opencodeSurface', () => {
 			provider: {
 				marimohub: {
 					npm: '@ai-sdk/openai-compatible',
-					name: 'marimo Hub',
+					name: 'marimohub',
 					models: { [model]: { name: model } },
 					options: {
 						baseURL: 'https://hub.example/api/ai/v1?tenant="one"',

--- a/packages/core/src/services/runtime/surfaces/opencode.test.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import type { AuthUser } from '../../../ports/auth';
+import { makeFakeSandbox } from '../../../testing/fakes';
+import { opencodeSurface } from './opencode';
+import type { SurfaceContext } from './types';
+
+const context: SurfaceContext = {
+	sessionId: 'sess_test',
+	projectId: 'proj_test',
+	notebookId: 'nb_test',
+	workspaceDir: '/workspace',
+	processWorkspaceDir: '/workspace',
+	notebookFile: 'notebook.py',
+	user: { id: 'user_test', email: 'user@example.com' } as AuthUser,
+	editIntent: 'persistent',
+	exposure: 'subdomain',
+	userDataDir: '/tmp/.marimohub/surfaces/sess_test/opencode',
+};
+
+describe('opencodeSurface', () => {
+	it('uses sandbox-local state and starts the web server', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const surface = opencodeSurface();
+
+		await surface.prepare?.(instance, context);
+
+		expect(surface.supportedExposures).toEqual(['subdomain']);
+		expect(surface.resources).toEqual({ memoryMb: 1024 });
+		expect(surface.readiness.path).toBe('/global/health');
+		expect(calls.writeFile[0].path).toBe(`${context.userDataDir}/config/opencode.json`);
+		expect(JSON.parse(String(calls.writeFile[0].content))).toEqual({
+			$schema: 'https://opencode.ai/config.json',
+		});
+		expect(surface.command(context, 4096)).toEqual({
+			cmd: ['opencode', 'web', '--hostname', '0.0.0.0', '--port', '4096'],
+			env: {
+				XDG_CONFIG_HOME: `${context.userDataDir}/config`,
+				XDG_DATA_HOME: `${context.userDataDir}/data`,
+				XDG_CACHE_HOME: `${context.userDataDir}/cache`,
+				XDG_STATE_HOME: `${context.userDataDir}/state`,
+				OPENCODE_CONFIG: `${context.userDataDir}/config/opencode.json`,
+				OPENCODE_DISABLE_AUTOUPDATE: 'true',
+			},
+		});
+		expect(surface.openUrl(new URL('https://surface.example/'), context, {})).toEqual(
+			new URL('https://surface.example/'),
+		);
+	});
+
+	it('reports the installed version and configured memory', async () => {
+		const { instance } = makeFakeSandbox();
+		instance.exec = async () => ({
+			success: true,
+			stdout: '1.18.17\n',
+			stderr: '',
+		});
+		const surface = opencodeSurface({ memoryMb: 1536 });
+
+		await expect(surface.probe(instance)).resolves.toEqual({
+			available: true,
+			version: '1.18.17',
+		});
+		expect(surface.resources).toEqual({ memoryMb: 1536 });
+	});
+
+	it('writes managed AI as an overridable custom provider', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const surface = opencodeSurface({
+			managedAi: {
+				baseUrl: 'https://hub.example/api/ai/v1',
+				apiKey: 'session-token',
+				model: 'gpt-test',
+			},
+		});
+
+		await surface.prepare?.(instance, context);
+
+		expect(JSON.parse(String(calls.writeFile[0].content))).toMatchObject({
+			model: 'marimohub/gpt-test',
+			provider: {
+				marimohub: {
+					npm: '@ai-sdk/openai-compatible',
+					options: {
+						baseURL: 'https://hub.example/api/ai/v1',
+						apiKey: 'session-token',
+					},
+					models: { 'gpt-test': { name: 'gpt-test' } },
+				},
+			},
+		});
+	});
+
+	it('reports a missing binary without exposing command output', async () => {
+		const { instance } = makeFakeSandbox();
+		instance.exec = async () => ({
+			success: false,
+			stdout: '',
+			stderr: 'private shell output',
+			error: { code: 'COMMAND_FAILED' },
+		});
+
+		await expect(opencodeSurface().probe(instance)).resolves.toEqual({
+			available: false,
+			reason: 'The sandbox image does not include opencode',
+		});
+	});
+
+	it('does not persist an empty version when the probe has no output', async () => {
+		const { instance } = makeFakeSandbox();
+		instance.exec = async () => ({
+			success: true,
+			stdout: '  \n',
+			stderr: '',
+		});
+
+		await expect(opencodeSurface().probe(instance)).resolves.toEqual({ available: true });
+	});
+
+	it('escapes managed provider values when it writes JSON', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const model = 'vendor/model"quoted';
+		const surface = opencodeSurface({
+			managedAi: {
+				baseUrl: 'https://hub.example/api/ai/v1?tenant="one"',
+				apiKey: 'token-with-"-quote',
+				model,
+			},
+		});
+
+		await surface.prepare?.(instance, context);
+		const config = JSON.parse(String(calls.writeFile[0].content));
+
+		expect(config).toEqual({
+			$schema: 'https://opencode.ai/config.json',
+			model: `marimohub/${model}`,
+			provider: {
+				marimohub: {
+					npm: '@ai-sdk/openai-compatible',
+					name: 'marimohub',
+					models: { [model]: { name: model } },
+					options: {
+						baseURL: 'https://hub.example/api/ai/v1?tenant="one"',
+						apiKey: 'token-with-"-quote',
+					},
+				},
+			},
+		});
+	});
+});

--- a/packages/core/src/services/runtime/surfaces/opencode.test.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.test.ts
@@ -31,15 +31,21 @@ describe('opencodeSurface', () => {
 			$schema: 'https://opencode.ai/config.json',
 		});
 		expect(surface.command(context, 4096)).toEqual({
-			cmd: ['opencode', 'web', '--hostname', '0.0.0.0', '--port', '4096'],
-			env: {
-				XDG_CONFIG_HOME: `${context.userDataDir}/config`,
-				XDG_DATA_HOME: `${context.userDataDir}/data`,
-				XDG_CACHE_HOME: `${context.userDataDir}/cache`,
-				XDG_STATE_HOME: `${context.userDataDir}/state`,
-				OPENCODE_CONFIG: `${context.userDataDir}/config/opencode/opencode.json`,
-				OPENCODE_DISABLE_AUTOUPDATE: 'true',
-			},
+			cmd: [
+				'env',
+				`XDG_CONFIG_HOME=${context.userDataDir}/config`,
+				`XDG_DATA_HOME=${context.userDataDir}/data`,
+				`XDG_CACHE_HOME=${context.userDataDir}/cache`,
+				`XDG_STATE_HOME=${context.userDataDir}/state`,
+				`OPENCODE_CONFIG=${context.userDataDir}/config/opencode/opencode.json`,
+				'OPENCODE_DISABLE_AUTOUPDATE=true',
+				'opencode',
+				'web',
+				'--hostname',
+				'0.0.0.0',
+				'--port',
+				'4096',
+			],
 		});
 		expect(surface.openUrl(new URL('https://surface.example/'), context, {})).toEqual(
 			new URL('https://surface.example/L3dvcmtzcGFjZQ/session'),

--- a/packages/core/src/services/runtime/surfaces/opencode.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.ts
@@ -1,0 +1,91 @@
+import type { SurfaceSpec } from './types';
+
+export interface OpenCodeManagedAiOptions {
+	baseUrl: string;
+	apiKey: string;
+	model: string;
+}
+
+export interface OpenCodeSurfaceOptions {
+	port?: number;
+	memoryMb?: number;
+	managedAi?: OpenCodeManagedAiOptions;
+}
+
+function openCodeConfig(managedAi: OpenCodeManagedAiOptions | undefined): string {
+	return JSON.stringify(
+		{
+			$schema: 'https://opencode.ai/config.json',
+			...(managedAi
+				? {
+						provider: {
+							marimohub: {
+								npm: '@ai-sdk/openai-compatible',
+								name: 'marimohub',
+								options: {
+									baseURL: managedAi.baseUrl,
+									apiKey: managedAi.apiKey,
+								},
+								models: {
+									[managedAi.model]: { name: managedAi.model },
+								},
+							},
+						},
+						model: `marimohub/${managedAi.model}`,
+					}
+				: {}),
+		},
+		null,
+		2,
+	);
+}
+
+export function opencodeSurface(options: OpenCodeSurfaceOptions = {}): SurfaceSpec {
+	return {
+		id: 'opencode',
+		primary: false,
+		defaultPort: options.port ?? 4096,
+		supportedExposures: ['subdomain'],
+		proxyPath: 'strip-prefix',
+		resources: { memoryMb: options.memoryMb ?? 1024 },
+		async probe(instance) {
+			const result = await instance.exec(
+				`command -v opencode >/dev/null 2>&1 && opencode --version`,
+				{ timeout: 10_000 },
+			);
+			if (!result.success) {
+				return {
+					available: false,
+					reason: 'The sandbox image does not include opencode',
+				};
+			}
+			const version = result.stdout.trim().split(/\s+/)[0];
+			return { available: true, ...(version ? { version } : {}) };
+		},
+		async prepare(instance, ctx) {
+			await instance.writeFiles([
+				{
+					path: `${ctx.userDataDir}/config/opencode.json`,
+					content: openCodeConfig(options.managedAi),
+				},
+			]);
+		},
+		command(ctx, port) {
+			return {
+				cmd: ['opencode', 'web', '--hostname', '0.0.0.0', '--port', String(port)],
+				env: {
+					XDG_CONFIG_HOME: `${ctx.userDataDir}/config`,
+					XDG_DATA_HOME: `${ctx.userDataDir}/data`,
+					XDG_CACHE_HOME: `${ctx.userDataDir}/cache`,
+					XDG_STATE_HOME: `${ctx.userDataDir}/state`,
+					OPENCODE_CONFIG: `${ctx.userDataDir}/config/opencode.json`,
+					OPENCODE_DISABLE_AUTOUPDATE: 'true',
+				},
+			};
+		},
+		readiness: { path: '/global/health', timeoutMs: 120_000 },
+		openUrl(base) {
+			return base;
+		},
+	};
+}

--- a/packages/core/src/services/runtime/surfaces/opencode.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.ts
@@ -1,3 +1,6 @@
+import { utf8ToBase64Url } from '../../../internal/base64url';
+import type { SandboxInstance } from '../../../ports/sandbox';
+import { shellQuote } from '../shell';
 import type { SurfaceSpec } from './types';
 
 export interface OpenCodeManagedAiOptions {
@@ -13,6 +16,7 @@ export interface OpenCodeSurfaceOptions {
 }
 
 function openCodeConfig(managedAi: OpenCodeManagedAiOptions | undefined): string {
+	const model = managedAi ? `marimohub/${managedAi.model}` : undefined;
 	return JSON.stringify(
 		{
 			$schema: 'https://opencode.ai/config.json',
@@ -21,7 +25,7 @@ function openCodeConfig(managedAi: OpenCodeManagedAiOptions | undefined): string
 						provider: {
 							marimohub: {
 								npm: '@ai-sdk/openai-compatible',
-								name: 'marimohub',
+								name: 'marimo Hub',
 								options: {
 									baseURL: managedAi.baseUrl,
 									apiKey: managedAi.apiKey,
@@ -31,13 +35,47 @@ function openCodeConfig(managedAi: OpenCodeManagedAiOptions | undefined): string
 								},
 							},
 						},
-						model: `marimohub/${managedAi.model}`,
+						model,
+						small_model: model,
 					}
 				: {}),
 		},
 		null,
 		2,
 	);
+}
+
+function workspaceSessionUrl(base: URL, workspaceDir: string, sessionId?: string): URL {
+	const url = new URL(base);
+	const workspace = utf8ToBase64Url(workspaceDir);
+	url.pathname = `/${workspace}/session${sessionId ? `/${sessionId}` : ''}`;
+	return url;
+}
+
+async function findOrCreateSession(
+	instance: SandboxInstance,
+	port: number,
+	workspaceDir: string,
+): Promise<string | undefined> {
+	const script = [
+		'import json,sys,urllib.parse,urllib.request',
+		'base=sys.argv[1]+"/session"',
+		'headers={"x-opencode-directory":urllib.parse.quote(sys.argv[2], safe="")}',
+		'list_request=urllib.request.Request(base+"?limit=1", headers=headers)',
+		'with urllib.request.urlopen(list_request, timeout=10) as response: sessions=json.load(response)',
+		'if sessions: print(sessions[0]["id"])',
+		'else:',
+		' headers["content-type"]="application/json"',
+		' request=urllib.request.Request(base, data=b"{}", headers=headers, method="POST")',
+		' with urllib.request.urlopen(request, timeout=10) as response: print(json.load(response)["id"])',
+	].join('\n');
+	const result = await instance.exec(
+		`python3 -c ${shellQuote(script)} ${shellQuote(`http://127.0.0.1:${port}`)} ${shellQuote(workspaceDir)}`,
+		{ timeout: 15_000 },
+	);
+	if (!result.success) return undefined;
+	const sessionId = result.stdout.trim();
+	return /^ses_[A-Za-z0-9]+$/.test(sessionId) ? sessionId : undefined;
 }
 
 export function opencodeSurface(options: OpenCodeSurfaceOptions = {}): SurfaceSpec {
@@ -63,14 +101,16 @@ export function opencodeSurface(options: OpenCodeSurfaceOptions = {}): SurfaceSp
 			return { available: true, ...(version ? { version } : {}) };
 		},
 		async prepare(instance, ctx) {
+			const configPath = `${ctx.userDataDir}/config/opencode/opencode.json`;
 			await instance.writeFiles([
 				{
-					path: `${ctx.userDataDir}/config/opencode.json`,
+					path: configPath,
 					content: openCodeConfig(options.managedAi),
 				},
 			]);
 		},
 		command(ctx, port) {
+			const configPath = `${ctx.userDataDir}/config/opencode/opencode.json`;
 			return {
 				cmd: ['opencode', 'web', '--hostname', '0.0.0.0', '--port', String(port)],
 				env: {
@@ -78,14 +118,18 @@ export function opencodeSurface(options: OpenCodeSurfaceOptions = {}): SurfaceSp
 					XDG_DATA_HOME: `${ctx.userDataDir}/data`,
 					XDG_CACHE_HOME: `${ctx.userDataDir}/cache`,
 					XDG_STATE_HOME: `${ctx.userDataDir}/state`,
-					OPENCODE_CONFIG: `${ctx.userDataDir}/config/opencode.json`,
+					OPENCODE_CONFIG: configPath,
 					OPENCODE_DISABLE_AUTOUPDATE: 'true',
 				},
 			};
 		},
 		readiness: { path: '/global/health', timeoutMs: 120_000 },
-		openUrl(base) {
-			return base;
+		openUrl(base, ctx) {
+			return workspaceSessionUrl(base, ctx.processWorkspaceDir);
+		},
+		async resolveOpenUrl(instance, base, ctx, { port }) {
+			const sessionId = await findOrCreateSession(instance, port, ctx.processWorkspaceDir);
+			return workspaceSessionUrl(base, ctx.processWorkspaceDir, sessionId);
 		},
 	};
 }

--- a/packages/core/src/services/runtime/surfaces/opencode.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.ts
@@ -109,16 +109,25 @@ export function opencodeSurface(options: OpenCodeSurfaceOptions = {}): SurfaceSp
 		},
 		command(ctx, port) {
 			const configPath = `${ctx.userDataDir}/config/opencode/opencode.json`;
+			const environment = {
+				XDG_CONFIG_HOME: `${ctx.userDataDir}/config`,
+				XDG_DATA_HOME: `${ctx.userDataDir}/data`,
+				XDG_CACHE_HOME: `${ctx.userDataDir}/cache`,
+				XDG_STATE_HOME: `${ctx.userDataDir}/state`,
+				OPENCODE_CONFIG: configPath,
+				OPENCODE_DISABLE_AUTOUPDATE: 'true',
+			};
 			return {
-				cmd: ['opencode', 'web', '--hostname', '0.0.0.0', '--port', String(port)],
-				env: {
-					XDG_CONFIG_HOME: `${ctx.userDataDir}/config`,
-					XDG_DATA_HOME: `${ctx.userDataDir}/data`,
-					XDG_CACHE_HOME: `${ctx.userDataDir}/cache`,
-					XDG_STATE_HOME: `${ctx.userDataDir}/state`,
-					OPENCODE_CONFIG: configPath,
-					OPENCODE_DISABLE_AUTOUPDATE: 'true',
-				},
+				cmd: [
+					'env',
+					...Object.entries(environment).map(([key, value]) => `${key}=${value}`),
+					'opencode',
+					'web',
+					'--hostname',
+					'0.0.0.0',
+					'--port',
+					String(port),
+				],
 			};
 		},
 		readiness: { path: '/global/health', timeoutMs: 120_000 },

--- a/packages/core/src/services/runtime/surfaces/opencode.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.ts
@@ -24,7 +24,7 @@ function openCodeConfig(managedAi: OpenCodeManagedAiOptions | undefined): string
 						provider: {
 							marimohub: {
 								npm: '@ai-sdk/openai-compatible',
-								name: 'marimo Hub',
+								name: 'marimohub',
 								options: {
 									baseURL: managedAi.baseUrl,
 									apiKey: managedAi.apiKey,
@@ -55,21 +55,28 @@ async function findOrCreateSession(
 	instance: SandboxInstance,
 	port: number,
 	workspaceDir: string,
+	initialModel?: string,
 ): Promise<string | undefined> {
+	const createBody = JSON.stringify(
+		initialModel ? { model: { id: initialModel, providerID: 'marimohub' } } : {},
+	);
 	const script = [
 		'import json,sys,urllib.parse,urllib.request',
 		'base=sys.argv[1]+"/session"',
 		'headers={"x-opencode-directory":urllib.parse.quote(sys.argv[2], safe="")}',
-		'list_request=urllib.request.Request(base+"?limit=1", headers=headers)',
-		'with urllib.request.urlopen(list_request, timeout=10) as response: sessions=json.load(response)',
-		'if sessions: print(sessions[0]["id"])',
-		'else:',
-		' headers["content-type"]="application/json"',
-		' request=urllib.request.Request(base, data=b"{}", headers=headers, method="POST")',
-		' with urllib.request.urlopen(request, timeout=10) as response: print(json.load(response)["id"])',
+		...(initialModel
+			? []
+			: [
+					'list_request=urllib.request.Request(base+"?limit=1", headers=headers)',
+					'with urllib.request.urlopen(list_request, timeout=10) as response: sessions=json.load(response)',
+					'if sessions: print(sessions[0]["id"]); sys.exit(0)',
+				]),
+		'headers["content-type"]="application/json"',
+		'request=urllib.request.Request(base, data=sys.argv[3].encode(), headers=headers, method="POST")',
+		'with urllib.request.urlopen(request, timeout=10) as response: print(json.load(response)["id"])',
 	].join('\n');
 	const result = await instance.exec(
-		`python3 -c ${shellQuote(script)} ${shellQuote(`http://127.0.0.1:${port}`)} ${shellQuote(workspaceDir)}`,
+		`python3 -c ${shellQuote(script)} ${shellQuote(`http://127.0.0.1:${port}`)} ${shellQuote(workspaceDir)} ${shellQuote(createBody)}`,
 		{ timeout: 15_000 },
 	);
 	if (!result.success) return undefined;
@@ -135,7 +142,12 @@ export function opencodeSurface(options: OpenCodeSurfaceOptions = {}): SurfaceSp
 			return workspaceSessionUrl(base, ctx.processWorkspaceDir);
 		},
 		async resolveOpenUrl(instance, base, ctx, { port }) {
-			const sessionId = await findOrCreateSession(instance, port, ctx.processWorkspaceDir);
+			const sessionId = await findOrCreateSession(
+				instance,
+				port,
+				ctx.processWorkspaceDir,
+				options.managedAi?.model,
+			);
 			return workspaceSessionUrl(base, ctx.processWorkspaceDir, sessionId);
 		},
 	};

--- a/packages/core/src/services/runtime/surfaces/opencode.ts
+++ b/packages/core/src/services/runtime/surfaces/opencode.ts
@@ -11,7 +11,6 @@ export interface OpenCodeManagedAiOptions {
 
 export interface OpenCodeSurfaceOptions {
 	port?: number;
-	memoryMb?: number;
 	managedAi?: OpenCodeManagedAiOptions;
 }
 
@@ -85,7 +84,6 @@ export function opencodeSurface(options: OpenCodeSurfaceOptions = {}): SurfaceSp
 		defaultPort: options.port ?? 4096,
 		supportedExposures: ['subdomain'],
 		proxyPath: 'strip-prefix',
-		resources: { memoryMb: options.memoryMb ?? 1024 },
 		async probe(instance) {
 			const result = await instance.exec(
 				`command -v opencode >/dev/null 2>&1 && opencode --version`,

--- a/packages/core/src/services/runtime/surfaces/types.ts
+++ b/packages/core/src/services/runtime/surfaces/types.ts
@@ -1,7 +1,9 @@
 import type { AuthUser } from '../../../ports/auth';
 import type { SandboxInstance } from '../../../ports/sandbox';
 
-export type SurfaceId = 'marimo' | 'vscode';
+export const SECONDARY_SURFACE_IDS = ['vscode', 'opencode'] as const;
+export type SecondarySurfaceId = (typeof SECONDARY_SURFACE_IDS)[number];
+export type SurfaceId = 'marimo' | SecondarySurfaceId;
 
 export interface SurfaceContext {
 	sessionId: string;
@@ -28,10 +30,13 @@ export interface SurfaceSpec {
 	id: SurfaceId;
 	primary: boolean;
 	defaultPort: number;
+	supportedExposures: readonly SurfaceContext['exposure'][];
+	supportsOpenPath?: boolean;
 	proxyPath: 'strip-prefix' | 'preserve-prefix';
 	probe(instance: SandboxInstance): Promise<SurfaceProbe>;
 	prepare?(instance: SandboxInstance, ctx: SurfaceContext): Promise<void>;
 	command(ctx: SurfaceContext, port: number): { cmd: string[]; env?: Record<string, string> };
 	readiness: { path: string; timeoutMs: number };
 	openUrl(base: URL, ctx: SurfaceContext, opts: { open?: string }): URL;
+	resources?: { memoryMb: number };
 }

--- a/packages/core/src/services/runtime/surfaces/types.ts
+++ b/packages/core/src/services/runtime/surfaces/types.ts
@@ -38,5 +38,11 @@ export interface SurfaceSpec {
 	command(ctx: SurfaceContext, port: number): { cmd: string[]; env?: Record<string, string> };
 	readiness: { path: string; timeoutMs: number };
 	openUrl(base: URL, ctx: SurfaceContext, opts: { open?: string }): URL;
+	resolveOpenUrl?(
+		instance: SandboxInstance,
+		base: URL,
+		ctx: SurfaceContext,
+		opts: { open?: string; port: number },
+	): Promise<URL>;
 	resources?: { memoryMb: number };
 }

--- a/packages/core/src/services/runtime/surfaces/types.ts
+++ b/packages/core/src/services/runtime/surfaces/types.ts
@@ -44,5 +44,4 @@ export interface SurfaceSpec {
 		ctx: SurfaceContext,
 		opts: { open?: string; port: number },
 	): Promise<URL>;
-	resources?: { memoryMb: number };
 }

--- a/packages/core/src/services/runtime/surfaces/vscode.ts
+++ b/packages/core/src/services/runtime/surfaces/vscode.ts
@@ -43,6 +43,8 @@ export function vscodeSurface(options: VscodeSurfaceOptions = {}): SurfaceSpec {
 		id: 'vscode',
 		primary: false,
 		defaultPort: options.port ?? 8443,
+		supportedExposures: ['proxy', 'subdomain'],
+		supportsOpenPath: true,
 		proxyPath: flavor === 'code-server' ? 'strip-prefix' : 'preserve-prefix',
 		async probe(instance) {
 			const result = await instance.exec(

--- a/packages/web/src/api/hooks.test.tsx
+++ b/packages/web/src/api/hooks.test.tsx
@@ -6,7 +6,6 @@ import { browseKeys, notebookKeys, projectKeys, sessionKeys } from './queryKeys'
 import {
 	refreshBrowseQueries,
 	resetBrowseRefreshBudgetForTests,
-	SURFACE_START_TIMEOUT_MS,
 	useBrowseCapabilityQuery,
 	useBrowseTablePreview,
 	useBrowseTablesQuery,
@@ -33,10 +32,6 @@ import {
 
 const PID = 'proj-1';
 const NID = 'nb-1';
-
-it('keeps the VS Code polling window beyond the server startup phase budgets', () => {
-	expect(SURFACE_START_TIMEOUT_MS).toBeGreaterThan(150_000);
-});
 
 type FetchHandler = (url: RequestInfo | URL, init?: RequestInit | Request) => Promise<Response>;
 

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -1785,63 +1785,6 @@ export function useStopSession(
 	);
 }
 
-const SURFACE_POLL_INTERVAL_MS = 1_000;
-export const SURFACE_START_TIMEOUT_MS = 180_000;
-
-export function useEnsureVscodeSurface(projectId: string, notebookId: string) {
-	return useMutation({
-		mutationFn: async ({ sessionId, open }: { sessionId: string; open?: string }) => {
-			const params = {
-				path: { pid: projectId, nid: notebookId, sid: sessionId, surface: 'vscode' as const },
-			};
-			let surface = await apiData(
-				apiClient.POST('/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/surfaces/{surface}', {
-					params,
-					body: open ? { open } : {},
-				}),
-			);
-			const deadline = Date.now() + SURFACE_START_TIMEOUT_MS;
-			while (surface.status === 'starting' && Date.now() < deadline) {
-				await new Promise<void>((resolve) => {
-					setTimeout(resolve, SURFACE_POLL_INTERVAL_MS);
-				});
-				surface = await apiData(
-					apiClient.GET(
-						'/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/surfaces/{surface}',
-						{ params },
-					),
-				);
-			}
-			if (surface.status !== 'ready' || !surface.url) {
-				throw new Error(surface.last_error ?? 'VS Code did not become ready');
-			}
-			return surface;
-		},
-	});
-}
-
-export function useStopVscodeSurface(projectId: string, notebookId: string) {
-	return useApiMutation(
-		(sessionId: string) =>
-			apiData(
-				apiClient.DELETE(
-					'/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/surfaces/{surface}',
-					{
-						params: {
-							path: {
-								pid: projectId,
-								nid: notebookId,
-								sid: sessionId,
-								surface: 'vscode',
-							},
-						},
-					},
-				),
-			),
-		() => [sessionKeys.listByProject(projectId)],
-	);
-}
-
 export function useEditorSessionQuery(
 	projectId: string,
 	notebookId: string,

--- a/packages/web/src/api/surfaces.test.tsx
+++ b/packages/web/src/api/surfaces.test.tsx
@@ -1,0 +1,153 @@
+import { act, waitFor } from '@testing-library/react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { jsonOk, renderHookWithClient } from '@/test/render';
+import { SURFACE_START_TIMEOUT_MS, useSurfaceActions } from './surfaces';
+
+const PID = 'proj-1';
+const NID = 'nb-1';
+
+function stubFetch(handler: (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+	const fetchMock = vi.fn(handler);
+	vi.stubGlobal('fetch', fetchMock);
+	return fetchMock;
+}
+
+function jsonError(code: string, message: string, status: number) {
+	return new Response(JSON.stringify({ success: false, error: { code, message } }), {
+		status,
+		headers: { 'content-type': 'application/json' },
+	});
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.unstubAllGlobals();
+});
+
+it('keeps the polling window beyond the server startup phase budgets', () => {
+	expect(SURFACE_START_TIMEOUT_MS).toBeGreaterThan(150_000);
+});
+
+it('polls an OpenCode start until the surface is ready', async () => {
+	vi.useFakeTimers();
+	const fetchMock = stubFetch(async (url, init) => {
+		if (!String(url).endsWith('/surfaces/opencode')) {
+			throw new Error(`unexpected fetch: ${String(url)}`);
+		}
+		if (init?.method === 'POST') {
+			return jsonOk({ id: 'opencode', status: 'starting' });
+		}
+		return jsonOk({ id: 'opencode', status: 'ready', url: 'https://opencode.example/' });
+	});
+	const { result } = renderHookWithClient(() => useSurfaceActions(PID, NID));
+	let completion!: ReturnType<typeof result.current.start.mutateAsync>;
+	act(() => {
+		completion = result.current.start.mutateAsync({
+			surfaceId: 'opencode',
+			sessionId: 'sess-1',
+		});
+	});
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(1_000);
+	});
+
+	await expect(completion).resolves.toMatchObject({
+		id: 'opencode',
+		status: 'ready',
+		url: 'https://opencode.example/',
+	});
+	expect(fetchMock).toHaveBeenCalledTimes(2);
+	expect(result.current.states.opencode).toMatchObject({
+		sessionId: 'sess-1',
+		surface: { status: 'ready', url: 'https://opencode.example/' },
+	});
+});
+
+it('reports a terminal polling failure without caching the surface', async () => {
+	vi.useFakeTimers();
+	stubFetch(async (_url, init) =>
+		init?.method === 'POST'
+			? jsonOk({ id: 'opencode', status: 'starting' })
+			: jsonOk({
+					id: 'opencode',
+					status: 'failed',
+					last_error: 'OpenCode exited before readiness',
+				}),
+	);
+	const { result } = renderHookWithClient(() => useSurfaceActions(PID, NID));
+	let completion!: ReturnType<typeof result.current.start.mutateAsync>;
+	act(() => {
+		completion = result.current.start.mutateAsync({
+			surfaceId: 'opencode',
+			sessionId: 'sess-1',
+		});
+	});
+	const rejected = expect(completion).rejects.toThrow('OpenCode exited before readiness');
+	await act(async () => {
+		await vi.advanceTimersByTimeAsync(1_000);
+		await rejected;
+		await vi.advanceTimersByTimeAsync(0);
+	});
+
+	expect(result.current.states.opencode).toBeUndefined();
+});
+
+it('keeps the ready state when stopping the surface fails', async () => {
+	stubFetch(async (_url, init) => {
+		if (init?.method === 'POST') {
+			return jsonOk({ id: 'opencode', status: 'ready', url: 'https://opencode.example/' });
+		}
+		return jsonError('SERVICE_UNAVAILABLE', 'sandbox is unavailable', 503);
+	});
+	const { result } = renderHookWithClient(() => useSurfaceActions(PID, NID));
+
+	await act(async () => {
+		await result.current.start.mutateAsync({ surfaceId: 'opencode', sessionId: 'sess-1' });
+	});
+	await act(async () => {
+		await expect(
+			result.current.stop.mutateAsync({ surfaceId: 'opencode', sessionId: 'sess-1' }),
+		).rejects.toMatchObject({ code: 'SERVICE_UNAVAILABLE' });
+	});
+
+	expect(result.current.states.opencode).toMatchObject({
+		sessionId: 'sess-1',
+		surface: { status: 'ready', url: 'https://opencode.example/' },
+	});
+	expect(result.current.stopping.size).toBe(0);
+});
+
+it('tracks concurrent surface starts independently', async () => {
+	let resolveVscode!: (response: Response) => void;
+	let resolveOpenCode!: (response: Response) => void;
+	stubFetch(async (url) => {
+		return new Promise<Response>((resolve) => {
+			if (String(url).endsWith('/surfaces/vscode')) resolveVscode = resolve;
+			else if (String(url).endsWith('/surfaces/opencode')) resolveOpenCode = resolve;
+			else throw new Error(`unexpected fetch: ${String(url)}`);
+		});
+	});
+	const { result } = renderHookWithClient(() => useSurfaceActions(PID, NID));
+
+	act(() => {
+		result.current.start.mutate({ surfaceId: 'vscode', sessionId: 'sess-1' });
+		result.current.start.mutate({ surfaceId: 'opencode', sessionId: 'sess-1' });
+	});
+	await waitFor(() => {
+		expect(result.current.starting).toEqual(new Set(['vscode', 'opencode']));
+		expect(resolveVscode).toBeTypeOf('function');
+		expect(resolveOpenCode).toBeTypeOf('function');
+	});
+
+	resolveVscode(jsonOk({ id: 'vscode', status: 'ready', url: 'https://vscode.example/' }));
+	await waitFor(() => {
+		expect(result.current.starting).toEqual(new Set(['opencode']));
+		expect(result.current.states.vscode?.surface.status).toBe('ready');
+	});
+
+	resolveOpenCode(jsonOk({ id: 'opencode', status: 'ready', url: 'https://opencode.example/' }));
+	await waitFor(() => {
+		expect(result.current.starting.size).toBe(0);
+		expect(result.current.states.opencode?.surface.status).toBe('ready');
+	});
+});

--- a/packages/web/src/api/surfaces.ts
+++ b/packages/web/src/api/surfaces.ts
@@ -1,0 +1,107 @@
+import { useMutation, useMutationState } from '@tanstack/react-query';
+import { useState } from 'react';
+import { SURFACE_LABELS } from '@/lib/surfaces';
+import type { SecondarySurfaceId, Surface } from '@/types';
+import { apiClient, apiData } from './client';
+import { useInvalidate } from './mutation';
+import { sessionKeys } from './queryKeys';
+
+const SURFACE_POLL_INTERVAL_MS = 1_000;
+export const SURFACE_START_TIMEOUT_MS = 180_000;
+
+interface StartSurfaceVariables {
+	surfaceId: SecondarySurfaceId;
+	sessionId: string;
+	open?: string;
+}
+
+interface StopSurfaceVariables {
+	surfaceId: SecondarySurfaceId;
+	sessionId: string;
+}
+
+interface SurfaceActionState {
+	sessionId: string;
+	surface: Surface;
+}
+
+function surfaceParams(projectId: string, notebookId: string, variables: StopSurfaceVariables) {
+	return {
+		path: {
+			pid: projectId,
+			nid: notebookId,
+			sid: variables.sessionId,
+			surface: variables.surfaceId,
+		},
+	};
+}
+
+export function useSurfaceActions(projectId: string, notebookId: string) {
+	const [states, setStates] = useState<Partial<Record<SecondarySurfaceId, SurfaceActionState>>>({});
+	const invalidate = useInvalidate();
+	const startKey = ['surface', projectId, notebookId, 'start'] as const;
+	const stopKey = ['surface', projectId, notebookId, 'stop'] as const;
+	const start = useMutation({
+		mutationKey: startKey,
+		mutationFn: async (variables: StartSurfaceVariables) => {
+			const { surfaceId, open } = variables;
+			const params = surfaceParams(projectId, notebookId, variables);
+			let surface = await apiData(
+				apiClient.POST('/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/surfaces/{surface}', {
+					params,
+					body: open ? { open } : {},
+				}),
+			);
+			const deadline = Date.now() + SURFACE_START_TIMEOUT_MS;
+			while (surface.status === 'starting' && Date.now() < deadline) {
+				await new Promise<void>((resolve) => {
+					setTimeout(resolve, SURFACE_POLL_INTERVAL_MS);
+				});
+				surface = await apiData(
+					apiClient.GET(
+						'/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/surfaces/{surface}',
+						{ params },
+					),
+				);
+			}
+			if (surface.status !== 'ready' || !surface.url) {
+				throw new Error(surface.last_error ?? `${SURFACE_LABELS[surfaceId]} did not become ready`);
+			}
+			return surface;
+		},
+		onSuccess: (surface, { surfaceId, sessionId }) => {
+			setStates((current) => ({ ...current, [surfaceId]: { sessionId, surface } }));
+		},
+	});
+	const stop = useMutation({
+		mutationKey: stopKey,
+		mutationFn: (variables: StopSurfaceVariables) =>
+			apiData(
+				apiClient.DELETE(
+					'/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/surfaces/{surface}',
+					{ params: surfaceParams(projectId, notebookId, variables) },
+				),
+			),
+		onSuccess: (_, { surfaceId, sessionId }) => {
+			setStates((current) => ({
+				...current,
+				[surfaceId]: { sessionId, surface: { status: 'stopped' } },
+			}));
+			invalidate(sessionKeys.listByProject(projectId));
+		},
+	});
+	const starting = new Set(
+		useMutationState({
+			filters: { mutationKey: startKey, status: 'pending', exact: true },
+			select: (mutation) => (mutation.state.variables as StartSurfaceVariables).surfaceId,
+		}),
+	);
+	const stopping = new Set(
+		useMutationState({
+			filters: { mutationKey: stopKey, status: 'pending', exact: true },
+			select: (mutation) => (mutation.state.variables as StopSurfaceVariables).surfaceId,
+		}),
+	);
+
+	return { start, stop, states, starting, stopping };
+}

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -31,6 +31,7 @@ describe('NotebookPage viewer modes', () => {
 		});
 		renderPage();
 
+		expect(screen.queryByRole('tablist', { name: 'Notebook applications' })).toBeNull();
 		await user.click(await screen.findByRole('button', { name: 'Surfaces' }));
 		expect(screen.getByRole('menuitem', { name: 'Start VS Code' })).toBeInTheDocument();
 		expect(screen.queryByRole('menuitem', { name: 'Stop VS Code' })).toBeNull();
@@ -39,9 +40,11 @@ describe('NotebookPage viewer modes', () => {
 			'src',
 			'https://vscode.example/?folder=/workspace',
 		);
+		expect(screen.getByRole('tablist', { name: 'Notebook applications' })).toBeVisible();
 
 		await chooseSurfaceAction(user, 'Stop VS Code');
 		await waitFor(() => expect(screen.queryByTitle('Forecast in VS Code')).toBeNull());
+		expect(screen.queryByRole('tablist', { name: 'Notebook applications' })).toBeNull();
 	});
 
 	it('keeps surface iframes mounted while the most recent split replaces the previous one', async () => {

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { sessionKeys } from '@/api/queryKeys';
@@ -11,6 +11,14 @@ import {
 	sessionPosts,
 } from './NotebookPage.testWorld';
 
+async function chooseSurfaceAction(
+	user: ReturnType<typeof userEvent.setup>,
+	name: string,
+): Promise<void> {
+	await user.click(await screen.findByRole('button', { name: 'Surfaces' }));
+	await user.click(await screen.findByRole('menuitem', { name }));
+}
+
 describe('NotebookPage viewer modes', () => {
 	it('opens and stops the configured VS Code iframe for an authorized editor', async () => {
 		const user = userEvent.setup();
@@ -18,19 +26,118 @@ describe('NotebookPage viewer modes', () => {
 			role: 'editor',
 			vscode: { embed: 'iframe' },
 			session: runningSession({
-				can: { attach: true, stop: true, surfaces: { vscode: true } },
+				can: { attach: true, stop: true, surfaces: { vscode: true, opencode: false } },
 			}),
 		});
 		renderPage();
 
-		await user.click(await screen.findByRole('button', { name: 'Open in VS Code' }));
+		await user.click(await screen.findByRole('button', { name: 'Surfaces' }));
+		expect(screen.getByRole('menuitem', { name: 'Start VS Code' })).toBeInTheDocument();
+		expect(screen.queryByRole('menuitem', { name: 'Stop VS Code' })).toBeNull();
+		await user.click(screen.getByRole('menuitem', { name: 'Start VS Code' }));
 		expect(await screen.findByTitle('Forecast in VS Code')).toHaveAttribute(
 			'src',
 			'https://vscode.example/?folder=/workspace',
 		);
 
-		await user.click(screen.getByRole('button', { name: 'Stop VS Code' }));
+		await chooseSurfaceAction(user, 'Stop VS Code');
 		await waitFor(() => expect(screen.queryByTitle('Forecast in VS Code')).toBeNull());
+	});
+
+	it('keeps surface iframes mounted while the most recent split replaces the previous one', async () => {
+		const user = userEvent.setup();
+		const fetch = makeFetch({
+			role: 'editor',
+			vscode: { embed: 'iframe' },
+			opencode: { embed: 'iframe' },
+			session: runningSession({
+				can: { attach: true, stop: true, surfaces: { vscode: true, opencode: true } },
+			}),
+		});
+		renderPage();
+
+		const notebookFrame = await screen.findByTitle('Forecast');
+		const notebookPanel = notebookFrame.closest('[role="tabpanel"]');
+		await chooseSurfaceAction(user, 'Start VS Code');
+		const vscodeFrame = await screen.findByTitle('Forecast in VS Code');
+		const vscodePanel = vscodeFrame.closest('[role="tabpanel"]');
+		await chooseSurfaceAction(user, 'Start OpenCode');
+		const opencodeFrame = await screen.findByTitle('Forecast in OpenCode');
+		expect(opencodeFrame).toHaveAttribute('src', 'https://opencode.example/');
+		expect(screen.getByTitle('Forecast in VS Code')).toBe(vscodeFrame);
+		expect(vscodeFrame.parentElement).toBe(vscodePanel);
+		expect(screen.getByTitle('Forecast')).toBe(notebookFrame);
+		expect(notebookFrame.parentElement).toBe(notebookPanel);
+		expect(vscodePanel).toHaveAttribute('inert');
+		expect(opencodeFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
+		expect(screen.getByRole('separator', { name: 'Resize split view' })).toBeInTheDocument();
+
+		const openCodeCall = fetch.mock.calls.find(
+			([url, init]) => String(url).endsWith('/surfaces/opencode') && init?.method === 'POST',
+		);
+		expect(JSON.parse(String(openCodeCall?.[1]?.body))).toEqual({});
+
+		await chooseSurfaceAction(user, 'Stop VS Code');
+		expect(screen.getByTitle('Forecast in OpenCode')).toBeInTheDocument();
+		expect(
+			fetch.mock.calls.some(
+				([url, init]) => String(url).endsWith('/surfaces/vscode') && init?.method === 'DELETE',
+			),
+		).toBe(true);
+	});
+
+	it('opens a tab surface locally and only pops it out on request', async () => {
+		const user = userEvent.setup();
+		const open = vi.spyOn(window, 'open').mockReturnValue(null);
+		makeFetch({
+			role: 'editor',
+			opencode: { embed: 'tab' },
+			session: runningSession({
+				can: { attach: true, stop: true, surfaces: { vscode: false, opencode: true } },
+			}),
+		});
+		renderPage();
+
+		await chooseSurfaceAction(user, 'Start OpenCode');
+		expect(await screen.findByTitle('Forecast in OpenCode')).toHaveAttribute(
+			'src',
+			'https://opencode.example/',
+		);
+		expect(screen.getByRole('tab', { name: /OpenCode/ })).toHaveAttribute('aria-selected', 'true');
+		expect(open).not.toHaveBeenCalled();
+
+		await user.click(screen.getByRole('button', { name: 'Open OpenCode in a new browser tab' }));
+		expect(open).toHaveBeenCalledWith('https://opencode.example/', '_blank', 'noopener,noreferrer');
+	});
+
+	it('confirms before stopping a surface from its application tab', async () => {
+		const user = userEvent.setup();
+		const fetch = makeFetch({
+			role: 'editor',
+			opencode: { embed: 'tab' },
+			session: runningSession({
+				can: { attach: true, stop: true, surfaces: { vscode: false, opencode: true } },
+			}),
+		});
+		renderPage();
+
+		await chooseSurfaceAction(user, 'Start OpenCode');
+		await screen.findByTitle('Forecast in OpenCode');
+		await user.click(screen.getByRole('button', { name: 'Close OpenCode' }));
+		expect(screen.getByRole('dialog')).toHaveTextContent('Unsaved editor state may be lost.');
+		expect(
+			fetch.mock.calls.some(
+				([url, init]) => String(url).endsWith('/surfaces/opencode') && init?.method === 'DELETE',
+			),
+		).toBe(false);
+
+		await user.click(screen.getByRole('button', { name: 'Stop OpenCode' }));
+		await waitFor(() => expect(screen.queryByTitle('Forecast in OpenCode')).toBeNull());
+		expect(
+			fetch.mock.calls.some(
+				([url, init]) => String(url).endsWith('/surfaces/opencode') && init?.method === 'DELETE',
+			),
+		).toBe(true);
 	});
 
 	it('opens the configured entry notebook for a synced source', async () => {
@@ -41,12 +148,12 @@ describe('NotebookPage viewer modes', () => {
 			entryNotebook: 'apps/main.py',
 			vscode: { embed: 'iframe' },
 			session: runningSession({
-				can: { attach: true, stop: true, surfaces: { vscode: true } },
+				can: { attach: true, stop: true, surfaces: { vscode: true, opencode: false } },
 			}),
 		});
 		renderPage();
 
-		await user.click(await screen.findByRole('button', { name: 'Open in VS Code' }));
+		await chooseSurfaceAction(user, 'Start VS Code');
 		await waitFor(() => {
 			const call = fetch.mock.calls.find(
 				([url, init]) => String(url).endsWith('/surfaces/vscode') && init?.method === 'POST',
@@ -55,7 +162,7 @@ describe('NotebookPage viewer modes', () => {
 		});
 	});
 
-	it('waits for synced notebook metadata before offering VS Code', async () => {
+	it('disables VS Code start until synced notebook metadata is available', async () => {
 		let releaseNotebook!: () => void;
 		const notebookPromise = new Promise<void>((resolve) => {
 			releaseNotebook = resolve;
@@ -68,15 +175,21 @@ describe('NotebookPage viewer modes', () => {
 			notebookPromise,
 			vscode: { embed: 'iframe' },
 			session: runningSession({
-				can: { attach: true, stop: true, surfaces: { vscode: true } },
+				can: { attach: true, stop: true, surfaces: { vscode: true, opencode: false } },
 			}),
 		});
 		renderPage();
 
 		await screen.findByRole('button', { name: 'Stop' });
-		expect(screen.queryByRole('button', { name: 'Open in VS Code' })).toBeNull();
+		await user.click(screen.getByRole('button', { name: 'Surfaces' }));
+		expect(screen.getByRole('menuitem', { name: 'Start VS Code' })).toHaveAttribute(
+			'aria-disabled',
+			'true',
+		);
 		releaseNotebook();
-		await user.click(await screen.findByRole('button', { name: 'Open in VS Code' }));
+		const startVscode = screen.getByRole('menuitem', { name: 'Start VS Code' });
+		await waitFor(() => expect(startVscode).not.toHaveAttribute('aria-disabled'));
+		await user.click(startVscode);
 		await waitFor(() => {
 			const call = fetch.mock.calls.find(
 				([url, init]) => String(url).endsWith('/surfaces/vscode') && init?.method === 'POST',
@@ -98,15 +211,20 @@ describe('NotebookPage viewer modes', () => {
 				status: 409,
 			},
 			session: runningSession({
-				can: { attach: true, stop: true, surfaces: { vscode: true } },
+				can: { attach: true, stop: true, surfaces: { vscode: true, opencode: false } },
 			}),
 		});
 		renderPage();
 
-		await user.click(await screen.findByRole('button', { name: 'Open in VS Code' }));
+		await chooseSurfaceAction(user, 'Start VS Code');
 		await waitFor(() => expect(screen.queryByTitle('Forecast in VS Code')).toBeNull());
-		expect(screen.getByRole('button', { name: 'Open in VS Code' })).toBeEnabled();
 		expect(screen.getByRole('button', { name: 'Stop' })).toBeEnabled();
+		await user.click(screen.getByRole('button', { name: 'Surfaces' }));
+		await waitFor(() =>
+			expect(screen.getByRole('menuitem', { name: 'Start VS Code' })).not.toHaveAttribute(
+				'aria-disabled',
+			),
+		);
 	});
 
 	it('keeps the VS Code frame open when stopping the surface fails', async () => {
@@ -120,16 +238,21 @@ describe('NotebookPage viewer modes', () => {
 				status: 503,
 			},
 			session: runningSession({
-				can: { attach: true, stop: true, surfaces: { vscode: true } },
+				can: { attach: true, stop: true, surfaces: { vscode: true, opencode: false } },
 			}),
 		});
 		renderPage();
 
-		await user.click(await screen.findByRole('button', { name: 'Open in VS Code' }));
+		await chooseSurfaceAction(user, 'Start VS Code');
 		const frame = await screen.findByTitle('Forecast in VS Code');
-		await user.click(screen.getByRole('button', { name: 'Stop VS Code' }));
+		await chooseSurfaceAction(user, 'Stop VS Code');
 		await waitFor(() => expect(screen.getByTitle('Forecast in VS Code')).toBe(frame));
-		expect(screen.getByRole('button', { name: 'Stop VS Code' })).toBeEnabled();
+		await user.click(screen.getByRole('button', { name: 'Surfaces' }));
+		await waitFor(() =>
+			expect(screen.getByRole('menuitem', { name: 'Stop VS Code' })).not.toHaveAttribute(
+				'aria-disabled',
+			),
+		);
 	});
 
 	it('starts shared editing without requesting exclusive ownership state', async () => {

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -89,6 +89,42 @@ describe('NotebookPage viewer modes', () => {
 		).toBe(true);
 	});
 
+	it('opens and closes each surface when concurrent actions settle out of order', async () => {
+		let resolveVscodeStart!: () => void;
+		let resolveOpenCodeStart!: () => void;
+		let resolveVscodeStop!: () => void;
+		let resolveOpenCodeStop!: () => void;
+		const user = userEvent.setup();
+		makeFetch({
+			role: 'editor',
+			vscode: { embed: 'iframe' },
+			opencode: { embed: 'iframe' },
+			vscodeStartPromise: new Promise((resolve) => (resolveVscodeStart = resolve)),
+			opencodeStartPromise: new Promise((resolve) => (resolveOpenCodeStart = resolve)),
+			vscodeStopPromise: new Promise((resolve) => (resolveVscodeStop = resolve)),
+			opencodeStopPromise: new Promise((resolve) => (resolveOpenCodeStop = resolve)),
+			session: runningSession({
+				can: { attach: true, stop: true, surfaces: { vscode: true, opencode: true } },
+			}),
+		});
+		renderPage();
+
+		await chooseSurfaceAction(user, 'Start VS Code');
+		await chooseSurfaceAction(user, 'Start OpenCode');
+		resolveOpenCodeStart();
+		expect(await screen.findByTitle('Forecast in OpenCode')).toBeInTheDocument();
+		resolveVscodeStart();
+		expect(await screen.findByTitle('Forecast in VS Code')).toBeInTheDocument();
+
+		await chooseSurfaceAction(user, 'Stop VS Code');
+		await chooseSurfaceAction(user, 'Stop OpenCode');
+		resolveOpenCodeStop();
+		await waitFor(() => expect(screen.queryByTitle('Forecast in OpenCode')).toBeNull());
+		expect(screen.getByTitle('Forecast in VS Code')).toBeInTheDocument();
+		resolveVscodeStop();
+		await waitFor(() => expect(screen.queryByTitle('Forecast in VS Code')).toBeNull());
+	});
+
 	it('opens a tab surface locally and only pops it out on request', async () => {
 		const user = userEvent.setup();
 		const open = vi.spyOn(window, 'open').mockReturnValue(null);

--- a/packages/web/src/components/NotebookPage/NotebookPage.testWorld.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.testWorld.tsx
@@ -70,6 +70,10 @@ interface FetchOptions {
 	vscodeStopError?: { code: string; message: string; status: number };
 	opencodeStartError?: { code: string; message: string; status: number };
 	opencodeStopError?: { code: string; message: string; status: number };
+	vscodeStartPromise?: Promise<void>;
+	vscodeStopPromise?: Promise<void>;
+	opencodeStartPromise?: Promise<void>;
+	opencodeStopPromise?: Promise<void>;
 	omitSourceControlCapability?: boolean;
 	changeRequestFailures?: number;
 	changeRequestFailOn?: number[];
@@ -117,6 +121,7 @@ export function makeFetch(opts: FetchOptions) {
 			return ok({ ...response, reused: false });
 		}
 		if (method === 'POST' && url.endsWith('/surfaces/vscode')) {
+			await opts.vscodeStartPromise;
 			if (opts.vscodeStartError) {
 				const { code, message, status } = opts.vscodeStartError;
 				return new Response(JSON.stringify({ success: false, error: { code, message } }), {
@@ -131,6 +136,7 @@ export function makeFetch(opts: FetchOptions) {
 			});
 		}
 		if (method === 'POST' && url.endsWith('/surfaces/opencode')) {
+			await opts.opencodeStartPromise;
 			if (opts.opencodeStartError) {
 				const { code, message, status } = opts.opencodeStartError;
 				return new Response(JSON.stringify({ success: false, error: { code, message } }), {
@@ -145,6 +151,7 @@ export function makeFetch(opts: FetchOptions) {
 			});
 		}
 		if (method === 'DELETE' && url.endsWith('/surfaces/vscode')) {
+			await opts.vscodeStopPromise;
 			if (opts.vscodeStopError) {
 				const { code, message, status } = opts.vscodeStopError;
 				return new Response(JSON.stringify({ success: false, error: { code, message } }), {
@@ -155,6 +162,7 @@ export function makeFetch(opts: FetchOptions) {
 			return ok(undefined);
 		}
 		if (method === 'DELETE' && url.endsWith('/surfaces/opencode')) {
+			await opts.opencodeStopPromise;
 			if (opts.opencodeStopError) {
 				const { code, message, status } = opts.opencodeStopError;
 				return new Response(JSON.stringify({ success: false, error: { code, message } }), {

--- a/packages/web/src/components/NotebookPage/NotebookPage.testWorld.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.testWorld.tsx
@@ -65,8 +65,11 @@ interface FetchOptions {
 	meFailures?: number;
 	sourceControlProviders?: string[];
 	vscode?: { embed: 'tab' | 'iframe' };
+	opencode?: { embed: 'tab' | 'iframe' };
 	vscodeStartError?: { code: string; message: string; status: number };
 	vscodeStopError?: { code: string; message: string; status: number };
+	opencodeStartError?: { code: string; message: string; status: number };
+	opencodeStopError?: { code: string; message: string; status: number };
 	omitSourceControlCapability?: boolean;
 	changeRequestFailures?: number;
 	changeRequestFailOn?: number[];
@@ -127,9 +130,33 @@ export function makeFetch(opts: FetchOptions) {
 				url: 'https://vscode.example/?folder=/workspace',
 			});
 		}
+		if (method === 'POST' && url.endsWith('/surfaces/opencode')) {
+			if (opts.opencodeStartError) {
+				const { code, message, status } = opts.opencodeStartError;
+				return new Response(JSON.stringify({ success: false, error: { code, message } }), {
+					status,
+					headers: { 'content-type': 'application/json' },
+				});
+			}
+			return ok({
+				id: 'opencode',
+				status: 'ready',
+				url: 'https://opencode.example/',
+			});
+		}
 		if (method === 'DELETE' && url.endsWith('/surfaces/vscode')) {
 			if (opts.vscodeStopError) {
 				const { code, message, status } = opts.vscodeStopError;
+				return new Response(JSON.stringify({ success: false, error: { code, message } }), {
+					status,
+					headers: { 'content-type': 'application/json' },
+				});
+			}
+			return ok(undefined);
+		}
+		if (method === 'DELETE' && url.endsWith('/surfaces/opencode')) {
+			if (opts.opencodeStopError) {
+				const { code, message, status } = opts.opencodeStopError;
 				return new Response(JSON.stringify({ success: false, error: { code, message } }), {
 					status,
 					headers: { 'content-type': 'application/json' },
@@ -240,16 +267,28 @@ export function makeFetch(opts: FetchOptions) {
 				compute_profiles: opts.computeProfiles ?? [],
 				compute_profile_override: opts.computeProfileOverride ?? 'none',
 				editor_sandbox_sharing: opts.editorSharing ?? 'shared',
-				surfaces: opts.vscode
-					? [
-							{
-								id: 'vscode',
-								flavor: 'code-server',
-								start: 'on-demand',
-								embed: opts.vscode.embed,
-							},
-						]
-					: [],
+				surfaces: [
+					...(opts.vscode
+						? [
+								{
+									id: 'vscode' as const,
+									flavor: 'code-server' as const,
+									start: 'on-demand' as const,
+									embed: opts.vscode.embed,
+								},
+							]
+						: []),
+					...(opts.opencode
+						? [
+								{
+									id: 'opencode' as const,
+									start: 'on-demand' as const,
+									embed: opts.opencode.embed,
+									managed_ai: true,
+								},
+							]
+						: []),
+				],
 			});
 		}
 		if (url.endsWith('/me')) {

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -756,6 +756,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 								splitKey={splitApplicationKey}
 								onSplitKeyChange={setSplitApplicationKey}
 								onClose={stopApplicationTab}
+								hideTabListWhenSingle
 								className="size-full"
 							/>
 						)}

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -4,8 +4,10 @@ import {
 	AlertTriangle,
 	AppWindow,
 	ArrowLeft,
+	Bot,
 	Code2,
 	Eye,
+	FileCode2,
 	GitBranch,
 	Pencil,
 	RefreshCw,
@@ -15,12 +17,14 @@ import {
 	Button,
 	Chip,
 	ConfirmDialog,
+	ApplicationTabs,
 	IconButton,
 	IconLink,
 	StatusDot,
 	SessionStatusDot,
 	UserLabel,
 } from '@/components/ui';
+import type { ApplicationTabItem } from '@/components/ui';
 import {
 	useCapabilitiesQuery,
 	useNotebookQuery,
@@ -28,11 +32,10 @@ import {
 	useProjectSessionsQuery,
 	useEditorSessionQuery,
 	useTakeoverEditorSession,
-	useEnsureVscodeSurface,
-	useStopVscodeSurface,
 	useUserQuery,
 	useUsersQuery,
 } from '@/api/hooks';
+import { useSurfaceActions } from '@/api/surfaces';
 import { useNotebookSession } from '@/hooks/useNotebookSession';
 import type { SessionEnded } from '@/hooks/useNotebookSession';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
@@ -47,6 +50,13 @@ import { sessionConnectionHint, isSessionStale, sessionsByNotebook } from '@/lib
 import { useTheme } from '@/context/ThemeContext';
 import type { Theme } from '@/context/ThemeContext';
 import { canManageProject } from '@/lib/roles';
+import { SurfaceMenu } from './SurfaceMenu';
+import type { SecondarySurfaceFrame } from './SurfaceMenu';
+
+const SURFACE_TAB_ICONS = {
+	vscode: Code2,
+	opencode: Bot,
+};
 
 /** Copy for the app page's terminal panel, keyed by how the session ended. */
 function endedPanel(ended: SessionEnded): { title: string; message: string; canRestart: boolean } {
@@ -120,8 +130,9 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 	const confirmEditStop = useDisclosure();
 	const confirmTakeover = useDisclosure();
 	const [editIntent, setEditIntent] = useState<'temporary' | undefined>();
-	const [stoppedVscodeSessionId, setStoppedVscodeSessionId] = useState<string>();
-	const [vscodeFrame, setVscodeFrame] = useState<{ sessionId: string; url: string }>();
+	const [secondaryFrames, setSecondaryFrames] = useState<readonly SecondarySurfaceFrame[]>([]);
+	const [selectedApplicationKey, setSelectedApplicationKey] = useState('notebook');
+	const [splitApplicationKey, setSplitApplicationKey] = useState<string | null>(null);
 
 	// The viewer branch (server-enforced regardless): editors get a session as
 	// always; a viewer gets an edit kernel only when the deployment's evaluated
@@ -169,8 +180,7 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 	const identityStateFailed =
 		needsEditorState && editorStateQuery.isSuccess && !!editorState?.holder && userQuery.isError;
 	const takeover = useTakeoverEditorSession(pid!, nid!);
-	const ensureVscode = useEnsureVscodeSurface(pid!, nid!);
-	const stopVscode = useStopVscodeSurface(pid!, nid!);
+	const surfaceActions = useSurfaceActions(pid!, nid!);
 
 	const {
 		session,
@@ -293,21 +303,54 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 		computeProfiles.length > 0 &&
 		error?.kind === 'startup' &&
 		error.generic === true;
-	const vscodeCapability = capabilities?.surfaces?.find((surface) => surface.id === 'vscode');
-	const ensuredVscodeState =
-		ensureVscode.variables?.sessionId === session?.session_id ? ensureVscode.data : undefined;
-	const vscodeState =
-		stoppedVscodeSessionId === session?.session_id
-			? { status: 'stopped' as const }
-			: (ensuredVscodeState ?? session?.surfaces?.vscode);
-	const vscodeFrameUrl =
-		vscodeFrame && vscodeFrame.sessionId === session?.session_id ? vscodeFrame.url : undefined;
-	const canUseVscode =
-		!isApp &&
-		!!notebook &&
-		!!session?.can.surfaces?.vscode &&
-		!!vscodeCapability &&
-		session.status === 'running';
+	const activeSecondaryFrames = useMemo(
+		() => secondaryFrames.filter((frame) => frame.sessionId === session?.session_id),
+		[secondaryFrames, session?.session_id],
+	);
+	const applicationTabs = useMemo<ApplicationTabItem[]>(
+		() => [
+			{
+				id: 'notebook',
+				label: 'Notebook',
+				icon: <FileCode2 />,
+				panel: (
+					<iframe
+						className="size-full border-0"
+						src={iframeSrc}
+						sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+						allow="clipboard-read; clipboard-write"
+						title={title}
+					/>
+				),
+				...(iframeSrc ? { browserUrl: iframeSrc } : {}),
+			},
+			...activeSecondaryFrames.map((frame) => {
+				const SurfaceIcon = SURFACE_TAB_ICONS[frame.surfaceId];
+				return {
+					id: frame.surfaceId,
+					label: frame.label,
+					icon: <SurfaceIcon />,
+					panel: (
+						<iframe
+							className="size-full border-0"
+							src={frame.url}
+							sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
+							allow="clipboard-read; clipboard-write"
+							title={`${title} in ${frame.label}`}
+						/>
+					),
+					browserUrl: frame.url,
+					close: {
+						title: `Stop ${frame.label}?`,
+						description: `Stop ${frame.label} and close its tab? Unsaved editor state may be lost.`,
+						confirmLabel: `Stop ${frame.label}`,
+						pendingLabel: `Stopping ${frame.label}...`,
+					},
+				};
+			}),
+		],
+		[activeSecondaryFrames, iframeSrc, title],
+	);
 
 	const backToProject = () => {
 		void navigate(`/projects/${pid}`);
@@ -323,36 +366,45 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 		stop();
 		backToProject();
 	};
-	const openVscode = () => {
-		if (!session || !notebook) return;
-		const entryNotebook =
-			notebook.source.type === 'git' ? notebook.source.entry_notebook : 'notebook.py';
-		setStoppedVscodeSessionId(undefined);
-		const embed = vscodeCapability?.embed === 'iframe';
-		const tab = embed ? null : window.open('about:blank', '_blank');
-		if (tab) tab.opener = null;
-		ensureVscode.mutate(
-			{ sessionId: session.session_id, open: entryNotebook },
-			{
-				onSuccess: (surface) => {
-					if (embed) setVscodeFrame({ sessionId: session.session_id, url: surface.url! });
-					else if (tab) tab.location.href = surface.url!;
-					else window.open(surface.url, '_blank', 'noopener,noreferrer');
-				},
-				onError: () => tab?.close(),
-			},
-		);
-	};
-	const closeVscode = () => {
-		if (!session) return;
-		const sessionId = session.session_id;
-		stopVscode.mutate(sessionId, {
-			onSuccess: () => {
-				setStoppedVscodeSessionId(sessionId);
-				setVscodeFrame(undefined);
-				ensureVscode.reset();
-			},
+	const openSecondaryFrame = (frame: SecondarySurfaceFrame) => {
+		setSecondaryFrames((current) => {
+			const index = current.findIndex(
+				(candidate) =>
+					candidate.sessionId === frame.sessionId && candidate.surfaceId === frame.surfaceId,
+			);
+			if (index === -1) return [...current, frame];
+			if (current[index]?.url === frame.url && current[index]?.embed === frame.embed)
+				return current;
+			return current.map((candidate, candidateIndex) =>
+				candidateIndex === index ? frame : candidate,
+			);
 		});
+		if (frame.embed === 'iframe') {
+			setSelectedApplicationKey('notebook');
+			setSplitApplicationKey(frame.surfaceId);
+		} else {
+			setSelectedApplicationKey(frame.surfaceId);
+			setSplitApplicationKey(null);
+		}
+	};
+	const closeSecondaryFrame = (
+		surfaceId: SecondarySurfaceFrame['surfaceId'],
+		sessionId: string,
+	) => {
+		setSecondaryFrames((current) =>
+			current.filter((frame) => frame.sessionId !== sessionId || frame.surfaceId !== surfaceId),
+		);
+		setSelectedApplicationKey((current) => (current === surfaceId ? 'notebook' : current));
+		setSplitApplicationKey((current) => (current === surfaceId ? null : current));
+	};
+	const stopApplicationTab = async (tab: ApplicationTabItem) => {
+		const frame = activeSecondaryFrames.find((candidate) => candidate.surfaceId === tab.id);
+		if (!frame) return;
+		await surfaceActions.stop.mutateAsync({
+			surfaceId: frame.surfaceId,
+			sessionId: frame.sessionId,
+		});
+		closeSecondaryFrame(frame.surfaceId, frame.sessionId);
 	};
 	const takeOver = () => {
 		const holder = editorState?.holder;
@@ -510,27 +562,15 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 							Stop
 						</Button>
 					)}
-					{canUseVscode && (
-						<Button
-							variant="unstyled"
-							className="flex h-[26px] items-center gap-1 rounded-md border border-input px-2 text-xs text-muted-foreground transition-colors hover:border-primary hover:text-primary max-md:min-h-11"
-							isDisabled={ensureVscode.isPending}
-							onPress={openVscode}
-						>
-							<Code2 className="size-3" />
-							{ensureVscode.isPending ? 'Starting VS Code...' : 'Open in VS Code'}
-						</Button>
-					)}
-					{canUseVscode && vscodeState?.status === 'ready' && (
-						<Button
-							variant="unstyled"
-							className="flex h-[26px] items-center rounded-md px-2 text-xs text-muted-foreground hover:text-destructive max-md:min-h-11"
-							isDisabled={stopVscode.isPending}
-							onPress={closeVscode}
-						>
-							Stop VS Code
-						</Button>
-					)}
+					<SurfaceMenu
+						actions={surfaceActions}
+						session={session}
+						capabilities={capabilities}
+						notebook={notebook}
+						isApp={isApp}
+						onOpenFrame={openSecondaryFrame}
+						onCloseFrame={closeSecondaryFrame}
+					/>
 				</div>
 			</header>
 
@@ -696,27 +736,27 @@ export function NotebookPage({ variant = 'edit' }: { variant?: 'edit' | 'app' })
 						</div>
 					)}
 					<div
-						className={cn(
-							'flex-1 overflow-hidden',
-							vscodeFrameUrl && 'grid grid-cols-2',
-							takeover.isPending && 'pointer-events-none',
-						)}
+						className={cn('flex-1 overflow-hidden', takeover.isPending && 'pointer-events-none')}
 						aria-hidden={takeover.isPending || undefined}
 					>
-						<iframe
-							className="size-full border-0"
-							src={iframeSrc}
-							sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
-							allow="clipboard-read; clipboard-write"
-							title={title}
-						/>
-						{vscodeFrameUrl && (
+						{isApp ? (
 							<iframe
-								className="size-full border-0 border-l"
-								src={vscodeFrameUrl}
-								sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
+								className="size-full border-0"
+								src={iframeSrc}
+								sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
 								allow="clipboard-read; clipboard-write"
-								title={`${title} in VS Code`}
+								title={title}
+							/>
+						) : (
+							<ApplicationTabs
+								ariaLabel="Notebook applications"
+								tabs={applicationTabs}
+								selectedKey={selectedApplicationKey}
+								onSelectionChange={setSelectedApplicationKey}
+								splitKey={splitApplicationKey}
+								onSplitKeyChange={setSplitApplicationKey}
+								onClose={stopApplicationTab}
+								className="size-full"
 							/>
 						)}
 					</div>

--- a/packages/web/src/components/NotebookPage/SurfaceMenu.tsx
+++ b/packages/web/src/components/NotebookPage/SurfaceMenu.tsx
@@ -113,10 +113,14 @@ export function SurfaceMenu({
 			if (!notebook) return;
 			open = control.openPath(notebook);
 		}
-		actions.start.mutate(
-			{ surfaceId: control.id, sessionId: session.session_id, ...(open ? { open } : {}) },
-			{
-				onSuccess: (surface) => {
+		void actions.start
+			.mutateAsync({
+				surfaceId: control.id,
+				sessionId: session.session_id,
+				...(open ? { open } : {}),
+			})
+			.then(
+				(surface) => {
 					onOpenFrame({
 						sessionId: session.session_id,
 						surfaceId: control.id,
@@ -125,18 +129,16 @@ export function SurfaceMenu({
 						embed: control.capability.embed,
 					});
 				},
-			},
-		);
+				() => null,
+			);
 	};
 
 	const stop = (control: (typeof controls)[number]) => {
 		if (!session) return;
 		const sessionId = session.session_id;
-		actions.stop.mutate(
-			{ surfaceId: control.id, sessionId },
-			{
-				onSuccess: () => onCloseFrame(control.id, sessionId),
-			},
+		void actions.stop.mutateAsync({ surfaceId: control.id, sessionId }).then(
+			() => onCloseFrame(control.id, sessionId),
+			() => null,
 		);
 	};
 

--- a/packages/web/src/components/NotebookPage/SurfaceMenu.tsx
+++ b/packages/web/src/components/NotebookPage/SurfaceMenu.tsx
@@ -1,0 +1,167 @@
+import { Bot, ChevronDown, Code2, Square } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { useSurfaceActions } from '@/api/surfaces';
+import { DropdownMenu } from '@/components/ui';
+import type { DropdownMenuOption } from '@/components/ui';
+import { SURFACE_LABELS } from '@/lib/surfaces';
+import type { Capabilities, NotebookDetail, SecondarySurfaceId, Session } from '@/types';
+
+export interface SecondarySurfaceFrame {
+	sessionId: string;
+	surfaceId: SecondarySurfaceId;
+	label: string;
+	url: string;
+	embed: 'tab' | 'iframe';
+}
+
+interface SurfaceDefinition {
+	id: SecondarySurfaceId;
+	label: string;
+	icon: LucideIcon;
+	openPath?: (notebook: NotebookDetail) => string;
+}
+
+type SurfaceDefinitions = {
+	[Id in SecondarySurfaceId]: Omit<SurfaceDefinition, 'id'> & { id: Id };
+};
+
+const SURFACE_DEFINITIONS = {
+	vscode: {
+		id: 'vscode',
+		label: SURFACE_LABELS.vscode,
+		icon: Code2,
+		openPath: (notebook) =>
+			notebook.source.type === 'git' ? notebook.source.entry_notebook : 'notebook.py',
+	},
+	opencode: { id: 'opencode', label: SURFACE_LABELS.opencode, icon: Bot },
+} satisfies SurfaceDefinitions;
+
+interface SurfaceMenuProps {
+	actions: ReturnType<typeof useSurfaceActions>;
+	session?: Session | null;
+	capabilities?: Capabilities;
+	notebook?: NotebookDetail;
+	isApp: boolean;
+	onOpenFrame: (frame: SecondarySurfaceFrame) => void;
+	onCloseFrame: (surfaceId: SecondarySurfaceId, sessionId: string) => void;
+}
+
+export function SurfaceMenu({
+	actions,
+	session,
+	capabilities,
+	notebook,
+	isApp,
+	onOpenFrame,
+	onCloseFrame,
+}: SurfaceMenuProps) {
+	const controls = (capabilities?.surfaces ?? [])
+		.map((capability) => {
+			const definition: SurfaceDefinition = SURFACE_DEFINITIONS[capability.id];
+			const actionState = actions.states[definition.id];
+			const state =
+				actionState && actionState.sessionId === session?.session_id
+					? actionState.surface
+					: session?.surfaces?.[definition.id];
+			return {
+				...definition,
+				capability,
+				state,
+				canStart: !definition.openPath || !!notebook,
+				isStarting: actions.starting.has(definition.id),
+				isStopping: actions.stopping.has(definition.id),
+			};
+		})
+		.filter(
+			(control) => !isApp && !!session?.can.surfaces?.[control.id] && session.status === 'running',
+		);
+
+	if (controls.length === 0) return null;
+
+	const options: DropdownMenuOption[] = controls.flatMap((control, index) => {
+		const SurfaceIcon = control.icon;
+		return [
+			{
+				id: `start:${control.id}`,
+				label: control.isStarting
+					? `Starting ${control.label}...`
+					: control.state?.status === 'ready'
+						? `Open ${control.label}`
+						: `Start ${control.label}`,
+				icon: <SurfaceIcon className="size-3.5" />,
+				separatorBefore: index > 0,
+				isDisabled: !control.canStart || control.isStarting || control.isStopping,
+			},
+			...(control.state?.status === 'ready'
+				? [
+						{
+							id: `stop:${control.id}`,
+							label: `Stop ${control.label}`,
+							icon: <Square className="size-3" />,
+							isDisabled: control.isStopping,
+							danger: true,
+						},
+					]
+				: []),
+		];
+	});
+
+	const start = (control: (typeof controls)[number]) => {
+		if (!session) return;
+		let open: string | undefined;
+		if (control.openPath) {
+			if (!notebook) return;
+			open = control.openPath(notebook);
+		}
+		actions.start.mutate(
+			{ surfaceId: control.id, sessionId: session.session_id, ...(open ? { open } : {}) },
+			{
+				onSuccess: (surface) => {
+					onOpenFrame({
+						sessionId: session.session_id,
+						surfaceId: control.id,
+						label: control.label,
+						url: surface.url!,
+						embed: control.capability.embed,
+					});
+				},
+			},
+		);
+	};
+
+	const stop = (control: (typeof controls)[number]) => {
+		if (!session) return;
+		const sessionId = session.session_id;
+		actions.stop.mutate(
+			{ surfaceId: control.id, sessionId },
+			{
+				onSuccess: () => onCloseFrame(control.id, sessionId),
+			},
+		);
+	};
+
+	const handleAction = (action: string) => {
+		const control = controls.find(
+			(candidate) => action === `start:${candidate.id}` || action === `stop:${candidate.id}`,
+		);
+		if (!control) return;
+		if (action === `start:${control.id}`) start(control);
+		else stop(control);
+	};
+
+	return (
+		<DropdownMenu
+			label="Surfaces"
+			icon={
+				<>
+					<Code2 className="size-3" />
+					<span>Surfaces</span>
+					<ChevronDown className="size-3" />
+				</>
+			}
+			triggerClassName="h-[26px] w-auto gap-1 rounded-md border border-input px-2 text-xs hover:border-primary hover:bg-transparent hover:text-primary max-md:h-11"
+			options={options}
+			onAction={handleAction}
+		/>
+	);
+}

--- a/packages/web/src/components/WorkspaceBrowser/WorkspaceBrowserDialog.tsx
+++ b/packages/web/src/components/WorkspaceBrowser/WorkspaceBrowserDialog.tsx
@@ -63,6 +63,8 @@ const itemStateClass =
 const itemClass = `group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none ${itemStateClass}`;
 const treeItemClass = `${itemClass} py-1`;
 const gridItemClass = `group flex h-28 flex-col items-center justify-center gap-1.5 rounded-lg border border-transparent p-2 text-center outline-none ${itemStateClass}`;
+const tableColumnHeaderClass =
+	'border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground';
 const menuClass = 'min-w-40 rounded-md border bg-popover p-1 text-popover-foreground shadow-lg';
 const menuItemClass =
 	'cursor-default rounded-sm px-2 py-1.5 text-sm outline-none data-[focused]:bg-accent data-[disabled]:opacity-40';
@@ -141,28 +143,32 @@ function ExplorerItems({
 						id="name"
 						isRowHeader
 						allowsSorting
-						className="sticky top-0 bg-card p-2 text-left text-xs"
+						width="2fr"
+						className={cn(tableColumnHeaderClass, 'text-left')}
 					>
 						Name
 					</Finder.Column>
 					<Finder.Column
 						id="kind"
 						allowsSorting
-						className="sticky top-0 w-36 bg-card p-2 text-left text-xs"
+						width="1.25fr"
+						className={cn(tableColumnHeaderClass, 'text-left')}
 					>
 						Type
 					</Finder.Column>
 					<Finder.Column
 						id="size"
 						allowsSorting
-						className="sticky top-0 w-24 bg-card p-2 text-right text-xs"
+						width={88}
+						className={cn(tableColumnHeaderClass, 'text-right')}
 					>
 						Size
 					</Finder.Column>
 					<Finder.Column
 						id="modifiedAt"
 						allowsSorting
-						className="sticky top-0 w-44 bg-card p-2 text-left text-xs"
+						width={176}
+						className={cn(tableColumnHeaderClass, 'text-left')}
 					>
 						Modified
 					</Finder.Column>
@@ -177,7 +183,7 @@ function ExplorerItems({
 							className={cn('outline-none', itemStateClass)}
 							style={{ width: 'inherit', height: 'inherit' }}
 						>
-							<Finder.Cell className="border-b p-2 text-sm">
+							<Finder.Cell className="border-b px-3 py-2 text-sm">
 								<span className="flex min-w-0 items-center gap-2">
 									<ItemIcon item={item} />
 									<EditableItemName
@@ -188,13 +194,13 @@ function ExplorerItems({
 									/>
 								</span>
 							</Finder.Cell>
-							<Finder.Cell className="truncate border-b p-2 text-xs text-muted-foreground">
+							<Finder.Cell className="truncate border-b px-3 py-2 text-xs text-muted-foreground">
 								{itemType(item)}
 							</Finder.Cell>
-							<Finder.Cell className="border-b p-2 text-right text-xs text-muted-foreground tabular-nums">
+							<Finder.Cell className="border-b px-3 py-2 text-right text-xs text-muted-foreground tabular-nums">
 								{item.kind === 'file' ? formatFileSize(item.size) : '—'}
 							</Finder.Cell>
-							<Finder.Cell className="border-b p-2 text-xs text-muted-foreground tabular-nums">
+							<Finder.Cell className="border-b px-3 py-2 text-xs text-muted-foreground tabular-nums">
 								{itemModifiedAt(item)}
 							</Finder.Cell>
 						</Finder.Item>

--- a/packages/web/src/components/ui/ApplicationTabs.test.tsx
+++ b/packages/web/src/components/ui/ApplicationTabs.test.tsx
@@ -1,0 +1,267 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Bot, Code2, FileCode2 } from 'lucide-react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApplicationTabs } from './ApplicationTabs';
+import type { ApplicationTabItem } from './ApplicationTabs';
+
+function applicationTabs(): ApplicationTabItem[] {
+	return [
+		{
+			id: 'notebook',
+			label: 'Notebook',
+			icon: <FileCode2 />,
+			panel: <iframe src="https://notebook.example/" title="Notebook frame" />,
+			browserUrl: 'https://notebook.example/',
+		},
+		{
+			id: 'vscode',
+			label: 'VS Code',
+			icon: <Code2 />,
+			panel: <iframe src="https://vscode.example/" title="VS Code frame" />,
+			browserUrl: 'https://vscode.example/',
+			close: {
+				title: 'Close VS Code?',
+				description: 'Unsaved editor UI state will be lost.',
+				confirmLabel: 'Close VS Code',
+				pendingLabel: 'Closing VS Code...',
+			},
+		},
+		{
+			id: 'opencode',
+			label: 'OpenCode',
+			icon: <Bot />,
+			panel: <iframe src="https://opencode.example/" title="OpenCode frame" />,
+		},
+	];
+}
+
+describe('ApplicationTabs', () => {
+	it('keeps every panel mounted while the selection changes', async () => {
+		const user = userEvent.setup();
+		render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs()}
+				defaultSelectedKey="notebook"
+			/>,
+		);
+
+		const notebookFrame = screen.getByTitle('Notebook frame');
+		const vscodeFrame = screen.getByTitle('VS Code frame');
+		await user.click(screen.getByRole('tab', { name: /VS Code/ }));
+
+		expect(screen.getByTitle('Notebook frame')).toBe(notebookFrame);
+		expect(screen.getByTitle('VS Code frame')).toBe(vscodeFrame);
+		expect(vscodeFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
+		expect(notebookFrame.closest('[role="tabpanel"]')).toHaveAttribute('inert');
+	});
+
+	it('shows at most one secondary panel and never remounts an iframe', async () => {
+		const user = userEvent.setup();
+		const onSplitKeyChange = vi.fn();
+		render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs()}
+				defaultSelectedKey="notebook"
+				onSplitKeyChange={onSplitKeyChange}
+			/>,
+		);
+
+		const notebookFrame = screen.getByTitle('Notebook frame');
+		const vscodeFrame = screen.getByTitle('VS Code frame');
+		const opencodeFrame = screen.getByTitle('OpenCode frame');
+		const panelParents = new Map([
+			[notebookFrame, notebookFrame.parentElement],
+			[vscodeFrame, vscodeFrame.parentElement],
+			[opencodeFrame, opencodeFrame.parentElement],
+		]);
+
+		await user.click(screen.getByRole('button', { name: 'Open OpenCode to the side' }));
+		expect(screen.getByRole('separator', { name: 'Resize split view' })).toBeInTheDocument();
+		expect(notebookFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
+		expect(opencodeFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
+		expect(vscodeFrame.closest('[role="tabpanel"]')).toHaveAttribute('inert');
+
+		await user.click(screen.getByRole('button', { name: 'Open VS Code to the side' }));
+		expect(notebookFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
+		expect(vscodeFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
+		expect(opencodeFrame.closest('[role="tabpanel"]')).toHaveAttribute('inert');
+		expect(screen.getAllByRole('tabpanel')).toHaveLength(2);
+
+		expect(screen.getByTitle('Notebook frame')).toBe(notebookFrame);
+		expect(screen.getByTitle('VS Code frame')).toBe(vscodeFrame);
+		expect(screen.getByTitle('OpenCode frame')).toBe(opencodeFrame);
+		for (const [frame, parent] of panelParents) expect(frame.parentElement).toBe(parent);
+
+		await user.click(screen.getByRole('button', { name: 'Close VS Code split view' }));
+		expect(screen.queryByRole('separator', { name: 'Resize split view' })).toBeNull();
+		expect(vscodeFrame.closest('[role="tabpanel"]')).toHaveAttribute('inert');
+		expect(onSplitKeyChange.mock.calls).toEqual([['opencode'], ['vscode'], [null]]);
+	});
+
+	it('swaps the primary and secondary panels without moving their nodes', async () => {
+		const user = userEvent.setup();
+		render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs()}
+				defaultSelectedKey="notebook"
+				defaultSplitKey="opencode"
+			/>,
+		);
+
+		const notebookFrame = screen.getByTitle('Notebook frame');
+		const opencodeFrame = screen.getByTitle('OpenCode frame');
+		await user.click(screen.getByRole('tab', { name: /OpenCode/ }));
+
+		expect(screen.getByRole('tab', { name: /OpenCode/ })).toHaveAttribute('aria-selected', 'true');
+		expect(notebookFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
+		expect(opencodeFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
+		expect(screen.getByTitle('Notebook frame')).toBe(notebookFrame);
+		expect(screen.getByTitle('OpenCode frame')).toBe(opencodeFrame);
+	});
+
+	it('resizes the split by keyboard and pointer within safe bounds', () => {
+		const onSplitSizeChange = vi.fn();
+		render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs()}
+				defaultSelectedKey="notebook"
+				defaultSplitKey="opencode"
+				onSplitSizeChange={onSplitSizeChange}
+			/>,
+		);
+
+		const separator = screen.getByRole('separator', { name: 'Resize split view' });
+		fireEvent.keyDown(separator, { key: 'ArrowRight' });
+		expect(separator).toHaveAttribute('aria-valuenow', '52');
+
+		fireEvent.keyDown(separator, { key: 'Home' });
+		expect(separator).toHaveAttribute('aria-valuenow', '20');
+		fireEvent.keyDown(separator, { key: 'ArrowLeft' });
+		expect(separator).toHaveAttribute('aria-valuenow', '20');
+
+		const panels = screen.getByTitle('Notebook frame').closest('[data-application-panels]');
+		expect(panels).not.toBeNull();
+		vi.spyOn(panels as HTMLElement, 'getBoundingClientRect').mockReturnValue({
+			left: 100,
+			right: 1100,
+			top: 0,
+			bottom: 600,
+			width: 1000,
+			height: 600,
+			x: 100,
+			y: 0,
+			toJSON: () => null,
+		});
+		fireEvent.pointerDown(separator, { pointerId: 1, clientX: 300 });
+		fireEvent.pointerMove(separator, { pointerId: 1, clientX: 700 });
+		fireEvent.pointerUp(separator, { pointerId: 1 });
+		expect(separator).toHaveAttribute('aria-valuenow', '60');
+
+		fireEvent.keyDown(separator, { key: 'End' });
+		fireEvent.keyDown(separator, { key: 'ArrowRight' });
+		expect(separator).toHaveAttribute('aria-valuenow', '80');
+		expect(onSplitSizeChange).toHaveBeenLastCalledWith(80);
+	});
+
+	it('does not move panel nodes when the visible tab order changes', () => {
+		const tabs = applicationTabs();
+		const { rerender } = render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={tabs}
+				order={['notebook', 'vscode', 'opencode']}
+			/>,
+		);
+		const originalFrames = new Map(
+			['Notebook frame', 'VS Code frame', 'OpenCode frame'].map((title) => [
+				title,
+				screen.getByTitle(title),
+			]),
+		);
+
+		rerender(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={[tabs[2], tabs[0], tabs[1]]}
+				order={['opencode', 'notebook', 'vscode']}
+			/>,
+		);
+
+		expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+			'OpenCode',
+			'Notebook',
+			'VS Code',
+		]);
+		for (const [title, frame] of originalFrames) {
+			expect(screen.getByTitle(title)).toBe(frame);
+		}
+	});
+
+	it('reorders tabs with the keyboard shortcut on the drag handle', () => {
+		const onOrderChange = vi.fn();
+		render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs()}
+				onOrderChange={onOrderChange}
+			/>,
+		);
+
+		fireEvent.keyDown(screen.getByRole('button', { name: 'Reorder Notebook' }), {
+			key: 'ArrowRight',
+			altKey: true,
+			shiftKey: true,
+		});
+
+		expect(onOrderChange).toHaveBeenCalledWith(['vscode', 'notebook', 'opencode']);
+		expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+			'VS Code',
+			'Notebook',
+			'OpenCode',
+		]);
+	});
+
+	it('opens a panel URL directly in a new browser tab', async () => {
+		const user = userEvent.setup();
+		const open = vi.spyOn(window, 'open').mockReturnValue(null);
+		render(<ApplicationTabs ariaLabel="Workspace applications" tabs={applicationTabs()} />);
+
+		await user.click(screen.getByRole('button', { name: 'Open Notebook in a new browser tab' }));
+
+		expect(open).toHaveBeenCalledWith('https://notebook.example/', '_blank', 'noopener,noreferrer');
+	});
+
+	it('confirms and awaits a close before dismissing the dialog', async () => {
+		const user = userEvent.setup();
+		let finishClose!: () => void;
+		const onClose = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					finishClose = resolve;
+				}),
+		);
+		render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs()}
+				onClose={onClose}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Close VS Code' }));
+		expect(screen.getByRole('dialog')).toHaveTextContent('Unsaved editor UI state will be lost.');
+		expect(onClose).not.toHaveBeenCalled();
+
+		await user.click(screen.getByRole('button', { name: 'Close VS Code' }));
+		expect(onClose).toHaveBeenCalledWith(expect.objectContaining({ id: 'vscode' }));
+		expect(screen.getByText('Closing VS Code...')).toBeInTheDocument();
+
+		await act(async () => finishClose());
+		await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+	});
+});

--- a/packages/web/src/components/ui/ApplicationTabs.test.tsx
+++ b/packages/web/src/components/ui/ApplicationTabs.test.tsx
@@ -37,6 +37,26 @@ function applicationTabs(): ApplicationTabItem[] {
 }
 
 describe('ApplicationTabs', () => {
+	it('hides its tab bar until a second application is present', () => {
+		const { rerender } = render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs().slice(0, 1)}
+				hideTabListWhenSingle
+			/>,
+		);
+
+		expect(screen.queryByRole('tablist', { name: 'Workspace applications' })).toBeNull();
+		rerender(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs().slice(0, 2)}
+				hideTabListWhenSingle
+			/>,
+		);
+		expect(screen.getByRole('tablist', { name: 'Workspace applications' })).toBeVisible();
+	});
+
 	it('keeps every panel mounted while the selection changes', async () => {
 		const user = userEvent.setup();
 		render(

--- a/packages/web/src/components/ui/ApplicationTabs.tsx
+++ b/packages/web/src/components/ui/ApplicationTabs.tsx
@@ -58,6 +58,7 @@ export interface ApplicationTabsProps {
 	className?: string;
 	tabListClassName?: string;
 	panelsClassName?: string;
+	hideTabListWhenSingle?: boolean;
 }
 
 type DropPosition = 'before' | 'after';
@@ -369,6 +370,7 @@ export function ApplicationTabs({
 	className,
 	tabListClassName,
 	panelsClassName,
+	hideTabListWhenSingle = false,
 }: ApplicationTabsProps) {
 	const instanceId = useId();
 	const tabKeys = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
@@ -406,6 +408,7 @@ export function ApplicationTabs({
 	const [isClosePending, setIsClosePending] = useState(false);
 	const closingTab = closeKey ? tabsById.get(closeKey) : undefined;
 	const isReorderable = tabs.length > 1;
+	const showTabList = !hideTabListWhenSingle || tabs.length > 1;
 
 	const changeSplitKey = (nextKey: string | null) => {
 		if (splitKey === undefined) setInternalSplitKey(nextKey);
@@ -453,44 +456,46 @@ export function ApplicationTabs({
 				keyboardActivation="automatic"
 				className={cn('flex min-h-0 flex-1 flex-col bg-background', className)}
 			>
-				<div className="flex h-9 shrink-0 items-end border-b bg-muted/50">
-					<TabList
-						aria-label={ariaLabel}
-						className={cn(
-							'flex h-full min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-							tabListClassName,
-						)}
-					>
-						{visibleOrder.map((key) => {
-							const tab = tabsById.get(key);
-							return tab ? (
-								<ApplicationTab
-									key={tab.id}
-									tab={tab}
-									order={visibleOrder}
-									tabDomId={`${instanceId}-tab-${tab.id}`}
-									panelDomId={`${instanceId}-panel-${tab.id}`}
-									isReorderable={isReorderable}
-									isPrimary={tab.id === primaryKey}
-									isSplit={tab.id === activeSplitKey}
-									canSplit={
-										allowsSplitView &&
-										tab.isSplittable !== false &&
-										!tab.isDisabled &&
-										tabs.length > 1
-									}
-									canClose={!!onClose}
-									onMove={changeOrder}
-									onRequestSplit={changeSplitKey}
-									onRequestClose={(item) => setCloseKey(item.id)}
-								/>
-							) : null;
-						})}
-					</TabList>
-					{actions ? (
-						<div className="flex h-full shrink-0 items-center border-l px-1">{actions}</div>
-					) : null}
-				</div>
+				{showTabList ? (
+					<div className="flex h-9 shrink-0 items-end border-b bg-muted/50">
+						<TabList
+							aria-label={ariaLabel}
+							className={cn(
+								'flex h-full min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+								tabListClassName,
+							)}
+						>
+							{visibleOrder.map((key) => {
+								const tab = tabsById.get(key);
+								return tab ? (
+									<ApplicationTab
+										key={tab.id}
+										tab={tab}
+										order={visibleOrder}
+										tabDomId={`${instanceId}-tab-${tab.id}`}
+										panelDomId={`${instanceId}-panel-${tab.id}`}
+										isReorderable={isReorderable}
+										isPrimary={tab.id === primaryKey}
+										isSplit={tab.id === activeSplitKey}
+										canSplit={
+											allowsSplitView &&
+											tab.isSplittable !== false &&
+											!tab.isDisabled &&
+											tabs.length > 1
+										}
+										canClose={!!onClose}
+										onMove={changeOrder}
+										onRequestSplit={changeSplitKey}
+										onRequestClose={(item) => setCloseKey(item.id)}
+									/>
+								) : null;
+							})}
+						</TabList>
+						{actions ? (
+							<div className="flex h-full shrink-0 items-center border-l px-1">{actions}</div>
+						) : null}
+					</div>
+				) : null}
 				<div
 					ref={panelsRef}
 					data-application-panels=""

--- a/packages/web/src/components/ui/ApplicationTabs.tsx
+++ b/packages/web/src/components/ui/ApplicationTabs.tsx
@@ -1,0 +1,560 @@
+import { useId, useMemo, useRef, useState } from 'react';
+import type {
+	HTMLAttributes,
+	PointerEvent as ReactPointerEvent,
+	ReactNode,
+	RefObject,
+} from 'react';
+import { Button, Tab, TabList, Tabs, useDrag, useDrop } from 'react-aria-components';
+import { ExternalLink, GripVertical, PanelRightClose, PanelRightOpen, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { ConfirmDialog } from './ConfirmDialog';
+
+/* oxlint-disable jsx-a11y/prefer-tag-over-role -- An adjustable separator must be focusable and interactive. */
+
+const APPLICATION_TAB_DRAG_TYPE = 'application/x-marimohub-application-tab';
+const DEFAULT_SPLIT_SIZE = 50;
+const MIN_SPLIT_SIZE = 20;
+const MAX_SPLIT_SIZE = 80;
+
+export interface ApplicationTabCloseConfirmation {
+	title: string;
+	description: ReactNode;
+	confirmLabel?: string;
+	pendingLabel?: string;
+}
+
+export interface ApplicationTabItem {
+	id: string;
+	label: string;
+	icon: ReactNode;
+	panel: ReactNode;
+	isDisabled?: boolean;
+	close?: ApplicationTabCloseConfirmation;
+	browserUrl?: string;
+	isSplittable?: boolean;
+	panelClassName?: string;
+}
+
+export interface ApplicationTabsProps {
+	ariaLabel: string;
+	tabs: readonly ApplicationTabItem[];
+	selectedKey?: string;
+	defaultSelectedKey?: string;
+	onSelectionChange?: (key: string) => void;
+	order?: readonly string[];
+	defaultOrder?: readonly string[];
+	onOrderChange?: (keys: readonly string[]) => void;
+	onClose?: (tab: ApplicationTabItem) => void | Promise<void>;
+	onCloseError?: (error: unknown, tab: ApplicationTabItem) => void;
+	allowsSplitView?: boolean;
+	splitKey?: string | null;
+	defaultSplitKey?: string | null;
+	onSplitKeyChange?: (key: string | null) => void;
+	splitSize?: number;
+	defaultSplitSize?: number;
+	onSplitSizeChange?: (size: number) => void;
+	actions?: ReactNode;
+	className?: string;
+	tabListClassName?: string;
+	panelsClassName?: string;
+}
+
+type DropPosition = 'before' | 'after';
+
+function sameKeys(left: readonly string[], right: readonly string[]): boolean {
+	return left.length === right.length && left.every((key, index) => key === right[index]);
+}
+
+function reconcileOrder(order: readonly string[], availableKeys: readonly string[]): string[] {
+	const available = new Set(availableKeys);
+	const next = order.filter((key) => available.has(key));
+	const included = new Set(next);
+
+	for (const key of availableKeys) {
+		if (!included.has(key)) next.push(key);
+	}
+
+	return next;
+}
+
+function moveKey(
+	order: readonly string[],
+	sourceKey: string,
+	targetKey: string,
+	position: DropPosition,
+): string[] {
+	if (sourceKey === targetKey || !order.includes(sourceKey) || !order.includes(targetKey)) {
+		return [...order];
+	}
+
+	const next = order.filter((key) => key !== sourceKey);
+	const targetIndex = next.indexOf(targetKey);
+	const insertionIndex = position === 'after' ? targetIndex + 1 : targetIndex;
+	next.splice(insertionIndex, 0, sourceKey);
+	return next;
+}
+
+function clampSplitSize(size: number): number {
+	if (!Number.isFinite(size)) return DEFAULT_SPLIT_SIZE;
+	return Math.min(MAX_SPLIT_SIZE, Math.max(MIN_SPLIT_SIZE, size));
+}
+
+function useStablePanelOrder(tabKeys: readonly string[]): string[] {
+	const [panelOrder, setPanelOrder] = useState(() => [...tabKeys]);
+	const nextPanelOrder = reconcileOrder(panelOrder, tabKeys);
+
+	if (!sameKeys(panelOrder, nextPanelOrder)) {
+		// Panel order records mount history. Keeping it separate from the visible
+		// tab order prevents React from moving a mounted iframe during reordering.
+		setPanelOrder(nextPanelOrder);
+		return nextPanelOrder;
+	}
+
+	return panelOrder;
+}
+
+interface ApplicationTabProps {
+	tab: ApplicationTabItem;
+	order: readonly string[];
+	tabDomId: string;
+	panelDomId: string;
+	isReorderable: boolean;
+	isPrimary: boolean;
+	isSplit: boolean;
+	canSplit: boolean;
+	canClose: boolean;
+	onMove: (sourceKey: string, targetKey: string, position: DropPosition) => void;
+	onRequestSplit: (key: string | null) => void;
+	onRequestClose: (tab: ApplicationTabItem) => void;
+}
+
+function ApplicationTab({
+	tab,
+	order,
+	tabDomId,
+	panelDomId,
+	isReorderable,
+	isPrimary,
+	isSplit,
+	canSplit,
+	canClose,
+	onMove,
+	onRequestSplit,
+	onRequestClose,
+}: ApplicationTabProps) {
+	const ref = useRef<HTMLFieldSetElement>(null);
+	const [dropPosition, setDropPosition] = useState<DropPosition>();
+	const { dragProps, dragButtonProps, isDragging } = useDrag({
+		hasDragButton: true,
+		isDisabled: !isReorderable || tab.isDisabled,
+		getItems: () => [
+			{
+				[APPLICATION_TAB_DRAG_TYPE]: tab.id,
+				'text/plain': tab.label,
+			},
+		],
+		getAllowedDropOperations: () => ['move'],
+	});
+
+	const positionForPoint = (x: number): DropPosition => {
+		const width = ref.current?.getBoundingClientRect().width ?? 0;
+		return x > width / 2 ? 'after' : 'before';
+	};
+
+	const { dropProps, isDropTarget } = useDrop({
+		ref,
+		isDisabled: !isReorderable || tab.isDisabled,
+		getDropOperation: (types) => (types.has(APPLICATION_TAB_DRAG_TYPE) ? 'move' : 'cancel'),
+		onDropEnter: (event) => setDropPosition(positionForPoint(event.x)),
+		onDropMove: (event) => setDropPosition(positionForPoint(event.x)),
+		onDropExit: () => setDropPosition(undefined),
+		onDrop: (event) => {
+			const position = positionForPoint(event.x);
+			setDropPosition(undefined);
+			const item = event.items.find(
+				(candidate) => candidate.kind === 'text' && candidate.types.has(APPLICATION_TAB_DRAG_TYPE),
+			);
+			if (item?.kind !== 'text') return;
+			void item.getText(APPLICATION_TAB_DRAG_TYPE).then((sourceKey) => {
+				onMove(sourceKey, tab.id, position);
+			});
+		},
+	});
+
+	const moveWithKeyboard = (direction: -1 | 1) => {
+		const currentIndex = order.indexOf(tab.id);
+		const targetKey = order[currentIndex + direction];
+		if (!targetKey) return;
+		onMove(tab.id, targetKey, direction < 0 ? 'before' : 'after');
+	};
+
+	return (
+		<Tab
+			id={tab.id}
+			isDisabled={tab.isDisabled}
+			render={(domProps) => (
+				<div
+					{...(domProps as HTMLAttributes<HTMLDivElement>)}
+					id={tabDomId}
+					aria-controls={panelDomId}
+				/>
+			)}
+			className={({ isSelected, isFocusVisible }) =>
+				cn(
+					'group relative flex h-9 min-w-28 max-w-56 shrink-0 cursor-default items-center gap-1.5 border-r border-border/70 px-2 text-xs outline-none transition-colors',
+					isSelected
+						? 'bg-background text-foreground before:absolute before:inset-x-0 before:top-0 before:h-0.5 before:bg-primary'
+						: 'bg-muted/30 text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+					isSplit && !isSelected && 'bg-primary/5 text-foreground',
+					isFocusVisible && 'inset-ring-2 inset-ring-ring',
+					isDragging && 'opacity-50',
+				)
+			}
+		>
+			<fieldset
+				{...dragProps}
+				{...dropProps}
+				ref={ref}
+				tabIndex={isReorderable && !tab.isDisabled ? -1 : undefined}
+				aria-label={`Drop ${tab.label} tab here`}
+				className="flex min-w-0 flex-1 items-center gap-1.5 border-0 p-0"
+			>
+				{isReorderable ? (
+					<Button
+						{...dragButtonProps}
+						aria-label={`Reorder ${tab.label}`}
+						onKeyDown={(event) => {
+							if (!event.altKey || !event.shiftKey) return;
+							if (event.key === 'ArrowLeft') moveWithKeyboard(-1);
+							else if (event.key === 'ArrowRight') moveWithKeyboard(1);
+							else return;
+							event.preventDefault();
+						}}
+						className="-ml-1 flex size-5 shrink-0 cursor-grab items-center justify-center rounded-sm text-muted-foreground/70 opacity-0 outline-none hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100 pressed:cursor-grabbing"
+					>
+						<GripVertical className="size-3" />
+					</Button>
+				) : null}
+				<span className="shrink-0 text-muted-foreground [&>svg]:size-3.5">{tab.icon}</span>
+				<span className="min-w-0 flex-1 truncate">{tab.label}</span>
+				{isSplit ? (
+					<Button
+						aria-label={`Close ${tab.label} split view`}
+						className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 outline-none hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100"
+						onPress={() => onRequestSplit(null)}
+					>
+						<PanelRightClose className="size-3.5" />
+					</Button>
+				) : canSplit && !isPrimary ? (
+					<Button
+						aria-label={`Open ${tab.label} to the side`}
+						className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 outline-none hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100"
+						onPress={() => onRequestSplit(tab.id)}
+					>
+						<PanelRightOpen className="size-3.5" />
+					</Button>
+				) : null}
+				{tab.browserUrl ? (
+					<Button
+						aria-label={`Open ${tab.label} in a new browser tab`}
+						className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 outline-none hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100"
+						onPress={() => {
+							const opened = window.open(tab.browserUrl, '_blank', 'noopener,noreferrer');
+							if (opened) opened.opener = null;
+						}}
+					>
+						<ExternalLink className="size-3" />
+					</Button>
+				) : null}
+				{tab.close && canClose ? (
+					<Button
+						aria-label={`Close ${tab.label}`}
+						className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 outline-none hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100 group-data-[selected]:opacity-100"
+						onPress={() => onRequestClose(tab)}
+					>
+						<X className="size-3.5" />
+					</Button>
+				) : null}
+				{isDropTarget && dropPosition ? (
+					<span
+						aria-hidden="true"
+						className={cn(
+							'pointer-events-none absolute inset-y-1 z-10 w-0.5 rounded-full bg-primary',
+							dropPosition === 'before' ? '-left-px' : '-right-px',
+						)}
+					/>
+				) : null}
+			</fieldset>
+		</Tab>
+	);
+}
+
+interface SplitResizeHandleProps {
+	containerRef: RefObject<HTMLDivElement | null>;
+	size: number;
+	onSizeChange: (size: number) => void;
+}
+
+function SplitResizeHandle({ containerRef, size, onSizeChange }: SplitResizeHandleProps) {
+	const activePointerId = useRef<number | undefined>(undefined);
+
+	const finishPointerResize = (event: ReactPointerEvent<HTMLDivElement>) => {
+		if (activePointerId.current !== event.pointerId) return;
+		activePointerId.current = undefined;
+		if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+			event.currentTarget.releasePointerCapture(event.pointerId);
+		}
+	};
+
+	return (
+		<div
+			role="separator"
+			aria-label="Resize split view"
+			aria-orientation="vertical"
+			aria-valuemin={MIN_SPLIT_SIZE}
+			aria-valuemax={MAX_SPLIT_SIZE}
+			aria-valuenow={Math.round(size)}
+			aria-valuetext={`${Math.round(size)}% left pane`}
+			tabIndex={0}
+			className="relative col-start-2 row-start-1 z-10 flex w-1.5 touch-none cursor-col-resize select-none items-center justify-center border-0 outline-none before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-border before:transition-colors after:absolute after:left-1/2 after:h-6 after:w-1 after:-translate-x-1/2 after:rounded-full after:bg-muted-foreground/30 after:transition-colors hover:before:bg-primary hover:after:bg-primary focus-visible:before:bg-primary focus-visible:after:bg-primary"
+			onDoubleClick={() => onSizeChange(DEFAULT_SPLIT_SIZE)}
+			onKeyDown={(event) => {
+				const step = event.shiftKey ? 10 : 2;
+				let nextSize: number | undefined;
+				if (event.key === 'ArrowLeft') nextSize = size - step;
+				else if (event.key === 'ArrowRight') nextSize = size + step;
+				else if (event.key === 'Home') nextSize = MIN_SPLIT_SIZE;
+				else if (event.key === 'End') nextSize = MAX_SPLIT_SIZE;
+				if (nextSize === undefined) return;
+				event.preventDefault();
+				onSizeChange(nextSize);
+			}}
+			onPointerDown={(event) => {
+				activePointerId.current = event.pointerId;
+				event.currentTarget.setPointerCapture(event.pointerId);
+				event.preventDefault();
+			}}
+			onPointerMove={(event) => {
+				if (activePointerId.current !== event.pointerId) return;
+				const bounds = containerRef.current?.getBoundingClientRect();
+				if (!bounds?.width) return;
+				onSizeChange(((event.clientX - bounds.left) / bounds.width) * 100);
+			}}
+			onPointerUp={finishPointerResize}
+			onPointerCancel={finishPointerResize}
+		/>
+	);
+}
+
+export function ApplicationTabs({
+	ariaLabel,
+	tabs,
+	selectedKey,
+	defaultSelectedKey,
+	onSelectionChange,
+	order,
+	defaultOrder,
+	onOrderChange,
+	onClose,
+	onCloseError,
+	allowsSplitView = true,
+	splitKey,
+	defaultSplitKey,
+	onSplitKeyChange,
+	splitSize,
+	defaultSplitSize = DEFAULT_SPLIT_SIZE,
+	onSplitSizeChange,
+	actions,
+	className,
+	tabListClassName,
+	panelsClassName,
+}: ApplicationTabsProps) {
+	const instanceId = useId();
+	const tabKeys = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
+	const tabsById = useMemo(() => new Map(tabs.map((tab) => [tab.id, tab])), [tabs]);
+	const [internalSelectedKey, setInternalSelectedKey] = useState(
+		() => defaultSelectedKey ?? tabKeys[0],
+	);
+	const [internalOrder, setInternalOrder] = useState(() =>
+		reconcileOrder(defaultOrder ?? tabKeys, tabKeys),
+	);
+	const [internalSplitKey, setInternalSplitKey] = useState<string | null>(
+		() => defaultSplitKey ?? null,
+	);
+	const [internalSplitSize, setInternalSplitSize] = useState(() =>
+		clampSplitSize(defaultSplitSize),
+	);
+	const visibleOrder = reconcileOrder(order ?? internalOrder, tabKeys);
+	const panelOrder = useStablePanelOrder(tabKeys);
+	const requestedPrimaryKey = selectedKey ?? internalSelectedKey;
+	const primaryKey = tabsById.has(requestedPrimaryKey) ? requestedPrimaryKey : tabKeys[0];
+	const requestedSplitKey = splitKey === undefined ? internalSplitKey : splitKey;
+	const splitTab = requestedSplitKey ? tabsById.get(requestedSplitKey) : undefined;
+	const activeSplitKey =
+		allowsSplitView &&
+		!!splitTab &&
+		requestedSplitKey !== primaryKey &&
+		!splitTab.isDisabled &&
+		splitTab.isSplittable !== false
+			? requestedSplitKey
+			: null;
+	const activeSplitSize = clampSplitSize(splitSize ?? internalSplitSize);
+	const hasSplit = activeSplitKey !== null;
+	const panelsRef = useRef<HTMLDivElement>(null);
+	const [closeKey, setCloseKey] = useState<string>();
+	const [isClosePending, setIsClosePending] = useState(false);
+	const closingTab = closeKey ? tabsById.get(closeKey) : undefined;
+	const isReorderable = tabs.length > 1;
+
+	const changeSplitKey = (nextKey: string | null) => {
+		if (splitKey === undefined) setInternalSplitKey(nextKey);
+		onSplitKeyChange?.(nextKey);
+	};
+
+	const changeSplitSize = (nextSize: number) => {
+		const clampedSize = clampSplitSize(nextSize);
+		if (clampedSize === activeSplitSize) return;
+		if (splitSize === undefined) setInternalSplitSize(clampedSize);
+		onSplitSizeChange?.(clampedSize);
+	};
+
+	const changeSelection = (nextKey: string) => {
+		if (nextKey === activeSplitKey && primaryKey) changeSplitKey(primaryKey);
+		if (selectedKey === undefined) setInternalSelectedKey(nextKey);
+		onSelectionChange?.(nextKey);
+	};
+
+	const changeOrder = (sourceKey: string, targetKey: string, position: DropPosition) => {
+		const next = moveKey(visibleOrder, sourceKey, targetKey, position);
+		if (sameKeys(next, visibleOrder)) return;
+		if (order === undefined) setInternalOrder(next);
+		onOrderChange?.(next);
+	};
+
+	const confirmClose = async () => {
+		if (!closingTab || !onClose) return;
+		setIsClosePending(true);
+		try {
+			await onClose(closingTab);
+			setCloseKey(undefined);
+		} catch (error) {
+			onCloseError?.(error, closingTab);
+		} finally {
+			setIsClosePending(false);
+		}
+	};
+
+	return (
+		<>
+			<Tabs
+				selectedKey={primaryKey}
+				onSelectionChange={(key) => changeSelection(String(key))}
+				keyboardActivation="automatic"
+				className={cn('flex min-h-0 flex-1 flex-col bg-background', className)}
+			>
+				<div className="flex h-9 shrink-0 items-end border-b bg-muted/50">
+					<TabList
+						aria-label={ariaLabel}
+						className={cn(
+							'flex h-full min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+							tabListClassName,
+						)}
+					>
+						{visibleOrder.map((key) => {
+							const tab = tabsById.get(key);
+							return tab ? (
+								<ApplicationTab
+									key={tab.id}
+									tab={tab}
+									order={visibleOrder}
+									tabDomId={`${instanceId}-tab-${tab.id}`}
+									panelDomId={`${instanceId}-panel-${tab.id}`}
+									isReorderable={isReorderable}
+									isPrimary={tab.id === primaryKey}
+									isSplit={tab.id === activeSplitKey}
+									canSplit={
+										allowsSplitView &&
+										tab.isSplittable !== false &&
+										!tab.isDisabled &&
+										tabs.length > 1
+									}
+									canClose={!!onClose}
+									onMove={changeOrder}
+									onRequestSplit={changeSplitKey}
+									onRequestClose={(item) => setCloseKey(item.id)}
+								/>
+							) : null;
+						})}
+					</TabList>
+					{actions ? (
+						<div className="flex h-full shrink-0 items-center border-l px-1">{actions}</div>
+					) : null}
+				</div>
+				<div
+					ref={panelsRef}
+					data-application-panels=""
+					className={cn(
+						'relative min-h-0 flex-1 overflow-hidden',
+						hasSplit && 'grid grid-rows-[minmax(0,1fr)]',
+						panelsClassName,
+					)}
+					style={
+						hasSplit
+							? {
+									gridTemplateColumns: `${activeSplitSize}fr 0.375rem ${100 - activeSplitSize}fr`,
+								}
+							: undefined
+					}
+				>
+					{panelOrder.map((key) => {
+						const tab = tabsById.get(key);
+						const isPrimary = key === primaryKey;
+						const isSplit = key === activeSplitKey;
+						const isVisible = isPrimary || isSplit;
+						return tab ? (
+							<div
+								key={tab.id}
+								id={`${instanceId}-panel-${tab.id}`}
+								role="tabpanel"
+								aria-labelledby={`${instanceId}-tab-${tab.id}`}
+								aria-hidden={isVisible ? undefined : true}
+								inert={isVisible ? undefined : true}
+								className={cn(
+									'min-h-0 min-w-0 overflow-hidden outline-none',
+									!isVisible && 'hidden',
+									isVisible && !hasSplit && 'absolute inset-0',
+									isPrimary && hasSplit && 'col-start-1 row-start-1',
+									isSplit && 'col-start-3 row-start-1',
+									tab.panelClassName,
+								)}
+							>
+								{tab.panel}
+							</div>
+						) : null;
+					})}
+					{hasSplit ? (
+						<SplitResizeHandle
+							containerRef={panelsRef}
+							size={activeSplitSize}
+							onSizeChange={changeSplitSize}
+						/>
+					) : null}
+				</div>
+			</Tabs>
+
+			{closingTab?.close ? (
+				<ConfirmDialog
+					isOpen
+					onClose={() => setCloseKey(undefined)}
+					title={closingTab.close.title}
+					description={closingTab.close.description}
+					confirmLabel={closingTab.close.confirmLabel ?? 'Close'}
+					pendingLabel={closingTab.close.pendingLabel ?? 'Closing...'}
+					isPending={isClosePending}
+					onConfirm={() => void confirmClose()}
+				/>
+			) : null}
+		</>
+	);
+}

--- a/packages/web/src/components/ui/DropdownMenu.test.tsx
+++ b/packages/web/src/components/ui/DropdownMenu.test.tsx
@@ -11,6 +11,7 @@ function setup(onAction = vi.fn()) {
 			icon={<MoreHorizontal />}
 			options={[
 				{ id: 'download-file', label: 'Download notebook file' },
+				{ id: 'disabled', label: 'Unavailable action', isDisabled: true },
 				{ id: 'delete', label: 'Delete', danger: true, separatorBefore: true },
 			]}
 			onAction={onAction}
@@ -46,5 +47,17 @@ describe('DropdownMenu', () => {
 		const separator = screen.getByRole('separator');
 		const deleteItem = screen.getByRole('menuitem', { name: 'Delete' });
 		expect(separator.nextElementSibling).toBe(deleteItem);
+	});
+
+	it('does not fire actions for disabled items', async () => {
+		const user = userEvent.setup();
+		const { onAction } = setup();
+
+		await user.click(screen.getByRole('button', { name: 'Notebook actions' }));
+		const item = screen.getByRole('menuitem', { name: 'Unavailable action' });
+		expect(item).toHaveAttribute('aria-disabled', 'true');
+		await user.click(item);
+
+		expect(onAction).not.toHaveBeenCalled();
 	});
 });

--- a/packages/web/src/components/ui/DropdownMenu.tsx
+++ b/packages/web/src/components/ui/DropdownMenu.tsx
@@ -8,12 +8,13 @@ export interface DropdownMenuOption {
 	label: ReactNode;
 	icon?: ReactNode;
 	separatorBefore?: boolean;
+	isDisabled?: boolean;
 	/** Render the item in the destructive style (e.g. Delete). */
 	danger?: boolean;
 }
 
 export interface DropdownMenuProps {
-	/** Accessible label for the trigger button (it is icon-only). */
+	/** Accessible label for the trigger button. */
 	label: string;
 	/** Trigger icon, e.g. `<MoreHorizontal className="size-4" />`. */
 	icon: ReactNode;
@@ -25,9 +26,9 @@ export interface DropdownMenuProps {
 }
 
 /**
- * A small overflow ("…") menu built on react-aria-components, mirroring the
- * popover/menu styling used by the header user menu. The trigger is icon-only;
- * the popover is portaled, so item clicks never bubble to an enclosing row.
+ * A small menu built on react-aria-components, mirroring the popover/menu
+ * styling used by the header user menu. The popover is portaled, so item clicks
+ * never bubble to an enclosing row.
  */
 export function DropdownMenu({
 	label,
@@ -61,8 +62,9 @@ export function DropdownMenu({
 						<MenuItem
 							key={opt.id}
 							id={opt.id}
+							isDisabled={opt.isDisabled}
 							className={cn(
-								'flex cursor-pointer items-center gap-2 px-3 py-2 text-[13px] outline-none transition-colors max-md:min-h-11',
+								'flex cursor-pointer items-center gap-2 px-3 py-2 text-[13px] outline-none transition-colors data-[disabled]:cursor-default data-[disabled]:opacity-50 max-md:min-h-11',
 								opt.danger
 									? 'text-destructive focus:bg-destructive/10'
 									: 'text-popover-foreground focus:bg-muted',

--- a/packages/web/src/components/ui/index.ts
+++ b/packages/web/src/components/ui/index.ts
@@ -71,3 +71,10 @@ export type { CopyFieldProps } from './CopyField';
 export { WriteOnceWarning } from './WriteOnceWarning';
 
 export { ErrorBoundary } from './ErrorBoundary';
+
+export { ApplicationTabs } from './ApplicationTabs';
+export type {
+	ApplicationTabCloseConfirmation,
+	ApplicationTabItem,
+	ApplicationTabsProps,
+} from './ApplicationTabs';

--- a/packages/web/src/lib/surfaces.ts
+++ b/packages/web/src/lib/surfaces.ts
@@ -1,0 +1,6 @@
+import type { SecondarySurfaceId } from '@/types';
+
+export const SURFACE_LABELS = {
+	vscode: 'VS Code',
+	opencode: 'OpenCode',
+} as const satisfies Record<SecondarySurfaceId, string>;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -81,6 +81,10 @@ export type GitNotebookCreateResult = ClientGitNotebookCreateResult;
 /** A sync URL + write-once token, returned on synced-notebook creation and token rotation. */
 export type SyncToken = ClientSyncToken;
 export type Session = ClientSession;
+export type SecondarySurfaceId = NonNullable<
+	components['schemas']['SessionCreateBody']['surfaces']
+>[number];
+export type Surface = components['schemas']['Surface'];
 export type EditorSessionState = components['schemas']['EditorSessionState'];
 /** An integration kind's catalog card + JSON Schema for its config form. */
 export type IntegrationKind = ClientIntegrationKind;

--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -7,7 +7,7 @@ import { gzipSync } from 'node:zlib';
 // accidental growth should be fixed at the import or dependency that caused it.
 const BUDGETS_KIB = {
 	js: 3000,
-	css: 13,
+	css: 14,
 };
 
 const dist = fileURLToPath(new URL('../packages/web/dist/', import.meta.url));


### PR DESCRIPTION
Adds OpenCode Web as a subdomain-only session surface that shares the existing edit sandbox and has an independent lifecycle. Managed AI uses session-scoped credentials, while project and BYOK OpenCode providers remain supported.

Generalizes surface configuration, authorization, APIs, clients, Helm values, sandbox images, and documentation for VS Code and OpenCode. The notebook UI uses one Surfaces menu and keeps running tools in reorderable application tabs with optional split view.