### PR TITLE
feat(web): add change-compute button on idle notebook rows

### DIFF
--- a/packages/web/src/components/Project/Project.actions.test.tsx
+++ b/packages/web/src/components/Project/Project.actions.test.tsx
@@ -8,6 +8,7 @@ import {
 	makeFetch,
 	renderProject,
 	runningSession,
+	stoppableSession,
 } from './Project.testWorld';
 
 describe('Project — Notebook Actions: configuration', () => {
@@ -111,7 +112,7 @@ describe('Project — Notebook Actions: configuration', () => {
 		expect(screen.queryByText('small')).not.toBeInTheDocument();
 	});
 
-	it('lets editors change compute from the notebook overflow menu', async () => {
+	it('lets editors change compute from the notebook list chip button', async () => {
 		const user = userEvent.setup();
 		const calls = makeFetch({
 			role: 'editor',
@@ -126,7 +127,7 @@ describe('Project — Notebook Actions: configuration', () => {
 		});
 		await renderProject();
 
-		await chooseNotebookAction(user, 'Change compute…');
+		await user.click(screen.getByRole('button', { name: 'Change compute for Forecast' }));
 		const dialog = await screen.findByRole('dialog');
 		expect(within(dialog).getByRole('radio', { name: /Default \(small\)/ })).toBeChecked();
 		await user.click(within(dialog).getByRole('radio', { name: /large/ }));
@@ -142,6 +143,29 @@ describe('Project — Notebook Actions: configuration', () => {
 				),
 			).toBe(true),
 		);
+	});
+
+	it('keeps change compute in the overflow menu when a session is running', async () => {
+		const user = userEvent.setup();
+		makeFetch({
+			role: 'editor',
+			sessions: [stoppableSession()],
+			capabilities: {
+				federation: { available: false },
+				compute_profiles: [
+					{ name: 'small', cpu: 1, memory_bytes: 2 * 1024 ** 3 },
+					{ name: 'large', cpu: 8, memory_bytes: 32 * 1024 ** 3 },
+				],
+				compute_profile_override: 'editors',
+			},
+		});
+		await renderProject();
+
+		expect(
+			screen.queryByRole('button', { name: 'Change compute for Forecast' }),
+		).not.toBeInTheDocument();
+		await chooseNotebookAction(user, 'Change compute…');
+		expect(await screen.findByRole('dialog')).toBeInTheDocument();
 	});
 
 	it('labels and restarts the edit session when edit and app are both live', async () => {
@@ -264,6 +288,9 @@ describe('Project — Notebook Actions: configuration', () => {
 		});
 		await renderProject();
 
+		expect(
+			screen.queryByRole('button', { name: 'Change compute for Forecast' }),
+		).not.toBeInTheDocument();
 		await user.click(screen.getByRole('button', { name: /Notebook actions for/ }));
 		expect(await screen.findByText('Rename')).toBeInTheDocument();
 		expect(screen.queryByText('Change compute…')).not.toBeInTheDocument();

--- a/packages/web/src/components/Project/Project.tsx
+++ b/packages/web/src/components/Project/Project.tsx
@@ -821,6 +821,17 @@ export function Project() {
 											<Power className="size-4" />
 										</IconButton>
 									)}
+									{/* Idle notebooks: change compute without opening the overflow menu. */}
+									{offersComputeChoice && !stoppableEdit && !live?.app && (
+										<IconButton
+											label={`Change compute for ${nb.title}`}
+											tooltip="Change compute…"
+											className="opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 max-md:opacity-100"
+											onPress={() => computeProfileModal.open(nb)}
+										>
+											<Cpu className="size-4" />
+										</IconButton>
+									)}
 									<DropdownMenu
 										label={`Notebook actions for ${nb.title}`}
 										icon={<MoreHorizontal className="size-4" />}


### PR DESCRIPTION
## Summary
- Add a Cpu icon button next to each idle notebook’s overflow menu so editors can change compute without opening the menu.
- Keep the existing overflow action when a session is running (and when the inline button is hidden).
## Test plan
- [x] With multiple compute profiles and overrides enabled, hover an idle notebook row and confirm the chip button opens Change compute
- [ ] Save a new profile and confirm the notebook’s stored profile updates
- [ ] With a running edit or app session, confirm the chip is hidden and Change compute… remains in the overflow menu
- [ ] With a single profile or overrides disabled, confirm neither the chip nor the menu item appears