### PR TITLE
fix(core): trust restored Git worktrees on Modal

### DIFF
--- a/development_docs/source_control_publishing.md
+++ b/development_docs/source_control_publishing.md
@@ -53,7 +53,10 @@ Pull-mode GitHub sources store a shallow Git directory for the exact synced
 commit. The control plane restores it when the session starts. Repository
 credentials never enter the sandbox. Pull sources therefore use
 `git-working-tree`. Push sources use this strategy only when the uploaded archive
-contains `.git`.
+contains `.git`. Restored `.git` metadata may be owned by a different uid than
+the kernel user (Modal filesystem writes), so capture passes
+`-c safe.directory=<workdir>` and provision marks that directory in the sandbox
+gitconfig.
 
 The Git strategy uses Git only to discover paths and operations. The control plane reads the final
 file bytes through the sandbox port, hashes them, and stores normal provider-neutral proposal

--- a/packages/core/src/services/content/NotebookProposalService.test.ts
+++ b/packages/core/src/services/content/NotebookProposalService.test.ts
@@ -58,6 +58,7 @@ interface GitSandboxOptions {
 	gitAvailable?: boolean;
 	baseCommitAvailable?: boolean;
 	baseCommitOutput?: string;
+	baseCommitStderr?: string;
 	diffFails?: boolean;
 	sizes?: Record<string, number>;
 	secureReadFailures?: readonly string[];
@@ -71,12 +72,12 @@ function makeGitSandbox(options: GitSandboxOptions) {
 				? execResult(false, '', 'not a repository')
 				: execResult(true, 'git-working-tree', '');
 		}
-		if (command.includes('git rev-parse --verify')) {
+		if (command.includes('rev-parse --verify')) {
 			return options.baseCommitAvailable === false
-				? execResult(false, '', 'unknown revision')
+				? execResult(false, '', options.baseCommitStderr ?? 'unknown revision')
 				: execResult(true, options.baseCommitOutput ?? `${GIT_COMMIT}\n`, '');
 		}
-		if (command.includes('git diff --name-status')) {
+		if (command.includes('diff --name-status')) {
 			const output =
 				options.diffOutput ??
 				(options.diff ?? [])
@@ -87,7 +88,7 @@ function makeGitSandbox(options: GitSandboxOptions) {
 				? execResult(false, '', 'diff failed')
 				: execResult(true, output, '');
 		}
-		if (command.includes('git ls-files --others')) {
+		if (command.includes('ls-files --others')) {
 			return execResult(
 				true,
 				options.untrackedOutput ?? (options.untracked ?? []).map((path) => `${path}\0`).join(''),
@@ -290,6 +291,13 @@ describe('NotebookProposalService', () => {
 			{ path: 'old.txt', operation: 'delete' },
 		]);
 		expect(exec).toHaveBeenCalledWith(expect.stringContaining('--exclude-standard'));
+		const gitCommands = exec.mock.calls
+			.map(([command]) => command)
+			.filter((command) => command.includes('git -c'));
+		expect(gitCommands.length).toBeGreaterThan(0);
+		expect(gitCommands.every((command) => command.includes('safe.directory=/workspace'))).toBe(
+			true,
+		);
 		const proposalPaths = paths
 			.project(projectId)
 			.notebook(notebookId)
@@ -419,7 +427,9 @@ describe('NotebookProposalService', () => {
 			diffFails: true,
 		});
 
-		await expect(capture(instance)).rejects.toThrow('Could not inspect the Git working tree');
+		await expect(capture(instance)).rejects.toThrow(
+			'Could not inspect the Git working tree: diff failed',
+		);
 	});
 
 	it('does not silently fall back when the pinned commit is absent from a Git working tree', async () => {
@@ -428,8 +438,22 @@ describe('NotebookProposalService', () => {
 			baseCommitAvailable: false,
 		});
 
-		await expect(capture(instance)).rejects.toThrow('does not contain the pinned source commit');
+		await expect(capture(instance)).rejects.toThrow(
+			'does not contain the pinned source commit: unknown revision',
+		);
 		expect(calls.readFile).toHaveLength(0);
+	});
+
+	it('includes git stderr when the working tree is untrusted', async () => {
+		const { instance, calls, exec } = makeGitSandbox({
+			files: { 'dashboard.py': 'print("after")' },
+			baseCommitAvailable: false,
+			baseCommitStderr: "fatal: detected dubious ownership in repository at '/workspace'",
+		});
+
+		await expect(capture(instance)).rejects.toThrow('dubious ownership');
+		expect(calls.readFile).toHaveLength(0);
+		expect(exec).toHaveBeenCalledWith(expect.stringContaining('safe.directory=/workspace'));
 	});
 
 	it('rejects an invalid commit returned by Git', async () => {

--- a/packages/core/src/services/content/proposalCapture.ts
+++ b/packages/core/src/services/content/proposalCapture.ts
@@ -131,6 +131,20 @@ function gitPathspec(): string {
 	return ['.', ...GIT_EXCLUDE_PATHS].map(shellQuote).join(' ');
 }
 
+function gitInWorkdir(workdir: string, args: string): string {
+	// Modal restores `.git` as a different uid than the kernel user. Git 2.35+
+	// then refuses the worktree unless this directory is trusted; `-c` keeps
+	// capture working on sessions provisioned before gitconfig was updated.
+	return `cd ${shellQuote(workdir)} && git -c ${shellQuote(`safe.directory=${workdir}`)} ${args}`;
+}
+
+function gitConflict(message: string, result: { stdout: string; stderr: string }): ConflictError {
+	const detail = (result.stderr.trim() || result.stdout.trim())
+		.replaceAll(/\s+/g, ' ')
+		.slice(0, 1000);
+	return new ConflictError(detail ? `${message}: ${detail}` : message);
+}
+
 async function hasGitWorkingTree(sandbox: SandboxInstance, workdir: string): Promise<boolean> {
 	const result = await sandbox.exec(
 		`cd ${shellQuote(workdir)} && test -e .git && command -v git >/dev/null 2>&1 && printf git-working-tree`,
@@ -144,10 +158,10 @@ async function resolvedGitBase(
 	commit: string,
 ): Promise<string> {
 	const result = await sandbox.exec(
-		`cd ${shellQuote(workdir)} && git rev-parse --verify ${shellQuote(`${commit}^{commit}`)}`,
+		gitInWorkdir(workdir, `rev-parse --verify ${shellQuote(`${commit}^{commit}`)}`),
 	);
 	if (!result.success) {
-		throw new ConflictError('The Git working tree does not contain the pinned source commit');
+		throw gitConflict('The Git working tree does not contain the pinned source commit', result);
 	}
 	const resolved = result.stdout.trim();
 	if (!/^[0-9a-fA-F]{40,64}$/.test(resolved)) {
@@ -234,14 +248,15 @@ async function captureGitWorkingTree(
 	const pathspec = gitPathspec();
 	const [diff, untracked] = await Promise.all([
 		sandbox.exec(
-			`cd ${shellQuote(workdir)} && git diff --name-status -z --no-renames ${shellQuote(resolvedBase)} -- ${pathspec}`,
+			gitInWorkdir(
+				workdir,
+				`diff --name-status -z --no-renames ${shellQuote(resolvedBase)} -- ${pathspec}`,
+			),
 		),
-		sandbox.exec(
-			`cd ${shellQuote(workdir)} && git ls-files --others --exclude-standard -z -- ${pathspec}`,
-		),
+		sandbox.exec(gitInWorkdir(workdir, `ls-files --others --exclude-standard -z -- ${pathspec}`)),
 	]);
 	if (!diff.success || !untracked.success) {
-		throw new ConflictError('Could not inspect the Git working tree');
+		throw gitConflict('Could not inspect the Git working tree', !diff.success ? diff : untracked);
 	}
 	const operations = parseGitDiff(diff.stdout);
 	for (const path of parseNullTerminated(untracked.stdout, 'untracked-file output')) {

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -1127,6 +1127,11 @@ describe('SandboxProvisioner', () => {
 			expect(calls.writeFile.some((file) => file.path.endsWith('app.py'))).toBe(false);
 			expect(calls.exec.some((command) => command.startsWith('python3 '))).toBe(true);
 			expect(calls.exec.find((command) => command.startsWith('python3 '))).toMatch(/ 1$/);
+			expect(
+				calls.exec.some((command) =>
+					command.includes("git config --global --add safe.directory '/workspace'"),
+				),
+			).toBe(true);
 			expect(result.counters).toMatchObject({
 				files_objects: 1,
 				files_bytes: archive.byteLength,
@@ -1328,6 +1333,11 @@ describe('SandboxProvisioner', () => {
 			expect(restored).toContain(`${MOUNT_PATH}/.git/HEAD`);
 			expect(restored).toContain(`${MOUNT_PATH}/.git/objects/pack/pack-a.pack`);
 			expect(result.counters).toMatchObject({ files_objects: 3 });
+			expect(
+				calls.exec.some((command) =>
+					command.includes("git config --global --add safe.directory '/workspace'"),
+				),
+			).toBe(true);
 		});
 
 		it('preserves Git metadata stored in an ordinary copied workspace', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -673,6 +673,19 @@ export class SandboxProvisioner {
 		mountPath: string,
 		workspacePrefix: string,
 	): Promise<WorkspaceLoadResult> {
+		const loaded = await this.restoreWorkspaceFiles(sandbox, options, mountPath, workspacePrefix);
+		if (options.gitPrefix) {
+			await this.markGitWorkdirTrusted(sandbox, mountPath);
+		}
+		return loaded;
+	}
+
+	private async restoreWorkspaceFiles(
+		sandbox: SandboxInstance,
+		options: ProvisionOptions,
+		mountPath: string,
+		workspacePrefix: string,
+	): Promise<WorkspaceLoadResult> {
 		if (
 			options.workspaceLoadMode === 'copy-only' &&
 			options.workspaceArchive &&
@@ -718,6 +731,13 @@ export class SandboxProvisioner {
 			};
 		}
 		return this.loadWorkspaceObjects(sandbox, options, mountPath, workspacePrefix);
+	}
+
+	private async markGitWorkdirTrusted(sandbox: SandboxInstance, workdir: string): Promise<void> {
+		// Restored `.git` is often a different uid than the kernel user (Modal).
+		await sandbox.exec(
+			`if command -v git >/dev/null 2>&1; then git config --global --add safe.directory ${shellQuote(workdir)}; fi`,
+		);
 	}
 
 	private async loadWorkspaceObjects(


### PR DESCRIPTION
## Summary
Fixes https://github.com/marimo-team/marimohub/issues/276.
On Modal, restored `.git` is a different uid than the kernel user. Git 2.35+ then refuses the worktree (`fatal: detected dubious ownership`), and capture mapped any `rev-parse` failure to “pinned source commit missing.” Confirmed in-session: `git config --global --add safe.directory /workspace` made Open PR succeed.
- Capture git commands pass `-c safe.directory=<workdir>` (works on sessions already running)
- Pull-source provision marks that directory in the sandbox gitconfig (user-facing `git` in the cell)
- Conflict errors include git stderr instead of discarding it
## Verification
- [x] `vp check` on the changed files
- [x] `vp test` `NotebookProposalService.test.ts` `SandboxProvisioner.test.ts`  passed)
- [ ] `pnpm check`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [ ] Re-hit Open PR on a **new** Modal session after this ships (no manual gitconfig cell)
## Notes
- Docs updated or not needed: `development_docs/source_control_publishing.md` records the ownership mismatch
- Security impact: trusts only the hub’s own sandbox workdir, not `safe.directory=*`