### PR TITLE
feat(web): add compute and image options to git notebooks

### DIFF
--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -1352,6 +1352,8 @@ export function useCreateSyncedNotebook(projectId: string) {
 			root_path?: string;
 			entry_notebook: string;
 			sync_mode?: 'push' | 'pull';
+			base_image?: string;
+			compute_profile?: string;
 		}) =>
 			apiData(
 				apiClient.POST('/api/v1/projects/{pid}/notebooks/git', {

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.test.tsx
@@ -6,7 +6,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { SyncedNotebookDialog } from './SyncedNotebookDialog';
 
-function renderDialog(fetchImpl = vi.fn(), pullAvailable: boolean | Promise<boolean> = false) {
+interface ResourceOptions {
+	sandboxImages?: string[];
+	computeProfiles?: { name: string; cpu?: number; memory_bytes?: number }[];
+	computeProfileOverride?: 'none' | 'editors';
+}
+
+function renderDialog(
+	fetchImpl = vi.fn(),
+	pullAvailable: boolean | Promise<boolean> = false,
+	resources: ResourceOptions = {},
+) {
 	vi.stubGlobal(
 		'fetch',
 		vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
@@ -19,6 +29,9 @@ function renderDialog(fetchImpl = vi.fn(), pullAvailable: boolean | Promise<bool
 							source_control: {
 								pull_source_providers: available ? ['github'] : [],
 							},
+							sandbox_images: resources.sandboxImages ?? [],
+							compute_profiles: resources.computeProfiles ?? [],
+							compute_profile_override: resources.computeProfileOverride ?? 'none',
 						},
 					}),
 					{ headers: { 'content-type': 'application/json' } },
@@ -131,6 +144,53 @@ describe('SyncedNotebookDialog', () => {
 			token: 'mhsync_secret',
 			syncMode: 'push',
 		});
+	});
+
+	it('stores selected container and compute options', async () => {
+		const user = userEvent.setup();
+		const fetchImpl = vi.fn(
+			async (_url: RequestInfo | URL, _init?: RequestInit) =>
+				new Response(
+					JSON.stringify({
+						success: true,
+						data: { notebook: { id: 'nb-9', title: 'Dash' } },
+					}),
+					{ headers: { 'content-type': 'application/json' } },
+				),
+		);
+		renderDialog(fetchImpl, false, {
+			sandboxImages: ['registry.example.com/marimo:cpu', 'registry.example.com/marimo:gpu'],
+			computeProfiles: [
+				{ name: 'small', cpu: 1, memory_bytes: 2 * 1024 ** 3 },
+				{ name: 'large', cpu: 8, memory_bytes: 32 * 1024 ** 3 },
+			],
+			computeProfileOverride: 'editors',
+		});
+
+		await user.type(screen.getByLabelText('Notebook name'), 'Dash');
+		await user.type(screen.getByLabelText('Repository'), 'acme/analytics');
+		await user.type(screen.getByLabelText('Notebook file'), 'dashboard.py');
+		await user.click(await screen.findByRole('radio', { name: /gpu/ }));
+		await user.click(screen.getByRole('radio', { name: /large/ }));
+		await user.click(screen.getByRole('button', { name: 'Create' }));
+
+		const [, init] = fetchImpl.mock.calls[0];
+		expect(JSON.parse(init!.body as string)).toMatchObject({
+			base_image: 'registry.example.com/marimo:gpu',
+			compute_profile: 'large',
+		});
+	});
+
+	it('hides container and compute fields when there is no alternative option', async () => {
+		renderDialog(vi.fn(), true, {
+			sandboxImages: ['registry.example.com/marimo:cpu'],
+			computeProfiles: [{ name: 'small', cpu: 1, memory_bytes: 2 * 1024 ** 3 }],
+			computeProfileOverride: 'editors',
+		});
+
+		expect(await screen.findByText('Connect to GitHub')).toBeInTheDocument();
+		expect(screen.queryByText('Base image')).not.toBeInTheDocument();
+		expect(screen.queryByText('Compute')).not.toBeInTheDocument();
 	});
 
 	it('offers GitHub pull mode and creates without CI credentials', async () => {

--- a/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
+++ b/packages/web/src/components/Notebook/SyncedNotebookDialog.tsx
@@ -19,6 +19,8 @@ import {
 	isRepoInput,
 	REPO_INPUT_HINT,
 } from '@/lib/git';
+import { baseImageOptions, DEFAULT_BASE_IMAGE } from './baseImage';
+import { computeProfileOptions, DEFAULT_COMPUTE_PROFILE } from './computeProfiles';
 
 export interface SyncedNotebookCreated {
 	notebookId: string;
@@ -43,6 +45,8 @@ const syncedSchema = z
 		branch: requiredText('Branch'),
 		rootPath: optionalText(),
 		entryNotebook: requiredText('Notebook file').regex(ENTRY_NOTEBOOK_PATTERN, ENTRY_NOTEBOOK_HINT),
+		baseImage: z.string(),
+		computeProfile: z.string(),
 	})
 	.superRefine((value, context) => {
 		if (value.syncMode === 'pull' && isRepoInput(value.repo) && !isGitHubRepoInput(value.repo)) {
@@ -61,6 +65,8 @@ const emptyValues = (syncMode: 'push' | 'pull') => ({
 	branch: 'main',
 	rootPath: '',
 	entryNotebook: '',
+	baseImage: DEFAULT_BASE_IMAGE,
+	computeProfile: DEFAULT_COMPUTE_PROFILE,
 });
 
 export function SyncedNotebookDialog({
@@ -73,6 +79,11 @@ export function SyncedNotebookDialog({
 	const pullAvailable = (capabilities?.source_control?.pull_source_providers ?? []).includes(
 		'github',
 	);
+	const sandboxImages = capabilities?.sandbox_images ?? [];
+	const offersImageChoice = sandboxImages.length > 1;
+	const computeProfiles = capabilities?.compute_profiles ?? [];
+	const offersComputeChoice =
+		capabilities?.compute_profile_override === 'editors' && computeProfiles.length > 1;
 	const initialValues = emptyValues(pullAvailable ? 'pull' : 'push');
 	const createSynced = useCreateSyncedNotebook(projectId);
 	const form = useAppForm({
@@ -88,6 +99,10 @@ export function SyncedNotebookDialog({
 					root_path: value.syncMode === 'pull' ? '' : value.rootPath.trim() || undefined,
 					entry_notebook: value.entryNotebook.trim(),
 					sync_mode: value.syncMode,
+					...(value.baseImage !== DEFAULT_BASE_IMAGE ? { base_image: value.baseImage } : {}),
+					...(value.computeProfile !== DEFAULT_COMPUTE_PROFILE
+						? { compute_profile: value.computeProfile }
+						: {}),
 				});
 				if (data.sync_error) {
 					toast.warning(`Created "${data.notebook.title}", but the first sync failed`, {
@@ -149,6 +164,20 @@ export function SyncedNotebookDialog({
 			<form.AppField name="title">
 				{(f) => <f.TextField label="Notebook name" placeholder="my_dashboard" autoFocus />}
 			</form.AppField>
+			{offersImageChoice && (
+				<form.AppField name="baseImage">
+					{(f) => (
+						<f.RadioGroupField label="Base image" options={baseImageOptions(sandboxImages)} />
+					)}
+				</form.AppField>
+			)}
+			{offersComputeChoice && (
+				<form.AppField name="computeProfile">
+					{(f) => (
+						<f.RadioGroupField label="Compute" options={computeProfileOptions(computeProfiles)} />
+					)}
+				</form.AppField>
+			)}
 			<form.AppField name="repo">
 				{(f) => (
 					<f.TextField


### PR DESCRIPTION
Adds Base image and Compute selectors to the git-backed notebook creation dialog when the deployment exposes meaningful alternatives. Selected values are sent through the existing git notebook API, while defaults remain omitted.

Reuses the same option builders and capability rules as local notebook creation, with focused coverage for conditional rendering and request payloads.