### PR TITLE
feat(config): add managed Amazon Bedrock AI backend

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/generate.test.ts.snap
@@ -1683,6 +1683,202 @@ const app = createApi({
 });"
 `;
 
+exports[`config -> code generators > s3 + modal + oidc, bedrock ai > .env 1`] = `
+"# --- Storage ---
+MARIMOHUB_STORAGE_BACKEND=s3
+MARIMOHUB_STORAGE_S3_BUCKET=_replace_me_  # e.g. orgname-marimohub
+MARIMOHUB_STORAGE_S3_ENDPOINT=https://s3.us-east-1.amazonaws.com
+MARIMOHUB_STORAGE_S3_REGION=us-east-1
+MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID=  # secret
+MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY=  # secret
+MARIMOHUB_STORAGE_S3_FORCE_PATH_STYLE=true
+
+# --- Compute ---
+MARIMOHUB_COMPUTE_BACKEND=modal
+MARIMOHUB_COMPUTE_IMAGE=_replace_me_  # e.g. ghcr.io/orgname/marimo-sandbox:latest
+MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=hub.example.com
+MARIMOHUB_COMPUTE_WORKDIR=/workspace
+MARIMOHUB_COMPUTE_ASSET_URL=https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist
+MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS=120
+MARIMOHUB_COMPUTE_MODAL_TOKEN_ID=_replace_me_  # required, secret
+MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET=_replace_me_  # required, secret
+MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT=notebooks
+MARIMOHUB_COMPUTE_MODAL_APP_NAME=marimohub
+
+# --- Auth ---
+MARIMOHUB_AUTH_BACKEND=oidc
+MARIMOHUB_AUTH_OIDC_ISSUER=_replace_me_  # e.g. https://accounts.example.com
+MARIMOHUB_AUTH_OIDC_CLIENT_ID=_replace_me_  # required
+MARIMOHUB_AUTH_OIDC_CLIENT_SECRET=_replace_me_  # required, secret
+MARIMOHUB_AUTH_OIDC_REDIRECT_URI=_replace_me_  # e.g. https://hub.example.com/api/auth/callback
+MARIMOHUB_AUTH_OIDC_AUDIENCE=
+MARIMOHUB_AUTH_OIDC_PROMPT=consent
+MARIMOHUB_AUTH_SESSION_SECRET=_replace_me_  # required, secret
+MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS=_replace_me_  # e.g. example.com,example.org
+
+# --- Managed AI ---
+MARIMOHUB_AI_BACKEND=bedrock
+MARIMOHUB_AI_AWS_REGION=eu-west-1
+MARIMOHUB_AI_MODEL=eu.anthropic.claude-opus-4-7
+MARIMOHUB_AI_ALLOWED_MODELS=gpt-4o-mini,gpt-4o
+MARIMOHUB_AI_MAX_TOKENS=4096
+MARIMOHUB_AI_RULES=Prefer polars over pandas.
+MARIMOHUB_AI_TOKEN_TTL_SECONDS=3600
+
+# --- Options ---
+MARIMOHUB_EDITOR_SANDBOX_SHARING=shared
+MARIMOHUB_PERSIST_WORKSPACE=source"
+`;
+
+exports[`config -> code generators > s3 + modal + oidc, bedrock ai > compose 1`] = `
+"services:
+  marimohub:
+    image: ghcr.io/marimo-team/marimohub:latest
+    ports:
+      - '3000:3000'
+    environment:
+      MARIMOHUB_STORAGE_BACKEND: s3
+      MARIMOHUB_STORAGE_S3_BUCKET: _replace_me_ # e.g. orgname-marimohub
+      MARIMOHUB_STORAGE_S3_ENDPOINT: https://s3.us-east-1.amazonaws.com
+      MARIMOHUB_STORAGE_S3_REGION: us-east-1
+      MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID: ""
+      MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY: ""
+      MARIMOHUB_STORAGE_S3_FORCE_PATH_STYLE: true
+      MARIMOHUB_COMPUTE_BACKEND: modal
+      MARIMOHUB_COMPUTE_IMAGE: _replace_me_ # e.g. ghcr.io/orgname/marimo-sandbox:latest
+      MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
+      MARIMOHUB_COMPUTE_WORKDIR: /workspace
+      MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+      MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
+      MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: _replace_me_
+      MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: _replace_me_
+      MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: notebooks
+      MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
+      MARIMOHUB_AUTH_BACKEND: oidc
+      MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
+      MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
+      MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
+      MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
+      MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+      MARIMOHUB_AUTH_OIDC_PROMPT: consent
+      MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_
+      MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
+      MARIMOHUB_AI_BACKEND: bedrock
+      MARIMOHUB_AI_AWS_REGION: eu-west-1
+      MARIMOHUB_AI_MODEL: eu.anthropic.claude-opus-4-7
+      MARIMOHUB_AI_ALLOWED_MODELS: "gpt-4o-mini,gpt-4o"
+      MARIMOHUB_AI_MAX_TOKENS: 4096
+      MARIMOHUB_AI_RULES: "Prefer polars over pandas."
+      MARIMOHUB_AI_TOKEN_TTL_SECONDS: 3600
+      MARIMOHUB_EDITOR_SANDBOX_SHARING: shared
+      MARIMOHUB_PERSIST_WORKSPACE: source"
+`;
+
+exports[`config -> code generators > s3 + modal + oidc, bedrock ai > helm 1`] = `
+"# Non-secret MARIMOHUB_* config -> ConfigMap.
+config:
+  MARIMOHUB_STORAGE_BACKEND: s3
+  MARIMOHUB_STORAGE_S3_BUCKET: _replace_me_ # e.g. orgname-marimohub
+  MARIMOHUB_STORAGE_S3_ENDPOINT: https://s3.us-east-1.amazonaws.com
+  MARIMOHUB_STORAGE_S3_REGION: us-east-1
+  MARIMOHUB_STORAGE_S3_FORCE_PATH_STYLE: true
+  MARIMOHUB_COMPUTE_BACKEND: modal
+  MARIMOHUB_COMPUTE_IMAGE: _replace_me_ # e.g. ghcr.io/orgname/marimo-sandbox:latest
+  MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: hub.example.com
+  MARIMOHUB_COMPUTE_WORKDIR: /workspace
+  MARIMOHUB_COMPUTE_ASSET_URL: "https://cdn.jsdelivr.net/npm/@marimo-team/frontend@{version}/dist"
+  MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS: 120
+  MARIMOHUB_COMPUTE_MODAL_ENVIRONMENT: notebooks
+  MARIMOHUB_COMPUTE_MODAL_APP_NAME: marimohub
+  MARIMOHUB_AUTH_BACKEND: oidc
+  MARIMOHUB_AUTH_OIDC_ISSUER: _replace_me_ # e.g. https://accounts.example.com
+  MARIMOHUB_AUTH_OIDC_CLIENT_ID: _replace_me_
+  MARIMOHUB_AUTH_OIDC_REDIRECT_URI: _replace_me_ # e.g. https://hub.example.com/api/auth/callback
+  MARIMOHUB_AUTH_OIDC_AUDIENCE: ""
+  MARIMOHUB_AUTH_OIDC_PROMPT: consent
+  MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: _replace_me_ # e.g. example.com,example.org
+  MARIMOHUB_AI_BACKEND: bedrock
+  MARIMOHUB_AI_AWS_REGION: eu-west-1
+  MARIMOHUB_AI_MODEL: eu.anthropic.claude-opus-4-7
+  MARIMOHUB_AI_ALLOWED_MODELS: "gpt-4o-mini,gpt-4o"
+  MARIMOHUB_AI_MAX_TOKENS: 4096
+  MARIMOHUB_AI_RULES: "Prefer polars over pandas."
+  MARIMOHUB_AI_TOKEN_TTL_SECONDS: 3600
+  MARIMOHUB_EDITOR_SANDBOX_SHARING: shared
+  MARIMOHUB_PERSIST_WORKSPACE: source
+
+# Secret values -> Secret (prefer secrets.existingSecret in production).
+secrets:
+  data:
+    MARIMOHUB_STORAGE_S3_ACCESS_KEY_ID: ""
+    MARIMOHUB_STORAGE_S3_SECRET_ACCESS_KEY: ""
+    MARIMOHUB_COMPUTE_MODAL_TOKEN_ID: _replace_me_
+    MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET: _replace_me_
+    MARIMOHUB_AUTH_OIDC_CLIENT_SECRET: _replace_me_
+    MARIMOHUB_AUTH_SESSION_SECRET: _replace_me_"
+`;
+
+exports[`config -> code generators > s3 + modal + oidc, bedrock ai > library 1`] = `
+"import { createApi } from '@marimo-hub/api';
+import { createServices } from '@marimo-hub/core';
+import { createAwsSigV4Fetch } from '@marimo-hub/credentials-aws';
+import { S3Storage } from '@marimo-hub/storage-s3';
+import { ModalCompute } from '@marimo-hub/compute-modal';
+import { createOidcAuth } from '@marimo-hub/auth-oidc';
+
+const bucket = new S3Storage({
+	bucket: process.env.MARIMOHUB_STORAGE_S3_BUCKET!,
+	endpoint: "https://s3.us-east-1.amazonaws.com",
+	region: "us-east-1",
+	forcePathStyle: true,
+});
+
+const compute = new ModalCompute({
+	tokenId: process.env.MARIMOHUB_COMPUTE_MODAL_TOKEN_ID!,
+	tokenSecret: process.env.MARIMOHUB_COMPUTE_MODAL_TOKEN_SECRET!,
+	image: process.env.MARIMOHUB_COMPUTE_IMAGE!,
+	idleTimeout: process.env.MARIMOHUB_COMPUTE_IDLE_TIMEOUT,
+});
+
+const { authenticator, routes: authRoutes } = createOidcAuth({
+	issuer: process.env.MARIMOHUB_AUTH_OIDC_ISSUER!,
+	clientId: process.env.MARIMOHUB_AUTH_OIDC_CLIENT_ID!,
+	clientSecret: process.env.MARIMOHUB_AUTH_OIDC_CLIENT_SECRET!,
+	redirectUri: process.env.MARIMOHUB_AUTH_OIDC_REDIRECT_URI!,
+	sessionSecret: process.env.MARIMOHUB_AUTH_SESSION_SECRET!,
+	allowedEmailDomains: (process.env.MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS ?? '').split(','),
+});
+
+const ai = {
+	upstreamBaseUrl: \`https://bedrock-runtime.\${process.env.MARIMOHUB_AI_AWS_REGION!}.amazonaws.com/openai/v1\`,
+	upstreamFetch: createAwsSigV4Fetch({
+		region: process.env.MARIMOHUB_AI_AWS_REGION!,
+		service: 'bedrock',
+	}),
+	model: process.env.MARIMOHUB_AI_MODEL!,
+	signingSecret: process.env.MARIMOHUB_AUTH_SESSION_SECRET!,
+};
+
+const app = createApi({
+	services: createServices(bucket),
+	bucket,
+	compute,
+	authenticator,
+	authRoutes,
+	ai,
+	sandbox: {
+		bucket: {
+			name: process.env.MARIMOHUB_STORAGE_S3_BUCKET ?? '',
+			endpoint: process.env.MARIMOHUB_STORAGE_S3_ENDPOINT ?? '',
+		},
+		hostname: process.env.MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME ?? '',
+		workdir: process.env.MARIMOHUB_COMPUTE_WORKDIR ?? '/workspace',
+		persistWorkspace: "source",
+	},
+	policy: {},
+});"
+`;
+
 exports[`config -> code generators > s3 + modal + oidc, managed ai > .env 1`] = `
 "# --- Storage ---
 MARIMOHUB_STORAGE_BACKEND=s3

--- a/apps/docs/.vitepress/wizard/generate.test.ts
+++ b/apps/docs/.vitepress/wizard/generate.test.ts
@@ -98,6 +98,16 @@ const CASES: Record<string, WizardSelection> = {
 		ai: 'openai-compatible',
 		values: { MARIMOHUB_AI_MODEL: 'gpt-4o-mini' },
 	},
+	's3 + modal + oidc, bedrock ai': {
+		storage: 's3',
+		compute: 'modal',
+		auth: 'oidc',
+		ai: 'bedrock',
+		values: {
+			MARIMOHUB_AI_MODEL: 'eu.anthropic.claude-opus-4-7',
+			MARIMOHUB_AI_AWS_REGION: 'eu-west-1',
+		},
+	},
 	's3 + modal + oidc, value overrides': {
 		storage: 's3',
 		compute: 'modal',

--- a/apps/docs/.vitepress/wizard/generate.ts
+++ b/apps/docs/.vitepress/wizard/generate.ts
@@ -18,7 +18,7 @@ export interface WizardSelection {
 	storage: string;
 	compute: string;
 	auth: string;
-	/** Managed-AI backend: `none` (default) or `openai-compatible`. */
+	/** Managed-AI backend: `none` (default), `bedrock`, or `openai-compatible`. */
 	ai: string;
 	/** Extra option id -> value (e.g. persist workspace, sandbox image). */
 	options?: Record<string, string>;
@@ -364,6 +364,9 @@ export function generateLibrary(sel: WizardSelection): string {
 		`import { createApi } from '@marimo-hub/api';`,
 		...(usesExternalLibrary ? [`import { loadAdapterLibraries } from '@marimo-hub/config';`] : []),
 		`import { createServices } from '@marimo-hub/core';`,
+		...(sel.ai === 'bedrock'
+			? [`import { createAwsSigV4Fetch } from '@marimo-hub/credentials-aws';`]
+			: []),
 		...storage.imports,
 		...compute.imports,
 		...auth.imports,
@@ -374,19 +377,34 @@ export function generateLibrary(sel: WizardSelection): string {
 	const bind = AUTH_BIND[sel.auth] ?? ((rhs: string) => `const authResult = ${rhs};`);
 
 	// Managed AI is an optional `ai` dep (a plain config object, not an adapter),
-	// only emitted when an upstream is selected.
-	const aiOn = sel.ai === 'openai-compatible';
-	const aiDecl = aiOn
-		? [
-				`const ai = {`,
-				`\tupstreamBaseUrl: process.env.MARIMOHUB_AI_UPSTREAM_BASE_URL!,`,
-				`\tupstreamApiKey: process.env.MARIMOHUB_AI_UPSTREAM_API_KEY!,`,
-				`\tmodel: process.env.MARIMOHUB_AI_MODEL!,`,
-				`\tsigningSecret: process.env.MARIMOHUB_AUTH_SESSION_SECRET!,`,
-				`};`,
-				``,
-			]
-		: [];
+	// only emitted when a backend is selected. Bedrock signs upstream requests with
+	// SigV4 (no API key) instead of a bearer key.
+	const aiOn = sel.ai === 'openai-compatible' || sel.ai === 'bedrock';
+	const aiDecl =
+		sel.ai === 'bedrock'
+			? [
+					`const ai = {`,
+					`\tupstreamBaseUrl: \`https://bedrock-runtime.\${process.env.MARIMOHUB_AI_AWS_REGION!}.amazonaws.com/openai/v1\`,`,
+					`\tupstreamFetch: createAwsSigV4Fetch({`,
+					`\t\tregion: process.env.MARIMOHUB_AI_AWS_REGION!,`,
+					`\t\tservice: 'bedrock',`,
+					`\t}),`,
+					`\tmodel: process.env.MARIMOHUB_AI_MODEL!,`,
+					`\tsigningSecret: process.env.MARIMOHUB_AUTH_SESSION_SECRET!,`,
+					`};`,
+					``,
+				]
+			: aiOn
+				? [
+						`const ai = {`,
+						`\tupstreamBaseUrl: process.env.MARIMOHUB_AI_UPSTREAM_BASE_URL!,`,
+						`\tupstreamApiKey: process.env.MARIMOHUB_AI_UPSTREAM_API_KEY!,`,
+						`\tmodel: process.env.MARIMOHUB_AI_MODEL!,`,
+						`\tsigningSecret: process.env.MARIMOHUB_AUTH_SESSION_SECRET!,`,
+						`};`,
+						``,
+					]
+				: [];
 
 	const body = [
 		...(usesExternalLibrary

--- a/apps/docs/.vitepress/wizard/setup.ts
+++ b/apps/docs/.vitepress/wizard/setup.ts
@@ -44,7 +44,8 @@ const DOC_HREFS: Record<string, string> = {
 	'compute/local': '/compute#local-dev',
 	'compute/none': '/compute#none',
 	'compute/library': '/compute#external-library',
-	'ai/openai-compatible': '/ai#configuration',
+	'ai/bedrock': '/ai#amazon-bedrock',
+	'ai/openai-compatible': '/ai#openai-compatible-provider',
 	'ai/none': '/ai#what-the-user-can-override',
 };
 

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -31,7 +31,7 @@ The full set of variables:
 | -------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
 | `MARIMOHUB_AI_BACKEND`           | —        | `none` (default), `bedrock`, or `openai-compatible`.                                                                 |
 | `MARIMOHUB_AI_AWS_REGION`        | Bedrock  | AWS region for Bedrock. Falls back to `AWS_REGION` or `AWS_DEFAULT_REGION`.                                          |
-| `MARIMOHUB_AI_UPSTREAM_BASE_URL` | yes      | Upstream OpenAI-compatible base URL, e.g. `https://api.openai.com/v1`. The proxy POSTs to `<base>/chat/completions`. |
+| `MARIMOHUB_AI_UPSTREAM_BASE_URL` | API key  | Upstream OpenAI-compatible base URL, e.g. `https://api.openai.com/v1`. The proxy POSTs to `<base>/chat/completions`. |
 | `MARIMOHUB_AI_UPSTREAM_API_KEY`  | API key  | The real upstream key. Held server-side; never injected into a sandbox.                                              |
 | `MARIMOHUB_AI_MODEL`             | yes      | Default model id surfaced to marimo, e.g. `gpt-4o-mini`.                                                             |
 | `MARIMOHUB_AI_ALLOWED_MODELS`    | no       | Comma-separated allowlist; off-list requests fall back to the default model.                                         |

--- a/docs/ai.md
+++ b/docs/ai.md
@@ -9,13 +9,19 @@ API key. When managed AI is on, marimohub points marimo's assistant at a provide
 **you** configure and pays for. Chat, autocomplete, and "generate with AI" work
 when someone opens a notebook.
 
-It's optional and off by default. Turn it on by setting one upstream provider; the
-real provider key stays on the server and is never exposed to notebook code.
+It's optional and off by default. Turn it on by setting one upstream provider;
+provider credentials stay on the server and are never exposed to notebook code.
 
 ## Configuration
 
-Set `MARIMOHUB_AI_BACKEND=openai-compatible` plus the upstream details. When
-configured, managed AI is injected into **every** session deployment-wide.
+Select Bedrock or an API-key-backed OpenAI-compatible upstream. When configured,
+managed AI is injected into **every** session deployment-wide.
+
+### Amazon Bedrock
+
+<!--@include: ./setup/ai/bedrock.md-->
+
+### OpenAI-compatible provider
 
 <!--@include: ./setup/ai/openai-compatible.md-->
 
@@ -23,9 +29,10 @@ The full set of variables:
 
 | Variable                         | Required | Description                                                                                                          |
 | -------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
-| `MARIMOHUB_AI_BACKEND`           | —        | `none` (default) or `openai-compatible`.                                                                             |
+| `MARIMOHUB_AI_BACKEND`           | —        | `none` (default), `bedrock`, or `openai-compatible`.                                                                 |
+| `MARIMOHUB_AI_AWS_REGION`        | Bedrock  | AWS region for Bedrock. Falls back to `AWS_REGION` or `AWS_DEFAULT_REGION`.                                          |
 | `MARIMOHUB_AI_UPSTREAM_BASE_URL` | yes      | Upstream OpenAI-compatible base URL, e.g. `https://api.openai.com/v1`. The proxy POSTs to `<base>/chat/completions`. |
-| `MARIMOHUB_AI_UPSTREAM_API_KEY`  | yes      | The real upstream key. Held server-side; never injected into a sandbox.                                              |
+| `MARIMOHUB_AI_UPSTREAM_API_KEY`  | API key  | The real upstream key. Held server-side; never injected into a sandbox.                                              |
 | `MARIMOHUB_AI_MODEL`             | yes      | Default model id surfaced to marimo, e.g. `gpt-4o-mini`.                                                             |
 | `MARIMOHUB_AI_ALLOWED_MODELS`    | no       | Comma-separated allowlist; off-list requests fall back to the default model.                                         |
 | `MARIMOHUB_AI_UPSTREAM_PROJECT`  | no       | Optional `OpenAI-Project` header forwarded upstream (e.g. W&B Inference `entity/project` attribution).               |
@@ -38,8 +45,9 @@ are signed with it (the same secret that signs login cookies).
 
 ## Providers
 
-Any OpenAI-compatible endpoint works. Set `MARIMOHUB_AI_UPSTREAM_BASE_URL` to the
-provider's base and `MARIMOHUB_AI_MODEL` to one of its model ids:
+For API-key-backed providers, any OpenAI-compatible endpoint works. Set
+`MARIMOHUB_AI_UPSTREAM_BASE_URL` to the provider's base and
+`MARIMOHUB_AI_MODEL` to one of its model ids:
 
 | Provider              | Base URL                            | Notes                                               |
 | --------------------- | ----------------------------------- | --------------------------------------------------- |
@@ -56,10 +64,10 @@ provider's base and `MARIMOHUB_AI_MODEL` to one of its model ids:
    files. The config registers a custom AI provider pointed at marimohub's own
    proxy using a short-lived, session-scoped token as the `api_key`.
 2. **Proxy.** marimohub hosts an OpenAI-compatible endpoint at `/api/ai/v1`. It
-   verifies the session token, then forwards the request to your upstream with the
-   **real** key (held server-side), streaming the response back.
+   verifies the session token, authenticates the upstream request server-side, and
+   streams the response back.
 
-Notebook kernels run untrusted code, so the real provider key is never written into
+Notebook kernels run untrusted code, so provider credentials are never written into
 a sandbox — only a minted, expiring, session-scoped token. This mirrors how
 [Workload Identity Federation](/workload-identity-federation) avoids long-lived storage
 keys.
@@ -80,8 +88,8 @@ if the notebook session remains active.
 ## Proxy contract
 
 The proxy implements the subset of the OpenAI API that marimo calls server-side.
-All endpoints require a valid bearer session token; the upstream key is added
-server-side.
+All endpoints require a valid bearer session token; upstream authentication is
+applied server-side.
 
 - `POST /api/ai/v1/chat/completions` — forwards to the upstream, streaming SSE when
   `stream: true`. The request `model` is normalized to a managed model.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -431,9 +431,9 @@ Optional: let a notebook reach cloud resources (object storage, and for AWS any 
 
 ## Managed AI
 
-Selected by `MARIMOHUB_AI_BACKEND` (default `none`); one of `none`, `openai-compatible`.
+Selected by `MARIMOHUB_AI_BACKEND` (default `none`); one of `none`, `bedrock`, `openai-compatible`.
 
-Optional: auto-configure the marimo AI assistant to use a managed provider, so it works with no user-supplied key. The hub injects a `marimo.toml` pointing at its own OpenAI-compatible proxy (`/api/ai/v1`) with a short-lived, session-scoped token; the proxy holds the real upstream key server-side and forwards requests. The real key is NEVER injected into a sandbox. Deployment-wide and default-on when configured. See docs/ai.md.
+Optional: auto-configure the marimo AI assistant to use a managed provider, so it works with no user-supplied credentials. The hub injects a `marimo.toml` pointing at its own OpenAI-compatible proxy (`/api/ai/v1`) with a short-lived, session-scoped token; the proxy authenticates upstream requests server-side. Provider credentials are NEVER injected into a sandbox. Deployment-wide and default-on when configured. See docs/ai.md.
 
 ### Off
 
@@ -442,6 +442,21 @@ Optional: auto-configure the marimo AI assistant to use a managed provider, so i
 No managed AI. The marimo assistant still works if a user supplies their own key in marimo settings.
 
 _No environment variables to set here._
+
+### Amazon Bedrock
+
+`MARIMOHUB_AI_BACKEND=bedrock`
+
+Uses the Amazon Bedrock OpenAI-compatible endpoint and signs requests with the runtime AWS identity. No Bedrock API key or AWS credential is injected into a sandbox.
+
+| Variable | Description | Required | Default | Example |
+| --- | --- | --- | --- | --- |
+| `MARIMOHUB_AI_AWS_REGION` | AWS region for Bedrock. Falls back to AWS_REGION or AWS_DEFAULT_REGION. | Yes | — | `eu-west-1` |
+| `MARIMOHUB_AI_MODEL` | Default model id surfaced to marimo. | Yes | — | `gpt-4o-mini` |
+| `MARIMOHUB_AI_ALLOWED_MODELS` | Comma-separated allowlist of model ids; off-list requests fall back to the default model. Unset allows any model on OpenAI-compatible upstreams, or restricts Bedrock to MARIMOHUB_AI_MODEL. | — | — | `gpt-4o-mini,gpt-4o` |
+| `MARIMOHUB_AI_MAX_TOKENS` | Optional `[ai] max_tokens` written into the injected notebook config. | — | — | `4096` |
+| `MARIMOHUB_AI_RULES` | Optional `[ai] rules` (custom assistant instructions). | — | — | `Prefer polars over pandas.` |
+| `MARIMOHUB_AI_TOKEN_TTL_SECONDS` | Per-session token lifetime in seconds. | — | `3600` | — |
 
 ### OpenAI-compatible upstream
 
@@ -454,8 +469,8 @@ Fronts any OpenAI-compatible upstream (OpenAI, OpenRouter, LiteLLM, or Anthropic
 | `MARIMOHUB_AI_UPSTREAM_BASE_URL` | OpenAI-compatible upstream base URL; the proxy POSTs to `<base>/chat/completions`. | Yes | — | `https://api.openai.com/v1` |
 | `MARIMOHUB_AI_UPSTREAM_API_KEY` 🔒 | The real upstream provider key. Held server-side; never injected. | Yes | — | `sk-...` |
 | `MARIMOHUB_AI_UPSTREAM_PROJECT` | Optional `OpenAI-Project` header forwarded upstream — e.g. W&B Inference uses `entity/project` for usage attribution. Omit for providers that ignore it. | — | — | `my-team/my-project` |
-| `MARIMOHUB_AI_MODEL` | Default upstream model id surfaced to marimo. | Yes | — | `gpt-4o-mini` |
-| `MARIMOHUB_AI_ALLOWED_MODELS` | Comma-separated allowlist of upstream model ids; off-list requests fall back to the default model. Unset allows any model. | — | — | `gpt-4o-mini,gpt-4o` |
+| `MARIMOHUB_AI_MODEL` | Default model id surfaced to marimo. | Yes | — | `gpt-4o-mini` |
+| `MARIMOHUB_AI_ALLOWED_MODELS` | Comma-separated allowlist of model ids; off-list requests fall back to the default model. Unset allows any model on OpenAI-compatible upstreams, or restricts Bedrock to MARIMOHUB_AI_MODEL. | — | — | `gpt-4o-mini,gpt-4o` |
 | `MARIMOHUB_AI_MAX_TOKENS` | Optional `[ai] max_tokens` written into the injected notebook config. | — | — | `4096` |
 | `MARIMOHUB_AI_RULES` | Optional `[ai] rules` (custom assistant instructions). | — | — | `Prefer polars over pandas.` |
 | `MARIMOHUB_AI_TOKEN_TTL_SECONDS` | Per-session token lifetime in seconds. | — | `3600` | — |

--- a/docs/setup/ai/bedrock.md
+++ b/docs/setup/ai/bedrock.md
@@ -1,0 +1,21 @@
+<!-- Setup snippet — included by docs/ai.md and rendered in the deployment wizard. -->
+
+Use Amazon Bedrock's OpenAI-compatible endpoint with the hub's AWS identity.
+The hub signs upstream requests with SigV4; no Bedrock API key or AWS credential
+is written into a sandbox.
+
+```bash
+MARIMOHUB_AI_BACKEND=bedrock
+MARIMOHUB_AI_AWS_REGION=eu-west-1
+MARIMOHUB_AI_MODEL=eu.anthropic.claude-opus-4-7
+# MARIMOHUB_AI_ALLOWED_MODELS=model-a,model-b
+```
+
+The runtime identity needs `bedrock:InvokeModel` and
+`bedrock:InvokeModelWithResponseStream` for the configured inference profiles or
+foundation models. On EKS, use IRSA or EKS Pod Identity; the standard AWS
+credential chain also supports local development credentials.
+
+When `MARIMOHUB_AI_ALLOWED_MODELS` is unset, Bedrock is restricted to
+`MARIMOHUB_AI_MODEL`. Set an explicit comma-separated allowlist to expose more
+models.

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -160,13 +160,15 @@ export interface SandboxConfig {
  * Managed-AI capability: the upstream provider the proxy fronts plus the secret it
  * signs/verifies session tokens with. Present enables auto-injection of marimo AI
  * config into every session and the `/api/ai/v1` proxy; absent disables both. The
- * upstream key lives here (server-side) and is NEVER injected into a sandbox.
+ * upstream credentials live server-side and are NEVER injected into a sandbox.
  */
 export interface AiProxyConfig {
 	/** Upstream OpenAI-compatible base URL; the proxy POSTs to `<base>/chat/completions`. */
 	upstreamBaseUrl: string;
-	/** The real upstream provider key — server-side only. */
-	upstreamApiKey: string;
+	/** The real upstream provider key — server-side only. Omitted for request-signed backends. */
+	upstreamApiKey?: string;
+	/** Optional fetch adapter that authenticates the upstream request (for example, AWS SigV4). */
+	upstreamFetch?: (request: Request) => Promise<Response>;
 	/**
 	 * Optional `OpenAI-Project` header value sent upstream (e.g. W&B Inference uses
 	 * it as `entity/project` for usage attribution). Omit for providers that ignore it.

--- a/packages/api/src/routes/ai.test.ts
+++ b/packages/api/src/routes/ai.test.ts
@@ -262,6 +262,21 @@ describe('POST /api/ai/v1/chat/completions', () => {
 		expect(req.headers.get('openai-project')).toBeNull();
 	});
 
+	it('uses a request-authenticating fetch adapter without adding a bearer key', async () => {
+		const upstreamFetch = vi.fn(async (request: Request) => {
+			expect(request.headers.get('authorization')).toBeNull();
+			return new Response('ok', { status: 200 });
+		});
+		const res = await post(
+			await token(),
+			{ model: 'm', messages: [] },
+			{ ai: { ...AI, upstreamApiKey: undefined, upstreamFetch } },
+		);
+
+		expect(res.status).toBe(200);
+		expect(upstreamFetch).toHaveBeenCalledOnce();
+	});
+
 	it('falls back to the default model when off the allowlist', async () => {
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')

--- a/packages/api/src/routes/ai.ts
+++ b/packages/api/src/routes/ai.ts
@@ -1,10 +1,10 @@
 /**
  * OpenAI-compatible AI proxy for managed-AI notebooks (`/api/ai/v1`).
  *
- * Notebook kernels run untrusted user code, so they never hold the real upstream
- * provider key — only a short-lived, session-scoped token marimohub mints at
+ * Notebook kernels run untrusted user code, so they never hold upstream
+ * credentials — only a short-lived, session-scoped token marimohub mints at
  * provision time (see `marimoAiContributor`). This route verifies that token,
- * then forwards the request to the configured upstream with the real key,
+ * then authenticates and forwards the request to the configured upstream,
  * streaming the response straight back. It authenticates by the token alone, so
  * it lives OUTSIDE the `/api/v1/*` cookie-auth + CSRF guards.
  *
@@ -45,8 +45,8 @@ function normalizeModel(model: unknown, provider: string): string | undefined {
 }
 
 /**
- * Forward a JSON request body to `<upstream>{path}` with the real key, streaming the
- * response back. Shared by the chat-completions and responses endpoints.
+ * Forward a JSON request body to `<upstream>{path}`, applying the configured
+ * authentication and streaming the response back.
  */
 async function forward(c: Context<AiEnv>, path: string): Promise<Response> {
 	const ai = c.get('deps').ai!;
@@ -69,16 +69,15 @@ async function forward(c: Context<AiEnv>, path: string): Promise<Response> {
 	try {
 		// `proxy` streams the upstream body back and drops hop-by-hop/encoding
 		// headers; we pass our own headers so the client's session token is never
-		// forwarded and the real upstream key is added server-side.
-		const headers: Record<string, string> = {
-			'content-type': 'application/json',
-			authorization: `Bearer ${ai.upstreamApiKey}`,
-		};
+		// forwarded. The configured key or request signer authenticates upstream.
+		const headers: Record<string, string> = { 'content-type': 'application/json' };
+		if (ai.upstreamApiKey) headers.authorization = `Bearer ${ai.upstreamApiKey}`;
 		if (ai.upstreamProject) headers['openai-project'] = ai.upstreamProject;
 		const res = await proxy(`${ai.upstreamBaseUrl}${path}`, {
 			method: 'POST',
 			headers,
 			body: JSON.stringify(payload),
+			customFetch: ai.upstreamFetch,
 		});
 		logEvent({
 			level: 'info',

--- a/packages/config/src/ai.test.ts
+++ b/packages/config/src/ai.test.ts
@@ -29,6 +29,42 @@ describe('makeAi', () => {
 		expect(ai?.tokenTtlSeconds).toBe(900);
 	});
 
+	it('wires Bedrock through its regional OpenAI-compatible endpoint without an API key', () => {
+		const { ai } = makeAi({
+			MARIMOHUB_AI_BACKEND: 'bedrock',
+			MARIMOHUB_AUTH_SESSION_SECRET: 'secret',
+			MARIMOHUB_AI_AWS_REGION: 'eu-west-1',
+			MARIMOHUB_AI_MODEL: 'eu.anthropic.claude-opus-4-7',
+		});
+
+		expect(ai).toMatchObject({
+			upstreamBaseUrl: 'https://bedrock-runtime.eu-west-1.amazonaws.com/v1',
+			upstreamApiKey: undefined,
+			allowedModels: ['eu.anthropic.claude-opus-4-7'],
+		});
+		expect(ai?.upstreamFetch).toBeTypeOf('function');
+	});
+
+	it('accepts AWS_REGION for the Bedrock region', () => {
+		const { ai } = makeAi({
+			MARIMOHUB_AI_BACKEND: 'bedrock',
+			MARIMOHUB_AUTH_SESSION_SECRET: 'secret',
+			AWS_REGION: 'us-east-1',
+			MARIMOHUB_AI_MODEL: 'model',
+		});
+		expect(ai?.upstreamBaseUrl).toContain('bedrock-runtime.us-east-1.amazonaws.com');
+	});
+
+	it('requires a region for Bedrock', () => {
+		expect(() =>
+			makeAi({
+				MARIMOHUB_AI_BACKEND: 'bedrock',
+				MARIMOHUB_AUTH_SESSION_SECRET: 'secret',
+				MARIMOHUB_AI_MODEL: 'model',
+			}),
+		).toThrow(/MARIMOHUB_AI_AWS_REGION/);
+	});
+
 	it('leaves the token TTL undefined when unset (mint falls back to its default)', () => {
 		expect(makeAi(aiEnv).ai?.tokenTtlSeconds).toBeUndefined();
 	});

--- a/packages/config/src/ai.test.ts
+++ b/packages/config/src/ai.test.ts
@@ -38,7 +38,7 @@ describe('makeAi', () => {
 		});
 
 		expect(ai).toMatchObject({
-			upstreamBaseUrl: 'https://bedrock-runtime.eu-west-1.amazonaws.com/v1',
+			upstreamBaseUrl: 'https://bedrock-runtime.eu-west-1.amazonaws.com/openai/v1',
 			upstreamApiKey: undefined,
 			allowedModels: ['eu.anthropic.claude-opus-4-7'],
 		});

--- a/packages/config/src/ai.ts
+++ b/packages/config/src/ai.ts
@@ -28,7 +28,11 @@ export function sqlGenerationInstructions(
 }
 
 function bedrockRegion(env: Env): string {
-	const region = env.MARIMOHUB_AI_AWS_REGION ?? env.AWS_REGION ?? env.AWS_DEFAULT_REGION;
+	// First non-empty candidate: an explicitly empty MARIMOHUB_AI_AWS_REGION must
+	// not mask a valid AWS_REGION / AWS_DEFAULT_REGION fallback.
+	const region = [env.MARIMOHUB_AI_AWS_REGION, env.AWS_REGION, env.AWS_DEFAULT_REGION]
+		.map((v) => v?.trim())
+		.find((v) => v);
 	if (region) return region;
 	throw new ConfigError(
 		'Missing required env var: MARIMOHUB_AI_AWS_REGION (AWS_REGION and AWS_DEFAULT_REGION are also accepted)',
@@ -78,7 +82,7 @@ export function makeAi(env: Env): Pick<ApiDeps, 'ai'> {
 	const awsRegion = backend === 'bedrock' ? bedrockRegion(env) : undefined;
 	const upstreamBaseUrl =
 		awsRegion !== undefined
-			? `https://bedrock-runtime.${awsRegion}.amazonaws.com/v1`
+			? `https://bedrock-runtime.${awsRegion}.amazonaws.com/openai/v1`
 			: requiredVar(env, 'MARIMOHUB_AI_UPSTREAM_BASE_URL', {
 					remediation:
 						'Set the upstream OpenAI-compatible base URL, e.g. https://api.openai.com/v1',

--- a/packages/config/src/ai.ts
+++ b/packages/config/src/ai.ts
@@ -1,12 +1,13 @@
 /**
  * Wire the managed-AI proxy from the `MARIMOHUB_AI_BACKEND` selector and its
- * backend vars. All-or-nothing: `none` (default) disables it, `openai-compatible`
- * fronts one OpenAI-compatible upstream. The session-token signing secret is reused
+ * backend vars. All-or-nothing: `none` (default) disables it; enabled backends
+ * front one OpenAI-compatible upstream. The session-token signing secret is reused
  * from `MARIMOHUB_AUTH_SESSION_SECRET` (like the proxy-exposure routing tokens), so
  * there is no separate AI key to manage.
  */
 import type { ApiDeps } from '@marimo-hub/api';
 import { Seconds } from '@marimo-hub/core';
+import { createAwsSigV4Fetch } from '@marimo-hub/credentials-aws';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { generateText } from 'ai';
 import { parseIntEnv, parseList, requiredVar } from './env';
@@ -26,12 +27,25 @@ export function sqlGenerationInstructions(
 	);
 }
 
+function bedrockRegion(env: Env): string {
+	const region = env.MARIMOHUB_AI_AWS_REGION ?? env.AWS_REGION ?? env.AWS_DEFAULT_REGION;
+	if (region) return region;
+	throw new ConfigError(
+		'Missing required env var: MARIMOHUB_AI_AWS_REGION (AWS_REGION and AWS_DEFAULT_REGION are also accepted)',
+		{
+			variable: 'MARIMOHUB_AI_AWS_REGION',
+			remediation: 'Set the AWS region that hosts the Bedrock models, e.g. eu-west-1.',
+			docs: DOCS,
+		},
+	);
+}
+
 export function makeAi(env: Env): Pick<ApiDeps, 'ai'> {
 	const backend = env.MARIMOHUB_AI_BACKEND?.trim().toLowerCase();
 	if (backend === undefined || backend === '' || backend === 'none') return {};
-	if (backend !== 'openai-compatible') {
+	if (backend !== 'openai-compatible' && backend !== 'bedrock') {
 		throw new ConfigError(
-			`Unknown MARIMOHUB_AI_BACKEND: ${env.MARIMOHUB_AI_BACKEND} (supported: openai-compatible, none).`,
+			`Unknown MARIMOHUB_AI_BACKEND: ${env.MARIMOHUB_AI_BACKEND} (supported: bedrock, openai-compatible, none).`,
 			{ variable: 'MARIMOHUB_AI_BACKEND', docs: DOCS },
 		);
 	}
@@ -61,24 +75,38 @@ export function makeAi(env: Env): Pick<ApiDeps, 'ai'> {
 			},
 		);
 	}
-	const upstreamBaseUrl = requiredVar(env, 'MARIMOHUB_AI_UPSTREAM_BASE_URL', {
-		remediation: 'Set the upstream OpenAI-compatible base URL, e.g. https://api.openai.com/v1',
-		docs: DOCS,
-	}).replace(/\/+$/, '');
-	const upstreamApiKey = requiredVar(env, 'MARIMOHUB_AI_UPSTREAM_API_KEY', {
-		remediation: 'Set the upstream provider API key (held server-side, never injected).',
-		docs: DOCS,
-	});
+	const awsRegion = backend === 'bedrock' ? bedrockRegion(env) : undefined;
+	const upstreamBaseUrl =
+		awsRegion !== undefined
+			? `https://bedrock-runtime.${awsRegion}.amazonaws.com/v1`
+			: requiredVar(env, 'MARIMOHUB_AI_UPSTREAM_BASE_URL', {
+					remediation:
+						'Set the upstream OpenAI-compatible base URL, e.g. https://api.openai.com/v1',
+					docs: DOCS,
+				}).replace(/\/+$/, '');
+	const upstreamApiKey =
+		backend === 'openai-compatible'
+			? requiredVar(env, 'MARIMOHUB_AI_UPSTREAM_API_KEY', {
+					remediation: 'Set the upstream provider API key (held server-side, never injected).',
+					docs: DOCS,
+				})
+			: undefined;
+	const upstreamFetch =
+		awsRegion !== undefined
+			? createAwsSigV4Fetch({ region: awsRegion, service: 'bedrock' })
+			: undefined;
 	const model = requiredVar(env, 'MARIMOHUB_AI_MODEL', {
 		remediation: 'Set the default upstream model id, e.g. gpt-4o-mini',
 		docs: DOCS,
 	});
-	const upstreamProject = env.MARIMOHUB_AI_UPSTREAM_PROJECT;
+	const upstreamProject =
+		backend === 'openai-compatible' ? env.MARIMOHUB_AI_UPSTREAM_PROJECT : undefined;
 	const provider = createOpenAICompatible({
 		name: 'marimohub-managed-ai',
 		baseURL: upstreamBaseUrl,
 		apiKey: upstreamApiKey,
 		headers: upstreamProject ? { 'OpenAI-Project': upstreamProject } : undefined,
+		fetch: upstreamFetch,
 	});
 	const maxTokens = parseIntEnv(env, 'MARIMOHUB_AI_MAX_TOKENS');
 	if (maxTokens !== undefined && (!Number.isSafeInteger(maxTokens) || maxTokens < 1)) {
@@ -92,9 +120,11 @@ export function makeAi(env: Env): Pick<ApiDeps, 'ai'> {
 			upstreamBaseUrl,
 			upstreamApiKey,
 			upstreamProject,
+			upstreamFetch,
 			model,
 			signingSecret,
-			allowedModels: parseList(env.MARIMOHUB_AI_ALLOWED_MODELS),
+			allowedModels:
+				parseList(env.MARIMOHUB_AI_ALLOWED_MODELS) ?? (backend === 'bedrock' ? [model] : undefined),
 			maxTokens,
 			rules: env.MARIMOHUB_AI_RULES,
 			tokenTtlSeconds: tokenTtl === undefined ? undefined : Seconds.of(tokenTtl),

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -61,6 +61,45 @@ const AUTH_ALLOWED_EMAIL_DOMAINS: ConfigVar = {
 	required: true,
 };
 
+// Shared by every managed-AI backend (Bedrock, OpenAI-compatible); the config
+// registry requires one definition per variable id.
+const AI_MODEL: ConfigVar = {
+	id: 'MARIMOHUB_AI_MODEL',
+	name: 'Default model',
+	description: 'Default model id surfaced to marimo.',
+	example: 'gpt-4o-mini',
+	required: true,
+};
+
+const AI_ALLOWED_MODELS: ConfigVar = {
+	id: 'MARIMOHUB_AI_ALLOWED_MODELS',
+	name: 'Allowed models',
+	description:
+		'Comma-separated allowlist of model ids; off-list requests fall back to the default model. Unset allows any model on OpenAI-compatible upstreams, or restricts Bedrock to MARIMOHUB_AI_MODEL.',
+	example: 'gpt-4o-mini,gpt-4o',
+};
+
+const AI_MAX_TOKENS: ConfigVar = {
+	id: 'MARIMOHUB_AI_MAX_TOKENS',
+	name: 'Max tokens',
+	description: 'Optional `[ai] max_tokens` written into the injected notebook config.',
+	example: '4096',
+};
+
+const AI_RULES: ConfigVar = {
+	id: 'MARIMOHUB_AI_RULES',
+	name: 'Assistant rules',
+	description: 'Optional `[ai] rules` (custom assistant instructions).',
+	example: 'Prefer polars over pandas.',
+};
+
+const AI_TOKEN_TTL_SECONDS: ConfigVar = {
+	id: 'MARIMOHUB_AI_TOKEN_TTL_SECONDS',
+	name: 'Session token TTL (seconds)',
+	description: 'Per-session token lifetime in seconds.',
+	default: '3600',
+};
+
 export const CONFIG_SPEC: ConfigGroup[] = [
 	{
 		name: 'Storage',
@@ -1360,7 +1399,7 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 		selector: 'MARIMOHUB_AI_BACKEND',
 		selectorDefault: 'none',
 		description:
-			'Optional: auto-configure the marimo AI assistant to use a managed provider, so it works with no user-supplied key. The hub injects a `marimo.toml` pointing at its own OpenAI-compatible proxy (`/api/ai/v1`) with a short-lived, session-scoped token; the proxy holds the real upstream key server-side and forwards requests. The real key is NEVER injected into a sandbox. Deployment-wide and default-on when configured. See docs/ai.md.',
+			'Optional: auto-configure the marimo AI assistant to use a managed provider, so it works with no user-supplied credentials. The hub injects a `marimo.toml` pointing at its own OpenAI-compatible proxy (`/api/ai/v1`) with a short-lived, session-scoped token; the proxy authenticates upstream requests server-side. Provider credentials are NEVER injected into a sandbox. Deployment-wide and default-on when configured. See docs/ai.md.',
 		backends: [
 			{
 				name: 'Off',
@@ -1368,6 +1407,26 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 				description:
 					'No managed AI. The marimo assistant still works if a user supplies their own key in marimo settings.',
 				vars: [],
+			},
+			{
+				name: 'Amazon Bedrock',
+				selectorValue: 'bedrock',
+				description:
+					'Uses the Amazon Bedrock OpenAI-compatible endpoint and signs requests with the runtime AWS identity. No Bedrock API key or AWS credential is injected into a sandbox.',
+				vars: [
+					{
+						id: 'MARIMOHUB_AI_AWS_REGION',
+						name: 'AWS region',
+						description: 'AWS region for Bedrock. Falls back to AWS_REGION or AWS_DEFAULT_REGION.',
+						example: 'eu-west-1',
+						required: true,
+					},
+					AI_MODEL,
+					AI_ALLOWED_MODELS,
+					AI_MAX_TOKENS,
+					AI_RULES,
+					AI_TOKEN_TTL_SECONDS,
+				],
 			},
 			{
 				name: 'OpenAI-compatible upstream',
@@ -1398,38 +1457,11 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 							'Optional `OpenAI-Project` header forwarded upstream — e.g. W&B Inference uses `entity/project` for usage attribution. Omit for providers that ignore it.',
 						example: 'my-team/my-project',
 					},
-					{
-						id: 'MARIMOHUB_AI_MODEL',
-						name: 'Default model',
-						description: 'Default upstream model id surfaced to marimo.',
-						example: 'gpt-4o-mini',
-						required: true,
-					},
-					{
-						id: 'MARIMOHUB_AI_ALLOWED_MODELS',
-						name: 'Allowed models',
-						description:
-							'Comma-separated allowlist of upstream model ids; off-list requests fall back to the default model. Unset allows any model.',
-						example: 'gpt-4o-mini,gpt-4o',
-					},
-					{
-						id: 'MARIMOHUB_AI_MAX_TOKENS',
-						name: 'Max tokens',
-						description: 'Optional `[ai] max_tokens` written into the injected notebook config.',
-						example: '4096',
-					},
-					{
-						id: 'MARIMOHUB_AI_RULES',
-						name: 'Assistant rules',
-						description: 'Optional `[ai] rules` (custom assistant instructions).',
-						example: 'Prefer polars over pandas.',
-					},
-					{
-						id: 'MARIMOHUB_AI_TOKEN_TTL_SECONDS',
-						name: 'Session token TTL (seconds)',
-						description: 'Per-session token lifetime in seconds.',
-						default: '3600',
-					},
+					AI_MODEL,
+					AI_ALLOWED_MODELS,
+					AI_MAX_TOKENS,
+					AI_RULES,
+					AI_TOKEN_TTL_SECONDS,
 				],
 			},
 		],

--- a/packages/credentials-aws/package.json
+++ b/packages/credentials-aws/package.json
@@ -18,7 +18,11 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
+		"@aws-crypto/sha256-js": "catalog:",
+		"@aws-sdk/credential-provider-node": "catalog:",
 		"@marimo-hub/core": "workspace:*",
+		"@smithy/signature-v4": "catalog:",
+		"@smithy/types": "catalog:",
 		"ofetch": "catalog:",
 		"zod": "catalog:"
 	},

--- a/packages/credentials-aws/src/index.ts
+++ b/packages/credentials-aws/src/index.ts
@@ -21,6 +21,9 @@ import { FetchError, ofetch } from 'ofetch';
 import { z } from 'zod';
 import type { CredentialBroker, TempS3Creds } from '@marimo-hub/core';
 
+export { createAwsSigV4Fetch } from './sigv4';
+export type { AwsSigV4FetchOptions } from './sigv4';
+
 /** Default request timeout for the exchange (ms). */
 const DEFAULT_TIMEOUT_MS = 10_000;
 

--- a/packages/credentials-aws/src/sigv4.test.ts
+++ b/packages/credentials-aws/src/sigv4.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createAwsSigV4Fetch } from './sigv4';
+
+const credentials = {
+	accessKeyId: 'AKIDEXAMPLE',
+	secretAccessKey: 'secret',
+	sessionToken: 'session-token',
+};
+
+describe('createAwsSigV4Fetch', () => {
+	it('signs the exact request passed to the underlying fetch', async () => {
+		const fetchImpl = vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) => new Response('ok'),
+		);
+		const signedFetch = createAwsSigV4Fetch({
+			region: 'eu-west-1',
+			service: 'bedrock',
+			credentials,
+			fetch: fetchImpl,
+		});
+
+		await signedFetch('https://bedrock-runtime.eu-west-1.amazonaws.com/v1/chat/completions', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ model: 'eu.example-model', messages: [] }),
+		});
+
+		expect(fetchImpl).toHaveBeenCalledOnce();
+		const [url, init] = fetchImpl.mock.calls[0];
+		expect(url).toBe('https://bedrock-runtime.eu-west-1.amazonaws.com/v1/chat/completions');
+		const headers = new Headers(init?.headers);
+		expect(headers.get('authorization')).toMatch(
+			/^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\/\d{8}\/eu-west-1\/bedrock\/aws4_request,/,
+		);
+		expect(headers.get('x-amz-security-token')).toBe('session-token');
+		expect(headers.get('x-amz-date')).toMatch(/^\d{8}T\d{6}Z$/);
+		expect(new TextDecoder().decode(init?.body as ArrayBuffer)).toContain('eu.example-model');
+	});
+});

--- a/packages/credentials-aws/src/sigv4.ts
+++ b/packages/credentials-aws/src/sigv4.ts
@@ -1,0 +1,61 @@
+import { Sha256 } from '@aws-crypto/sha256-js';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import { SignatureV4 } from '@smithy/signature-v4';
+import type { AwsCredentialIdentity, Provider, QueryParameterBag } from '@smithy/types';
+
+export interface AwsSigV4FetchOptions {
+	region: string;
+	service: string;
+	credentials?: AwsCredentialIdentity | Provider<AwsCredentialIdentity>;
+	fetch?: typeof globalThis.fetch;
+}
+
+function queryParameters(url: URL): QueryParameterBag {
+	const query: QueryParameterBag = {};
+	for (const [key, value] of url.searchParams) {
+		const current = query[key];
+		if (current === undefined || current === null) query[key] = value;
+		else if (Array.isArray(current)) current.push(value);
+		else query[key] = [current, value];
+	}
+	return query;
+}
+
+export function createAwsSigV4Fetch(options: AwsSigV4FetchOptions): typeof globalThis.fetch {
+	const fetchImpl = options.fetch ?? globalThis.fetch;
+	const signer = new SignatureV4({
+		credentials: options.credentials ?? defaultProvider(),
+		region: options.region,
+		service: options.service,
+		sha256: Sha256,
+	});
+
+	return async (input, init) => {
+		const request = new Request(input, init);
+		const url = new URL(request.url);
+		const body =
+			request.method === 'GET' || request.method === 'HEAD'
+				? undefined
+				: await request.clone().arrayBuffer();
+		const headers = Object.fromEntries(request.headers);
+		headers.host = url.host;
+		const signed = await signer.sign({
+			method: request.method,
+			protocol: url.protocol,
+			hostname: url.hostname,
+			port: url.port ? Number(url.port) : undefined,
+			path: url.pathname,
+			query: queryParameters(url),
+			headers,
+			body,
+		});
+
+		return fetchImpl(request.url, {
+			method: request.method,
+			headers: signed.headers,
+			body,
+			signal: request.signal,
+			redirect: 'error',
+		});
+	};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,12 +9,18 @@ catalogs:
     '@ai-sdk/openai-compatible':
       specifier: ^3.0.17
       version: 3.0.17
+    '@aws-crypto/sha256-js':
+      specifier: ^5.2.0
+      version: 5.2.0
     '@aws-sdk/client-s3':
       specifier: ^3.1066.0
       version: 3.1066.0
     '@aws-sdk/client-secrets-manager':
       specifier: ^3.1066.0
       version: 3.1076.0
+    '@aws-sdk/credential-provider-node':
+      specifier: ^3.972.59
+      version: 3.972.59
     '@azure/core-auth':
       specifier: ^1.11.0
       version: 1.11.0
@@ -117,6 +123,12 @@ catalogs:
     '@smithy/node-http-handler':
       specifier: ^4.9.1
       version: 4.9.1
+    '@smithy/signature-v4':
+      specifier: ^5.6.0
+      version: 5.6.0
+    '@smithy/types':
+      specifier: ^4.15.0
+      version: 4.15.0
     '@tailwindcss/vite':
       specifier: ^4.3.0
       version: 4.3.0
@@ -1076,9 +1088,21 @@ importers:
 
   packages/credentials-aws:
     dependencies:
+      '@aws-crypto/sha256-js':
+        specifier: 'catalog:'
+        version: 5.2.0
+      '@aws-sdk/credential-provider-node':
+        specifier: 'catalog:'
+        version: 3.972.59
       '@marimo-hub/core':
         specifier: workspace:*
         version: link:../core
+      '@smithy/signature-v4':
+        specifier: 'catalog:'
+        version: 5.6.0
+      '@smithy/types':
+        specifier: 'catalog:'
+        version: 4.15.0
       ofetch:
         specifier: 'catalog:'
         version: 1.5.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,8 +7,10 @@ blockExoticSubdeps: true
 
 catalog:
   '@ai-sdk/openai-compatible': ^3.0.17
+  '@aws-crypto/sha256-js': ^5.2.0
   '@aws-sdk/client-s3': ^3.1066.0
   '@aws-sdk/client-secrets-manager': ^3.1066.0
+  '@aws-sdk/credential-provider-node': ^3.972.59
   '@azure/core-auth': ^1.11.0
   '@azure/identity': ^4.13.1
   '@azure/storage-blob': ^12.33.0
@@ -43,6 +45,8 @@ catalog:
   '@opentelemetry/sdk-trace-node': ^2.9.0
   '@oxlint/plugins': 1.67.0
   '@smithy/node-http-handler': ^4.9.1
+  '@smithy/signature-v4': ^5.6.0
+  '@smithy/types': ^4.15.0
   '@tailwindcss/vite': ^4.3.0
   '@tanstack/react-form': ^1.33.0
   '@tanstack/react-store': ^0.11.0


### PR DESCRIPTION
## Summary

Adds a managed **Amazon Bedrock** AI backend so operators can front the marimo
assistant with Bedrock without holding a static provider key.

Selecting `MARIMOHUB_AI_BACKEND=bedrock` points the proxy at Bedrock's
OpenAI-compatible endpoint (`https://bedrock-runtime.<region>.amazonaws.com/v1`)
and signs each upstream request with **AWS SigV4**, resolving credentials from
the standard AWS credential chain via `@aws-sdk/credential-provider-node`'s
`defaultProvider()`.

The motivation is **keyless auth on EKS**: `defaultProvider()` picks up **IRSA**
or **EKS Pod Identity** automatically, so the hub needs no long-lived AWS keys,
and — as with the existing WIF S3 broker — nothing is injected into a sandbox.
Notebook kernels still receive only the short-lived, session-scoped proxy token.
The credential chain also covers local dev creds, env vars, and instance/task
roles, so the same backend works off-EKS.

### What's in the change

- **`packages/credentials-aws`** — new `createAwsSigV4Fetch()`, a `fetch`
  adapter that SigV4-signs the outgoing request (default credentials from
  `defaultProvider()`, overridable for tests).
- **`packages/api`** — optional `upstreamFetch` on `AiProxyConfig`; when present
  the proxy authenticates via that adapter instead of adding a bearer key. The
  OpenAI-compatible path is unchanged.
- **`packages/config`** — wires the `bedrock` backend: region from
  `MARIMOHUB_AI_AWS_REGION` (falls back to `AWS_REGION` / `AWS_DEFAULT_REGION`),
  no API key, `MARIMOHUB_AI_ALLOWED_MODELS` defaults to just `MARIMOHUB_AI_MODEL`.
  The AI config vars shared across backends are hoisted to single definitions to
  satisfy the config-registry uniqueness invariant.
- **Docs + wizard** — `docs/setup/ai/bedrock.md`, the `## Managed AI` reference
  (regenerated `docs/configuration.md`), and a wizard setup snippet + docs deep
  link.

Respects the ports-and-adapters boundary: the SigV4 signer lives in the
`credentials-aws` adapter; `packages/api` stays vendor-free behind the
`upstreamFetch` seam; only `packages/config` imports the adapter.

## Verification

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [~] `pnpm test` — affected packages pass: `@marimo-hub/credentials-aws`,
  `@marimo-hub/config`, `@marimo-hub/api`, `@marimo-hub/docs`. `packages/web`
  tests fail locally with `TypeError: localStorage.clear is not a function`,
  which is a local Node 25 vs required Node 24 environment issue — this branch
  does not touch `packages/web` or `apps/server`, so those are pre-existing and
  unrelated. CI on Node 24 should be the source of truth.

For docs:

- [x] `pnpm --filter @marimo-hub/docs test`
- [x] `pnpm --filter @marimo-hub/config docs:generate` (committed)

## Notes

- **Docs updated**: yes — Bedrock setup snippet, config reference, wizard link.
- **Security impact**: no static AWS credential or Bedrock key is stored in the
  hub or written into a sandbox; upstream requests are SigV4-signed server-side
  with the runtime identity. The runtime role needs `bedrock:InvokeModel` and
  `bedrock:InvokeModelWithResponseStream` for the configured
  models/inference-profiles.

---
🤖 Authored with [Claude Code](https://claude.com/claude-code) (Opus 4.8), reviewed by @monolith-james.
