### PR TITLE
feat(auth): restrict project creation by OIDC group

### DIFF
--- a/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
+++ b/apps/docs/.vitepress/wizard/__snapshots__/setup.test.ts.snap
@@ -36,6 +36,7 @@ Pointer to the provider array. Then set at least one group policy:</p>
 <pre><code class="language-bash">MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM=/groups
 MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS=hub-users
 MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS=hub-platform-admins
+MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS=hub-project-creators
 MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS=hub-viewers
 MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS=hub-editors
 MARIMOHUB_AUTH_OIDC_DEFAULT_MANAGER_GROUPS=hub-project-managers
@@ -43,6 +44,14 @@ MARIMOHUB_AUTH_OIDC_DEFAULT_MANAGER_GROUPS=hub-project-managers
 <p>Nested claims use JSON Pointer syntax, such as <code>/realm_access/roles</code>.
 <code>ALLOWED_GROUPS</code> controls login. The other lists map groups to internal
 entitlements. The session cookie stores mapped entitlements, not raw groups.</p>
+<p><code>PROJECT_CREATION_GROUPS</code> controls who can create projects:</p>
+<ul>
+<li>If the variable is not set, all authenticated users can create projects.</li>
+<li>If the value is empty, only super admins can create projects.</li>
+<li>If the value contains group IDs, super admins and matching users can create projects.</li>
+</ul>
+<p>If no super admin is configured, an empty value prevents every user from creating projects.</p>
+<p>An empty value does not require <code>GROUPS_CLAIM</code>. A non-empty value requires the claim and creates a group-derived session entitlement.</p>
 <p>Group sessions last at most one hour by default. This limit bounds the delay
 after an IdP removes a user from a group. Kernels inherit the session JWT expiry
 as a fixed authorization deadline. Active editors cannot extend it. Session
@@ -54,8 +63,9 @@ potential data loss.</p>
 marimohub accepts at most 200 group IDs. It does not resolve group-overage
 references from the provider. Configure the IdP to emit only the groups that
 marimohub needs.
-Group-derived roles apply only to the browser session. They do not transfer to
-personal access tokens.</p>
+Group-derived roles and project-creation access apply only to the browser session. They do not transfer to personal access tokens.</p>
+<p>After you enable project-creation groups, matching users must sign in again. Existing sessions do not contain the new entitlement.</p>
+<p>For a strict rollout, first deploy the new version without the variable. Then set the variable after all replicas run the new version.</p>
 <p>The user ID is the OIDC <code>sub</code> within the configured issuer. The same <code>sub</code> from
 another issuer can identify a different person. Therefore, an issuer URL change
 is an identity migration. Reconcile stored owners and members before the change.</p>

--- a/development_docs/auth.md
+++ b/development_docs/auth.md
@@ -42,17 +42,18 @@ The adapter then mints the `mh_session` cookie. Protocol code uses
 [`oauth4webapi`](https://github.com/panva/oauth4webapi). Cookie signing uses
 [`jose`](https://github.com/panva/jose).
 
-| Variable                                 | Req | Description                                                    |
-| ---------------------------------------- | --- | -------------------------------------------------------------- |
-| `MARIMOHUB_AUTH_OIDC_ISSUER`             | ✓   | For example, `https://accounts.google.com`.                    |
-| `MARIMOHUB_AUTH_OIDC_CLIENT_ID`          | ✓   | OAuth client ID.                                               |
-| `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET`      | ✓   | OAuth client secret (sent via `client_secret_post`).           |
-| `MARIMOHUB_AUTH_OIDC_REDIRECT_URI`       | ✓   | **Must be** `<your-origin>/api/auth/callback`.                 |
-| `MARIMOHUB_AUTH_SESSION_SECRET`          | ✓   | HS256 cookie-signing key with ≥32 random bytes.                |
-| `MARIMOHUB_AUTH_OIDC_AUDIENCE`           |     | Deprecated and ignored; `aud` must contain the client ID.      |
-| `MARIMOHUB_AUTH_OIDC_SCOPES`             |     | Defaults to `openid email profile`. Keep `openid` and `email`. |
-| `MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION` |     | `required` (default) or explicit `trusted-issuer`.             |
-| `MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM`       |     | JSON Pointer for opt-in group policy and entitlement mapping.  |
+| Variable                                      | Req | Description                                                               |
+| --------------------------------------------- | --- | ------------------------------------------------------------------------- |
+| `MARIMOHUB_AUTH_OIDC_ISSUER`                  | ✓   | For example, `https://accounts.google.com`.                               |
+| `MARIMOHUB_AUTH_OIDC_CLIENT_ID`               | ✓   | OAuth client ID.                                                          |
+| `MARIMOHUB_AUTH_OIDC_CLIENT_SECRET`           | ✓   | OAuth client secret (sent via `client_secret_post`).                      |
+| `MARIMOHUB_AUTH_OIDC_REDIRECT_URI`            | ✓   | **Must be** `<your-origin>/api/auth/callback`.                            |
+| `MARIMOHUB_AUTH_SESSION_SECRET`               | ✓   | HS256 cookie-signing key with ≥32 random bytes.                           |
+| `MARIMOHUB_AUTH_OIDC_AUDIENCE`                |     | Deprecated and ignored; `aud` must contain the client ID.                 |
+| `MARIMOHUB_AUTH_OIDC_SCOPES`                  |     | Defaults to `openid email profile`. Keep `openid` and `email`.            |
+| `MARIMOHUB_AUTH_OIDC_EMAIL_VERIFICATION`      |     | `required` (default) or explicit `trusted-issuer`.                        |
+| `MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM`            |     | JSON Pointer for opt-in group policy and entitlement mapping.             |
+| `MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS` |     | Exact groups permitted to create projects. Empty means super admins only. |
 
 **Routes** are public and mount before the authentication guard.
 `GET /api/auth/login` starts the flow. `/api/auth/callback` exchanges the code
@@ -81,9 +82,9 @@ Each deployment supports one issuer. Stored user IDs use that issuer's `sub`.
 An issuer change is an identity migration. Reconcile stored owners and members
 before the change.
 
-The session stores mapped entitlements, not raw groups. Group-derived roles do
-not transfer to personal access tokens. Group-authorized kernels use the session
-JWT expiry as a fixed authorization deadline. Active editors cannot extend it.
+The session stores mapped entitlements, not raw groups. Group-derived roles and
+project-creation access do not transfer to personal access tokens.
+Group-authorized kernels use the session JWT expiry as a fixed authorization deadline. Active editors cannot extend it.
 Session reuse keeps the earliest credential deadline presented by any caller.
 At expiry, the lifecycle destroys the kernel and the proxy closes WebSockets.
 This teardown skips the final capture so that the kernel stops promptly.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,6 +321,7 @@ App-native OpenID Connect (the production backend). If the allowlist contains on
 | `MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM` | RFC 6901 JSON Pointer to an array of exact provider group IDs. Required for group policy. | — | — | `/groups` |
 | `MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS` | Exact comma-separated group IDs. A user must belong to at least one. Missing or malformed group data fails closed. | — | — | — |
 | `MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS` | Exact comma-separated group IDs mapped to marimohub super-admin. | — | — | — |
+| `MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS` | Exact comma-separated group IDs permitted to create projects. Unset allows all authenticated users. An empty value allows only super admins. | — | — | — |
 | `MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS` | Groups granted a deployment-wide default viewer role. | — | — | — |
 | `MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS` | Groups granted a deployment-wide default editor role. | — | — | — |
 | `MARIMOHUB_AUTH_OIDC_DEFAULT_MANAGER_GROUPS` | Groups granted a deployment-wide default project-manager role. | — | — | — |

--- a/docs/setup/auth/oidc.md
+++ b/docs/setup/auth/oidc.md
@@ -45,6 +45,7 @@ Pointer to the provider array. Then set at least one group policy:
 MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM=/groups
 MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS=hub-users
 MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS=hub-platform-admins
+MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS=hub-project-creators
 MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS=hub-viewers
 MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS=hub-editors
 MARIMOHUB_AUTH_OIDC_DEFAULT_MANAGER_GROUPS=hub-project-managers
@@ -53,6 +54,16 @@ MARIMOHUB_AUTH_OIDC_DEFAULT_MANAGER_GROUPS=hub-project-managers
 Nested claims use JSON Pointer syntax, such as `/realm_access/roles`.
 `ALLOWED_GROUPS` controls login. The other lists map groups to internal
 entitlements. The session cookie stores mapped entitlements, not raw groups.
+
+`PROJECT_CREATION_GROUPS` controls who can create projects:
+
+- If the variable is not set, all authenticated users can create projects.
+- If the value is empty, only super admins can create projects.
+- If the value contains group IDs, super admins and matching users can create projects.
+
+If no super admin is configured, an empty value prevents every user from creating projects.
+
+An empty value does not require `GROUPS_CLAIM`. A non-empty value requires the claim and creates a group-derived session entitlement.
 
 Group sessions last at most one hour by default. This limit bounds the delay
 after an IdP removes a user from a group. Kernels inherit the session JWT expiry
@@ -66,8 +77,11 @@ Missing, malformed, or oversized group data cannot satisfy the login policy.
 marimohub accepts at most 200 group IDs. It does not resolve group-overage
 references from the provider. Configure the IdP to emit only the groups that
 marimohub needs.
-Group-derived roles apply only to the browser session. They do not transfer to
-personal access tokens.
+Group-derived roles and project-creation access apply only to the browser session. They do not transfer to personal access tokens.
+
+After you enable project-creation groups, matching users must sign in again. Existing sessions do not contain the new entitlement.
+
+For a strict rollout, first deploy the new version without the variable. Then set the variable after all replicas run the new version.
 
 The user ID is the OIDC `sub` within the configured issuer. The same `sub` from
 another issuer can identify a different person. Therefore, an issuer URL change

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -127,11 +127,14 @@ components:
             - 'null'
         is_super_admin:
           type: boolean
+        can_create_projects:
+          type: boolean
       required:
         - id
         - email
         - logout_url
         - is_super_admin
+        - can_create_projects
     DeploymentInfo:
       type: object
       properties:

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -243,6 +243,8 @@ export interface PolicyConfig {
 	 * session-only OIDC group entitlements do not. Unset = no super admins.
 	 */
 	superAdmins?: string[];
+	/** Require super-admin or OIDC project-creator entitlement for project creation. */
+	projectCreationRestricted?: boolean;
 }
 
 export interface ConfigSettingSummary {

--- a/packages/api/src/me.test.ts
+++ b/packages/api/src/me.test.ts
@@ -14,6 +14,7 @@ describe('GET /api/v1/me', () => {
 			picture_url: null,
 			logout_url: null,
 			is_super_admin: false,
+			can_create_projects: true,
 		});
 	});
 
@@ -38,6 +39,23 @@ describe('GET /api/v1/me', () => {
 	it('flags a configured super admin', async () => {
 		const { request } = createTestApi({ deps: { policy: { superAdmins: [ACTOR] } } });
 		expect((await expectOk(await request('GET', '/me'))).is_super_admin).toBe(true);
+	});
+
+	it('reports the effective project-creation capability', async () => {
+		const denied = createTestApi({ deps: { policy: { projectCreationRestricted: true } } });
+		expect((await expectOk(await denied.request('GET', '/me'))).can_create_projects).toBe(false);
+
+		const authenticator: Authenticator = {
+			authenticate: async () => ({
+				id: ACTOR,
+				email: `${ACTOR}@example.com`,
+				entitlements: ['project-creator'],
+			}),
+		};
+		const allowed = createTestApi({
+			deps: { authenticator, policy: { projectCreationRestricted: true } },
+		});
+		expect((await expectOk(await allowed.request('GET', '/me'))).can_create_projects).toBe(true);
 	});
 
 	it('surfaces the authenticator logout URL when one is provided', async () => {

--- a/packages/api/src/routes/projects.test.ts
+++ b/packages/api/src/routes/projects.test.ts
@@ -174,6 +174,49 @@ describe('Project routes', () => {
 		expect(data.id).toMatch(/^proj-/);
 	});
 
+	it('POST /projects rejects users without restricted project-creation access', async () => {
+		const restricted = createTestApi({
+			bucket,
+			deps: { policy: { projectCreationRestricted: true } },
+		});
+		await expectError(
+			await restricted.request(
+				'POST',
+				'/projects',
+				{ name: 'Denied', description: 'Denied' },
+				{ 'Idempotency-Key': 'denied-project' },
+			),
+			403,
+			'FORBIDDEN',
+		);
+		expect(await expectPage(await restricted.request('GET', '/projects'))).toEqual([]);
+		expect((await bucket.list({ prefix: paths.idempotencyPrefix })).objects).toEqual([]);
+	});
+
+	it.each([
+		['project creator', ['project-creator'], []],
+		['group-derived super admin', ['super-admin'], []],
+		['static super admin', [], [ACTOR]],
+	] as const)('POST /projects allows a restricted %s', async (_name, entitlements, superAdmins) => {
+		const allowed = createTestApi({
+			bucket,
+			deps: {
+				authenticator: {
+					authenticate: async () => ({
+						id: ACTOR,
+						email: `${ACTOR}@example.com`,
+						entitlements,
+					}),
+				},
+				policy: { projectCreationRestricted: true, superAdmins: [...superAdmins] },
+			},
+		});
+		await expectOk(
+			await allowed.request('POST', '/projects', { name: 'Allowed', description: 'Allowed' }),
+			201,
+		);
+	});
+
 	it('POST /projects validates body — name required', async () => {
 		const res = await request('POST', '/projects', { description: 'no name' });
 		await expectError(res, 422);

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -1,7 +1,9 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import {
 	ASSIGNABLE_ROLES,
+	canCreateProject,
 	effectiveRole,
+	ForbiddenError,
 	notificationRouter,
 	resolveMemberRecipient,
 	roleAtLeast,
@@ -316,6 +318,9 @@ app.openapi(listProjects, async (c) => {
 app.openapi(createProject, async (c) => {
 	const deps = c.get('deps');
 	const user = c.get('user');
+	if (!canCreateProject(user, deps.policy)) {
+		throw new ForbiddenError('Project creation is restricted to authorized users');
+	}
 	const body = c.req.valid('json');
 	const data = await idempotentCreate(c, 'POST /projects', async () => {
 		const project = await deps.services.projects.createProject(body, user.id);

--- a/packages/api/src/routes/system.ts
+++ b/packages/api/src/routes/system.ts
@@ -1,5 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import {
+	canCreateProject,
 	DEFAULT_SANDBOX_STARTUP_TIMEOUT_MS,
 	isSuperAdmin,
 	MAX_REQUEST_BYTES,
@@ -54,6 +55,7 @@ app.openapi(meRoute, (c) => {
 		picture_url: user.pictureUrl ?? null,
 		logout_url: logoutUrl,
 		is_super_admin: isSuperAdmin(user, deps.policy.superAdmins),
+		can_create_projects: canCreateProject(user, deps.policy),
 	});
 });
 

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -937,6 +937,8 @@ export const MeResponseSchema = z
 		logout_url: z.string().nullable(),
 		/** Static or OIDC group-derived super admin: implicit admin everywhere. */
 		is_super_admin: z.boolean(),
+		/** Whether the current credential can create projects. */
+		can_create_projects: z.boolean(),
 	})
 	.openapi('Me');
 

--- a/packages/auth-oidc/src/index.test.ts
+++ b/packages/auth-oidc/src/index.test.ts
@@ -1214,6 +1214,7 @@ describe('OIDC routes', () => {
 				claim: '/realm_access/roles',
 				allowed: ['hub-users'],
 				superAdmin: ['hub-admins'],
+				projectCreation: ['hub-users'],
 				defaultRoles: { editor: ['hub-editors'], manager: ['hub-admins'] },
 			},
 		});
@@ -1227,8 +1228,29 @@ describe('OIDC routes', () => {
 		await expect(
 			authenticator.authenticate(requestWithCookie(sessionCookie.split('=')[1])),
 		).resolves.toMatchObject({
-			entitlements: ['super-admin', 'default-role:manager'],
+			entitlements: ['super-admin', 'project-creator', 'default-role:manager'],
 		});
+	});
+
+	it('does not grant project creation without an exact group match', async () => {
+		oauthMock.getValidatedIdTokenClaims.mockReturnValue({
+			sub: 'user-1',
+			email: 'user@example.com',
+			email_verified: true,
+			groups: ['project-creators-child'],
+		});
+		const { authenticator, routes } = makeOidc({
+			groups: { claim: '/groups', projectCreation: ['project-creators'] },
+		});
+		const txn = await beginOidcTransaction(routes);
+
+		const res = await routes.request('/api/auth/callback?code=abc&state=state-1', {
+			headers: { cookie: txn },
+		});
+		const sessionCookie = cookiePair(res, SESSION_COOKIE);
+		const user = await authenticator.authenticate(requestWithCookie(sessionCookie.split('=')[1]));
+
+		expect(user).not.toHaveProperty('entitlements');
 	});
 
 	it('maps a manager-only group without granting super-admin', async () => {

--- a/packages/auth-oidc/src/index.ts
+++ b/packages/auth-oidc/src/index.ts
@@ -32,6 +32,8 @@ export interface OidcGroupPolicy {
 	allowed?: string[];
 	/** Groups mapped to deployment super-admin. */
 	superAdmin?: string[];
+	/** Groups permitted to create projects. */
+	projectCreation?: string[];
 	/** Groups mapped to a per-user deployment-wide default project role. */
 	defaultRoles?: Partial<Record<AssignableRole, string[]>>;
 	/** Maximum accepted group count (default 200, maximum 200). */
@@ -202,6 +204,7 @@ function validateGroupPolicy(policy: OidcGroupPolicy): void {
 	const lists = [
 		policy.allowed,
 		policy.superAdmin,
+		policy.projectCreation,
 		...ASSIGNABLE_ROLES.map((role) => policy.defaultRoles?.[role]),
 	].filter((list): list is string[] => list !== undefined);
 	if (lists.length === 0) throw new Error('OIDC groups claim requires at least one group policy');
@@ -245,6 +248,9 @@ function mappedEntitlements(groups: readonly string[], policy: OidcGroupPolicy):
 	const entitlements = new Set<AuthEntitlement>();
 	if (policy.superAdmin?.some((group) => memberships.has(group))) {
 		entitlements.add('super-admin');
+	}
+	if (policy.projectCreation?.some((group) => memberships.has(group))) {
+		entitlements.add('project-creator');
 	}
 	for (const role of ASSIGNABLE_ROLES) {
 		if (policy.defaultRoles?.[role]?.some((group) => memberships.has(group))) {

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -1566,6 +1566,7 @@ export interface components {
 			picture_url?: string | null;
 			logout_url: string | null;
 			is_super_admin: boolean;
+			can_create_projects: boolean;
 		};
 		DeploymentInfo: {
 			version: string;

--- a/packages/config/src/auth.test.ts
+++ b/packages/config/src/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { makeAuth } from './auth';
+import { makeAuth, projectCreationRestricted } from './auth';
 import { ConfigError } from './errors';
 
 /**
@@ -194,6 +194,56 @@ describe('makeAuth oidc required vars', () => {
 		).toThrow(/RFC 6901 JSON Pointer/);
 	});
 
+	it.each(['', '   ', ',,,'])('accepts an empty project-creation group policy (%j)', (value) => {
+		expect(() =>
+			makeAuth({ ...oidcEnv, MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: value }),
+		).not.toThrow();
+	});
+
+	it.each(['', '   ', ',,,'])(
+		'rejects an unused groups claim with an empty project-creation policy (%j)',
+		(value) => {
+			expect(() =>
+				makeAuth({
+					...oidcEnv,
+					MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+					MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: value,
+				}),
+			).toThrow(/requires at least one group policy/);
+		},
+	);
+
+	it('requires a claim pointer for non-empty project-creation groups', () => {
+		expect(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: 'project-creators',
+			}),
+		).toThrow(/GROUPS_CLAIM/);
+	});
+
+	it('restricts project creation only when the OIDC variable is present', () => {
+		expect(projectCreationRestricted(oidcEnv)).toBe(false);
+		expect(
+			projectCreationRestricted({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: '',
+			}),
+		).toBe(true);
+		expect(
+			projectCreationRestricted({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: 'project-creators',
+			}),
+		).toBe(true);
+		expect(
+			projectCreationRestricted({
+				...proxyHeaderEnv,
+				MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: 'project-creators',
+			}),
+		).toBe(false);
+	});
+
 	it.each([
 		['missing leading slash', 'groups'],
 		['invalid tilde escape', '/realm~2access/roles'],
@@ -211,6 +261,7 @@ describe('makeAuth oidc required vars', () => {
 	it.each([
 		'MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS',
 		'MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS',
+		'MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS',
 		'MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS',
 		'MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS',
 		'MARIMOHUB_AUTH_OIDC_DEFAULT_MANAGER_GROUPS',
@@ -239,6 +290,23 @@ describe('makeAuth oidc required vars', () => {
 
 		expect(error.message).toContain('expected at most 200 group ids');
 		expect(error.opts.variable).toBe('MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS');
+	});
+
+	it.each([
+		['too many groups', Array.from({ length: 201 }, (_, i) => `group-${i}`).join(',')],
+		['oversized group id', 'g'.repeat(257)],
+		['control character', 'project-creators,bad\u007fgroup'],
+	])('rejects invalid project-creation group lists: %s', (_name, groups) => {
+		const error = getConfigError(() =>
+			makeAuth({
+				...oidcEnv,
+				MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+				MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: groups,
+			}),
+		);
+
+		expect(error.message).toContain('expected at most 200 group ids');
+		expect(error.opts.variable).toBe('MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS');
 	});
 
 	it('requires HTTPS issuer and redirect URLs', () => {

--- a/packages/config/src/auth.ts
+++ b/packages/config/src/auth.ts
@@ -200,11 +200,14 @@ function parseGroupPolicy(env: Env): OidcGroupPolicy | undefined {
 	const claim = env.MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM?.trim();
 	const allowed = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_ALLOWED_GROUPS');
 	const superAdmin = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_SUPER_ADMIN_GROUPS');
+	const projectCreation = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS');
 	const viewer = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS');
 	const editor = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_DEFAULT_EDITOR_GROUPS');
 	const manager = checkedGroups(env, 'MARIMOHUB_AUTH_OIDC_DEFAULT_MANAGER_GROUPS');
-	const configured = Boolean(claim || allowed || superAdmin || viewer || editor || manager);
-	if (!configured) return undefined;
+	const mappedPolicy = Boolean(
+		allowed || superAdmin || projectCreation || viewer || editor || manager,
+	);
+	if (!claim && !mappedPolicy) return undefined;
 	if (
 		!claim ||
 		!claim.startsWith('/') ||
@@ -221,7 +224,7 @@ function parseGroupPolicy(env: Env): OidcGroupPolicy | undefined {
 			},
 		);
 	}
-	if (!allowed && !superAdmin && !viewer && !editor && !manager) {
+	if (!mappedPolicy) {
 		throw new ConfigError('An OIDC groups claim requires at least one group policy.', {
 			variable: 'MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM',
 		});
@@ -230,6 +233,7 @@ function parseGroupPolicy(env: Env): OidcGroupPolicy | undefined {
 		claim,
 		...(allowed ? { allowed } : {}),
 		...(superAdmin ? { superAdmin } : {}),
+		...(projectCreation ? { projectCreation } : {}),
 		...(viewer || editor || manager
 			? {
 					defaultRoles: {
@@ -240,6 +244,14 @@ function parseGroupPolicy(env: Env): OidcGroupPolicy | undefined {
 				}
 			: {}),
 	};
+}
+
+export function projectCreationRestricted(env: Env): boolean {
+	// Raw presence is intentional: checkedGroups collapses empty and omitted values,
+	// but this policy needs that distinction. createFromEnv calls makeAuth first to validate it.
+	return (
+		authBackend(env) === 'oidc' && env.MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS !== undefined
+	);
 }
 
 export function makeAuth(env: Env): { authenticator: Authenticator; authRoutes?: Hono } {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -630,6 +630,40 @@ describe('createFromEnv oidc email-domain allowlist', () => {
 		const deps = createFromEnv({ ...oidcEnv, MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: '*' });
 		expect(deps.authenticator).toBeDefined();
 	});
+
+	it('wires project-creation restriction for empty and non-empty OIDC policies', () => {
+		const unrestricted = createFromEnv({
+			...oidcEnv,
+			MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: '*',
+		});
+		expect(unrestricted.policy.projectCreationRestricted).toBeUndefined();
+
+		const superAdminsOnly = createFromEnv({
+			...oidcEnv,
+			MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: '*',
+			MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: '',
+		});
+		expect(superAdminsOnly.policy.projectCreationRestricted).toBe(true);
+
+		const groupRestricted = createFromEnv({
+			...oidcEnv,
+			MARIMOHUB_AUTH_ALLOWED_EMAIL_DOMAINS: '*',
+			MARIMOHUB_AUTH_OIDC_GROUPS_CLAIM: '/groups',
+			MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: 'project-creators',
+		});
+		expect(groupRestricted.policy.projectCreationRestricted).toBe(true);
+	});
+
+	it('ignores OIDC project-creation groups for other auth backends', () => {
+		const deps = createFromEnv({
+			MARIMOHUB_STORAGE_BACKEND: 'memory',
+			MARIMOHUB_ALLOW_EPHEMERAL_STORAGE: 'true',
+			MARIMOHUB_COMPUTE_BACKEND: 'none',
+			MARIMOHUB_AUTH_BACKEND: 'dev',
+			MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS: 'project-creators',
+		});
+		expect(deps.policy.projectCreationRestricted).toBeUndefined();
+	});
 });
 
 describe('createFromEnv sandbox-host isolation guard', () => {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -47,7 +47,7 @@ import type {
 } from '@marimo-hub/core';
 import type { ApiDeps, SessionLifetimeConfig } from '@marimo-hub/api';
 import { makeAi } from './ai';
-import { authBackend, makeAuth } from './auth';
+import { authBackend, makeAuth, projectCreationRestricted } from './auth';
 import { buildConfigSummary } from './configSummary';
 import { computeBackend, makeCompute, resolveSandboxImages } from './compute';
 import {
@@ -610,6 +610,7 @@ export function createFromEnv(
 			editorSandboxSharing,
 			allowedOrigins: parseList(env.MARIMOHUB_ALLOWED_ORIGINS),
 			superAdmins: parseList(env.MARIMOHUB_SUPER_ADMINS),
+			...(projectCreationRestricted(env) ? { projectCreationRestricted: true } : {}),
 			maxConcurrentSessionsPerUser: parseCap(
 				env,
 				'MARIMOHUB_MAX_SESSIONS_PER_USER',

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -960,6 +960,13 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 						optIn: true,
 					},
 					{
+						id: 'MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS',
+						name: 'Project creation groups',
+						description:
+							'Exact comma-separated group IDs permitted to create projects. Unset allows all authenticated users. An empty value allows only super admins.',
+						optIn: true,
+					},
+					{
 						id: 'MARIMOHUB_AUTH_OIDC_DEFAULT_VIEWER_GROUPS',
 						name: 'Default viewer groups',
 						description: 'Groups granted a deployment-wide default viewer role.',

--- a/packages/core/src/authz.test.ts
+++ b/packages/core/src/authz.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+	canCreateProject,
 	canAct,
 	canSeeProjectEntry,
 	effectiveRole,
@@ -180,6 +181,35 @@ describe('authz', () => {
 					entitlements: ['default-role:manager'],
 				}),
 			).toBe(false);
+		});
+	});
+
+	describe('canCreateProject', () => {
+		it('allows all authenticated users when project creation is unrestricted', () => {
+			expect(canCreateProject(STRANGER)).toBe(true);
+			expect(canCreateProject(STRANGER, { projectCreationRestricted: false })).toBe(true);
+		});
+
+		it('allows project creators and super admins when project creation is restricted', () => {
+			expect(canCreateProject(STRANGER, { projectCreationRestricted: true })).toBe(false);
+			expect(
+				canCreateProject(
+					{ ...STRANGER, entitlements: ['project-creator'] },
+					{ projectCreationRestricted: true },
+				),
+			).toBe(true);
+			expect(
+				canCreateProject(STRANGER, {
+					projectCreationRestricted: true,
+					superAdmins: [STRANGER.id],
+				}),
+			).toBe(true);
+			expect(
+				canCreateProject(
+					{ ...STRANGER, entitlements: ['super-admin'] },
+					{ projectCreationRestricted: true },
+				),
+			).toBe(true);
 		});
 	});
 

--- a/packages/core/src/authz.ts
+++ b/packages/core/src/authz.ts
@@ -63,6 +63,8 @@ export interface AuthzPolicy {
 	defaultRole?: AssignableRole | null;
 	/** MARIMOHUB_SUPER_ADMINS entries: emails (contain `@`) or user ids. */
 	superAdmins?: readonly string[];
+	/** Whether project creation requires super-admin or OIDC project-creator entitlement. */
+	projectCreationRestricted?: boolean;
 }
 
 /**
@@ -75,6 +77,14 @@ export function isSuperAdmin(subject: AuthSubject, superAdmins?: readonly string
 	return (
 		subject.entitlements?.includes('super-admin') === true ||
 		anyRefMatchesSubject(superAdmins, subject)
+	);
+}
+
+export function canCreateProject(subject: AuthSubject, policy?: AuthzPolicy): boolean {
+	if (!policy?.projectCreationRestricted) return true;
+	return (
+		isSuperAdmin(subject, policy.superAdmins) ||
+		subject.entitlements?.includes('project-creator') === true
 	);
 }
 

--- a/packages/core/src/ports/auth.ts
+++ b/packages/core/src/ports/auth.ts
@@ -11,6 +11,7 @@ import type { UserId } from '../ids';
 
 export const AUTH_ENTITLEMENTS = [
 	'super-admin',
+	'project-creator',
 	'default-role:viewer',
 	'default-role:editor',
 	'default-role:manager',

--- a/packages/web/src/components/Project/ProjectMembersDialog.test.tsx
+++ b/packages/web/src/components/Project/ProjectMembersDialog.test.tsx
@@ -41,6 +41,7 @@ const OWNER_USER: User = {
 	email: DIRECTORY[OWNER].email,
 	logout_url: null,
 	is_super_admin: false,
+	can_create_projects: true,
 };
 let currentTestUser = OWNER_USER;
 
@@ -321,6 +322,7 @@ describe('ProjectMembersDialog — admin', () => {
 				email: DIRECTORY[EDITOR].email,
 				logout_url: null,
 				is_super_admin: false,
+				can_create_projects: true,
 			},
 			members: MEMBERS.map((member) =>
 				member.user_id === EDITOR ? { ...member, role: 'manager' } : member,
@@ -400,7 +402,13 @@ describe('ProjectMembersDialog — admin', () => {
 describe('ProjectMembersDialog — non-admin', () => {
 	it('renders a read-only list: no role selects, no remove, no add picker', async () => {
 		makeFetch({
-			currentUser: { id: 'u-invitee', email: INVITED, logout_url: null, is_super_admin: false },
+			currentUser: {
+				id: 'u-invitee',
+				email: INVITED,
+				logout_url: null,
+				is_super_admin: false,
+				can_create_projects: true,
+			},
 			directory: {
 				...DIRECTORY,
 				'u-invitee': { id: 'u-invitee', email: INVITED, name: 'Pending Person' },
@@ -422,6 +430,7 @@ describe('ProjectMembersDialog — non-admin', () => {
 				email: DIRECTORY[EDITOR].email,
 				logout_url: null,
 				is_super_admin: false,
+				can_create_projects: true,
 			},
 			members: [...MEMBERS, { user_id: legacy, role: 'admin' }],
 			directory: {
@@ -438,7 +447,13 @@ describe('ProjectMembersDialog — non-admin', () => {
 describe('ProjectMembersDialog — current access', () => {
 	it('recognizes the current user through a matching email invite', async () => {
 		makeFetch({
-			currentUser: { id: 'u-invitee', email: INVITED, logout_url: null, is_super_admin: false },
+			currentUser: {
+				id: 'u-invitee',
+				email: INVITED,
+				logout_url: null,
+				is_super_admin: false,
+				can_create_projects: true,
+			},
 			directory: {
 				...DIRECTORY,
 				'u-invitee': { id: 'u-invitee', email: INVITED, name: 'Pending Person' },
@@ -453,7 +468,13 @@ describe('ProjectMembersDialog — current access', () => {
 
 	it('shows default access without inserting a synthetic member row', async () => {
 		makeFetch({
-			currentUser: { id: NINA.id, email: NINA.email, logout_url: null, is_super_admin: false },
+			currentUser: {
+				id: NINA.id,
+				email: NINA.email,
+				logout_url: null,
+				is_super_admin: false,
+				can_create_projects: true,
+			},
 			capabilities: { ...CAPABILITIES, default_role: 'editor' } as Capabilities,
 			directory: { ...DIRECTORY, [NINA.id]: NINA },
 		});
@@ -467,7 +488,13 @@ describe('ProjectMembersDialog — current access', () => {
 
 	it('labels a non-member super admin as a deployment super admin', async () => {
 		makeFetch({
-			currentUser: { id: NINA.id, email: NINA.email, logout_url: null, is_super_admin: true },
+			currentUser: {
+				id: NINA.id,
+				email: NINA.email,
+				logout_url: null,
+				is_super_admin: true,
+				can_create_projects: true,
+			},
 			directory: { ...DIRECTORY, [NINA.id]: NINA },
 		});
 		// A super admin sees `your_role: admin` even without a member row.
@@ -492,7 +519,13 @@ describe('ProjectMembersDialog — current access', () => {
 	it('shows deployment-aware role details on focus', async () => {
 		const user = userEvent.setup();
 		makeFetch({
-			currentUser: { id: 'u-invitee', email: INVITED, logout_url: null, is_super_admin: false },
+			currentUser: {
+				id: 'u-invitee',
+				email: INVITED,
+				logout_url: null,
+				is_super_admin: false,
+				can_create_projects: true,
+			},
 			capabilities: {
 				...CAPABILITIES,
 				viewer_mode: 'ephemeral-sandbox',

--- a/packages/web/src/components/ProjectList/ProjectList.test.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.test.tsx
@@ -7,6 +7,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ProjectSummary } from '@/types';
 import { ProjectList } from './ProjectList';
 
+const authState = vi.hoisted(() => ({ canCreateProjects: true as boolean | undefined }));
+
+vi.mock('@/context/AuthContext', () => ({
+	useAuth: () => ({ user: { can_create_projects: authState.canCreateProjects } }),
+}));
+
 type TestProject = ProjectSummary & { tags: string[] };
 
 function project(
@@ -27,7 +33,12 @@ function project(
 	} as TestProject;
 }
 
-function renderList(projects: TestProject[], route = '/') {
+function renderList(
+	projects: TestProject[],
+	route = '/',
+	canCreateProjects: boolean | undefined = true,
+) {
+	authState.canCreateProjects = canCreateProjects;
 	const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 		const url = new URL(String(input), 'http://localhost');
 		const q = url.searchParams.get('q')?.toLocaleLowerCase();
@@ -86,6 +97,25 @@ describe('ProjectList', () => {
 		await waitForLoaded();
 
 		expect(screen.getByText('No projects yet')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Create your first project' })).toBeInTheDocument();
+	});
+
+	it('hides project-creation actions when the server denies access', async () => {
+		renderList([], '/', false);
+		await waitForLoaded();
+
+		expect(screen.queryByRole('button', { name: 'New Project' })).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: 'Create your first project' }),
+		).not.toBeInTheDocument();
+		expect(screen.queryByRole('heading', { name: 'Create New Project' })).not.toBeInTheDocument();
+	});
+
+	it('keeps project creation available with an older user response', async () => {
+		renderList([], '/', undefined);
+		await waitForLoaded();
+
+		expect(screen.getByRole('button', { name: 'New Project' })).toBeInTheDocument();
 		expect(screen.getByRole('button', { name: 'Create your first project' })).toBeInTheDocument();
 	});
 

--- a/packages/web/src/components/ProjectList/ProjectList.tsx
+++ b/packages/web/src/components/ProjectList/ProjectList.tsx
@@ -22,6 +22,7 @@ import {
 import { useProjectsQuery, useCreateProject } from '@/api/hooks';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { useListFilters } from '@/hooks/useListFilters';
+import { useAuth } from '@/context/AuthContext';
 import type { ProjectSummary } from '@/types';
 
 const PROJECT_STATUS_FILTERS = [
@@ -37,6 +38,8 @@ const projectSchema = z.object({
 const EMPTY_PROJECT = { name: '', description: '' };
 
 export function ProjectList() {
+	const { user } = useAuth();
+	const canCreateProjects = user?.can_create_projects ?? user !== null;
 	const { filters, setFilters, filtersActive } = useListFilters(PROJECT_STATUS_FILTERS);
 	const createModal = useDisclosure();
 
@@ -65,10 +68,12 @@ export function ProjectList() {
 			<title>Projects · marimohub</title>
 			<PageHeader
 				actions={
-					<Button variant="primary" onPress={createModal.open}>
-						<Plus className="size-4" />
-						New Project
-					</Button>
+					canCreateProjects ? (
+						<Button variant="primary" onPress={createModal.open}>
+							<Plus className="size-4" />
+							New Project
+						</Button>
+					) : null
 				}
 			>
 				<div className="flex min-w-0 flex-col gap-0.5">
@@ -97,10 +102,12 @@ export function ProjectList() {
 						message="No projects yet"
 						description="Projects group related notebooks and their collaborators."
 						action={
-							<Button variant="default" onPress={createModal.open}>
-								<Plus className="size-4" />
-								Create your first project
-							</Button>
+							canCreateProjects ? (
+								<Button variant="default" onPress={createModal.open}>
+									<Plus className="size-4" />
+									Create your first project
+								</Button>
+							) : null
 						}
 					/>
 				}
@@ -116,22 +123,24 @@ export function ProjectList() {
 				))}
 			</ListResults>
 
-			<FormDialog
-				form={createForm}
-				isPending={createProject.isPending}
-				isOpen={createModal.isOpen}
-				onClose={createModal.close}
-				title="Create New Project"
-				submitLabel="Create"
-				pendingLabel="Creating..."
-			>
-				<createForm.AppField name="name">
-					{(f) => <f.TextField label="Project Name" placeholder="My Analysis" autoFocus />}
-				</createForm.AppField>
-				<createForm.AppField name="description">
-					{(f) => <f.TextField label="Description" placeholder="Optional description" />}
-				</createForm.AppField>
-			</FormDialog>
+			{canCreateProjects ? (
+				<FormDialog
+					form={createForm}
+					isPending={createProject.isPending}
+					isOpen={createModal.isOpen}
+					onClose={createModal.close}
+					title="Create New Project"
+					submitLabel="Create"
+					pendingLabel="Creating..."
+				>
+					<createForm.AppField name="name">
+						{(f) => <f.TextField label="Project Name" placeholder="My Analysis" autoFocus />}
+					</createForm.AppField>
+					<createForm.AppField name="description">
+						{(f) => <f.TextField label="Description" placeholder="Optional description" />}
+					</createForm.AppField>
+				</FormDialog>
+			) : null}
 		</PageContainer>
 	);
 }

--- a/packages/web/src/context/AuthContext.test.tsx
+++ b/packages/web/src/context/AuthContext.test.tsx
@@ -7,7 +7,13 @@ import type { User } from '@/types';
 import { jsonError, jsonOk, renderWithClient } from '@/test/render';
 import { AuthProvider, useAuth } from './AuthContext';
 
-const ME: User = { id: 'usr-1', email: 'ada@example.com', logout_url: null, is_super_admin: false };
+const ME: User = {
+	id: 'usr-1',
+	email: 'ada@example.com',
+	logout_url: null,
+	is_super_admin: false,
+	can_create_projects: true,
+};
 
 type AuthValue = ReturnType<typeof useAuth>;
 


### PR DESCRIPTION
Adds `MARIMOHUB_AUTH_OIDC_PROJECT_CREATION_GROUPS` with unrestricted behavior when omitted, superadmin-only behavior when empty, and exact OIDC group matching when populated. Group matches mint a browser-session `project-creator` entitlement, while non-OIDC backends ignore the setting.

Enforces the policy before project idempotency handling, exposes the server-computed capability on `/me`, hides unauthorized creation actions in the UI, and updates generated API/client/configuration artifacts and OIDC documentation.