### PR TITLE
fix(web): avoid false stale session warnings

### DIFF
--- a/packages/web/src/components/NotebookPage/NotebookPage.app.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.app.test.tsx
@@ -6,7 +6,7 @@ import { makeFetch, renderPage, runningSession, sessionPosts } from './NotebookP
 
 describe('NotebookPage app variant', () => {
 	const appSession = (overrides: Partial<Session> = {}) =>
-		runningSession({ mode: 'app', source_version_id: 'ver-head', ...overrides });
+		runningSession({ mode: 'app', source_version_id: 'ver-2', ...overrides });
 
 	it('starts a run session, shows app chrome, and hides edit-only affordances', async () => {
 		const impl = makeFetch({ role: 'editor', session: appSession() });
@@ -28,8 +28,8 @@ describe('NotebookPage app variant', () => {
 	it('shows the staleness banner when the app trails the notebook head', async () => {
 		makeFetch({
 			role: 'editor',
-			session: appSession({ source_version_id: 'ver-old' }),
-			headVersion: 'ver-head',
+			session: appSession({ source_version_id: 'ver-1' }),
+			headVersion: 'ver-2',
 		});
 		renderPage('app');
 
@@ -40,8 +40,8 @@ describe('NotebookPage app variant', () => {
 	it('suppresses the staleness banner while the notebook is being edited', async () => {
 		makeFetch({
 			role: 'editor',
-			session: appSession({ source_version_id: 'ver-old' }),
-			headVersion: 'ver-head',
+			session: appSession({ source_version_id: 'ver-1' }),
+			headVersion: 'ver-2',
 			projectSessions: [runningSession({ session_id: 'sess-edit', mode: 'edit' })],
 		});
 		const { container } = renderPage('app');
@@ -53,8 +53,8 @@ describe('NotebookPage app variant', () => {
 	it('does not suppress the staleness banner for a temporary editor', async () => {
 		makeFetch({
 			role: 'editor',
-			session: appSession({ source_version_id: 'ver-old' }),
-			headVersion: 'ver-head',
+			session: appSession({ source_version_id: 'ver-1' }),
+			headVersion: 'ver-2',
 			projectSessions: [runningSession({ session_id: 'sess-edit', mode: 'edit', ephemeral: true })],
 		});
 		renderPage('app');
@@ -66,8 +66,8 @@ describe('NotebookPage app variant', () => {
 		makeFetch({
 			role: 'editor',
 			sourceType: 'git',
-			session: appSession({ source_version_id: 'ver-old' }),
-			headVersion: 'ver-head',
+			session: appSession({ source_version_id: 'ver-1' }),
+			headVersion: 'ver-2',
 			projectSessions: [runningSession({ session_id: 'sess-edit', mode: 'edit' })],
 		});
 		renderPage('app');
@@ -77,7 +77,21 @@ describe('NotebookPage app variant', () => {
 
 	it('shows no staleness banner when the app serves the head version', async () => {
 		const { container } = (() => {
-			makeFetch({ role: 'editor', session: appSession(), headVersion: 'ver-head' });
+			makeFetch({ role: 'editor', session: appSession(), headVersion: 'ver-2' });
+			return renderPage('app');
+		})();
+
+		await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull());
+		expect(screen.queryByText(/serving an older version/)).toBeNull();
+	});
+
+	it('shows no staleness banner when notebook detail trails the app version', async () => {
+		const { container } = (() => {
+			makeFetch({
+				role: 'editor',
+				session: appSession({ source_version_id: 'ver-2' }),
+				headVersion: 'ver-1',
+			});
 			return renderPage('app');
 		})();
 
@@ -108,8 +122,8 @@ describe('NotebookPage app variant', () => {
 		makeFetch({
 			role: 'viewer',
 			viewerMode: 'applications',
-			session: appSession({ source_version_id: 'ver-old', can: { attach: true, stop: false } }),
-			headVersion: 'ver-head',
+			session: appSession({ source_version_id: 'ver-1', can: { attach: true, stop: false } }),
+			headVersion: 'ver-2',
 		});
 		renderPage('app');
 

--- a/packages/web/src/components/NotebookPage/NotebookPage.git.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.git.test.tsx
@@ -12,14 +12,14 @@ import {
 
 describe('NotebookPage git-synced editor', () => {
 	const gitEditSession = (overrides: Partial<Session> = {}) =>
-		runningSession({ source_version_id: 'ver-head', ...overrides });
+		runningSession({ source_version_id: 'ver-2', ...overrides });
 
 	it('shows the updated-on-GitHub banner when the session trails the head', async () => {
 		makeFetch({
 			role: 'editor',
 			sourceType: 'git',
-			session: gitEditSession({ source_version_id: 'ver-old' }),
-			headVersion: 'ver-head',
+			session: gitEditSession({ source_version_id: 'ver-1' }),
+			headVersion: 'ver-2',
 		});
 		renderPage();
 
@@ -79,10 +79,10 @@ describe('NotebookPage git-synced editor', () => {
 			role: 'editor',
 			sourceType: 'git',
 			session: gitEditSession({
-				source_version_id: 'ver-old',
+				source_version_id: 'ver-1',
 				can: { attach: true, stop: false },
 			}),
-			headVersion: 'ver-head',
+			headVersion: 'ver-2',
 		});
 		renderPage();
 
@@ -95,8 +95,8 @@ describe('NotebookPage git-synced editor', () => {
 	it('shows no banner on a local notebook even when versions differ', async () => {
 		makeFetch({
 			role: 'editor',
-			session: gitEditSession({ source_version_id: 'ver-old' }),
-			headVersion: 'ver-head',
+			session: gitEditSession({ source_version_id: 'ver-1' }),
+			headVersion: 'ver-2',
 		});
 		const { container } = renderPage();
 
@@ -109,8 +109,8 @@ describe('NotebookPage git-synced editor', () => {
 		const impl = makeFetch({
 			role: 'editor',
 			sourceType: 'git',
-			session: gitEditSession({ source_version_id: 'ver-old' }),
-			headVersion: 'ver-head',
+			session: gitEditSession({ source_version_id: 'ver-1' }),
+			headVersion: 'ver-2',
 		});
 		const { container } = renderPage();
 		await waitFor(() => expect(screen.getByText('Restart to update')).toBeInTheDocument());

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -532,11 +532,11 @@ describe('NotebookPage viewer modes', () => {
 			role: 'viewer',
 			viewerMode: 'ephemeral-sandbox',
 			sourceType: 'git',
-			headVersion: 'ver-head',
+			headVersion: 'ver-2',
 			session: runningSession({
 				ephemeral: true,
 				editor_sandbox_sharing: 'shared',
-				source_version_id: 'ver-old',
+				source_version_id: 'ver-1',
 			}),
 		});
 		renderPage();

--- a/packages/web/src/components/NotebookPage/NotebookPage.testWorld.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.testWorld.tsx
@@ -248,9 +248,9 @@ export function makeFetch(opts: FetchOptions) {
 								entry_notebook: opts.entryNotebook ?? 'app.py',
 								commit: 'deadbeefcafe0123',
 								last_synced_at: '2026-07-01T10:00:00Z',
-								current_version_id: opts.headVersion ?? 'ver-head',
+								current_version_id: opts.headVersion ?? 'ver-2',
 							}
-						: { type: 'local', current_version_id: opts.headVersion ?? 'ver-head' },
+						: { type: 'local', current_version_id: opts.headVersion ?? 'ver-2' },
 			});
 		}
 		if (url.includes('/capabilities')) {

--- a/packages/web/src/components/Project/AppSessionIndicator.test.tsx
+++ b/packages/web/src/components/Project/AppSessionIndicator.test.tsx
@@ -15,7 +15,7 @@ function makeAppSession(overrides: Partial<Session> = {}): Session {
 		user_id: 'user_1',
 		status: 'running',
 		mode: 'app',
-		source_version_id: 'ver-head',
+		source_version_id: 'ver-2',
 		started_at: '2026-06-24T12:00:00Z',
 		last_heartbeat: '2026-06-24T12:00:00Z',
 		...overrides,
@@ -28,7 +28,7 @@ function renderIndicator(
 		canControl = true,
 		canOpen = false,
 		editActive = false,
-		headVersion = 'ver-head',
+		headVersion = 'ver-2',
 		sourceType = 'local',
 		profiles = [],
 		computeProfile,
@@ -157,8 +157,8 @@ describe('AppSessionIndicator', () => {
 	});
 
 	it('suppresses the stale hint while the notebook is being edited', async () => {
-		renderIndicator(makeAppSession({ source_version_id: 'ver-old' }), {
-			headVersion: 'ver-head',
+		renderIndicator(makeAppSession({ source_version_id: 'ver-1' }), {
+			headVersion: 'ver-2',
 			editActive: true,
 		});
 		await userEvent.click(screen.getByRole('button'));
@@ -168,8 +168,8 @@ describe('AppSessionIndicator', () => {
 	});
 
 	it('shows the stale hint when the app trails the notebook head', async () => {
-		renderIndicator(makeAppSession({ source_version_id: 'ver-old' }), {
-			headVersion: 'ver-head',
+		renderIndicator(makeAppSession({ source_version_id: 'ver-1' }), {
+			headVersion: 'ver-2',
 		});
 		await userEvent.click(screen.getByRole('button'));
 
@@ -177,8 +177,8 @@ describe('AppSessionIndicator', () => {
 	});
 
 	it('does not suppress the stale hint during editing on a git-synced notebook', async () => {
-		renderIndicator(makeAppSession({ source_version_id: 'ver-old' }), {
-			headVersion: 'ver-head',
+		renderIndicator(makeAppSession({ source_version_id: 'ver-1' }), {
+			headVersion: 'ver-2',
 			sourceType: 'git',
 			editActive: true,
 		});
@@ -234,8 +234,8 @@ describe('AppSessionIndicator', () => {
 	// A version committed server-side (an edit session ending) invalidates
 	// nothing on the client, so a cached head would hide the hint for 5 minutes.
 	it('re-reads the notebook head each time the popover opens', async () => {
-		let head = 'ver-head';
-		renderIndicator(makeAppSession({ source_version_id: 'ver-head' }), {
+		let head = 'ver-2';
+		renderIndicator(makeAppSession({ source_version_id: 'ver-2' }), {
 			headVersion: () => head,
 		});
 		const trigger = screen.getByRole('button');
@@ -249,7 +249,7 @@ describe('AppSessionIndicator', () => {
 			expect(screen.queryByRole('button', { name: 'Restart' })).not.toBeInTheDocument(),
 		);
 
-		head = 'ver-next';
+		head = 'ver-3';
 		await userEvent.click(trigger);
 
 		expect(await screen.findByText(/Restart to update/)).toBeInTheDocument();

--- a/packages/web/src/components/Project/Project.actions.test.tsx
+++ b/packages/web/src/components/Project/Project.actions.test.tsx
@@ -376,7 +376,7 @@ describe('Project — Notebook Actions: configuration', () => {
 					...runningSession(),
 					session_id: 'sess-app',
 					mode: 'app',
-					source_version_id: 'ver-old',
+					source_version_id: 'ver-0',
 					can: { attach: true, stop: true },
 				} as Session,
 			],

--- a/packages/web/src/lib/sessions.test.ts
+++ b/packages/web/src/lib/sessions.test.ts
@@ -34,12 +34,16 @@ describe('rankSession', () => {
 });
 
 describe('isSessionStale', () => {
-	it('is stale only when both versions are known and differ', () => {
+	it('is stale only when both versions are known and the notebook head is newer', () => {
 		expect(isSessionStale({ source_version_id: 'a' }, 'b')).toBe(true);
 		expect(isSessionStale({ source_version_id: 'a' }, 'a')).toBe(false);
 		expect(isSessionStale({ source_version_id: undefined }, 'b')).toBe(false);
 		expect(isSessionStale({ source_version_id: 'a' }, null)).toBe(false);
 		expect(isSessionStale({ source_version_id: 'a' }, undefined)).toBe(false);
+	});
+
+	it('does not mark a newer session stale when notebook detail still has an older head', () => {
+		expect(isSessionStale({ source_version_id: 'b' }, 'a')).toBe(false);
 	});
 });
 

--- a/packages/web/src/lib/sessions.ts
+++ b/packages/web/src/lib/sessions.ts
@@ -29,6 +29,8 @@ export interface NotebookSessions {
  * must also suppress the hint while an edit session is live on the notebook
  * (`editActive`) — otherwise it flaps for the whole editing session. Git-synced
  * heads move only when a push lands, so no such suppression applies there.
+ * Version IDs sort in creation order; comparing directionally avoids a false
+ * warning when cached notebook detail trails the version used to start a session.
  */
 export function isSessionStale(
 	session: Pick<Session, 'source_version_id'>,
@@ -37,7 +39,7 @@ export function isSessionStale(
 	return (
 		!!session.source_version_id &&
 		!!currentVersionId &&
-		currentVersionId !== session.source_version_id
+		currentVersionId > session.source_version_id
 	);
 }
 


### PR DESCRIPTION
Session staleness now uses the chronological ordering of monotonic version IDs instead of treating every mismatch as evidence that the session is older. This prevents cached notebook detail from making a newly started app look stale.

Regression coverage includes the notebook page case where the session version is newer than the cached notebook head, and existing stale-version fixtures now model chronological ordering explicitly.