### PR TITLE
feat(admin): Add admin policy analyzer

### DIFF
--- a/development_docs/auth.md
+++ b/development_docs/auth.md
@@ -172,6 +172,38 @@ Known limits:
 - Deployment-wide sandbox storage credentials can cross label boundaries below
   the API. Use scoped credentials (WIF) or non-persistent workspaces.
 
+### Policy analyzer
+
+Super admins use **Admin → Policy** to examine policy decisions.
+The endpoints require a super-admin session and reject personal access tokens.
+The analyzer calls the production policy functions and returns a deterministic trace without generated reasoning.
+
+A version-1 suite contains 1 to 25 cases.
+Each case evaluates the configured OIDC login policy, the authorization engine, or both.
+Authorization covers entitlements, roles, action rules, session rules, and resource constraints.
+The analyzer compares each decision with the expected decision.
+A login denial skips authorization that depends on login entitlements.
+A case is valid when every stage finishes and every assertion matches.
+An expected denial is valid.
+Timeouts, module errors, malformed results, invalid contexts, and inaccessible stored resources invalidate a case.
+
+The analyzer grants no additional resource access.
+It loads only readable stored resources, and resource security labels still apply.
+Use hypothetical resources for inaccessible or counterfactual cases.
+Live subject context is available only for the signed-in admin.
+
+Suites remain in the browser unless the admin downloads them.
+The server does not store suites, and the page imports or exports the exact version-1 JSON format.
+
+CAUTION: Treat exported suites as sensitive data. They can contain sample claims and subject context.
+
+Each evaluation request records one `policy.analysis.run` event.
+The event contains bounded request and assertion metadata.
+It excludes claims, entitlements, labels, subject context, policy reasons, and module errors.
+
+Classification names come from `MARIMOHUB_AUTHZ_CLASSIFICATION_ORDER`.
+Examples use the notional names `LEVEL_1`, `LEVEL_2`, and `LEVEL_3`.
+
 ### Example: Google
 
 In the [Google Cloud Console](https://console.cloud.google.com/apis/credentials)

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -1440,24 +1440,45 @@ components:
         - cases
       additionalProperties: false
     PolicyCaseV1:
-      type: object
-      properties:
-        id:
-          type: string
-          minLength: 1
-          maxLength: 128
-        name:
-          type: string
-          minLength: 1
-          maxLength: 200
-        login:
-          $ref: '#/components/schemas/PolicyLoginStageV1'
-        authorization:
-          $ref: '#/components/schemas/PolicyAuthorizationStageV1'
-      required:
-        - id
-        - name
-      additionalProperties: false
+      anyOf:
+        - type: object
+          properties:
+            id:
+              type: string
+              minLength: 1
+              maxLength: 128
+            name:
+              type: string
+              minLength: 1
+              maxLength: 200
+            login:
+              $ref: '#/components/schemas/PolicyLoginStageV1'
+            authorization:
+              $ref: '#/components/schemas/PolicyAuthorizationStageV1'
+          required:
+            - id
+            - name
+            - login
+          additionalProperties: false
+        - type: object
+          properties:
+            id:
+              type: string
+              minLength: 1
+              maxLength: 128
+            name:
+              type: string
+              minLength: 1
+              maxLength: 200
+            login:
+              $ref: '#/components/schemas/PolicyLoginStageV1'
+            authorization:
+              $ref: '#/components/schemas/PolicyAuthorizationStageV1'
+          required:
+            - id
+            - name
+            - authorization
+          additionalProperties: false
     PolicyLoginStageV1:
       type: object
       properties:
@@ -1489,26 +1510,35 @@ components:
         - expected
       additionalProperties: false
     PolicyLoginExpectationV1:
-      type: object
-      properties:
-        outcome:
-          type: string
-          enum:
-            - allow
-            - deny
-        entitlements:
-          type: array
-          items:
-            type: string
-            enum:
-              - super-admin
-              - project-creator
-              - default-role:viewer
-              - default-role:editor
-              - default-role:manager
-      required:
-        - outcome
-      additionalProperties: false
+      oneOf:
+        - type: object
+          properties:
+            outcome:
+              type: string
+              enum:
+                - allow
+            entitlements:
+              type: array
+              items:
+                type: string
+                enum:
+                  - super-admin
+                  - project-creator
+                  - default-role:viewer
+                  - default-role:editor
+                  - default-role:manager
+          required:
+            - outcome
+          additionalProperties: false
+        - type: object
+          properties:
+            outcome:
+              type: string
+              enum:
+                - deny
+          required:
+            - outcome
+          additionalProperties: false
     PolicyAuthorizationStageV1:
       type: object
       properties:

--- a/packages/api/openapi.yaml
+++ b/packages/api/openapi.yaml
@@ -1098,6 +1098,678 @@ components:
       required:
         - default_role
         - super_admins
+    PolicyAnalyzerMetadata:
+      type: object
+      properties:
+        schema_version:
+          type: number
+          enum:
+            - 1
+        max_cases:
+          type: integer
+          exclusiveMinimum: 0
+        capabilities:
+          type: object
+          properties:
+            login_policy:
+              type: boolean
+            resource_security:
+              type: boolean
+            live_self_context:
+              type: boolean
+          required:
+            - login_policy
+            - resource_security
+            - live_self_context
+          additionalProperties: false
+        entitlements:
+          type: array
+          items:
+            type: string
+            enum:
+              - super-admin
+              - project-creator
+              - default-role:viewer
+              - default-role:editor
+              - default-role:manager
+        classification_order:
+          type: array
+          items:
+            type: string
+        actions:
+          type: array
+          items:
+            type: object
+            properties:
+              action:
+                type: string
+                enum:
+                  - project.create
+                  - admin.access
+                  - org-integration.manage
+                  - audit.global.read
+                  - project.read
+                  - project.update
+                  - project.delete
+                  - project.members.manage
+                  - project.events.read
+                  - project.alerts.manage
+                  - notebook.write
+                  - notebook.manage
+                  - integration.read
+                  - integration.use
+                  - integration.manage
+                  - change-request.publish
+                  - security-labels.raise
+                  - security-labels.lower
+                  - session.attach
+                  - session.stop
+                  - session.surface
+                  - session.proxy
+                  - session.start
+              scope:
+                type: string
+                enum:
+                  - deployment
+                  - project
+                  - session
+                  - session-start
+              minimum_role:
+                type:
+                  - string
+                  - 'null'
+                enum:
+                  - viewer
+                  - editor
+                  - manager
+                  - admin
+                  - null
+              denied_as:
+                type:
+                  - string
+                  - 'null'
+                enum:
+                  - not-found
+                  - forbidden
+                  - null
+              requires_super_admin:
+                type: boolean
+            required:
+              - action
+              - scope
+              - minimum_role
+              - denied_as
+              - requires_super_admin
+            additionalProperties: false
+      required:
+        - schema_version
+        - max_cases
+        - capabilities
+        - entitlements
+        - classification_order
+        - actions
+      additionalProperties: false
+    PolicySuiteResult:
+      type: object
+      properties:
+        valid:
+          type: boolean
+        summary:
+          $ref: '#/components/schemas/PolicySuiteSummary'
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyCaseResult'
+      required:
+        - valid
+        - summary
+        - cases
+      additionalProperties: false
+    PolicySuiteSummary:
+      type: object
+      properties:
+        case_count:
+          type: integer
+          minimum: 0
+        passed:
+          type: integer
+          minimum: 0
+        failed:
+          type: integer
+          minimum: 0
+      required:
+        - case_count
+        - passed
+        - failed
+      additionalProperties: false
+    PolicyCaseResult:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        valid:
+          type: boolean
+        login:
+          $ref: '#/components/schemas/PolicyLoginResult'
+        authorization:
+          $ref: '#/components/schemas/PolicyAuthorizationResult'
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              stage:
+                type: string
+                enum:
+                  - login
+                  - authorization
+              code:
+                type: string
+            required:
+              - stage
+              - code
+            additionalProperties: false
+      required:
+        - id
+        - name
+        - valid
+        - login
+        - authorization
+        - errors
+      additionalProperties: false
+    PolicyLoginResult:
+      type:
+        - object
+        - 'null'
+      properties:
+        outcome:
+          type: string
+          enum:
+            - allow
+            - deny
+            - timeout
+            - error
+            - invalid
+            - unavailable
+        duration_ms:
+          type: number
+          minimum: 0
+        entitlements:
+          type: array
+          items:
+            type: string
+            enum:
+              - super-admin
+              - project-creator
+              - default-role:viewer
+              - default-role:editor
+              - default-role:manager
+        reason:
+          type: string
+        problem:
+          type: string
+        assertion:
+          $ref: '#/components/schemas/PolicyAssertionResult'
+      required:
+        - outcome
+        - duration_ms
+        - entitlements
+        - assertion
+      additionalProperties: false
+    PolicyAssertionResult:
+      type: object
+      properties:
+        passed:
+          type: boolean
+        expected:
+          type: object
+          additionalProperties: {}
+      required:
+        - passed
+        - expected
+      additionalProperties: false
+    PolicyAuthorizationResult:
+      type:
+        - object
+        - 'null'
+      properties:
+        decision:
+          $ref: '#/components/schemas/PolicyAuthorizationDecision'
+        presentation:
+          type: string
+          enum:
+            - allowed
+            - forbidden
+            - not-found
+        trace:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyAuthorizationTraceStep'
+        assertion:
+          $ref: '#/components/schemas/PolicyAssertionResult'
+      required:
+        - decision
+        - presentation
+        - trace
+        - assertion
+      additionalProperties: false
+    PolicyAuthorizationDecision:
+      type: object
+      properties:
+        allowed:
+          type: boolean
+        role:
+          type:
+            - string
+            - 'null'
+          enum:
+            - viewer
+            - editor
+            - manager
+            - admin
+            - null
+        category:
+          type: string
+          enum:
+            - lifecycle
+            - visibility
+            - role
+            - session
+            - standing
+            - constraint
+        constraint_reason:
+          type: string
+          enum:
+            - missing-context
+            - constraint
+            - unavailable
+      required:
+        - allowed
+        - role
+      additionalProperties: false
+    PolicyAuthorizationTraceStep:
+      type: object
+      properties:
+        stage:
+          type: string
+          enum:
+            - action
+            - lifecycle
+            - role
+            - standing
+            - session
+            - constraint
+            - final
+        status:
+          type: string
+          enum:
+            - passed
+            - failed
+            - skipped
+        code:
+          type: string
+        details:
+          type: object
+          additionalProperties: {}
+      required:
+        - stage
+        - status
+        - code
+      additionalProperties: false
+    PolicySuiteV1:
+      type: object
+      properties:
+        schema_version:
+          type: number
+          enum:
+            - 1
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        cases:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyCaseV1'
+          minItems: 1
+          maxItems: 25
+      required:
+        - schema_version
+        - cases
+      additionalProperties: false
+    PolicyCaseV1:
+      type: object
+      properties:
+        id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        name:
+          type: string
+          minLength: 1
+          maxLength: 200
+        login:
+          $ref: '#/components/schemas/PolicyLoginStageV1'
+        authorization:
+          $ref: '#/components/schemas/PolicyAuthorizationStageV1'
+      required:
+        - id
+        - name
+      additionalProperties: false
+    PolicyLoginStageV1:
+      type: object
+      properties:
+        identity:
+          type: object
+          properties:
+            id:
+              type: string
+              minLength: 1
+            email:
+              type: string
+              minLength: 3
+              maxLength: 320
+          required:
+            - id
+            - email
+          additionalProperties: false
+        id_token_claims:
+          type: object
+          additionalProperties: {}
+        user_info_claims:
+          type: object
+          additionalProperties: {}
+        expected:
+          $ref: '#/components/schemas/PolicyLoginExpectationV1'
+      required:
+        - identity
+        - id_token_claims
+        - expected
+      additionalProperties: false
+    PolicyLoginExpectationV1:
+      type: object
+      properties:
+        outcome:
+          type: string
+          enum:
+            - allow
+            - deny
+        entitlements:
+          type: array
+          items:
+            type: string
+            enum:
+              - super-admin
+              - project-creator
+              - default-role:viewer
+              - default-role:editor
+              - default-role:manager
+      required:
+        - outcome
+      additionalProperties: false
+    PolicyAuthorizationStageV1:
+      type: object
+      properties:
+        subject:
+          type: object
+          properties:
+            id:
+              type: string
+              minLength: 1
+            email:
+              type: string
+              minLength: 3
+              maxLength: 320
+            entitlement_source:
+              type: string
+              enum:
+                - explicit
+                - login
+            entitlements:
+              type: array
+              items:
+                type: string
+                enum:
+                  - super-admin
+                  - project-creator
+                  - default-role:viewer
+                  - default-role:editor
+                  - default-role:manager
+          required:
+            - id
+            - email
+            - entitlement_source
+          additionalProperties: false
+        action:
+          type: string
+          enum:
+            - project.create
+            - admin.access
+            - org-integration.manage
+            - audit.global.read
+            - project.read
+            - project.update
+            - project.delete
+            - project.members.manage
+            - project.events.read
+            - project.alerts.manage
+            - notebook.write
+            - notebook.manage
+            - integration.read
+            - integration.use
+            - integration.manage
+            - change-request.publish
+            - security-labels.raise
+            - security-labels.lower
+            - session.attach
+            - session.stop
+            - session.surface
+            - session.proxy
+            - session.start
+        resource:
+          $ref: '#/components/schemas/PolicyAuthorizationResourceV1'
+        context:
+          $ref: '#/components/schemas/PolicyAuthorizationContextV1'
+        expected:
+          type: object
+          properties:
+            allowed:
+              type: boolean
+            denial_category:
+              type: string
+              enum:
+                - lifecycle
+                - visibility
+                - role
+                - session
+                - standing
+                - constraint
+          required:
+            - allowed
+          additionalProperties: false
+      required:
+        - subject
+        - action
+        - resource
+        - context
+        - expected
+      additionalProperties: false
+    PolicyAuthorizationResourceV1:
+      type: object
+      properties:
+        source:
+          type: string
+          enum:
+            - stored
+            - synthetic
+        kind:
+          type: string
+          enum:
+            - deployment
+            - project
+            - session
+            - session-start
+        project_id:
+          type: string
+        notebook_id:
+          type: string
+        session_id:
+          type: string
+        project:
+          type: object
+          properties:
+            owner:
+              type: string
+              minLength: 1
+            members:
+              type: array
+              items:
+                type: object
+                properties:
+                  user_id:
+                    type: string
+                    minLength: 1
+                  email:
+                    type: string
+                    minLength: 3
+                    maxLength: 320
+                  role:
+                    type: string
+                    enum:
+                      - viewer
+                      - editor
+                      - manager
+                      - admin
+                required:
+                  - role
+                additionalProperties: false
+              maxItems: 500
+            status:
+              type: string
+              enum:
+                - active
+                - deleted
+              default: active
+            security_labels:
+              type: object
+              properties:
+                classification:
+                  type: string
+                  pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,63}$
+                compartments:
+                  type: array
+                  items:
+                    type: string
+                    pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,63}$
+                  maxItems: 64
+              required:
+                - classification
+                - compartments
+              additionalProperties: false
+          required:
+            - owner
+            - members
+          additionalProperties: false
+        notebook_labels:
+          type: object
+          properties:
+            classification:
+              type: string
+              pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,63}$
+            compartments:
+              type: array
+              items:
+                type: string
+                pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,63}$
+              maxItems: 64
+          required:
+            - classification
+            - compartments
+          additionalProperties: false
+        session:
+          type: object
+          properties:
+            mode:
+              type: string
+              enum:
+                - edit
+                - app
+            ephemeral:
+              type: boolean
+            user_id:
+              type: string
+              minLength: 1
+            editor_sandbox_sharing:
+              type: string
+              enum:
+                - shared
+                - exclusive
+          required:
+            - user_id
+          additionalProperties: false
+        mode:
+          type: string
+          enum:
+            - edit
+            - app
+      required:
+        - source
+        - kind
+      additionalProperties: false
+    PolicyAuthorizationContextV1:
+      oneOf:
+        - type: object
+          properties:
+            mode:
+              type: string
+              enum:
+                - live-self
+          required:
+            - mode
+          additionalProperties: false
+        - type: object
+          properties:
+            mode:
+              type: string
+              enum:
+                - synthetic
+            value:
+              type:
+                - object
+                - 'null'
+              properties:
+                schemaVersion:
+                  type: number
+                  enum:
+                    - 1
+                classification:
+                  type: string
+                  pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,63}$
+                compartments:
+                  type: array
+                  items:
+                    type: string
+                    pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,63}$
+                  maxItems: 64
+                policyVersion:
+                  type: string
+                  pattern: ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,63}$
+                expiresAt:
+                  type: string
+                  format: date-time
+              required:
+                - schemaVersion
+                - classification
+                - compartments
+                - policyVersion
+                - expiresAt
+              additionalProperties: false
+          required:
+            - mode
+            - value
+          additionalProperties: false
     WorkspaceItem:
       type: object
       properties:
@@ -5790,6 +6462,149 @@ paths:
                       - true
                   data:
                     $ref: '#/components/schemas/DeploymentConfig'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/admin/policy-analyzer/metadata:
+    get:
+      operationId: admin.policyAnalyzer.metadata
+      tags:
+        - Admin
+      summary: Describe policy analyzer inputs
+      security: *a2
+      responses:
+        '200':
+          description: Policy analyzer metadata
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/PolicyAnalyzerMetadata'
+                required:
+                  - success
+                  - data
+        '401':
+          description: Authentication required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Access forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body too large
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '503':
+          description: Service unavailable
+          headers:
+            Retry-After:
+              schema:
+                type: string
+                description: Seconds to wait before retrying.
+                example: '5'
+              required: true
+              description: Seconds to wait before retrying.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /api/v1/admin/policy-analyzer/evaluate:
+    post:
+      operationId: admin.policyAnalyzer.evaluate
+      x-cli-hidden: true
+      tags:
+        - Admin
+      summary: Evaluate a policy test suite
+      security: *a2
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PolicySuiteV1'
+      responses:
+        '200':
+          description: Policy analysis results
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: '#/components/schemas/PolicySuiteResult'
                 required:
                   - success
                   - data

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -1,8 +1,10 @@
 import type { Hono, MiddlewareHandler } from 'hono';
 import type {
 	ResourceSecurityPolicy,
+	AuthenticatedPrincipal,
 	Authenticator,
 	AssignableRole,
+	AuthEntitlement,
 	AuthUser,
 	Bucket,
 	BucketConfig,
@@ -26,6 +28,7 @@ import type {
 	SourceControlRegistry,
 	ViewerMode,
 	WorkloadIdentityIssuer,
+	UserId,
 } from '@marimo-hub/core';
 
 /** The service bundle produced by `createServices(bucket)` in @marimo-hub/core. */
@@ -285,6 +288,25 @@ export interface ConfigSummary {
 	}[];
 }
 
+export type LoginPolicyAnalysisResult = { durationMs: number } & (
+	| { outcome: 'allow'; entitlements: readonly AuthEntitlement[] }
+	| { outcome: 'deny'; reason?: string }
+	| { outcome: 'timeout' }
+	| { outcome: 'error' }
+	| { outcome: 'invalid'; problem: string }
+);
+
+export interface PolicyAnalyzerCapability {
+	loginPolicy?: {
+		evaluate(input: {
+			identity: { id: UserId; email: string };
+			idTokenClaims: Record<string, unknown>;
+			userInfoClaims?: Record<string, unknown>;
+		}): Promise<LoginPolicyAnalysisResult>;
+	};
+	classificationOrder: readonly string[];
+}
+
 export interface BackgroundTaskScheduler {
 	defer(task: Promise<unknown>): void;
 }
@@ -343,6 +365,8 @@ export interface ApiDeps {
 	 * projects and notebooks fail closed without them.
 	 */
 	resourceSecurity?: ResourceSecurityPolicy;
+	/** Optional policy-analysis adapters and safe configuration metadata. */
+	policyAnalyzer?: PolicyAnalyzerCapability;
 	/**
 	 * Probe downstream deps (storage/auth/compute/WIF). Built by `@marimo-hub/config`;
 	 * logged once (non-fatal) at boot and served by `GET /api/health?deep=true`.
@@ -422,7 +446,7 @@ export interface ApiDeps {
 export type HonoEnv = {
 	Variables: {
 		deps: ApiDeps;
-		user: AuthUser;
+		user: AuthenticatedPrincipal;
 		/**
 		 * How the request authenticated, decided once in the authN middleware:
 		 * `pat` (a personal access token) or `session` (cookie/SSO). Routes that

--- a/packages/api/src/createApi.ts
+++ b/packages/api/src/createApi.ts
@@ -20,6 +20,7 @@ import {
 import type { ApiDeps, HonoEnv } from './context';
 import { describeError, errorMetadata, logEvent } from './log';
 import adminApp from './routes/admin';
+import policyAnalyzerApp from './routes/policyAnalyzer';
 import { createAiProxy } from './routes/ai';
 import eventsApp from './routes/events';
 import gitSyncApp from './routes/gitSync';
@@ -494,6 +495,7 @@ export function createApi(rawDeps: ApiDeps) {
 	app.route(API_PREFIX, projectAlertsApp);
 	app.route(API_PREFIX, eventsApp);
 	app.route(API_PREFIX, adminApp);
+	app.route(API_PREFIX, policyAnalyzerApp);
 	app.route(API_PREFIX, notebooksApp);
 	app.route(API_PREFIX, changeRequestsApp);
 	app.route(API_PREFIX, sessionsApp);

--- a/packages/api/src/routes/policyAnalyzer.test.ts
+++ b/packages/api/src/routes/policyAnalyzer.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest';
+import { LocalResourceConstraintPolicy } from '@marimo-hub/core';
+import type { Authenticator } from '@marimo-hub/core';
+import { ACTOR } from '@marimo-hub/core/testing';
+import { createInitializedBucket, createTestApi, expectError, expectOk } from '../testing';
+
+function authorizationCase(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'case-1',
+		name: 'Owner can read',
+		authorization: {
+			subject: {
+				id: ACTOR,
+				email: `${ACTOR}@example.com`,
+				entitlement_source: 'explicit',
+				entitlements: [],
+			},
+			action: 'project.read',
+			resource: {
+				source: 'synthetic',
+				kind: 'project',
+				project: { owner: ACTOR, members: [], status: 'active' },
+			},
+			context: { mode: 'synthetic', value: null },
+			expected: { allowed: true },
+			...overrides,
+		},
+	};
+}
+
+describe('policy analyzer routes', () => {
+	it('requires super-admin standing', async () => {
+		const { request } = createTestApi();
+		await expectError(await request('GET', '/admin/policy-analyzer/metadata'), 403, 'FORBIDDEN');
+	});
+
+	it.each([
+		['GET', '/admin/policy-analyzer/metadata', undefined],
+		[
+			'POST',
+			'/admin/policy-analyzer/evaluate',
+			{ schema_version: 1, cases: [authorizationCase()] },
+		],
+	] as const)('rejects personal access tokens on %s %s', async (method, path, body) => {
+		const authenticator: Authenticator = {
+			authenticate: async () => ({
+				id: ACTOR,
+				email: `${ACTOR}@example.com`,
+				credential: { kind: 'personal-access-token', id: 'tok-policy-analysis' },
+			}),
+		};
+		const { request } = createTestApi({
+			deps: { authenticator, policy: { superAdmins: [ACTOR] } },
+		});
+		const error = await expectError(await request(method, path, body), 403, 'FORBIDDEN');
+		expect(error.message).toContain('Personal access tokens cannot');
+	});
+
+	it('returns the configured action and entitlement metadata', async () => {
+		const { request } = createTestApi({
+			deps: {
+				policy: { superAdmins: [ACTOR] },
+				policyAnalyzer: { classificationOrder: ['LEVEL_1', 'LEVEL_2'] },
+			},
+		});
+		const data = await expectOk<{
+			classification_order: string[];
+			entitlements: string[];
+			actions: { action: string }[];
+		}>(await request('GET', '/admin/policy-analyzer/metadata'));
+		expect(data.classification_order).toEqual(['LEVEL_1', 'LEVEL_2']);
+		expect(data.entitlements).toContain('super-admin');
+		expect(data.actions).toContainEqual(expect.objectContaining({ action: 'project.read' }));
+	});
+
+	it('evaluates a synthetic authorization case and returns a bounded trace', async () => {
+		const { request } = createTestApi({ deps: { policy: { superAdmins: [ACTOR] } } });
+		const data = await expectOk<any>(
+			await request('POST', '/admin/policy-analyzer/evaluate', {
+				schema_version: 1,
+				cases: [authorizationCase()],
+			}),
+		);
+		expect(data).toMatchObject({
+			valid: true,
+			summary: { case_count: 1, passed: 1, failed: 0 },
+			cases: [
+				{
+					valid: true,
+					authorization: {
+						decision: { allowed: true, role: 'admin' },
+						assertion: { passed: true },
+					},
+				},
+			],
+		});
+		expect(data.cases[0].authorization.trace).toContainEqual(
+			expect.objectContaining({ stage: 'role', code: 'effective_role_static-super-admin' }),
+		);
+	});
+
+	it('links normalized login entitlements into authorization', async () => {
+		const { deps, request } = createTestApi({
+			deps: {
+				policy: { superAdmins: [ACTOR], projectCreationRestricted: true },
+				policyAnalyzer: {
+					classificationOrder: [],
+					loginPolicy: {
+						evaluate: async () => ({
+							outcome: 'allow',
+							entitlements: ['project-creator'],
+							durationMs: 2,
+						}),
+					},
+				},
+			},
+		});
+		const data = await expectOk<any>(
+			await request('POST', '/admin/policy-analyzer/evaluate', {
+				schema_version: 1,
+				cases: [
+					{
+						id: 'linked',
+						name: 'Creator entitlement',
+						login: {
+							identity: { id: 'new-user', email: 'new@example.com' },
+							id_token_claims: { group: 'creators' },
+							expected: { outcome: 'allow', entitlements: ['project-creator'] },
+						},
+						authorization: {
+							subject: {
+								id: 'new-user',
+								email: 'new@example.com',
+								entitlement_source: 'login',
+							},
+							action: 'project.create',
+							resource: { source: 'synthetic', kind: 'deployment' },
+							context: { mode: 'synthetic', value: null },
+							expected: { allowed: true },
+						},
+					},
+				],
+			}),
+		);
+		expect(data.valid).toBe(true);
+		expect(data.cases[0].login.entitlements).toEqual(['project-creator']);
+		expect(JSON.stringify(data)).not.toContain('creators');
+		const events = await deps.services.events.getEvents(new Date().toISOString().slice(0, 10));
+		const analysisEvents = events.filter((event) => event.event === 'policy.analysis.run');
+		expect(analysisEvents).toHaveLength(1);
+		expect(analysisEvents[0]).toMatchObject({
+			actor: ACTOR,
+			case_count: 1,
+			stages: ['login', 'authorization'],
+			actions: ['project.create'],
+			project_ids: [],
+			valid: true,
+			passed: 1,
+			failed: 0,
+		});
+		const auditJson = JSON.stringify(analysisEvents[0]);
+		expect(auditJson).not.toContain('creators');
+		expect(auditJson).not.toContain('project-creator');
+		expect(auditJson).not.toContain('new@example.com');
+	});
+
+	it('treats an expected login denial as valid and skips linked authorization', async () => {
+		const { request } = createTestApi({
+			deps: {
+				policy: { superAdmins: [ACTOR] },
+				policyAnalyzer: {
+					classificationOrder: [],
+					loginPolicy: {
+						evaluate: async () => ({ outcome: 'deny', reason: 'not_eligible', durationMs: 2 }),
+					},
+				},
+			},
+		});
+		const data = await expectOk<any>(
+			await request('POST', '/admin/policy-analyzer/evaluate', {
+				schema_version: 1,
+				cases: [
+					{
+						id: 'expected-denial',
+						name: 'Ineligible subject',
+						login: {
+							identity: { id: 'new-user', email: 'new@example.com' },
+							id_token_claims: {},
+							expected: { outcome: 'deny' },
+						},
+						authorization: {
+							subject: {
+								id: 'new-user',
+								email: 'new@example.com',
+								entitlement_source: 'login',
+							},
+							action: 'project.create',
+							resource: { source: 'synthetic', kind: 'deployment' },
+							context: { mode: 'synthetic', value: null },
+							expected: { allowed: false },
+						},
+					},
+				],
+			}),
+		);
+		expect(data).toMatchObject({
+			valid: true,
+			cases: [
+				{
+					valid: true,
+					login: { outcome: 'deny', assertion: { passed: true } },
+					authorization: null,
+					errors: [],
+				},
+			],
+		});
+	});
+
+	it('does not resolve live context for another identity', async () => {
+		const { request } = createTestApi({ deps: { policy: { superAdmins: [ACTOR] } } });
+		const data = await expectOk<any>(
+			await request('POST', '/admin/policy-analyzer/evaluate', {
+				schema_version: 1,
+				cases: [
+					authorizationCase({
+						subject: {
+							id: 'other-user',
+							email: 'other@example.com',
+							entitlement_source: 'explicit',
+						},
+						context: { mode: 'live-self' },
+					}),
+				],
+			}),
+		);
+		expect(data.valid).toBe(false);
+		expect(data.cases[0].errors).toEqual([
+			{ stage: 'authorization', code: 'live_context_requires_self' },
+		]);
+	});
+
+	it('checks the actual notebook labels before analyzing a stored session', async () => {
+		const bucket = await createInitializedBucket();
+		const setup = createTestApi({ bucket });
+		const project = await setup.deps.services.projects.createProject(
+			{ name: 'Stored policy project', description: '' },
+			ACTOR,
+		);
+		const notebook = await setup.deps.services.notebooks.createNotebook(
+			project.id,
+			{ title: 'Restricted', description: '', code: 'import marimo' },
+			ACTOR,
+		);
+		await setup.deps.services.notebooks.setSecurityLabels(
+			project.id,
+			notebook.id,
+			{ classification: 'LEVEL_2', compartments: [] },
+			ACTOR,
+		);
+		const session = await setup.deps.services.sessions.createSession({
+			project_id: project.id,
+			notebook_id: notebook.id,
+			user_id: ACTOR,
+		});
+		const { request } = createTestApi({
+			bucket,
+			deps: {
+				policy: { superAdmins: [ACTOR] },
+				resourceSecurity: {
+					constraints: new LocalResourceConstraintPolicy({
+						classificationOrder: ['LEVEL_1', 'LEVEL_2'],
+					}),
+				},
+			},
+		});
+		const data = await expectOk<any>(
+			await request('POST', '/admin/policy-analyzer/evaluate', {
+				schema_version: 1,
+				cases: [
+					authorizationCase({
+						action: 'session.attach',
+						resource: {
+							source: 'stored',
+							kind: 'session',
+							project_id: project.id,
+							session_id: session.session_id,
+						},
+					}),
+				],
+			}),
+		);
+		expect(data.valid).toBe(false);
+		expect(data.cases[0].errors).toEqual([
+			{ stage: 'authorization', code: 'stored_resource_inaccessible' },
+		]);
+	});
+});

--- a/packages/api/src/routes/policyAnalyzer.test.ts
+++ b/packages/api/src/routes/policyAnalyzer.test.ts
@@ -164,6 +164,87 @@ describe('policy analyzer routes', () => {
 		expect(auditJson).not.toContain('new@example.com');
 	});
 
+	it('does not assert login entitlements when the expectation omits them', async () => {
+		const { request } = createTestApi({
+			deps: {
+				policy: { superAdmins: [ACTOR] },
+				policyAnalyzer: {
+					classificationOrder: [],
+					loginPolicy: {
+						evaluate: async () => ({
+							outcome: 'allow',
+							entitlements: ['project-creator'],
+							durationMs: 2,
+						}),
+					},
+				},
+			},
+		});
+		const data = await expectOk<any>(
+			await request('POST', '/admin/policy-analyzer/evaluate', {
+				schema_version: 1,
+				cases: [
+					{
+						id: 'outcome-only',
+						name: 'Allow without entitlement assertion',
+						login: {
+							identity: { id: 'new-user', email: 'new@example.com' },
+							id_token_claims: {},
+							expected: { outcome: 'allow' },
+						},
+					},
+				],
+			}),
+		);
+		expect(data).toMatchObject({
+			valid: true,
+			cases: [
+				{
+					valid: true,
+					login: {
+						outcome: 'allow',
+						entitlements: ['project-creator'],
+						assertion: { passed: true },
+					},
+				},
+			],
+		});
+	});
+
+	it('rejects entitlement expectations for a denied login', async () => {
+		const { request } = createTestApi({ deps: { policy: { superAdmins: [ACTOR] } } });
+		await expectError(
+			await request('POST', '/admin/policy-analyzer/evaluate', {
+				schema_version: 1,
+				cases: [
+					{
+						id: 'invalid-denial',
+						name: 'Denied login with entitlements',
+						login: {
+							identity: { id: 'new-user', email: 'new@example.com' },
+							id_token_claims: {},
+							expected: { outcome: 'deny', entitlements: [] },
+						},
+					},
+				],
+			}),
+			422,
+			'VALIDATION_ERROR',
+		);
+	});
+
+	it('rejects a case without a login or authorization stage', async () => {
+		const { request } = createTestApi({ deps: { policy: { superAdmins: [ACTOR] } } });
+		await expectError(
+			await request('POST', '/admin/policy-analyzer/evaluate', {
+				schema_version: 1,
+				cases: [{ id: 'empty', name: 'No stages' }],
+			}),
+			422,
+			'VALIDATION_ERROR',
+		);
+	});
+
 	it('treats an expected login denial as valid and skips linked authorization', async () => {
 		const { request } = createTestApi({
 			deps: {

--- a/packages/api/src/routes/policyAnalyzer.ts
+++ b/packages/api/src/routes/policyAnalyzer.ts
@@ -1,0 +1,621 @@
+import { createRoute, z } from '@hono/zod-openapi';
+import {
+	ACTION_RULES,
+	AUTH_ENTITLEMENTS,
+	AUTHORIZATION_ACTIONS,
+	createProjectId,
+	NotebookId,
+	ProjectId,
+	ProjectSchema,
+	NotFoundError,
+	SECURITY_LABEL_TOKEN,
+	SessionId,
+	SESSION_MODES,
+	SubjectSecurityContextSchema,
+	UserId,
+	validateSubjectSecurityContext,
+} from '@marimo-hub/core';
+import type {
+	AuthEntitlement,
+	AuthorizationService,
+	AuthorizationDecision,
+	AuthorizationResource,
+	AuthorizationSubject,
+	Project,
+} from '@marimo-hub/core';
+import {
+	assertSessionAuthenticated,
+	assertSuperAdmin,
+	authorizationService,
+	commonErrors,
+	createApp,
+	errorResponses,
+	jsonContent,
+	loadAuthorizedNotebook,
+	loadVisibleProject,
+	SESSION_ONLY_SECURITY,
+} from '../shared';
+import type { ApiDeps, HonoEnv, LoginPolicyAnalysisResult } from '../context';
+import { appendAudit } from '../log';
+
+const MAX_POLICY_CASES = 25;
+
+const EntitlementSchema = z.enum(AUTH_ENTITLEMENTS);
+const AuthorizationActionSchema = z.enum(AUTHORIZATION_ACTIONS);
+const SecurityLabelsSchema = z.strictObject({
+	classification: z.string().regex(SECURITY_LABEL_TOKEN),
+	compartments: z.array(z.string().regex(SECURITY_LABEL_TOKEN)).max(64),
+});
+
+const ExpectedLoginSchema = z
+	.strictObject({
+		outcome: z.enum(['allow', 'deny']),
+		entitlements: z.array(EntitlementSchema).optional(),
+	})
+	.openapi('PolicyLoginExpectationV1');
+
+const LoginStageSchema = z
+	.strictObject({
+		identity: z.strictObject({ id: z.string().min(1), email: z.string().min(3).max(320) }),
+		id_token_claims: z.record(z.string(), z.unknown()),
+		user_info_claims: z.record(z.string(), z.unknown()).optional(),
+		expected: ExpectedLoginSchema,
+	})
+	.openapi('PolicyLoginStageV1');
+
+const SyntheticMemberSchema = z
+	.strictObject({
+		user_id: z.string().min(1).optional(),
+		email: z.string().min(3).max(320).optional(),
+		role: z.enum(['viewer', 'editor', 'manager', 'admin']),
+	})
+	.refine((member) => (member.user_id === undefined) !== (member.email === undefined), {
+		message: 'A member must contain one user_id or one email.',
+	});
+
+const SyntheticProjectSchema = z.strictObject({
+	owner: z.string().min(1),
+	members: z.array(SyntheticMemberSchema).max(500),
+	status: z.enum(['active', 'deleted']).default('active'),
+	security_labels: SecurityLabelsSchema.optional(),
+});
+
+const AnalysisResourceSchema = z
+	.strictObject({
+		source: z.enum(['stored', 'synthetic']),
+		kind: z.enum(['deployment', 'project', 'session', 'session-start']),
+		project_id: z.string().optional(),
+		notebook_id: z.string().optional(),
+		session_id: z.string().optional(),
+		project: SyntheticProjectSchema.optional(),
+		notebook_labels: SecurityLabelsSchema.optional(),
+		session: z
+			.strictObject({
+				mode: z.enum(SESSION_MODES).optional(),
+				ephemeral: z.boolean().optional(),
+				user_id: z.string().min(1),
+				editor_sandbox_sharing: z.enum(['shared', 'exclusive']).optional(),
+			})
+			.optional(),
+		mode: z.enum(SESSION_MODES).optional(),
+	})
+	.openapi('PolicyAuthorizationResourceV1');
+
+const AnalysisContextSchema = z
+	.discriminatedUnion('mode', [
+		z.strictObject({ mode: z.literal('live-self') }),
+		z.strictObject({
+			mode: z.literal('synthetic'),
+			value: SubjectSecurityContextSchema.nullable(),
+		}),
+	])
+	.openapi('PolicyAuthorizationContextV1');
+
+const AuthorizationStageSchema = z
+	.strictObject({
+		subject: z.strictObject({
+			id: z.string().min(1),
+			email: z.string().min(3).max(320),
+			entitlement_source: z.enum(['explicit', 'login']),
+			entitlements: z.array(EntitlementSchema).optional(),
+		}),
+		action: AuthorizationActionSchema,
+		resource: AnalysisResourceSchema,
+		context: AnalysisContextSchema,
+		expected: z.strictObject({
+			allowed: z.boolean(),
+			denial_category: z
+				.enum(['lifecycle', 'visibility', 'role', 'session', 'standing', 'constraint'])
+				.optional(),
+		}),
+	})
+	.openapi('PolicyAuthorizationStageV1');
+
+export const PolicyCaseSchema = z
+	.strictObject({
+		id: z.string().min(1).max(128),
+		name: z.string().min(1).max(200),
+		login: LoginStageSchema.optional(),
+		authorization: AuthorizationStageSchema.optional(),
+	})
+	.refine((entry) => entry.login !== undefined || entry.authorization !== undefined, {
+		message: 'A policy case must contain a login or authorization stage.',
+	})
+	.openapi('PolicyCaseV1');
+
+export const PolicySuiteV1Schema = z
+	.strictObject({
+		schema_version: z.literal(1),
+		name: z.string().min(1).max(200).optional(),
+		cases: z.array(PolicyCaseSchema).min(1).max(MAX_POLICY_CASES),
+	})
+	.openapi('PolicySuiteV1');
+
+const AssertionSchema = z
+	.strictObject({
+		passed: z.boolean(),
+		expected: z.record(z.string(), z.unknown()),
+	})
+	.openapi('PolicyAssertionResult');
+
+const LoginResultSchema = z
+	.strictObject({
+		outcome: z.enum(['allow', 'deny', 'timeout', 'error', 'invalid', 'unavailable']),
+		duration_ms: z.number().nonnegative(),
+		entitlements: z.array(EntitlementSchema),
+		reason: z.string().optional(),
+		problem: z.string().optional(),
+		assertion: AssertionSchema,
+	})
+	.openapi('PolicyLoginResult');
+
+const AuthorizationDecisionSchema = z
+	.strictObject({
+		allowed: z.boolean(),
+		role: z.enum(['viewer', 'editor', 'manager', 'admin']).nullable(),
+		category: z
+			.enum(['lifecycle', 'visibility', 'role', 'session', 'standing', 'constraint'])
+			.optional(),
+		constraint_reason: z.enum(['missing-context', 'constraint', 'unavailable']).optional(),
+	})
+	.openapi('PolicyAuthorizationDecision');
+
+const AuthorizationTraceStepSchema = z
+	.strictObject({
+		stage: z.enum(['action', 'lifecycle', 'role', 'standing', 'session', 'constraint', 'final']),
+		status: z.enum(['passed', 'failed', 'skipped']),
+		code: z.string(),
+		details: z.record(z.string(), z.unknown()).optional(),
+	})
+	.openapi('PolicyAuthorizationTraceStep');
+
+const AuthorizationResultSchema = z
+	.strictObject({
+		decision: AuthorizationDecisionSchema,
+		presentation: z.enum(['allowed', 'forbidden', 'not-found']),
+		trace: z.array(AuthorizationTraceStepSchema),
+		assertion: AssertionSchema,
+	})
+	.openapi('PolicyAuthorizationResult');
+
+const PolicyCaseResultSchema = z
+	.strictObject({
+		id: z.string(),
+		name: z.string(),
+		valid: z.boolean(),
+		login: LoginResultSchema.nullable(),
+		authorization: AuthorizationResultSchema.nullable(),
+		errors: z.array(
+			z.strictObject({ stage: z.enum(['login', 'authorization']), code: z.string() }),
+		),
+	})
+	.openapi('PolicyCaseResult');
+
+const PolicySuiteSummarySchema = z
+	.strictObject({
+		case_count: z.number().int().nonnegative(),
+		passed: z.number().int().nonnegative(),
+		failed: z.number().int().nonnegative(),
+	})
+	.openapi('PolicySuiteSummary');
+
+const PolicySuiteResultSchema = z
+	.strictObject({
+		valid: z.boolean(),
+		summary: PolicySuiteSummarySchema,
+		cases: z.array(PolicyCaseResultSchema),
+	})
+	.openapi('PolicySuiteResult');
+
+const PolicyAnalyzerMetadataSchema = z
+	.strictObject({
+		schema_version: z.literal(1),
+		max_cases: z.number().int().positive(),
+		capabilities: z.strictObject({
+			login_policy: z.boolean(),
+			resource_security: z.boolean(),
+			live_self_context: z.boolean(),
+		}),
+		entitlements: z.array(EntitlementSchema),
+		classification_order: z.array(z.string()),
+		actions: z.array(
+			z.strictObject({
+				action: AuthorizationActionSchema,
+				scope: z.enum(['deployment', 'project', 'session', 'session-start']),
+				minimum_role: z.enum(['viewer', 'editor', 'manager', 'admin']).nullable(),
+				denied_as: z.enum(['not-found', 'forbidden']).nullable(),
+				requires_super_admin: z.boolean(),
+			}),
+		),
+	})
+	.openapi('PolicyAnalyzerMetadata');
+
+const getMetadata = createRoute({
+	method: 'get',
+	path: '/admin/policy-analyzer/metadata',
+	operationId: 'admin.policyAnalyzer.metadata',
+	tags: ['Admin'],
+	summary: 'Describe policy analyzer inputs',
+	security: SESSION_ONLY_SECURITY,
+	responses: {
+		200: jsonContent(
+			z.object({ success: z.literal(true), data: PolicyAnalyzerMetadataSchema }),
+			'Policy analyzer metadata',
+		),
+		...commonErrors(),
+		...errorResponses(403),
+	},
+});
+
+const evaluateSuite = createRoute({
+	method: 'post',
+	path: '/admin/policy-analyzer/evaluate',
+	operationId: 'admin.policyAnalyzer.evaluate',
+	'x-cli-hidden': true,
+	tags: ['Admin'],
+	summary: 'Evaluate a policy test suite',
+	security: SESSION_ONLY_SECURITY,
+	request: {
+		body: { content: { 'application/json': { schema: PolicySuiteV1Schema } }, required: true },
+	},
+	responses: {
+		200: jsonContent(
+			z.object({ success: z.literal(true), data: PolicySuiteResultSchema }),
+			'Policy analysis results',
+		),
+		...commonErrors(),
+		...errorResponses(403, 422),
+	},
+});
+
+type PolicyCase = z.infer<typeof PolicyCaseSchema>;
+type LoginStage = NonNullable<PolicyCase['login']>;
+type AuthorizationStage = NonNullable<PolicyCase['authorization']>;
+type PolicyCaseResult = z.infer<typeof PolicyCaseResultSchema>;
+
+function normalizedEntitlements(values: readonly AuthEntitlement[]): AuthEntitlement[] {
+	const held = new Set(values);
+	return AUTH_ENTITLEMENTS.filter((entitlement) => held.has(entitlement));
+}
+
+function loginAssertion(stage: LoginStage, result: LoginPolicyAnalysisResult | undefined): boolean {
+	if (!result || (result.outcome !== 'allow' && result.outcome !== 'deny')) return false;
+	if (result.outcome !== stage.expected.outcome) return false;
+	if (result.outcome === 'deny') return true;
+	return (
+		JSON.stringify(normalizedEntitlements(result.entitlements)) ===
+		JSON.stringify(normalizedEntitlements(stage.expected.entitlements ?? []))
+	);
+}
+
+function loginResponse(stage: LoginStage, result?: LoginPolicyAnalysisResult) {
+	const passed = loginAssertion(stage, result);
+	if (!result) {
+		return {
+			outcome: 'unavailable' as const,
+			duration_ms: 0,
+			entitlements: [] as AuthEntitlement[],
+			assertion: { passed, expected: stage.expected },
+		};
+	}
+	return {
+		outcome: result.outcome,
+		duration_ms: result.durationMs,
+		entitlements: result.outcome === 'allow' ? [...result.entitlements] : [],
+		...('reason' in result && result.reason ? { reason: result.reason } : {}),
+		...('problem' in result ? { problem: result.problem } : {}),
+		assertion: { passed, expected: stage.expected },
+	};
+}
+
+function syntheticProject(input: z.infer<typeof SyntheticProjectSchema>): Project {
+	const now = new Date().toISOString();
+	return ProjectSchema.parse({
+		schema_version: 1,
+		id: createProjectId(),
+		name: 'Synthetic policy project',
+		description: '',
+		owner: input.owner,
+		members: input.members,
+		status: input.status,
+		created_at: now,
+		updated_at: now,
+		tags: [],
+		...(input.security_labels ? { security_labels: input.security_labels } : {}),
+	});
+}
+
+async function storedResource(
+	deps: ApiDeps,
+	caller: HonoEnv['Variables']['user'],
+	stage: AuthorizationStage,
+): Promise<AuthorizationResource> {
+	const input = stage.resource;
+	if (!input.project_id) throw new Error('stored_project_required');
+	const project = await loadVisibleProject(
+		deps.services.projects,
+		ProjectId.parse(input.project_id),
+		caller,
+		deps,
+	);
+	if (input.kind === 'session') {
+		if (!input.session_id) throw new Error('stored_session_required');
+		const session = await deps.services.sessions.getSession(
+			project.id,
+			SessionId.parse(input.session_id),
+		);
+		if (input.notebook_id && NotebookId.parse(input.notebook_id) !== session.notebook_id) {
+			throw new Error('stored_notebook_session_mismatch');
+		}
+		const notebook = await loadAuthorizedNotebook(deps, project, session.notebook_id, caller);
+		return {
+			kind: 'session',
+			project,
+			session,
+			notebookLabels: notebook.meta.security_labels,
+		};
+	}
+	let notebookLabels = input.notebook_labels;
+	if (input.notebook_id) {
+		const notebook = await loadAuthorizedNotebook(
+			deps,
+			project,
+			NotebookId.parse(input.notebook_id),
+			caller,
+		);
+		notebookLabels = notebook.meta.security_labels;
+	}
+	if (input.kind === 'project') return { kind: 'project', project, notebookLabels };
+	if (input.kind === 'session-start') {
+		if (!input.mode) throw new Error('session_mode_required');
+		return { kind: 'session-start', project, mode: input.mode, notebookLabels };
+	}
+	throw new Error('deployment_resource_must_not_be_stored');
+}
+
+function syntheticResource(stage: AuthorizationStage): AuthorizationResource {
+	const input = stage.resource;
+	if (input.kind === 'deployment') return { kind: 'deployment' };
+	if (!input.project) throw new Error('synthetic_project_required');
+	const project = syntheticProject(input.project);
+	if (input.kind === 'project') {
+		return { kind: 'project', project, notebookLabels: input.notebook_labels };
+	}
+	if (input.kind === 'session-start') {
+		if (!input.mode) throw new Error('session_mode_required');
+		return {
+			kind: 'session-start',
+			project,
+			mode: input.mode,
+			notebookLabels: input.notebook_labels,
+		};
+	}
+	if (!input.session) throw new Error('synthetic_session_required');
+	return {
+		kind: 'session',
+		project,
+		session: { ...input.session, user_id: UserId.parse(input.session.user_id) },
+		notebookLabels: input.notebook_labels,
+	};
+}
+
+function decisionResponse(decision: AuthorizationDecision) {
+	return decision.allowed
+		? { allowed: true, role: decision.role }
+		: {
+				allowed: false,
+				role: decision.role,
+				category: decision.category,
+				...(decision.constraintReason ? { constraint_reason: decision.constraintReason } : {}),
+			};
+}
+
+async function evaluateCase(
+	deps: ApiDeps,
+	caller: HonoEnv['Variables']['user'],
+	entry: PolicyCase,
+): Promise<PolicyCaseResult> {
+	const errors: PolicyCaseResult['errors'] = [];
+	let loginEvaluation: LoginPolicyAnalysisResult | undefined;
+	let login = null;
+	if (entry.login) {
+		if (!deps.policyAnalyzer?.loginPolicy) {
+			errors.push({ stage: 'login', code: 'login_policy_unavailable' });
+		} else {
+			try {
+				loginEvaluation = await deps.policyAnalyzer.loginPolicy.evaluate({
+					identity: {
+						id: UserId.parse(entry.login.identity.id),
+						email: entry.login.identity.email,
+					},
+					idTokenClaims: entry.login.id_token_claims,
+					...(entry.login.user_info_claims ? { userInfoClaims: entry.login.user_info_claims } : {}),
+				});
+			} catch {
+				loginEvaluation = { outcome: 'error', durationMs: 0 };
+			}
+			if (loginEvaluation.outcome === 'timeout' || loginEvaluation.outcome === 'error') {
+				errors.push({ stage: 'login', code: `login_policy_${loginEvaluation.outcome}` });
+			}
+			if (loginEvaluation.outcome === 'invalid') {
+				errors.push({ stage: 'login', code: 'login_policy_invalid_result' });
+			}
+		}
+		login = loginResponse(entry.login, loginEvaluation);
+	}
+
+	let authorization = null;
+	if (entry.authorization) {
+		const stage = entry.authorization;
+		const linked = stage.subject.entitlement_source === 'login';
+		if (linked && !entry.login) {
+			errors.push({ stage: 'authorization', code: 'linked_login_stage_required' });
+		} else if (linked && loginEvaluation?.outcome !== 'allow') {
+			authorization = null;
+		} else {
+			try {
+				const entitlements = normalizedEntitlements(
+					linked && loginEvaluation?.outcome === 'allow'
+						? loginEvaluation.entitlements
+						: (stage.subject.entitlements ?? []),
+				);
+				let subject: AuthorizationSubject = {
+					id: UserId.parse(stage.subject.id),
+					email: stage.subject.email,
+					entitlements,
+				};
+				let context: Parameters<AuthorizationService['analyze']>[3];
+				if (stage.context.mode === 'live-self') {
+					if (subject.id !== caller.id || subject.email !== caller.email) {
+						throw new Error('live_context_requires_self');
+					}
+					subject = { ...caller, entitlements };
+					context = { mode: 'live' };
+				} else {
+					const supplied = stage.context.value;
+					const validated = supplied === null ? null : validateSubjectSecurityContext(supplied);
+					if (supplied !== null && validated === null) throw new Error('synthetic_context_invalid');
+					context = { mode: 'synthetic', value: validated };
+				}
+				const resource =
+					stage.resource.source === 'stored'
+						? await storedResource(deps, caller, stage)
+						: syntheticResource(stage);
+				const analysis = await authorizationService(deps).analyze(
+					subject,
+					stage.action,
+					resource,
+					context,
+				);
+				const categoryMatches =
+					stage.expected.denial_category === undefined ||
+					(!analysis.decision.allowed &&
+						analysis.decision.category === stage.expected.denial_category);
+				const passed = analysis.decision.allowed === stage.expected.allowed && categoryMatches;
+				authorization = {
+					decision: decisionResponse(analysis.decision),
+					presentation: analysis.presentation,
+					trace: [...analysis.trace],
+					assertion: { passed, expected: stage.expected },
+				};
+			} catch (error) {
+				errors.push({
+					stage: 'authorization',
+					code:
+						error instanceof NotFoundError
+							? 'stored_resource_inaccessible'
+							: error instanceof Error && /^[a-z][a-z0-9_]+$/.test(error.message)
+								? error.message
+								: 'authorization_analysis_failed',
+				});
+			}
+		}
+	}
+
+	const valid =
+		errors.length === 0 &&
+		(login === null || login.assertion.passed) &&
+		(authorization === null || authorization.assertion.passed);
+	return { id: entry.id, name: entry.name, valid, login, authorization, errors };
+}
+
+const app = createApp();
+
+app.openapi(getMetadata, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	assertSessionAuthenticated(c, 'use the policy analyzer');
+	await assertSuperAdmin(user, deps);
+	return c.json(
+		{
+			success: true,
+			data: {
+				schema_version: 1 as const,
+				max_cases: MAX_POLICY_CASES,
+				capabilities: {
+					login_policy: deps.policyAnalyzer?.loginPolicy !== undefined,
+					resource_security: deps.resourceSecurity !== undefined,
+					live_self_context: deps.resourceSecurity?.subjectContext !== undefined,
+				},
+				entitlements: [...AUTH_ENTITLEMENTS],
+				classification_order: [...(deps.policyAnalyzer?.classificationOrder ?? [])],
+				actions: AUTHORIZATION_ACTIONS.map((action) => {
+					const rule = ACTION_RULES[action];
+					return {
+						action,
+						scope: rule.scope,
+						minimum_role: 'min' in rule ? rule.min : null,
+						denied_as: 'deniedAs' in rule ? rule.deniedAs : null,
+						requires_super_admin: 'requiresSuperAdmin' in rule && rule.requiresSuperAdmin === true,
+					};
+				}),
+			},
+		},
+		200,
+	);
+});
+
+app.openapi(evaluateSuite, async (c) => {
+	const deps = c.get('deps');
+	const user = c.get('user');
+	assertSessionAuthenticated(c, 'use the policy analyzer');
+	await assertSuperAdmin(user, deps);
+	const suite = c.req.valid('json');
+	const cases: PolicyCaseResult[] = [];
+	for (const entry of suite.cases) cases.push(await evaluateCase(deps, user, entry));
+	const passed = cases.filter((entry) => entry.valid).length;
+	const result = {
+		valid: passed === cases.length,
+		summary: { case_count: cases.length, passed, failed: cases.length - passed },
+		cases,
+	};
+	await appendAudit(
+		{ requestId: c.get('requestId'), method: c.req.method, path: c.req.path, userId: user.id },
+		'policy.analysis.run',
+		() =>
+			deps.services.events.append({
+				event: 'policy.analysis.run',
+				actor: user.id,
+				case_count: cases.length,
+				stages: suite.cases.flatMap((entry) => [
+					...(entry.login ? ['login'] : []),
+					...(entry.authorization ? ['authorization'] : []),
+				]),
+				actions: suite.cases.flatMap((entry) =>
+					entry.authorization ? [entry.authorization.action] : [],
+				),
+				project_ids: suite.cases.flatMap((entry) =>
+					entry.authorization?.resource.source === 'stored' &&
+					entry.authorization.resource.project_id
+						? [entry.authorization.resource.project_id]
+						: [],
+				),
+				valid: result.valid,
+				passed,
+				failed: cases.length - passed,
+			}),
+	);
+	return c.json({ success: true, data: result }, 200);
+});
+
+export default app;

--- a/packages/api/src/routes/policyAnalyzer.ts
+++ b/packages/api/src/routes/policyAnalyzer.ts
@@ -48,10 +48,13 @@ const SecurityLabelsSchema = z.strictObject({
 });
 
 const ExpectedLoginSchema = z
-	.strictObject({
-		outcome: z.enum(['allow', 'deny']),
-		entitlements: z.array(EntitlementSchema).optional(),
-	})
+	.discriminatedUnion('outcome', [
+		z.strictObject({
+			outcome: z.literal('allow'),
+			entitlements: z.array(EntitlementSchema).optional(),
+		}),
+		z.strictObject({ outcome: z.literal('deny') }),
+	])
 	.openapi('PolicyLoginExpectationV1');
 
 const LoginStageSchema = z
@@ -131,16 +134,24 @@ const AuthorizationStageSchema = z
 	})
 	.openapi('PolicyAuthorizationStageV1');
 
+const PolicyCaseBaseShape = {
+	id: z.string().min(1).max(128),
+	name: z.string().min(1).max(200),
+};
+
 export const PolicyCaseSchema = z
-	.strictObject({
-		id: z.string().min(1).max(128),
-		name: z.string().min(1).max(200),
-		login: LoginStageSchema.optional(),
-		authorization: AuthorizationStageSchema.optional(),
-	})
-	.refine((entry) => entry.login !== undefined || entry.authorization !== undefined, {
-		message: 'A policy case must contain a login or authorization stage.',
-	})
+	.union([
+		z.strictObject({
+			...PolicyCaseBaseShape,
+			login: LoginStageSchema,
+			authorization: AuthorizationStageSchema.optional(),
+		}),
+		z.strictObject({
+			...PolicyCaseBaseShape,
+			login: LoginStageSchema.optional(),
+			authorization: AuthorizationStageSchema,
+		}),
+	])
 	.openapi('PolicyCaseV1');
 
 export const PolicySuiteV1Schema = z
@@ -301,10 +312,12 @@ function normalizedEntitlements(values: readonly AuthEntitlement[]): AuthEntitle
 function loginAssertion(stage: LoginStage, result: LoginPolicyAnalysisResult | undefined): boolean {
 	if (!result || (result.outcome !== 'allow' && result.outcome !== 'deny')) return false;
 	if (result.outcome !== stage.expected.outcome) return false;
-	if (result.outcome === 'deny') return true;
+	if (stage.expected.outcome === 'deny') return true;
+	if (result.outcome !== 'allow') return false;
+	if (stage.expected.entitlements === undefined) return true;
 	return (
 		JSON.stringify(normalizedEntitlements(result.entitlements)) ===
-		JSON.stringify(normalizedEntitlements(stage.expected.entitlements ?? []))
+		JSON.stringify(normalizedEntitlements(stage.expected.entitlements))
 	);
 }
 

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -2166,12 +2166,19 @@ export interface components {
 			name?: string;
 			cases: components['schemas']['PolicyCaseV1'][];
 		};
-		PolicyCaseV1: {
-			id: string;
-			name: string;
-			login?: components['schemas']['PolicyLoginStageV1'];
-			authorization?: components['schemas']['PolicyAuthorizationStageV1'];
-		};
+		PolicyCaseV1:
+			| {
+					id: string;
+					name: string;
+					login: components['schemas']['PolicyLoginStageV1'];
+					authorization?: components['schemas']['PolicyAuthorizationStageV1'];
+			  }
+			| {
+					id: string;
+					name: string;
+					login?: components['schemas']['PolicyLoginStageV1'];
+					authorization: components['schemas']['PolicyAuthorizationStageV1'];
+			  };
 		PolicyLoginStageV1: {
 			identity: {
 				id: string;
@@ -2185,17 +2192,22 @@ export interface components {
 			};
 			expected: components['schemas']['PolicyLoginExpectationV1'];
 		};
-		PolicyLoginExpectationV1: {
-			/** @enum {string} */
-			outcome: 'allow' | 'deny';
-			entitlements?: (
-				| 'super-admin'
-				| 'project-creator'
-				| 'default-role:viewer'
-				| 'default-role:editor'
-				| 'default-role:manager'
-			)[];
-		};
+		PolicyLoginExpectationV1:
+			| {
+					/** @enum {string} */
+					outcome: 'allow';
+					entitlements?: (
+						| 'super-admin'
+						| 'project-creator'
+						| 'default-role:viewer'
+						| 'default-role:editor'
+						| 'default-role:manager'
+					)[];
+			  }
+			| {
+					/** @enum {string} */
+					outcome: 'deny';
+			  };
 		PolicyAuthorizationStageV1: {
 			subject: {
 				id: string;

--- a/packages/client/src/schema.ts
+++ b/packages/client/src/schema.ts
@@ -404,6 +404,40 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	'/api/v1/admin/policy-analyzer/metadata': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/** Describe policy analyzer inputs */
+		get: operations['admin.policyAnalyzer.metadata'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/v1/admin/policy-analyzer/evaluate': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/** Evaluate a policy test suite */
+		post: operations['admin.policyAnalyzer.evaluate'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	'/api/v1/projects/{pid}/notebooks/{nid}/workspace/files': {
 		parameters: {
 			query?: never;
@@ -2005,6 +2039,275 @@ export interface components {
 			default_role: 'manager' | 'editor' | 'viewer' | null;
 			super_admins: string[];
 		};
+		PolicyAnalyzerMetadata: {
+			/** @enum {number} */
+			schema_version: 1;
+			max_cases: number;
+			capabilities: {
+				login_policy: boolean;
+				resource_security: boolean;
+				live_self_context: boolean;
+			};
+			entitlements: (
+				| 'super-admin'
+				| 'project-creator'
+				| 'default-role:viewer'
+				| 'default-role:editor'
+				| 'default-role:manager'
+			)[];
+			classification_order: string[];
+			actions: {
+				/** @enum {string} */
+				action:
+					| 'project.create'
+					| 'admin.access'
+					| 'org-integration.manage'
+					| 'audit.global.read'
+					| 'project.read'
+					| 'project.update'
+					| 'project.delete'
+					| 'project.members.manage'
+					| 'project.events.read'
+					| 'project.alerts.manage'
+					| 'notebook.write'
+					| 'notebook.manage'
+					| 'integration.read'
+					| 'integration.use'
+					| 'integration.manage'
+					| 'change-request.publish'
+					| 'security-labels.raise'
+					| 'security-labels.lower'
+					| 'session.attach'
+					| 'session.stop'
+					| 'session.surface'
+					| 'session.proxy'
+					| 'session.start';
+				/** @enum {string} */
+				scope: 'deployment' | 'project' | 'session' | 'session-start';
+				/** @enum {string|null} */
+				minimum_role: 'viewer' | 'editor' | 'manager' | 'admin' | null;
+				/** @enum {string|null} */
+				denied_as: 'not-found' | 'forbidden' | null;
+				requires_super_admin: boolean;
+			}[];
+		};
+		PolicySuiteResult: {
+			valid: boolean;
+			summary: components['schemas']['PolicySuiteSummary'];
+			cases: components['schemas']['PolicyCaseResult'][];
+		};
+		PolicySuiteSummary: {
+			case_count: number;
+			passed: number;
+			failed: number;
+		};
+		PolicyCaseResult: {
+			id: string;
+			name: string;
+			valid: boolean;
+			login: components['schemas']['PolicyLoginResult'];
+			authorization: components['schemas']['PolicyAuthorizationResult'];
+			errors: {
+				/** @enum {string} */
+				stage: 'login' | 'authorization';
+				code: string;
+			}[];
+		};
+		PolicyLoginResult: {
+			/** @enum {string} */
+			outcome: 'allow' | 'deny' | 'timeout' | 'error' | 'invalid' | 'unavailable';
+			duration_ms: number;
+			entitlements: (
+				| 'super-admin'
+				| 'project-creator'
+				| 'default-role:viewer'
+				| 'default-role:editor'
+				| 'default-role:manager'
+			)[];
+			reason?: string;
+			problem?: string;
+			assertion: components['schemas']['PolicyAssertionResult'];
+		} | null;
+		PolicyAssertionResult: {
+			passed: boolean;
+			expected: {
+				[key: string]: unknown;
+			};
+		};
+		PolicyAuthorizationResult: {
+			decision: components['schemas']['PolicyAuthorizationDecision'];
+			/** @enum {string} */
+			presentation: 'allowed' | 'forbidden' | 'not-found';
+			trace: components['schemas']['PolicyAuthorizationTraceStep'][];
+			assertion: components['schemas']['PolicyAssertionResult'];
+		} | null;
+		PolicyAuthorizationDecision: {
+			allowed: boolean;
+			/** @enum {string|null} */
+			role: 'viewer' | 'editor' | 'manager' | 'admin' | null;
+			/** @enum {string} */
+			category?: 'lifecycle' | 'visibility' | 'role' | 'session' | 'standing' | 'constraint';
+			/** @enum {string} */
+			constraint_reason?: 'missing-context' | 'constraint' | 'unavailable';
+		};
+		PolicyAuthorizationTraceStep: {
+			/** @enum {string} */
+			stage: 'action' | 'lifecycle' | 'role' | 'standing' | 'session' | 'constraint' | 'final';
+			/** @enum {string} */
+			status: 'passed' | 'failed' | 'skipped';
+			code: string;
+			details?: {
+				[key: string]: unknown;
+			};
+		};
+		PolicySuiteV1: {
+			/** @enum {number} */
+			schema_version: 1;
+			name?: string;
+			cases: components['schemas']['PolicyCaseV1'][];
+		};
+		PolicyCaseV1: {
+			id: string;
+			name: string;
+			login?: components['schemas']['PolicyLoginStageV1'];
+			authorization?: components['schemas']['PolicyAuthorizationStageV1'];
+		};
+		PolicyLoginStageV1: {
+			identity: {
+				id: string;
+				email: string;
+			};
+			id_token_claims: {
+				[key: string]: unknown;
+			};
+			user_info_claims?: {
+				[key: string]: unknown;
+			};
+			expected: components['schemas']['PolicyLoginExpectationV1'];
+		};
+		PolicyLoginExpectationV1: {
+			/** @enum {string} */
+			outcome: 'allow' | 'deny';
+			entitlements?: (
+				| 'super-admin'
+				| 'project-creator'
+				| 'default-role:viewer'
+				| 'default-role:editor'
+				| 'default-role:manager'
+			)[];
+		};
+		PolicyAuthorizationStageV1: {
+			subject: {
+				id: string;
+				email: string;
+				/** @enum {string} */
+				entitlement_source: 'explicit' | 'login';
+				entitlements?: (
+					| 'super-admin'
+					| 'project-creator'
+					| 'default-role:viewer'
+					| 'default-role:editor'
+					| 'default-role:manager'
+				)[];
+			};
+			/** @enum {string} */
+			action:
+				| 'project.create'
+				| 'admin.access'
+				| 'org-integration.manage'
+				| 'audit.global.read'
+				| 'project.read'
+				| 'project.update'
+				| 'project.delete'
+				| 'project.members.manage'
+				| 'project.events.read'
+				| 'project.alerts.manage'
+				| 'notebook.write'
+				| 'notebook.manage'
+				| 'integration.read'
+				| 'integration.use'
+				| 'integration.manage'
+				| 'change-request.publish'
+				| 'security-labels.raise'
+				| 'security-labels.lower'
+				| 'session.attach'
+				| 'session.stop'
+				| 'session.surface'
+				| 'session.proxy'
+				| 'session.start';
+			resource: components['schemas']['PolicyAuthorizationResourceV1'];
+			context: components['schemas']['PolicyAuthorizationContextV1'];
+			expected: {
+				allowed: boolean;
+				/** @enum {string} */
+				denial_category?:
+					| 'lifecycle'
+					| 'visibility'
+					| 'role'
+					| 'session'
+					| 'standing'
+					| 'constraint';
+			};
+		};
+		PolicyAuthorizationResourceV1: {
+			/** @enum {string} */
+			source: 'stored' | 'synthetic';
+			/** @enum {string} */
+			kind: 'deployment' | 'project' | 'session' | 'session-start';
+			project_id?: string;
+			notebook_id?: string;
+			session_id?: string;
+			project?: {
+				owner: string;
+				members: {
+					user_id?: string;
+					email?: string;
+					/** @enum {string} */
+					role: 'viewer' | 'editor' | 'manager' | 'admin';
+				}[];
+				/**
+				 * @default active
+				 * @enum {string}
+				 */
+				status: 'active' | 'deleted';
+				security_labels?: {
+					classification: string;
+					compartments: string[];
+				};
+			};
+			notebook_labels?: {
+				classification: string;
+				compartments: string[];
+			};
+			session?: {
+				/** @enum {string} */
+				mode?: 'edit' | 'app';
+				ephemeral?: boolean;
+				user_id: string;
+				/** @enum {string} */
+				editor_sandbox_sharing?: 'shared' | 'exclusive';
+			};
+			/** @enum {string} */
+			mode?: 'edit' | 'app';
+		};
+		PolicyAuthorizationContextV1:
+			| {
+					/** @enum {string} */
+					mode: 'live-self';
+			  }
+			| {
+					/** @enum {string} */
+					mode: 'synthetic';
+					value: {
+						/** @enum {number} */
+						schemaVersion: 1;
+						classification: string;
+						compartments: string[];
+						policyVersion: string;
+						/** Format: date-time */
+						expiresAt: string;
+					} | null;
+			  };
 		WorkspaceItem: {
 			path: string;
 			name: string;
@@ -5551,6 +5854,170 @@ export interface operations {
 						/** @enum {boolean} */
 						success: true;
 						data: components['schemas']['DeploymentConfig'];
+					};
+				};
+			};
+			/** @description Authentication required */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Access forbidden */
+			403: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Request body too large */
+			413: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Validation error */
+			422: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Internal server error */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Service unavailable */
+			503: {
+				headers: {
+					/** @description Seconds to wait before retrying. */
+					'Retry-After': string;
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	'admin.policyAnalyzer.metadata': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Policy analyzer metadata */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						/** @enum {boolean} */
+						success: true;
+						data: components['schemas']['PolicyAnalyzerMetadata'];
+					};
+				};
+			};
+			/** @description Authentication required */
+			401: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Access forbidden */
+			403: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Request body too large */
+			413: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Validation error */
+			422: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Internal server error */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+			/** @description Service unavailable */
+			503: {
+				headers: {
+					/** @description Seconds to wait before retrying. */
+					'Retry-After': string;
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ErrorResponse'];
+				};
+			};
+		};
+	};
+	'admin.policyAnalyzer.evaluate': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['PolicySuiteV1'];
+			};
+		};
+		responses: {
+			/** @description Policy analysis results */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						/** @enum {boolean} */
+						success: true;
+						data: components['schemas']['PolicySuiteResult'];
 					};
 				};
 			};

--- a/packages/config/src/auth.ts
+++ b/packages/config/src/auth.ts
@@ -188,6 +188,16 @@ function parseSeconds(env: Env, key: string, fallback: number, min: number, max:
 	return value;
 }
 
+export function oidcLoginPolicyTimeoutSeconds(env: Env): number {
+	return parseSeconds(
+		env,
+		'MARIMOHUB_AUTH_OIDC_LOGIN_POLICY_TIMEOUT_SECONDS',
+		DEFAULT_LOGIN_POLICY_TIMEOUT_SECONDS,
+		1,
+		30,
+	);
+}
+
 function parseScopes(raw: string | undefined): string {
 	const scopes = [...new Set((raw?.trim() || 'openid email profile').split(/\s+/).filter(Boolean))];
 	if (!scopes.includes('openid') || !scopes.includes('email')) {
@@ -309,13 +319,7 @@ function parseLoginPolicy(
 	}
 	return {
 		policy,
-		timeoutSeconds: parseSeconds(
-			env,
-			'MARIMOHUB_AUTH_OIDC_LOGIN_POLICY_TIMEOUT_SECONDS',
-			DEFAULT_LOGIN_POLICY_TIMEOUT_SECONDS,
-			1,
-			30,
-		),
+		timeoutSeconds: oidcLoginPolicyTimeoutSeconds(env),
 	};
 }
 

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -633,6 +633,21 @@ describe('createFromEnv oidc login-policy library', () => {
 		).resolves.toMatchObject({ outcome: 'deny' });
 	});
 
+	it('uses the authentication timeout default when the timeout variable is blank', async () => {
+		const oidcLoginPolicy = { evaluate: () => ({ decision: 'deny' as const }) };
+		const deps = createFromEnv(
+			{ ...loginPolicyEnv, MARIMOHUB_AUTH_OIDC_LOGIN_POLICY_TIMEOUT_SECONDS: '  ' },
+			undefined,
+			{ libraries: { oidcLoginPolicy } },
+		);
+		await expect(
+			deps.policyAnalyzer?.loginPolicy?.evaluate({
+				identity: { id: ACTOR, email: 'actor@example.com' },
+				idTokenClaims: {},
+			}),
+		).resolves.toMatchObject({ outcome: 'deny' });
+	});
+
 	// The full loaded-module → callback-decision wiring is proven end to end in
 	// loginPolicyComposition.test.ts (it needs the oauth4webapi mock).
 });

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -620,11 +620,17 @@ describe('createFromEnv oidc login-policy library', () => {
 		expect(() => createFromEnv(loginPolicyEnv)).toThrow(/createFromEnvAsync/);
 	});
 
-	it('wires a preloaded login policy', () => {
+	it('wires a preloaded login policy into authentication and analysis', async () => {
 		const oidcLoginPolicy = { evaluate: () => ({ decision: 'deny' as const }) };
 		const deps = createFromEnv(loginPolicyEnv, undefined, { libraries: { oidcLoginPolicy } });
 		expect(deps.authenticator).toBeDefined();
 		expect(deps.authRoutes).toBeDefined();
+		await expect(
+			deps.policyAnalyzer?.loginPolicy?.evaluate({
+				identity: { id: ACTOR, email: 'actor@example.com' },
+				idTokenClaims: {},
+			}),
+		).resolves.toMatchObject({ outcome: 'deny' });
 	});
 
 	// The full loaded-module → callback-decision wiring is proven end to end in

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -46,8 +46,9 @@ import type {
 	ViewerMode,
 } from '@marimo-hub/core';
 import type { ApiDeps, SessionLifetimeConfig } from '@marimo-hub/api';
+import { evaluateLoginPolicy } from '@marimo-hub/auth-oidc';
 import { makeAi } from './ai';
-import { authBackend, makeAuth, projectCreationRestricted } from './auth';
+import { authBackend, makeAuth, oidcLoginPolicySelected, projectCreationRestricted } from './auth';
 import { buildConfigSummary } from './configSummary';
 import { computeBackend, makeCompute, resolveSandboxImages } from './compute';
 import {
@@ -63,7 +64,7 @@ import { createDuckDBHttpSessionFactory } from './duckdbHttpBroker';
 import { createGuardedHostResolver } from './integrationProbe';
 import { makeNotifier } from './notifications';
 import { makeProjectAlerts } from './projectAlerts';
-import { makeResourceSecurity } from './resourceSecurity';
+import { makeResourceSecurity, validateResourceSecurityEnv } from './resourceSecurity';
 import { makeSourceControl } from './sourceControl';
 import { makeStorage, makeSandboxBucketConfig, storageBackend } from './storage';
 import { loadAdapterLibraries } from './library';
@@ -518,6 +519,10 @@ export function createFromEnv(
 	// its own explicit acknowledgement above.
 	if (exposure.mode === 'subdomain') assertSandboxHostIsolated(env);
 	const { authenticator, authRoutes } = makeAuth(env, options?.libraries);
+	const configuredLoginPolicy =
+		authBackend(env) === 'oidc' && oidcLoginPolicySelected(env)
+			? options?.libraries?.oidcLoginPolicy
+			: undefined;
 	const sessionLifetime = parseSessionLifetime(env);
 	const sandboxImages = resolveSandboxImages(env);
 	const computeProfiles = parseComputeProfiles(env.MARIMOHUB_COMPUTE_PROFILES);
@@ -634,6 +639,20 @@ export function createFromEnv(
 			const resourceSecurity = makeResourceSecurity(env, options?.libraries);
 			return resourceSecurity ? { resourceSecurity } : {};
 		})(),
+		policyAnalyzer: {
+			classificationOrder: validateResourceSecurityEnv(env).order ?? [],
+			...(configuredLoginPolicy
+				? {
+						loginPolicy: {
+							evaluate: (input) =>
+								evaluateLoginPolicy(configuredLoginPolicy, input, {
+									timeoutMs:
+										Number(env.MARIMOHUB_AUTH_OIDC_LOGIN_POLICY_TIMEOUT_SECONDS ?? '5') * 1000,
+								}),
+						},
+					}
+				: {}),
+		},
 		// Read-only configuration for the super-admin settings page (secrets
 		// redacted at assembly).
 		configSummary: buildConfigSummary(env),

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -48,7 +48,13 @@ import type {
 import type { ApiDeps, SessionLifetimeConfig } from '@marimo-hub/api';
 import { evaluateLoginPolicy } from '@marimo-hub/auth-oidc';
 import { makeAi } from './ai';
-import { authBackend, makeAuth, oidcLoginPolicySelected, projectCreationRestricted } from './auth';
+import {
+	authBackend,
+	makeAuth,
+	oidcLoginPolicySelected,
+	oidcLoginPolicyTimeoutSeconds,
+	projectCreationRestricted,
+} from './auth';
 import { buildConfigSummary } from './configSummary';
 import { computeBackend, makeCompute, resolveSandboxImages } from './compute';
 import {
@@ -646,8 +652,7 @@ export function createFromEnv(
 						loginPolicy: {
 							evaluate: (input) =>
 								evaluateLoginPolicy(configuredLoginPolicy, input, {
-									timeoutMs:
-										Number(env.MARIMOHUB_AUTH_OIDC_LOGIN_POLICY_TIMEOUT_SECONDS ?? '5') * 1000,
+									timeoutMs: oidcLoginPolicyTimeoutSeconds(env) * 1000,
 								}),
 						},
 					}

--- a/packages/core/src/authz.test.ts
+++ b/packages/core/src/authz.test.ts
@@ -6,6 +6,7 @@ import {
 	effectiveRole,
 	isSuperAdmin,
 	requireRole,
+	resolveEffectiveRole,
 	roleAtLeast,
 } from './authz';
 import type { AuthSubject } from './authz';
@@ -47,6 +48,46 @@ describe('authz', () => {
 	});
 
 	describe('effectiveRole', () => {
+		it('reports every effective-role source', () => {
+			expect(resolveEffectiveRole(project, STRANGER, { superAdmins: [STRANGER.id] })).toEqual({
+				role: 'admin',
+				source: 'static-super-admin',
+			});
+			expect(resolveEffectiveRole(project, { ...STRANGER, entitlements: ['super-admin'] })).toEqual(
+				{ role: 'admin', source: 'entitlement-super-admin' },
+			);
+			expect(resolveEffectiveRole(project, OWNER)).toEqual({ role: 'admin', source: 'owner' });
+			expect(resolveEffectiveRole(project, MANAGER)).toEqual({
+				role: 'manager',
+				source: 'member-id',
+			});
+			expect(resolveEffectiveRole(project, INVITEE)).toEqual({
+				role: 'editor',
+				source: 'member-email',
+			});
+			expect(
+				resolveEffectiveRole(project, {
+					...STRANGER,
+					entitlements: ['default-role:manager'],
+				}),
+			).toEqual({ role: 'manager', source: 'entitlement-default' });
+			expect(resolveEffectiveRole(project, STRANGER, { defaultRole: 'viewer' })).toEqual({
+				role: 'viewer',
+				source: 'deployment-default',
+			});
+			expect(resolveEffectiveRole(project, STRANGER)).toEqual({ role: null, source: 'none' });
+		});
+
+		it('reports the deployment default when it ties an entitlement', () => {
+			expect(
+				resolveEffectiveRole(
+					project,
+					{ ...STRANGER, entitlements: ['default-role:editor'] },
+					{ defaultRole: 'editor' },
+				),
+			).toEqual({ role: 'editor', source: 'deployment-default' });
+		});
+
 		it('treats the owner as admin even if not listed as a member', () => {
 			const p = makeProject({ owner: OWNER.id, members: [] });
 			expect(effectiveRole(p, OWNER)).toBe('admin');

--- a/packages/core/src/authz.ts
+++ b/packages/core/src/authz.ts
@@ -67,6 +67,21 @@ export interface AuthzPolicy {
 	projectCreationRestricted?: boolean;
 }
 
+export type EffectiveRoleSource =
+	| 'static-super-admin'
+	| 'entitlement-super-admin'
+	| 'owner'
+	| 'member-id'
+	| 'member-email'
+	| 'entitlement-default'
+	| 'deployment-default'
+	| 'none';
+
+export interface EffectiveRoleResolution {
+	role: Role | null;
+	source: EffectiveRoleSource;
+}
+
 /**
  * Whether the caller is a deployment super admin, either from static config or
  * a mapped OIDC session entitlement. Super admins hold implicit `admin` on
@@ -108,15 +123,57 @@ export function effectiveRole(
 	subject: AuthSubject,
 	policy?: AuthzPolicy,
 ): Role | null {
-	if (isSuperAdmin(subject, policy?.superAdmins)) return 'admin';
-	if (project.owner === subject.id) return 'admin';
+	return resolveEffectiveRole(project, subject, policy).role;
+}
+
+export function resolveEffectiveRole(
+	project: Project,
+	subject: AuthSubject,
+	policy?: AuthzPolicy,
+): EffectiveRoleResolution {
+	if (subject.entitlements?.includes('super-admin') === true) {
+		return { role: 'admin', source: 'entitlement-super-admin' };
+	}
+	if (anyRefMatchesSubject(policy?.superAdmins, subject)) {
+		return { role: 'admin', source: 'static-super-admin' };
+	}
+	if (project.owner === subject.id) return { role: 'admin', source: 'owner' };
 	let best: Role | null = null;
+	let source: 'member-id' | 'member-email' | undefined;
 	for (const member of project.members) {
 		if (!memberRefMatchesSubject(member, subject)) continue;
-		if (best === null || RANK[member.role] > RANK[best]) best = member.role;
+		if (
+			best === null ||
+			RANK[member.role] > RANK[best] ||
+			(RANK[member.role] === RANK[best] &&
+				member.user_id !== undefined &&
+				source === 'member-email')
+		) {
+			best = member.role;
+			source = member.user_id !== undefined ? 'member-id' : 'member-email';
+		}
 		if (best === 'admin') break;
 	}
-	return best ?? subjectDefaultRole(subject, policy);
+	if (best !== null) return { role: best, source: source ?? 'member-id' };
+
+	let entitlementRole: AssignableRole | null = null;
+	for (const entitlement of subject.entitlements ?? []) {
+		const candidate = ENTITLEMENT_ROLE[entitlement];
+		if (candidate && (entitlementRole === null || RANK[candidate] > RANK[entitlementRole])) {
+			entitlementRole = candidate;
+		}
+	}
+	if (entitlementRole !== null) {
+		const deploymentRole = policy?.defaultRole ?? null;
+		if (deploymentRole !== null && RANK[deploymentRole] >= RANK[entitlementRole]) {
+			return { role: deploymentRole, source: 'deployment-default' };
+		}
+		return { role: entitlementRole, source: 'entitlement-default' };
+	}
+	if (policy?.defaultRole !== undefined && policy.defaultRole !== null) {
+		return { role: policy.defaultRole, source: 'deployment-default' };
+	}
+	return { role: null, source: 'none' };
 }
 
 /** True if the caller's role on the project is at least `min`. */

--- a/packages/core/src/ports/resourceConstraints.ts
+++ b/packages/core/src/ports/resourceConstraints.ts
@@ -28,10 +28,18 @@ export interface ConstraintResource {
  */
 export type ConstraintDenialReason = 'missing-context' | 'constraint' | 'unavailable';
 
+/** Optional bounded evidence for an operator-facing policy analysis. */
+export interface ConstraintEvidence {
+	heldClassification: string | null;
+	requiredClassification: string;
+	classificationSatisfied: boolean;
+	missingCompartments: readonly string[];
+}
+
 /** Whether the resource's extra restrictions are satisfied. */
 export type ConstraintDecision =
-	| { satisfied: true }
-	| { satisfied: false; reason: ConstraintDenialReason };
+	| { satisfied: true; evidence?: ConstraintEvidence }
+	| { satisfied: false; reason: ConstraintDenialReason; evidence?: ConstraintEvidence };
 
 export interface ResourceConstraintPolicy {
 	evaluate(

--- a/packages/core/src/ports/resourceConstraints.ts
+++ b/packages/core/src/ports/resourceConstraints.ts
@@ -36,10 +36,27 @@ export interface ConstraintEvidence {
 	missingCompartments: readonly string[];
 }
 
+export interface SatisfiedConstraintEvidence extends ConstraintEvidence {
+	classificationSatisfied: true;
+	missingCompartments: readonly [];
+}
+
+export type UnsatisfiedConstraintEvidence =
+	| (ConstraintEvidence & { classificationSatisfied: false })
+	| (ConstraintEvidence & {
+			classificationSatisfied: true;
+			missingCompartments: readonly [string, ...string[]];
+	  });
+
 /** Whether the resource's extra restrictions are satisfied. */
 export type ConstraintDecision =
-	| { satisfied: true; evidence?: ConstraintEvidence }
-	| { satisfied: false; reason: ConstraintDenialReason; evidence?: ConstraintEvidence };
+	| { satisfied: true; evidence?: SatisfiedConstraintEvidence }
+	| {
+			satisfied: false;
+			reason: 'constraint';
+			evidence?: UnsatisfiedConstraintEvidence;
+	  }
+	| { satisfied: false; reason: 'missing-context' | 'unavailable' };
 
 export interface ResourceConstraintPolicy {
 	evaluate(

--- a/packages/core/src/services/authorization/AuthorizationService.test.ts
+++ b/packages/core/src/services/authorization/AuthorizationService.test.ts
@@ -278,6 +278,29 @@ describe('AuthorizationService: list visibility', () => {
 });
 
 describe('AuthorizationService: contract', () => {
+	it('uses the enforcement decision as the analysis verdict', async () => {
+		for (const [who, action, resource] of [
+			[OWNER, 'project.read', onProject()],
+			[STRANGER, 'project.read', onProject()],
+			[VIEWER, 'notebook.write', onProject()],
+			[OWNER, 'session.start', { kind: 'session-start', project, mode: 'edit' }],
+		] as const) {
+			const authz = service();
+			const decision = await authz.authorize(who, action, resource);
+			const analysis = await authz.analyze(who, action, resource);
+			expect(analysis.decision).toEqual(decision);
+			expect(analysis.trace.at(-1)).toMatchObject({ stage: 'final' });
+		}
+	});
+
+	it('reports the role source and transport presentation', async () => {
+		const analysis = await service().analyze(STRANGER, 'project.read', onProject());
+		expect(analysis.presentation).toBe('not-found');
+		expect(analysis.trace).toContainEqual(
+			expect.objectContaining({ stage: 'role', code: 'effective_role_none' }),
+		);
+	});
+
 	it('rejects a resource whose kind does not match the action scope', async () => {
 		await expect(
 			service().authorize(OWNER, 'project.read', { kind: 'deployment' }),

--- a/packages/core/src/services/authorization/AuthorizationService.ts
+++ b/packages/core/src/services/authorization/AuthorizationService.ts
@@ -37,6 +37,8 @@ import type {
 	ConstraintDenialReason,
 	ConstraintEvidence,
 	ResourceConstraintPolicy,
+	SatisfiedConstraintEvidence,
+	UnsatisfiedConstraintEvidence,
 } from '../../ports/resourceConstraints';
 import { validateSubjectSecurityContext } from '../../ports/subjectContext';
 import type {
@@ -198,28 +200,52 @@ const CONSTRAINT_DENIAL_REASONS: ReadonlySet<string> = new Set([
 	'unavailable',
 ]);
 
+interface ParsedConstraintDecision {
+	decision: ConstraintDecision;
+	invalidEvidence: boolean;
+}
+
+interface IndexedConstraintEvidence extends ConstraintEvidence {
+	labelSetIndex: number;
+}
+
 /**
- * Shape-validate an adapter's decision — external output, not a trusted type.
- * A truthy-but-not-`true` `satisfied` or an unknown denial reason yields
- * `null`, which the caller treats as an `unavailable` denial.
+ * Evidence is diagnostic only: drop malformed evidence, but preserve a valid
+ * adapter verdict. A malformed verdict still fails closed.
  */
-function parseConstraintDecision(value: unknown): ConstraintDecision | null {
+function parseConstraintDecision(value: unknown): ParsedConstraintDecision | null {
 	if (typeof value !== 'object' || value === null) return null;
 	const decision = value as { satisfied?: unknown; reason?: unknown; evidence?: unknown };
-	const evidence = parseConstraintEvidence(decision.evidence);
-	if (decision.evidence !== undefined && evidence === null) return null;
 	if (decision.satisfied === true) {
-		return { satisfied: true, ...(evidence ? { evidence } : {}) };
+		const evidence = parseConstraintEvidence(decision.evidence);
+		const validEvidence =
+			evidence?.classificationSatisfied === true && evidence.missingCompartments.length === 0
+				? (evidence as SatisfiedConstraintEvidence)
+				: null;
+		return {
+			decision: { satisfied: true, ...(validEvidence ? { evidence: validEvidence } : {}) },
+			invalidEvidence: decision.evidence !== undefined && validEvidence === null,
+		};
 	}
 	if (
 		decision.satisfied === false &&
 		typeof decision.reason === 'string' &&
 		CONSTRAINT_DENIAL_REASONS.has(decision.reason)
 	) {
+		const reason = decision.reason as ConstraintDenialReason;
+		const evidence = parseConstraintEvidence(decision.evidence);
+		const validEvidence =
+			reason === 'constraint' &&
+			evidence !== null &&
+			(!evidence.classificationSatisfied || evidence.missingCompartments.length > 0)
+				? (evidence as UnsatisfiedConstraintEvidence)
+				: null;
 		return {
-			satisfied: false,
-			reason: decision.reason as ConstraintDenialReason,
-			...(evidence ? { evidence } : {}),
+			decision:
+				reason === 'constraint'
+					? { satisfied: false, reason, ...(validEvidence ? { evidence: validEvidence } : {}) }
+					: { satisfied: false, reason },
+			invalidEvidence: decision.evidence !== undefined && validEvidence === null,
 		};
 	}
 	return null;
@@ -229,7 +255,14 @@ function parseConstraintEvidence(value: unknown): ConstraintEvidence | null {
 	if (value === undefined) return null;
 	if (typeof value !== 'object' || value === null) return null;
 	const evidence = value as Record<string, unknown>;
+	const keys = new Set([
+		'heldClassification',
+		'requiredClassification',
+		'classificationSatisfied',
+		'missingCompartments',
+	]);
 	if (
+		Object.keys(evidence).some((key) => !keys.has(key)) ||
 		(evidence.heldClassification !== null &&
 			(typeof evidence.heldClassification !== 'string' ||
 				!SECURITY_LABEL_TOKEN.test(evidence.heldClassification))) ||
@@ -622,10 +655,16 @@ export class AuthorizationService {
 				this.emitSecurityEvent(SECURITY_EVENTS.constraintMiscount, 'project.read');
 				return labelStates.map((labels) => labels === null);
 			}
-			return decisions.map(
-				(decision, index) =>
-					labelStates[index] === null || parseConstraintDecision(decision)?.satisfied === true,
-			);
+			let invalidEvidence = false;
+			const allowed = decisions.map((decision, index) => {
+				const parsed = parseConstraintDecision(decision);
+				if (parsed?.invalidEvidence) invalidEvidence = true;
+				return labelStates[index] === null || parsed?.decision.satisfied === true;
+			});
+			if (invalidEvidence) {
+				this.emitSecurityEvent(SECURITY_EVENTS.constraintInvalid, 'project.read');
+			}
+			return allowed;
 		} catch (error) {
 			this.emitConstraintFailure(error, 'project.read');
 			return labelStates.map((labels) => labels === null);
@@ -685,18 +724,18 @@ export class AuthorizationService {
 		| {
 				satisfied: true;
 				contextExpiresAt: string;
-				evidence?: readonly ConstraintEvidence[];
+				evidence?: readonly IndexedConstraintEvidence[];
 		  }
 		| {
 				satisfied: false;
 				reason: ConstraintDenialReason;
-				evidence?: readonly ConstraintEvidence[];
+				evidence?: readonly IndexedConstraintEvidence[];
 		  }
 	> {
 		const batch = await this.constraintBatch(action, labelSets, getContext);
 		if (!batch.ok) return { satisfied: false, reason: batch.reason };
-		const evidence = batch.decisions.flatMap((decision) =>
-			decision.evidence ? [decision.evidence] : [],
+		const evidence = batch.decisions.flatMap((decision, labelSetIndex) =>
+			'evidence' in decision && decision.evidence ? [{ labelSetIndex, ...decision.evidence }] : [],
 		);
 		const denied = batch.decisions.find((decision) => !decision.satisfied);
 		if (denied?.satisfied === false) {
@@ -763,8 +802,8 @@ export class AuthorizationService {
 			let invalid = false;
 			const decisions = raw.map((decision) => {
 				const parsed = parseConstraintDecision(decision);
-				if (parsed === null) invalid = true;
-				return parsed ?? { satisfied: false as const, reason: 'unavailable' as const };
+				if (parsed === null || parsed.invalidEvidence) invalid = true;
+				return parsed?.decision ?? { satisfied: false as const, reason: 'unavailable' as const };
 			});
 			if (invalid) this.emitSecurityEvent(SECURITY_EVENTS.constraintInvalid, action);
 			return { ok: true, decisions, contextExpiresAt: context.expiresAt };

--- a/packages/core/src/services/authorization/AuthorizationService.ts
+++ b/packages/core/src/services/authorization/AuthorizationService.ts
@@ -23,8 +23,8 @@
 import {
 	canCreateProject,
 	canSeeProjectEntry,
-	effectiveRole,
 	isSuperAdmin,
+	resolveEffectiveRole,
 	roleAtLeast,
 	subjectDefaultRole,
 } from '../../authz';
@@ -35,6 +35,7 @@ import type { AuthenticatedPrincipal } from '../../ports/auth';
 import type {
 	ConstraintDecision,
 	ConstraintDenialReason,
+	ConstraintEvidence,
 	ResourceConstraintPolicy,
 } from '../../ports/resourceConstraints';
 import { validateSubjectSecurityContext } from '../../ports/subjectContext';
@@ -43,6 +44,7 @@ import type {
 	SubjectSecurityContextProvider,
 } from '../../ports/subjectContext';
 import type { ResourceSecurityLabels } from '../../securityLabels';
+import { MAX_SECURITY_COMPARTMENTS, SECURITY_LABEL_TOKEN } from '../../securityLabels';
 import type { EditorSandboxSharing, Role, SessionMode, ViewerMode } from '../../constants';
 import type { UserId } from '../../ids';
 import type { Project, Session } from '../../schema';
@@ -139,6 +141,23 @@ export type AuthorizationDecision =
 			constraintReason?: ConstraintDenialReason;
 	  };
 
+export interface AuthorizationTraceStep {
+	stage: 'action' | 'lifecycle' | 'role' | 'standing' | 'session' | 'constraint' | 'final';
+	status: 'passed' | 'failed' | 'skipped';
+	code: string;
+	details?: Readonly<Record<string, unknown>>;
+}
+
+export interface AuthorizationAnalysis {
+	decision: AuthorizationDecision;
+	presentation: 'allowed' | 'forbidden' | 'not-found';
+	trace: readonly AuthorizationTraceStep[];
+}
+
+export type AuthorizationAnalysisContext =
+	| { mode: 'live' }
+	| { mode: 'synthetic'; value: SubjectSecurityContext | null };
+
 const SESSION_ACTION_FOR: Record<SessionScopedAction, SessionAction> = {
 	'session.attach': 'attach',
 	'session.stop': 'stop',
@@ -186,16 +205,51 @@ const CONSTRAINT_DENIAL_REASONS: ReadonlySet<string> = new Set([
  */
 function parseConstraintDecision(value: unknown): ConstraintDecision | null {
 	if (typeof value !== 'object' || value === null) return null;
-	const decision = value as { satisfied?: unknown; reason?: unknown };
-	if (decision.satisfied === true) return { satisfied: true };
+	const decision = value as { satisfied?: unknown; reason?: unknown; evidence?: unknown };
+	const evidence = parseConstraintEvidence(decision.evidence);
+	if (decision.evidence !== undefined && evidence === null) return null;
+	if (decision.satisfied === true) {
+		return { satisfied: true, ...(evidence ? { evidence } : {}) };
+	}
 	if (
 		decision.satisfied === false &&
 		typeof decision.reason === 'string' &&
 		CONSTRAINT_DENIAL_REASONS.has(decision.reason)
 	) {
-		return { satisfied: false, reason: decision.reason as ConstraintDenialReason };
+		return {
+			satisfied: false,
+			reason: decision.reason as ConstraintDenialReason,
+			...(evidence ? { evidence } : {}),
+		};
 	}
 	return null;
+}
+
+function parseConstraintEvidence(value: unknown): ConstraintEvidence | null {
+	if (value === undefined) return null;
+	if (typeof value !== 'object' || value === null) return null;
+	const evidence = value as Record<string, unknown>;
+	if (
+		(evidence.heldClassification !== null &&
+			(typeof evidence.heldClassification !== 'string' ||
+				!SECURITY_LABEL_TOKEN.test(evidence.heldClassification))) ||
+		typeof evidence.requiredClassification !== 'string' ||
+		!SECURITY_LABEL_TOKEN.test(evidence.requiredClassification) ||
+		typeof evidence.classificationSatisfied !== 'boolean' ||
+		!Array.isArray(evidence.missingCompartments) ||
+		evidence.missingCompartments.length > MAX_SECURITY_COMPARTMENTS ||
+		evidence.missingCompartments.some(
+			(item) => typeof item !== 'string' || !SECURITY_LABEL_TOKEN.test(item),
+		)
+	) {
+		return null;
+	}
+	return {
+		heldClassification: evidence.heldClassification,
+		requiredClassification: evidence.requiredClassification,
+		classificationSatisfied: evidence.classificationSatisfied,
+		missingCompartments: evidence.missingCompartments as string[],
+	};
 }
 
 /** A catalog snapshot entry as list visibility reads it (denormalized members). */
@@ -232,6 +286,68 @@ export class AuthorizationService {
 			};
 		}
 		return { ...decision, subjectContextExpiresAt: constraint.contextExpiresAt };
+	}
+
+	async analyze(
+		subject: AuthorizationSubject,
+		action: AuthorizationAction,
+		resource: AuthorizationResource,
+		context: AuthorizationAnalysisContext = { mode: 'live' },
+	): Promise<AuthorizationAnalysis> {
+		const trace: AuthorizationTraceStep[] = [];
+		const { decision: baseline, labelSets } = this.decideBaseline(subject, action, resource, trace);
+		let decision = baseline;
+		if (baseline.allowed && labelSets.length > 0) {
+			const constraint = await this.evaluateLabelSets(
+				action,
+				labelSets,
+				context.mode === 'synthetic' ? async () => context.value : this.contextResolver(subject),
+			);
+			trace.push({
+				stage: 'constraint',
+				status: constraint.satisfied ? 'passed' : 'failed',
+				code: constraint.satisfied
+					? 'resource_constraints_satisfied'
+					: `resource_constraints_${constraint.reason}`,
+				details: {
+					contextMode: context.mode,
+					labelSetCount: labelSets.length,
+					...(constraint.evidence ? { evidence: constraint.evidence } : {}),
+				},
+			});
+			decision = constraint.satisfied
+				? { ...baseline, subjectContextExpiresAt: constraint.contextExpiresAt }
+				: {
+						allowed: false,
+						category: 'constraint',
+						role: baseline.role,
+						constraintReason: constraint.reason,
+					};
+		} else if (baseline.allowed) {
+			trace.push({ stage: 'constraint', status: 'skipped', code: 'resource_unlabeled' });
+		} else {
+			trace.push({
+				stage: 'constraint',
+				status: 'skipped',
+				code: 'baseline_denied',
+			});
+		}
+		const presentation = decision.allowed
+			? 'allowed'
+			: decision.category === 'lifecycle' ||
+				  decision.category === 'visibility' ||
+				  decision.category === 'constraint'
+				? 'not-found'
+				: 'forbidden';
+		trace.push({
+			stage: 'final',
+			status: decision.allowed ? 'passed' : 'failed',
+			code: decision.allowed
+				? 'authorization_allowed'
+				: `authorization_denied_${decision.category}`,
+			details: { presentation },
+		});
+		return { decision, presentation, trace };
 	}
 
 	/**
@@ -296,29 +412,74 @@ export class AuthorizationService {
 		subject: AuthorizationSubject,
 		action: AuthorizationAction,
 		resource: AuthorizationResource,
+		trace?: AuthorizationTraceStep[],
 	): { decision: AuthorizationDecision; labelSets: readonly ResourceSecurityLabels[] } {
 		const rule = ACTION_RULES[action];
 		if (resource.kind !== rule.scope) {
 			throw new Error(`Action ${action} requires a ${rule.scope} resource, got ${resource.kind}`);
 		}
+		trace?.push({
+			stage: 'action',
+			status: 'passed',
+			code: 'action_rule_loaded',
+			details: {
+				action,
+				scope: rule.scope,
+				...('min' in rule
+					? {
+							minimumRole: rule.min,
+							deniedAs: rule.deniedAs,
+							requiresSuperAdmin: rule.requiresSuperAdmin === true,
+						}
+					: {}),
+			},
+		});
 		if (resource.kind === 'deployment') {
+			const decision = this.decideDeployment(subject, action as DeploymentAction);
+			trace?.push({
+				stage: 'standing',
+				status: decision.allowed ? 'passed' : 'failed',
+				code: decision.allowed ? 'deployment_standing_satisfied' : 'deployment_standing_missing',
+				details: { entitlements: [...(subject.entitlements ?? [])] },
+			});
 			return {
-				decision: this.decideDeployment(subject, action as DeploymentAction),
+				decision,
 				labelSets: [],
 			};
 		}
 		// Lifecycle precedes every project-scoped rule on purpose: a soft-deleted
 		// project is unreachable for everyone, super admins included.
 		if (resource.project.status === 'deleted') {
+			trace?.push({ stage: 'lifecycle', status: 'failed', code: 'project_deleted' });
 			return { decision: { allowed: false, category: 'lifecycle', role: null }, labelSets: [] };
 		}
-		const role = effectiveRole(resource.project, subject, this.policy);
+		trace?.push({ stage: 'lifecycle', status: 'passed', code: 'project_active' });
+		const roleResolution = resolveEffectiveRole(resource.project, subject, this.policy);
+		const role = roleResolution.role;
+		trace?.push({
+			stage: 'role',
+			status: role === null ? 'failed' : 'passed',
+			code: `effective_role_${roleResolution.source}`,
+			details: { role, entitlements: [...(subject.entitlements ?? [])] },
+		});
 		const decision = ((): AuthorizationDecision => {
 			switch (resource.kind) {
 				case 'project': {
 					const projectRule = ACTION_RULES[action as ProjectAction];
 					if (projectRule.requiresSuperAdmin && !isSuperAdmin(subject, this.policy?.superAdmins)) {
+						trace?.push({
+							stage: 'standing',
+							status: 'failed',
+							code: 'super_admin_standing_missing',
+						});
 						return { allowed: false, category: 'standing', role };
+					}
+					if (projectRule.requiresSuperAdmin) {
+						trace?.push({
+							stage: 'standing',
+							status: 'passed',
+							code: 'super_admin_standing_satisfied',
+						});
 					}
 					if (roleAtLeast(role, projectRule.min)) return { allowed: true, role };
 					return {
@@ -329,14 +490,32 @@ export class AuthorizationService {
 				}
 				case 'session': {
 					const sessionAction = SESSION_ACTION_FOR[action as SessionScopedAction];
-					return sessionCan(sessionAction, this.sessionActor(subject, role), resource.session)
-						? { allowed: true, role }
-						: { allowed: false, category: 'session', role };
+					const allowed = sessionCan(
+						sessionAction,
+						this.sessionActor(subject, role),
+						resource.session,
+					);
+					trace?.push({
+						stage: 'session',
+						status: allowed ? 'passed' : 'failed',
+						code: allowed ? 'session_rule_satisfied' : 'session_rule_denied',
+						details: { sessionAction, mode: resource.session.mode ?? 'edit' },
+					});
+					return allowed ? { allowed: true, role } : { allowed: false, category: 'session', role };
 				}
-				case 'session-start':
-					return canStartSessionMode({ role, viewerMode: this.policy?.viewerMode }, resource.mode)
-						? { allowed: true, role }
-						: { allowed: false, category: 'session', role };
+				case 'session-start': {
+					const allowed = canStartSessionMode(
+						{ role, viewerMode: this.policy?.viewerMode },
+						resource.mode,
+					);
+					trace?.push({
+						stage: 'session',
+						status: allowed ? 'passed' : 'failed',
+						code: allowed ? 'session_start_satisfied' : 'session_start_denied',
+						details: { mode: resource.mode, viewerMode: this.policy?.viewerMode ?? 'static' },
+					});
+					return allowed ? { allowed: true, role } : { allowed: false, category: 'session', role };
+				}
 			}
 		})();
 		const labelSets = [
@@ -348,7 +527,7 @@ export class AuthorizationService {
 
 	/** The baseline role for display (`your_role`) and derived projections. */
 	role(subject: AuthSubject, project: Project): Role | null {
-		return effectiveRole(project, subject, this.policy);
+		return resolveEffectiveRole(project, subject, this.policy).role;
 	}
 
 	isSuperAdmin(subject: AuthSubject): boolean {
@@ -503,14 +682,35 @@ export class AuthorizationService {
 		labelSets: readonly ResourceSecurityLabels[],
 		getContext: () => Promise<SubjectSecurityContext | null>,
 	): Promise<
-		| { satisfied: true; contextExpiresAt: string }
-		| { satisfied: false; reason: ConstraintDenialReason }
+		| {
+				satisfied: true;
+				contextExpiresAt: string;
+				evidence?: readonly ConstraintEvidence[];
+		  }
+		| {
+				satisfied: false;
+				reason: ConstraintDenialReason;
+				evidence?: readonly ConstraintEvidence[];
+		  }
 	> {
 		const batch = await this.constraintBatch(action, labelSets, getContext);
 		if (!batch.ok) return { satisfied: false, reason: batch.reason };
+		const evidence = batch.decisions.flatMap((decision) =>
+			decision.evidence ? [decision.evidence] : [],
+		);
 		const denied = batch.decisions.find((decision) => !decision.satisfied);
-		if (denied?.satisfied === false) return denied;
-		return { satisfied: true, contextExpiresAt: batch.contextExpiresAt };
+		if (denied?.satisfied === false) {
+			return {
+				satisfied: false,
+				reason: denied.reason,
+				...(evidence.length > 0 ? { evidence } : {}),
+			};
+		}
+		return {
+			satisfied: true,
+			contextExpiresAt: batch.contextExpiresAt,
+			...(evidence.length > 0 ? { evidence } : {}),
+		};
 	}
 
 	/**

--- a/packages/core/src/services/authorization/LocalResourceConstraintPolicy.ts
+++ b/packages/core/src/services/authorization/LocalResourceConstraintPolicy.ts
@@ -50,9 +50,23 @@ export class LocalResourceConstraintPolicy implements ResourceConstraintPolicy {
 			classificationSatisfied,
 			missingCompartments,
 		};
-		return classificationSatisfied && missingCompartments.length === 0
-			? { satisfied: true, evidence }
-			: { satisfied: false, reason: 'constraint', evidence };
+		if (classificationSatisfied && missingCompartments.length === 0) {
+			return {
+				satisfied: true,
+				evidence: { ...evidence, classificationSatisfied: true, missingCompartments: [] },
+			};
+		}
+		return {
+			satisfied: false,
+			reason: 'constraint',
+			evidence: classificationSatisfied
+				? {
+						...evidence,
+						classificationSatisfied: true,
+						missingCompartments: missingCompartments as [string, ...string[]],
+					}
+				: { ...evidence, classificationSatisfied: false },
+		};
 	}
 
 	async evaluateMany(

--- a/packages/core/src/services/authorization/LocalResourceConstraintPolicy.ts
+++ b/packages/core/src/services/authorization/LocalResourceConstraintPolicy.ts
@@ -38,13 +38,21 @@ export class LocalResourceConstraintPolicy implements ResourceConstraintPolicy {
 		if (context === null) return { satisfied: false, reason: 'missing-context' };
 		const required = this.rank.get(resource.labels.classification);
 		const held = this.rank.get(context.classification);
-		if (required === undefined || held === undefined || held < required) {
-			return { satisfied: false, reason: 'constraint' };
-		}
 		const compartments = new Set(context.compartments);
-		return resource.labels.compartments.every((compartment) => compartments.has(compartment))
-			? { satisfied: true }
-			: { satisfied: false, reason: 'constraint' };
+		const missingCompartments = resource.labels.compartments.filter(
+			(compartment) => !compartments.has(compartment),
+		);
+		const classificationSatisfied =
+			required !== undefined && held !== undefined && held >= required;
+		const evidence = {
+			heldClassification: context.classification,
+			requiredClassification: resource.labels.classification,
+			classificationSatisfied,
+			missingCompartments,
+		};
+		return classificationSatisfied && missingCompartments.length === 0
+			? { satisfied: true, evidence }
+			: { satisfied: false, reason: 'constraint', evidence };
 	}
 
 	async evaluateMany(

--- a/packages/core/src/services/authorization/resourceSecurity.test.ts
+++ b/packages/core/src/services/authorization/resourceSecurity.test.ts
@@ -78,16 +78,26 @@ describe('LocalResourceConstraintPolicy', () => {
 		const labels = { classification: 'SECRET', compartments: ['element-a', 'element-b'] };
 		await expect(local().evaluate(context(), 'project.read', { labels })).resolves.toEqual({
 			satisfied: true,
+			evidence: {
+				heldClassification: 'SECRET',
+				requiredClassification: 'SECRET',
+				classificationSatisfied: true,
+				missingCompartments: [],
+			},
 		});
 		await expect(
 			local().evaluate(context({ classification: 'TOP_SECRET' }), 'project.read', { labels }),
-		).resolves.toEqual({ satisfied: true });
+		).resolves.toMatchObject({ satisfied: true });
 		await expect(
 			local().evaluate(context({ classification: 'CUI' }), 'project.read', { labels }),
-		).resolves.toEqual({ satisfied: false, reason: 'constraint' });
+		).resolves.toMatchObject({ satisfied: false, reason: 'constraint' });
 		await expect(
 			local().evaluate(context({ compartments: ['element-a'] }), 'project.read', { labels }),
-		).resolves.toEqual({ satisfied: false, reason: 'constraint' });
+		).resolves.toMatchObject({
+			satisfied: false,
+			reason: 'constraint',
+			evidence: { missingCompartments: ['element-b'] },
+		});
 		await expect(local().evaluate(null, 'project.read', { labels })).resolves.toEqual({
 			satisfied: false,
 			reason: 'missing-context',
@@ -99,12 +109,12 @@ describe('LocalResourceConstraintPolicy', () => {
 			local().evaluate(context(), 'project.read', {
 				labels: { classification: 'COSMIC', compartments: [] },
 			}),
-		).resolves.toEqual({ satisfied: false, reason: 'constraint' });
+		).resolves.toMatchObject({ satisfied: false, reason: 'constraint' });
 		await expect(
 			local().evaluate(context({ classification: 'COSMIC' }), 'project.read', {
 				labels: { classification: 'CUI', compartments: [] },
 			}),
-		).resolves.toEqual({ satisfied: false, reason: 'constraint' });
+		).resolves.toMatchObject({ satisfied: false, reason: 'constraint' });
 	});
 });
 

--- a/packages/core/src/services/authorization/resourceSecurity.test.ts
+++ b/packages/core/src/services/authorization/resourceSecurity.test.ts
@@ -445,6 +445,117 @@ describe('AuthorizationService: adapter trust boundary', () => {
 		).resolves.toEqual([true, false]);
 	});
 
+	it.each([
+		[
+			'contradicts a satisfied verdict',
+			{
+				heldClassification: 'SECRET',
+				requiredClassification: 'SECRET',
+				classificationSatisfied: false,
+				missingCompartments: [],
+			},
+		],
+		[
+			'contains an invalid classification',
+			{
+				heldClassification: 'NOT A LABEL',
+				requiredClassification: 'SECRET',
+				classificationSatisfied: true,
+				missingCompartments: [],
+			},
+		],
+		[
+			'contains an unexpected field',
+			{
+				heldClassification: 'SECRET',
+				requiredClassification: 'SECRET',
+				classificationSatisfied: true,
+				missingCompartments: [],
+				secretExplanation: 'adapter detail',
+			},
+		],
+	] as const)(
+		'drops evidence that %s without changing an allow verdict',
+		async (_name, evidence) => {
+			const response = { satisfied: true, evidence };
+			const constraints: ResourceConstraintPolicy = {
+				evaluate: async () => response as never,
+				evaluateMany: async (_ctx, _action, resources) => resources.map(() => response as never),
+			};
+			const authz = service({ constraints, subjectContext: providerOf(context()) });
+
+			await expect(authz.authorize(principal(), 'project.read', read)).resolves.toMatchObject({
+				allowed: true,
+			});
+			await expect(authz.authorizeMany(principal(), 'project.read', [read])).resolves.toMatchObject(
+				[{ allowed: true }],
+			);
+			await expect(
+				authz.projectLabelConstraints(principal(), [labeled.security_labels ?? null]),
+			).resolves.toEqual([true]);
+
+			const analysis = await authz.analyze(principal(), 'project.read', read);
+			const constraintStep = analysis.trace.find((step) => step.stage === 'constraint');
+			expect(constraintStep).toMatchObject({
+				status: 'passed',
+				code: 'resource_constraints_satisfied',
+				details: { labelSetCount: 1 },
+			});
+			expect(constraintStep?.details).not.toHaveProperty('evidence');
+		},
+	);
+
+	it('drops evidence that contradicts a denied verdict without changing the denial', async () => {
+		const response = {
+			satisfied: false,
+			reason: 'constraint',
+			evidence: {
+				heldClassification: 'SECRET',
+				requiredClassification: 'SECRET',
+				classificationSatisfied: true,
+				missingCompartments: [],
+			},
+		};
+		const authz = service({
+			constraints: {
+				evaluate: async () => response as never,
+				evaluateMany: async (_ctx, _action, resources) => resources.map(() => response as never),
+			},
+			subjectContext: providerOf(context()),
+		});
+
+		const analysis = await authz.analyze(principal(), 'project.read', read);
+		expect(analysis.decision).toEqual({
+			allowed: false,
+			category: 'constraint',
+			role: 'admin',
+			constraintReason: 'constraint',
+		});
+		const constraintStep = analysis.trace.find((step) => step.stage === 'constraint');
+		expect(constraintStep?.details).not.toHaveProperty('evidence');
+	});
+
+	it('indexes sparse evidence by its label-set position', async () => {
+		const evidence = {
+			heldClassification: 'SECRET',
+			requiredClassification: 'CUI',
+			classificationSatisfied: true as const,
+			missingCompartments: [] as const,
+		};
+		const constraints: ResourceConstraintPolicy = {
+			evaluate: async () => ({ satisfied: true }),
+			evaluateMany: async () => [{ satisfied: true }, { satisfied: true, evidence }],
+		};
+		const authz = service({ constraints, subjectContext: providerOf(context()) });
+		const analysis = await authz.analyze(principal(), 'project.read', {
+			...read,
+			notebookLabels: { classification: 'CUI', compartments: [] },
+		});
+
+		const constraintStep = analysis.trace.find((step) => step.stage === 'constraint');
+		expect(constraintStep?.details?.evidence).toEqual([{ labelSetIndex: 1, ...evidence }]);
+	});
+
 	it('never delegates a labeled resource to the adapter without a context', async () => {
 		// A hostile or buggy adapter that satisfies everything must still be
 		// unable to open a labeled resource for a context-less subject.

--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -11,39 +11,42 @@ afterEach(() => {
 });
 
 describe('App routes', () => {
-	it.each(['/admin/audit-logs', '/admin/users', '/admin/settings', '/admin/debug'])(
-		'redirects a non-super-admin away from %s',
-		async (path) => {
-			installMatchMedia(false);
-			const requests: string[] = [];
-			vi.stubGlobal(
-				'fetch',
-				vi.fn(async (input: RequestInfo | URL) => {
-					const url = String(input);
-					requests.push(url);
-					if (url === '/api/v1/me') {
-						return jsonOk({
-							id: 'user-one',
-							email: 'user@example.com',
-							logout_url: null,
-							is_super_admin: false,
-						});
-					}
-					if (url === '/api/v1/projects') return jsonOk({ items: [], next_cursor: null });
-					if (url === '/api/v1/version') return jsonOk({ version: 'test' });
-					throw new Error(`unexpected fetch: ${url}`);
-				}),
-			);
-			window.history.replaceState({}, '', path);
+	it.each([
+		'/admin/audit-logs',
+		'/admin/users',
+		'/admin/settings',
+		'/admin/policy-analyzer',
+		'/admin/debug',
+	])('redirects a non-super-admin away from %s', async (path) => {
+		installMatchMedia(false);
+		const requests: string[] = [];
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				requests.push(url);
+				if (url === '/api/v1/me') {
+					return jsonOk({
+						id: 'user-one',
+						email: 'user@example.com',
+						logout_url: null,
+						is_super_admin: false,
+					});
+				}
+				if (url === '/api/v1/projects') return jsonOk({ items: [], next_cursor: null });
+				if (url === '/api/v1/version') return jsonOk({ version: 'test' });
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		window.history.replaceState({}, '', path);
 
-			renderWithClient(<App />, { toaster: false });
+		renderWithClient(<App />, { toaster: false });
 
-			expect(await screen.findByRole('heading', { name: 'Projects' })).toBeInTheDocument();
-			expect(window.location.pathname).toBe('/');
-			expect(requests.some((url) => url.startsWith('/api/v1/events?'))).toBe(false);
-			expect(requests.some((url) => url.startsWith('/api/v1/admin/'))).toBe(false);
-		},
-	);
+		expect(await screen.findByRole('heading', { name: 'Projects' })).toBeInTheDocument();
+		expect(window.location.pathname).toBe('/');
+		expect(requests.some((url) => url.startsWith('/api/v1/events?'))).toBe(false);
+		expect(requests.some((url) => url.startsWith('/api/v1/admin/'))).toBe(false);
+	});
 
 	it('redirects /admin to /admin/users for a super admin', async () => {
 		installMatchMedia(false);
@@ -140,6 +143,10 @@ describe('App routes', () => {
 		expect(await screen.findByRole('heading', { name: 'Users' })).toBeInTheDocument();
 		expect(screen.getByRole('navigation', { name: 'Admin' })).toBeInTheDocument();
 		expect(screen.getByRole('link', { name: 'Debug' })).toHaveAttribute('href', '/admin/debug');
+		expect(screen.getByRole('link', { name: 'Policy' })).toHaveAttribute(
+			'href',
+			'/admin/policy-analyzer',
+		);
 		expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
 		expect(window.location.pathname).toBe('/admin/users');
 	});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -21,6 +21,7 @@ const DataBrowserPage = lazy(() => import('@/components/DataBrowser/DataBrowserP
 const AdminUsersPage = lazy(() => import('@/components/Admin/AdminUsersPage'));
 const AdminSettingsPage = lazy(() => import('@/components/Admin/AdminSettingsPage'));
 const AdminDebugPage = lazy(() => import('@/components/Admin/AdminDebugPage'));
+const AdminPolicyAnalyzerPage = lazy(() => import('@/components/Admin/AdminPolicyAnalyzerPage'));
 const CliLoginPage = lazy(() =>
 	import('@/components/Account/CliLoginPage').then((module) => ({ default: module.CliLoginPage })),
 );
@@ -134,6 +135,7 @@ function StandardLayout() {
 								<Route path="users" element={<AdminUsersPage />} />
 								<Route path="settings" element={<AdminSettingsPage />} />
 								<Route path="audit-logs" element={<AuditLogPage />} />
+								<Route path="policy-analyzer" element={<AdminPolicyAnalyzerPage />} />
 								<Route path="debug" element={<AdminDebugPage />} />
 							</Route>
 							<Route path="*" element={<NotFoundPage />} />

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -267,11 +267,12 @@ export function usePolicyAnalyzerMetadataQuery() {
 }
 
 export function useEvaluatePolicySuite() {
-	return useMutation({
-		mutationFn: (body: PolicySuiteV1): Promise<PolicySuiteResult> =>
+	return useApiMutation(
+		(body: PolicySuiteV1): Promise<PolicySuiteResult> =>
 			apiData(apiClient.POST('/api/v1/admin/policy-analyzer/evaluate', { body })),
-		meta: { suppressErrorToast: true },
-	});
+		() => [auditKeys.all],
+		{ suppressErrorToast: true },
+	);
 }
 
 // Projects

--- a/packages/web/src/api/hooks.ts
+++ b/packages/web/src/api/hooks.ts
@@ -35,6 +35,8 @@ import type {
 	ProjectListFilters,
 	NotebookListFilters,
 	SandboxStartupReport,
+	PolicySuiteV1,
+	PolicySuiteResult,
 } from '../types';
 
 /** How often the notebook table re-polls runtime status, in ms. */
@@ -253,6 +255,21 @@ export function useRunSandboxStartupTest(startupTimeoutSeconds = 120) {
 						startupTimeoutSeconds * 1000 + (body.environment_setup_benchmark ? 570_000 : 60_000),
 				}),
 			),
+		meta: { suppressErrorToast: true },
+	});
+}
+
+export function usePolicyAnalyzerMetadataQuery() {
+	return useSuspenseQuery({
+		queryKey: adminKeys.policyAnalyzer(),
+		queryFn: () => apiData(apiClient.GET('/api/v1/admin/policy-analyzer/metadata')),
+	});
+}
+
+export function useEvaluatePolicySuite() {
+	return useMutation({
+		mutationFn: (body: PolicySuiteV1): Promise<PolicySuiteResult> =>
+			apiData(apiClient.POST('/api/v1/admin/policy-analyzer/evaluate', { body })),
 		meta: { suppressErrorToast: true },
 	});
 }

--- a/packages/web/src/api/queryKeys.ts
+++ b/packages/web/src/api/queryKeys.ts
@@ -134,6 +134,7 @@ export const adminKeys = {
 	all: ['admin'] as const,
 	users: () => [...adminKeys.all, 'users'] as const,
 	config: () => [...adminKeys.all, 'config'] as const,
+	policyAnalyzer: () => [...adminKeys.all, 'policy-analyzer'] as const,
 };
 
 export const sessionKeys = {

--- a/packages/web/src/components/Admin/AdminLayout.tsx
+++ b/packages/web/src/components/Admin/AdminLayout.tsx
@@ -6,6 +6,7 @@ const TABS = [
 	{ to: '/admin/users', label: 'Users' },
 	{ to: '/admin/settings', label: 'Settings' },
 	{ to: '/admin/audit-logs', label: 'Audit logs' },
+	{ to: '/admin/policy-analyzer', label: 'Policy' },
 	{ to: '/admin/debug', label: 'Debug' },
 ];
 

--- a/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.test.tsx
+++ b/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.test.tsx
@@ -1,9 +1,28 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { jsonOk, renderWithClient } from '@/test/render';
 import { AuthProvider } from '@/context/AuthContext';
 import AdminPolicyAnalyzerPage from './AdminPolicyAnalyzerPage';
+
+function requestUrl(input: RequestInfo | URL): string {
+	if (input instanceof Request) {
+		const url = new URL(input.url);
+		return `${url.pathname}${url.search}`;
+	}
+	return String(input);
+}
+
+function requestOf(fetchMock: ReturnType<typeof vi.fn>, path: string): Request {
+	const call = fetchMock.mock.calls.find(
+		([input]) => requestUrl(input as RequestInfo | URL) === path,
+	);
+	if (!call) throw new Error(`expected a request to ${path}`);
+	const [input, init] = call as [RequestInfo | URL, RequestInit | undefined];
+	return input instanceof Request
+		? input
+		: new Request(new URL(String(input), 'http://test.local'), init);
+}
 
 afterEach(() => {
 	vi.unstubAllGlobals();
@@ -12,89 +31,87 @@ afterEach(() => {
 
 describe('AdminPolicyAnalyzerPage', () => {
 	it('builds a case and renders the deterministic trace', async () => {
-		vi.stubGlobal(
-			'fetch',
-			vi.fn(async (input: RequestInfo | URL) => {
-				const url = String(input);
-				if (url === '/api/v1/me') {
-					return jsonOk({
-						id: 'admin',
-						email: 'admin@example.com',
-						is_super_admin: true,
-						can_create_projects: true,
-						logout_url: null,
-					});
-				}
-				if (url === '/api/v1/admin/users') {
-					return jsonOk({
-						items: [
-							{
-								id: 'admin',
-								email: 'admin@example.com',
-								name: 'Admin',
-								updated_at: '2026-09-01T00:00:00.000Z',
-								suspended_at: null,
-								is_super_admin: true,
-							},
-						],
-						next_cursor: null,
-					});
-				}
-				if (url === '/api/v1/admin/policy-analyzer/metadata') {
-					return jsonOk({
-						schema_version: 1,
-						max_cases: 25,
-						capabilities: {
-							login_policy: false,
-							resource_security: true,
-							live_self_context: false,
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url === '/api/v1/me') {
+				return jsonOk({
+					id: 'admin',
+					email: 'admin@example.com',
+					is_super_admin: true,
+					can_create_projects: true,
+					logout_url: null,
+				});
+			}
+			if (url === '/api/v1/admin/users') {
+				return jsonOk({
+					items: [
+						{
+							id: 'admin',
+							email: 'admin@example.com',
+							name: 'Admin',
+							updated_at: '2026-09-01T00:00:00.000Z',
+							suspended_at: null,
+							is_super_admin: true,
 						},
-						entitlements: ['super-admin', 'project-creator'],
-						classification_order: ['LEVEL_1', 'LEVEL_2'],
-						actions: [
-							{
-								action: 'project.read',
-								scope: 'project',
-								minimum_role: 'viewer',
-								denied_as: 'not-found',
-								requires_super_admin: false,
+					],
+					next_cursor: null,
+				});
+			}
+			if (url === '/api/v1/admin/policy-analyzer/metadata') {
+				return jsonOk({
+					schema_version: 1,
+					max_cases: 25,
+					capabilities: {
+						login_policy: false,
+						resource_security: true,
+						live_self_context: false,
+					},
+					entitlements: ['super-admin', 'project-creator'],
+					classification_order: ['LEVEL_1', 'LEVEL_2'],
+					actions: [
+						{
+							action: 'project.read',
+							scope: 'project',
+							minimum_role: 'viewer',
+							denied_as: 'not-found',
+							requires_super_admin: false,
+						},
+					],
+				});
+			}
+			if (url.startsWith('/api/v1/projects?')) {
+				return jsonOk({ items: [], next_cursor: null });
+			}
+			if (url === '/api/v1/admin/policy-analyzer/evaluate') {
+				return jsonOk({
+					valid: true,
+					summary: { case_count: 1, passed: 1, failed: 0 },
+					cases: [
+						{
+							id: 'case-1',
+							name: 'Policy check',
+							valid: true,
+							login: null,
+							authorization: {
+								decision: { allowed: true, role: 'admin' },
+								presentation: 'allowed',
+								trace: [
+									{
+										stage: 'final',
+										status: 'passed',
+										code: 'authorization_allowed',
+									},
+								],
+								assertion: { passed: true, expected: { allowed: true } },
 							},
-						],
-					});
-				}
-				if (url.startsWith('/api/v1/projects?')) {
-					return jsonOk({ items: [], next_cursor: null });
-				}
-				if (url === '/api/v1/admin/policy-analyzer/evaluate') {
-					return jsonOk({
-						valid: true,
-						summary: { case_count: 1, passed: 1, failed: 0 },
-						cases: [
-							{
-								id: 'case-1',
-								name: 'Policy check',
-								valid: true,
-								login: null,
-								authorization: {
-									decision: { allowed: true, role: 'admin' },
-									presentation: 'allowed',
-									trace: [
-										{
-											stage: 'final',
-											status: 'passed',
-											code: 'authorization_allowed',
-										},
-									],
-									assertion: { passed: true, expected: { allowed: true } },
-								},
-								errors: [],
-							},
-						],
-					});
-				}
-				throw new Error(`unexpected fetch: ${url}`);
-			}),
-		);
+							errors: [],
+						},
+					],
+				});
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal('fetch', fetchMock);
 		const user = userEvent.setup();
 		renderWithClient(
 			<AuthProvider>
@@ -104,9 +121,13 @@ describe('AdminPolicyAnalyzerPage', () => {
 
 		expect(await screen.findByRole('heading', { name: 'Policy Analyzer' })).toBeInTheDocument();
 		expect(screen.getByText('Login Policy: Not Configured')).toBeInTheDocument();
-		expect(screen.queryByText('Explicit entitlements affect')).not.toBeInTheDocument();
-		await user.click(screen.getByText('Entitlements & Standing'));
-		expect(screen.getByText(/Explicit entitlements affect/)).toBeInTheDocument();
+		const entitlementsSummary = screen.getByText('Entitlements & Standing');
+		const entitlementsSection = entitlementsSummary.closest('details');
+		expect(entitlementsSection).not.toHaveAttribute('open');
+		expect(screen.getByText(/Explicit entitlements affect/)).not.toBeVisible();
+		await user.click(entitlementsSummary);
+		expect(entitlementsSection).toHaveAttribute('open');
+		expect(screen.getByText(/Explicit entitlements affect/)).toBeVisible();
 		expect(screen.getByRole('textbox', { name: 'JSON suite' })).not.toBeVisible();
 		await user.click(screen.getByText('JSON Test Suite'));
 		const suiteEditor = screen.getByRole('textbox', { name: 'JSON suite' });
@@ -121,5 +142,90 @@ describe('AdminPolicyAnalyzerPage', () => {
 		expect(
 			screen.getByText('The final authorization decision allows the action.'),
 		).toBeInTheDocument();
+	});
+
+	it('sends the API app mode for an app session scenario', async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = requestUrl(input);
+			if (url === '/api/v1/me') {
+				return jsonOk({
+					id: 'admin',
+					email: 'admin@example.com',
+					is_super_admin: true,
+					can_create_projects: true,
+					logout_url: null,
+				});
+			}
+			if (url === '/api/v1/admin/users') {
+				return jsonOk({ items: [], next_cursor: null });
+			}
+			if (url === '/api/v1/admin/policy-analyzer/metadata') {
+				return jsonOk({
+					schema_version: 1,
+					max_cases: 25,
+					capabilities: {
+						login_policy: false,
+						resource_security: true,
+						live_self_context: false,
+					},
+					entitlements: [],
+					classification_order: [],
+					actions: [
+						{
+							action: 'project.read',
+							scope: 'project',
+							minimum_role: 'viewer',
+							denied_as: 'not-found',
+							requires_super_admin: false,
+						},
+						{
+							action: 'session.start',
+							scope: 'session-start',
+							minimum_role: 'viewer',
+							denied_as: 'forbidden',
+							requires_super_admin: false,
+						},
+					],
+				});
+			}
+			if (url.startsWith('/api/v1/projects?')) {
+				return jsonOk({ items: [], next_cursor: null });
+			}
+			if (url === '/api/v1/admin/policy-analyzer/evaluate') {
+				return jsonOk({
+					valid: true,
+					summary: { case_count: 1, passed: 1, failed: 0 },
+					cases: [],
+				});
+			}
+			throw new Error(`unexpected fetch: ${url}`);
+		});
+		vi.stubGlobal('fetch', fetchMock);
+		const user = userEvent.setup();
+		renderWithClient(
+			<AuthProvider>
+				<AdminPolicyAnalyzerPage />
+			</AuthProvider>,
+		);
+
+		await screen.findByRole('heading', { name: 'Policy Analyzer' });
+		await user.selectOptions(screen.getByRole('combobox', { name: 'Action' }), 'session.start');
+		const mode = screen.getByRole('combobox', { name: 'Session Mode' });
+		expect(mode).toHaveValue('edit');
+		await user.selectOptions(mode, 'app');
+		await user.click(screen.getByRole('button', { name: /Run Scenario/ }));
+
+		await waitFor(() =>
+			expect(
+				fetchMock.mock.calls.some(
+					([input]) => requestUrl(input) === '/api/v1/admin/policy-analyzer/evaluate',
+				),
+			).toBe(true),
+		);
+		const request = requestOf(fetchMock, '/api/v1/admin/policy-analyzer/evaluate');
+		const suite = JSON.parse(await request.text()) as {
+			cases: { authorization: { resource: { mode?: string } } }[];
+		};
+		expect(suite.cases[0]?.authorization.resource.mode).toBe('app');
 	});
 });

--- a/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.test.tsx
+++ b/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { jsonOk, renderWithClient } from '@/test/render';
+import { AuthProvider } from '@/context/AuthContext';
+import AdminPolicyAnalyzerPage from './AdminPolicyAnalyzerPage';
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.restoreAllMocks();
+});
+
+describe('AdminPolicyAnalyzerPage', () => {
+	it('builds a case and renders the deterministic trace', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: RequestInfo | URL) => {
+				const url = String(input);
+				if (url === '/api/v1/me') {
+					return jsonOk({
+						id: 'admin',
+						email: 'admin@example.com',
+						is_super_admin: true,
+						can_create_projects: true,
+						logout_url: null,
+					});
+				}
+				if (url === '/api/v1/admin/users') {
+					return jsonOk({
+						items: [
+							{
+								id: 'admin',
+								email: 'admin@example.com',
+								name: 'Admin',
+								updated_at: '2026-09-01T00:00:00.000Z',
+								suspended_at: null,
+								is_super_admin: true,
+							},
+						],
+						next_cursor: null,
+					});
+				}
+				if (url === '/api/v1/admin/policy-analyzer/metadata') {
+					return jsonOk({
+						schema_version: 1,
+						max_cases: 25,
+						capabilities: {
+							login_policy: false,
+							resource_security: true,
+							live_self_context: false,
+						},
+						entitlements: ['super-admin', 'project-creator'],
+						classification_order: ['LEVEL_1', 'LEVEL_2'],
+						actions: [
+							{
+								action: 'project.read',
+								scope: 'project',
+								minimum_role: 'viewer',
+								denied_as: 'not-found',
+								requires_super_admin: false,
+							},
+						],
+					});
+				}
+				if (url.startsWith('/api/v1/projects?')) {
+					return jsonOk({ items: [], next_cursor: null });
+				}
+				if (url === '/api/v1/admin/policy-analyzer/evaluate') {
+					return jsonOk({
+						valid: true,
+						summary: { case_count: 1, passed: 1, failed: 0 },
+						cases: [
+							{
+								id: 'case-1',
+								name: 'Policy check',
+								valid: true,
+								login: null,
+								authorization: {
+									decision: { allowed: true, role: 'admin' },
+									presentation: 'allowed',
+									trace: [
+										{
+											stage: 'final',
+											status: 'passed',
+											code: 'authorization_allowed',
+										},
+									],
+									assertion: { passed: true, expected: { allowed: true } },
+								},
+								errors: [],
+							},
+						],
+					});
+				}
+				throw new Error(`unexpected fetch: ${url}`);
+			}),
+		);
+		const user = userEvent.setup();
+		renderWithClient(
+			<AuthProvider>
+				<AdminPolicyAnalyzerPage />
+			</AuthProvider>,
+		);
+
+		expect(await screen.findByRole('heading', { name: 'Policy Analyzer' })).toBeInTheDocument();
+		expect(screen.getByText('Login Policy: Not Configured')).toBeInTheDocument();
+		expect(screen.queryByText('Explicit entitlements affect')).not.toBeInTheDocument();
+		await user.click(screen.getByText('Entitlements & Standing'));
+		expect(screen.getByText(/Explicit entitlements affect/)).toBeInTheDocument();
+		expect(screen.getByRole('textbox', { name: 'JSON suite' })).not.toBeVisible();
+		await user.click(screen.getByText('JSON Test Suite'));
+		const suiteEditor = screen.getByRole('textbox', { name: 'JSON suite' });
+		expect(suiteEditor).toBeVisible();
+		fireEvent.change(suiteEditor, {
+			target: { value: JSON.stringify({ schema_version: 2, cases: [] }) },
+		});
+		expect(await screen.findAllByText('Use suite schema version 1.')).toHaveLength(2);
+		expect(screen.getByRole('button', { name: /Run Suite/ })).toBeDisabled();
+		await user.click(screen.getByRole('button', { name: /Run Scenario/ }));
+		expect(await screen.findByRole('heading', { name: 'Scenario Passed' })).toBeInTheDocument();
+		expect(
+			screen.getByText('The final authorization decision allows the action.'),
+		).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.tsx
+++ b/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.tsx
@@ -1,5 +1,5 @@
 import { useDeferredValue, useMemo, useRef, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { Dispatch, ReactNode, RefObject, SetStateAction } from 'react';
 import {
 	AlertTriangle,
 	Braces,
@@ -24,7 +24,13 @@ import {
 } from '@/api/hooks';
 import { useAuth } from '@/context/AuthContext';
 import { triggerDownload } from '@/lib/download';
-import type { PolicySuiteResult, PolicySuiteV1 } from '@/types';
+import type {
+	AdminUser,
+	PolicyAnalyzerMetadata,
+	PolicySuiteResult,
+	PolicySuiteV1,
+	ProjectSummary,
+} from '@/types';
 
 type PolicyCase = PolicySuiteV1['cases'][number];
 type Action = NonNullable<PolicyCase['authorization']>['action'];
@@ -35,6 +41,15 @@ type DenialCategory = NonNullable<
 	NonNullable<PolicyCase['authorization']>['expected']['denial_category']
 >;
 type SessionMode = NonNullable<NonNullable<PolicyCase['authorization']>['resource']['mode']>;
+type ActionRule = PolicyAnalyzerMetadata['actions'][number];
+type Scope = ActionRule['scope'];
+type ResourceSource = 'stored' | 'synthetic';
+type LoginOutcome = 'allow' | 'deny';
+type ContextMode = 'synthetic' | 'live-self';
+type Relationship = 'owner' | 'member' | 'none';
+type MemberRole = (typeof MEMBER_ROLES)[number];
+type ProjectStatus = 'active' | 'deleted';
+type SuiteInfo = { valid: true; count: number } | { valid: false; count: 0; message: string };
 
 const DENIAL_CATEGORIES: readonly DenialCategory[] = [
 	'lifecycle',
@@ -424,6 +439,1011 @@ function ResultCard({ result }: { result: PolicySuiteResult }) {
 	);
 }
 
+function AnalyzerOverview({ metadata }: { metadata: PolicyAnalyzerMetadata }) {
+	return (
+		<>
+			<div className="mb-6 grid gap-3 sm:grid-cols-3">
+				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
+					<ShieldCheck aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+					<div>
+						<p className="text-sm font-medium">Deterministic</p>
+						<p className="text-xs text-muted-foreground">No generated reasoning</p>
+					</div>
+				</div>
+				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
+					<LockKeyhole aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+					<div>
+						<p className="text-sm font-medium">Read-Only</p>
+						<p className="text-xs text-muted-foreground">No policy or access changes</p>
+					</div>
+				</div>
+				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
+					<Braces aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+					<div>
+						<p className="text-sm font-medium">Versioned</p>
+						<p className="text-xs text-muted-foreground">Portable version 1 suites</p>
+					</div>
+				</div>
+			</div>
+			<div className="mb-6 flex flex-wrap gap-2" aria-label="Analyzer capabilities">
+				<Chip>
+					Login Policy: {metadata.capabilities.login_policy ? 'Available' : 'Not Configured'}
+				</Chip>
+				<Chip>
+					Resource Security:{' '}
+					{metadata.capabilities.resource_security ? 'Available' : 'Not Configured'}
+				</Chip>
+				<Chip>{metadata.max_cases} Cases Maximum</Chip>
+			</div>
+		</>
+	);
+}
+
+interface SubjectStepProps {
+	metadata: PolicyAnalyzerMetadata;
+	users: readonly AdminUser[];
+	subjectId: string;
+	subjectEmail: string;
+	caseName: string;
+	entitlements: Entitlement[];
+	loginEnabled: boolean;
+	expectedLoginOutcome: LoginOutcome;
+	idClaims: string;
+	userInfoClaims: string;
+	onSelectUser: (id: string) => void;
+	onSubjectIdChange: (value: string) => void;
+	onSubjectEmailChange: (value: string) => void;
+	onCaseNameChange: (value: string) => void;
+	setEntitlements: Dispatch<SetStateAction<Entitlement[]>>;
+	onLoginEnabledChange: (value: boolean) => void;
+	onExpectedLoginOutcomeChange: (value: LoginOutcome) => void;
+	onIdClaimsChange: (value: string) => void;
+	onUserInfoClaimsChange: (value: string) => void;
+}
+
+function SubjectStep({
+	metadata,
+	users,
+	subjectId,
+	subjectEmail,
+	caseName,
+	entitlements,
+	loginEnabled,
+	expectedLoginOutcome,
+	idClaims,
+	userInfoClaims,
+	onSelectUser,
+	onSubjectIdChange,
+	onSubjectEmailChange,
+	onCaseNameChange,
+	setEntitlements,
+	onLoginEnabledChange,
+	onExpectedLoginOutcomeChange,
+	onIdClaimsChange,
+	onUserInfoClaimsChange,
+}: SubjectStepProps) {
+	const selectedEntitlements = useMemo(() => new Set(entitlements), [entitlements]);
+	return (
+		<StepCard
+			number={1}
+			title="Choose the Subject"
+			description="Select a known user or enter a hypothetical identity."
+		>
+			<div className="grid gap-3 sm:grid-cols-2">
+				<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+					Known User
+					<select
+						name="known-user"
+						autoComplete="off"
+						className={inputClass}
+						value={users.some((entry) => entry.id === subjectId) ? subjectId : ''}
+						onChange={(event) => {
+							if (event.target.value) onSelectUser(event.target.value);
+						}}
+					>
+						<option value="">Hypothetical user</option>
+						{users.map((entry) => (
+							<option key={entry.id} value={entry.id}>
+								{entry.name} · {entry.email}
+							</option>
+						))}
+					</select>
+				</label>
+				<TextField label="Subject ID" value={subjectId} onChange={onSubjectIdChange} />
+				<TextField label="Subject Email" value={subjectEmail} onChange={onSubjectEmailChange} />
+				<TextField label="Case Name" value={caseName} onChange={onCaseNameChange} />
+			</div>
+
+			<AdvancedSection title="Entitlements & Standing" summary={`${entitlements.length} selected`}>
+				<p className="mb-3 text-xs text-muted-foreground">
+					{loginEnabled
+						? 'Select the exact normalized entitlements expected from login. An allowed login passes them to authorization.'
+						: 'Explicit entitlements affect deployment standing and default roles.'}
+				</p>
+				<div className="grid gap-2 sm:grid-cols-2">
+					{metadata.entitlements.map((entitlement) => (
+						<label
+							key={entitlement}
+							className="flex min-h-9 items-center gap-2 rounded-md px-2 text-sm hover:bg-muted/50"
+						>
+							<input
+								type="checkbox"
+								aria-label={entitlement}
+								checked={selectedEntitlements.has(entitlement)}
+								onChange={(event) =>
+									setEntitlements((current) =>
+										event.target.checked
+											? [...current, entitlement]
+											: current.filter((item) => item !== entitlement),
+									)
+								}
+							/>
+							<code translate="no" className="break-all">
+								{entitlement}
+							</code>
+						</label>
+					))}
+				</div>
+			</AdvancedSection>
+
+			<div className="mt-4 rounded-lg border bg-muted/20 p-3">
+				<label aria-label="Evaluate the login policy" className="flex items-start gap-3 text-sm">
+					<input
+						type="checkbox"
+						aria-label="Evaluate the login policy"
+						className="mt-1"
+						checked={loginEnabled}
+						disabled={!metadata.capabilities.login_policy}
+						onChange={(event) => onLoginEnabledChange(event.target.checked)}
+					/>
+					<span>
+						<span className="font-medium">Evaluate the Login Policy</span>
+						<span className="mt-0.5 block text-xs text-muted-foreground">
+							{metadata.capabilities.login_policy
+								? 'Use sample claims and pass allowed entitlements to authorization.'
+								: 'No login policy is configured for this deployment.'}
+						</span>
+					</span>
+				</label>
+				{loginEnabled ? (
+					<div className="mt-4 grid gap-3 border-t pt-4 sm:grid-cols-2">
+						<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+							Expected Login Decision
+							<select
+								name="expected-login-decision"
+								autoComplete="off"
+								className={inputClass}
+								value={expectedLoginOutcome}
+								onChange={(event) =>
+									onExpectedLoginOutcomeChange(event.target.value as LoginOutcome)
+								}
+							>
+								<option value="allow">Allow</option>
+								<option value="deny">Deny</option>
+							</select>
+						</label>
+						<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground sm:col-span-2">
+							ID-Token Claims
+							<textarea
+								aria-label="ID-token claims"
+								name="id-token-claims"
+								autoComplete="off"
+								spellCheck={false}
+								className={textAreaClass}
+								rows={6}
+								value={idClaims}
+								onChange={(event) => onIdClaimsChange(event.target.value)}
+							/>
+						</label>
+						<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground sm:col-span-2">
+							UserInfo Claims <span className="font-normal">(Optional)</span>
+							<textarea
+								aria-label="UserInfo claims"
+								name="userinfo-claims"
+								autoComplete="off"
+								spellCheck={false}
+								className={textAreaClass}
+								rows={4}
+								placeholder={'{\n  "department": "analytics"\n}'}
+								value={userInfoClaims}
+								onChange={(event) => onUserInfoClaimsChange(event.target.value)}
+							/>
+						</label>
+					</div>
+				) : null}
+			</div>
+		</StepCard>
+	);
+}
+
+interface ResourceStepProps {
+	metadata: PolicyAnalyzerMetadata;
+	projects: readonly Pick<ProjectSummary, 'id' | 'name'>[];
+	action: Action;
+	actionRule: ActionRule | undefined;
+	scope: Scope;
+	source: ResourceSource;
+	projectId: string;
+	notebookId: string;
+	sessionId: string;
+	relationship: Relationship;
+	memberRole: MemberRole;
+	sessionMode: SessionMode;
+	projectStatus: ProjectStatus;
+	requiredClassification: string;
+	requiredCompartments: string;
+	onActionChange: (value: Action) => void;
+	onSourceChange: (value: ResourceSource) => void;
+	onProjectIdChange: (value: string) => void;
+	onNotebookIdChange: (value: string) => void;
+	onSessionIdChange: (value: string) => void;
+	onRelationshipChange: (value: Relationship) => void;
+	onMemberRoleChange: (value: MemberRole) => void;
+	onSessionModeChange: (value: SessionMode) => void;
+	onProjectStatusChange: (value: ProjectStatus) => void;
+	onRequiredClassificationChange: (value: string) => void;
+	onRequiredCompartmentsChange: (value: string) => void;
+}
+
+function ResourceStep({
+	metadata,
+	projects,
+	action,
+	actionRule,
+	scope,
+	source,
+	projectId,
+	notebookId,
+	sessionId,
+	relationship,
+	memberRole,
+	sessionMode,
+	projectStatus,
+	requiredClassification,
+	requiredCompartments,
+	onActionChange,
+	onSourceChange,
+	onProjectIdChange,
+	onNotebookIdChange,
+	onSessionIdChange,
+	onRelationshipChange,
+	onMemberRoleChange,
+	onSessionModeChange,
+	onProjectStatusChange,
+	onRequiredClassificationChange,
+	onRequiredCompartmentsChange,
+}: ResourceStepProps) {
+	return (
+		<StepCard
+			number={2}
+			title="Choose the Action & Resource"
+			description="The selected action controls which resource fields and rules apply."
+		>
+			<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+				Action
+				<select
+					name="authorization-action"
+					autoComplete="off"
+					className={inputClass}
+					value={action}
+					onChange={(event) => onActionChange(event.target.value as Action)}
+				>
+					{metadata.actions.map((entry) => (
+						<option key={entry.action} value={entry.action}>
+							{entry.action}
+						</option>
+					))}
+				</select>
+			</label>
+			<div className="mt-3 flex gap-2 rounded-lg border border-primary/15 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+				<Info aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+				<p>
+					Scope: <code translate="no">{scope}</code>
+					{actionRule?.minimum_role ? ` · Minimum role: ${actionRule.minimum_role}` : ''}
+					{actionRule?.requires_super_admin ? ' · Requires super admin' : ''}
+					{actionRule?.denied_as ? ` · Denial appears as ${actionRule.denied_as}` : ''}
+				</p>
+			</div>
+
+			{scope !== 'deployment' ? (
+				<>
+					<fieldset className="mt-4">
+						<legend className="text-xs font-medium text-muted-foreground">Resource Source</legend>
+						<div className="mt-1.5 grid grid-cols-2 gap-2">
+							{(['synthetic', 'stored'] as const).map((value) => (
+								<label
+									key={value}
+									className={`flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border px-3 text-sm ${
+										source === value
+											? 'border-primary bg-primary/5 text-primary'
+											: 'hover:bg-muted/50'
+									}`}
+								>
+									<input
+										type="radio"
+										aria-label={value === 'synthetic' ? 'Hypothetical' : 'Stored resource'}
+										name="resource-source"
+										checked={source === value}
+										onChange={() => onSourceChange(value)}
+									/>
+									{value === 'synthetic' ? 'Hypothetical' : 'Stored Resource'}
+								</label>
+							))}
+						</div>
+					</fieldset>
+
+					{source === 'stored' ? (
+						<div className="mt-4 grid gap-3 sm:grid-cols-2">
+							<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+								Project
+								<select
+									name="stored-project"
+									autoComplete="off"
+									className={inputClass}
+									value={projectId}
+									onChange={(event) => onProjectIdChange(event.target.value)}
+								>
+									<option value="">Select a project…</option>
+									{projects.map((project) => (
+										<option key={project.id} value={project.id}>
+											{project.name}
+										</option>
+									))}
+								</select>
+							</label>
+							<TextField
+								label="Notebook ID (Optional)"
+								value={notebookId}
+								onChange={onNotebookIdChange}
+							/>
+							{scope === 'session' ? (
+								<TextField label="Session ID" value={sessionId} onChange={onSessionIdChange} />
+							) : null}
+						</div>
+					) : (
+						<div className="mt-4 grid gap-3 sm:grid-cols-2">
+							<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+								Subject Relationship
+								<select
+									name="subject-relationship"
+									autoComplete="off"
+									className={inputClass}
+									value={relationship}
+									onChange={(event) => onRelationshipChange(event.target.value as Relationship)}
+								>
+									<option value="owner">Project Owner</option>
+									<option value="member">Project Member</option>
+									<option value="none">No Relationship</option>
+								</select>
+							</label>
+							{relationship === 'member' ? (
+								<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+									Member Role
+									<select
+										name="member-role"
+										autoComplete="off"
+										className={inputClass}
+										value={memberRole}
+										onChange={(event) => onMemberRoleChange(event.target.value as MemberRole)}
+									>
+										{MEMBER_ROLES.map((role) => (
+											<option key={role} value={role}>
+												{title(role)}
+											</option>
+										))}
+									</select>
+								</label>
+							) : null}
+						</div>
+					)}
+
+					{scope === 'session-start' || (scope === 'session' && source === 'synthetic') ? (
+						<label className="mt-3 flex max-w-xs flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+							Session Mode
+							<select
+								name="session-mode"
+								autoComplete="off"
+								className={inputClass}
+								value={sessionMode}
+								onChange={(event) => onSessionModeChange(event.target.value as SessionMode)}
+							>
+								<option value="edit">Edit</option>
+								<option value="app">App</option>
+							</select>
+						</label>
+					) : null}
+
+					{source === 'synthetic' ? (
+						<AdvancedSection
+							title="Resource Lifecycle & Labels"
+							summary={requiredClassification || title(projectStatus)}
+						>
+							<div className="grid gap-3 sm:grid-cols-2">
+								<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+									Project Status
+									<select
+										name="project-status"
+										autoComplete="off"
+										className={inputClass}
+										value={projectStatus}
+										onChange={(event) => onProjectStatusChange(event.target.value as ProjectStatus)}
+									>
+										<option value="active">Active</option>
+										<option value="deleted">Deleted</option>
+									</select>
+								</label>
+								<TextField
+									label="Required Classification"
+									placeholder={`${metadata.classification_order[0] ?? 'LEVEL_1'}…`}
+									value={requiredClassification}
+									onChange={onRequiredClassificationChange}
+								/>
+								<TextField
+									label="Required Compartments"
+									placeholder="team-a, project-b…"
+									value={requiredCompartments}
+									onChange={onRequiredCompartmentsChange}
+								/>
+							</div>
+							{metadata.classification_order.length > 0 ? (
+								<div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+									<span>Configured order:</span>
+									{metadata.classification_order.map((classification) => (
+										<Chip key={classification}>{classification}</Chip>
+									))}
+								</div>
+							) : null}
+						</AdvancedSection>
+					) : null}
+				</>
+			) : (
+				<p className="mt-3 text-sm text-muted-foreground">
+					This deployment-scoped action does not require a project or session resource.
+				</p>
+			)}
+		</StepCard>
+	);
+}
+
+interface ExpectedResultStepProps {
+	metadata: PolicyAnalyzerMetadata;
+	expectedAllowed: boolean;
+	expectedDenialCategory: DenialCategory | '';
+	loginEnabled: boolean;
+	expectedLoginOutcome: LoginOutcome;
+	contextMode: ContextMode;
+	heldClassification: string;
+	heldCompartments: string;
+	onExpectedAllowedChange: (value: boolean) => void;
+	onExpectedDenialCategoryChange: (value: DenialCategory | '') => void;
+	onContextModeChange: (value: ContextMode) => void;
+	onHeldClassificationChange: (value: string) => void;
+	onHeldCompartmentsChange: (value: string) => void;
+}
+
+function ExpectedResultStep({
+	metadata,
+	expectedAllowed,
+	expectedDenialCategory,
+	loginEnabled,
+	expectedLoginOutcome,
+	contextMode,
+	heldClassification,
+	heldCompartments,
+	onExpectedAllowedChange,
+	onExpectedDenialCategoryChange,
+	onContextModeChange,
+	onHeldClassificationChange,
+	onHeldCompartmentsChange,
+}: ExpectedResultStepProps) {
+	return (
+		<StepCard
+			number={3}
+			title="Set the Expected Result"
+			description="A scenario passes only when the actual decision matches this expectation."
+		>
+			<div className="grid gap-3 sm:grid-cols-2">
+				<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+					Expected Authorization Decision
+					<select
+						name="expected-authorization-decision"
+						autoComplete="off"
+						className={inputClass}
+						value={expectedAllowed ? 'allow' : 'deny'}
+						onChange={(event) => onExpectedAllowedChange(event.target.value === 'allow')}
+					>
+						<option value="allow">Allow</option>
+						<option value="deny">Deny</option>
+					</select>
+				</label>
+				{!expectedAllowed ? (
+					<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+						Expected Denial Category <span className="font-normal">(Optional)</span>
+						<select
+							name="expected-denial-category"
+							autoComplete="off"
+							className={inputClass}
+							value={expectedDenialCategory}
+							onChange={(event) =>
+								onExpectedDenialCategoryChange(event.target.value as DenialCategory | '')
+							}
+						>
+							<option value="">Any denial category</option>
+							{DENIAL_CATEGORIES.map((category) => (
+								<option key={category} value={category}>
+									{title(category)}
+								</option>
+							))}
+						</select>
+					</label>
+				) : null}
+			</div>
+			{loginEnabled && expectedLoginOutcome === 'deny' ? (
+				<div className="mt-3 flex gap-2 rounded-lg border border-primary/15 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+					<Info aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+					<p>
+						A denied login skips authorization. The authorization expectation applies only if the
+						login policy unexpectedly allows this subject.
+					</p>
+				</div>
+			) : null}
+
+			{metadata.capabilities.resource_security ? (
+				<AdvancedSection
+					title="Subject Security Context"
+					summary={contextMode === 'live-self' ? 'Live self' : heldClassification || 'None'}
+				>
+					<div className="grid gap-3 sm:grid-cols-2">
+						<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+							Context Source
+							<select
+								name="context-source"
+								autoComplete="off"
+								className={inputClass}
+								value={contextMode}
+								onChange={(event) => onContextModeChange(event.target.value as ContextMode)}
+							>
+								<option value="synthetic">Synthetic Context</option>
+								<option value="live-self" disabled={!metadata.capabilities.live_self_context}>
+									Live Context for Signed-In Admin
+								</option>
+							</select>
+						</label>
+						{contextMode === 'synthetic' ? (
+							<>
+								<TextField
+									label="Held Classification"
+									placeholder={`${metadata.classification_order.at(-1) ?? 'LEVEL_3'}…`}
+									value={heldClassification}
+									onChange={onHeldClassificationChange}
+								/>
+								<TextField
+									label="Held Compartments"
+									placeholder="team-a, project-b…"
+									value={heldCompartments}
+									onChange={onHeldCompartmentsChange}
+								/>
+							</>
+						) : (
+							<p className="self-end text-xs text-muted-foreground">
+								Live context is available only for the signed-in admin.
+							</p>
+						)}
+					</div>
+				</AdvancedSection>
+			) : null}
+		</StepCard>
+	);
+}
+
+interface ScenarioSummaryProps {
+	subjectEmail: string;
+	action: Action;
+	scope: Scope;
+	source: ResourceSource;
+	expectedAllowed: boolean;
+	loginEnabled: boolean;
+	expectedLoginOutcome: LoginOutcome;
+	isPending: boolean;
+	onRun: () => void;
+	onAddToSuite: () => void;
+}
+
+function ScenarioSummary({
+	subjectEmail,
+	action,
+	scope,
+	source,
+	expectedAllowed,
+	loginEnabled,
+	expectedLoginOutcome,
+	isPending,
+	onRun,
+	onAddToSuite,
+}: ScenarioSummaryProps) {
+	return (
+		<aside className="min-w-0 self-start rounded-xl border bg-card p-4 shadow-xs xl:sticky xl:top-4">
+			<h2 className="font-semibold">Scenario Summary</h2>
+			<dl className="mt-4 space-y-3 text-sm">
+				<div>
+					<dt className="text-xs text-muted-foreground">Subject</dt>
+					<dd className="truncate font-medium" title={subjectEmail}>
+						{subjectEmail}
+					</dd>
+				</div>
+				<div>
+					<dt className="text-xs text-muted-foreground">Action</dt>
+					<dd>
+						<code translate="no" className="break-all font-medium">
+							{action}
+						</code>
+					</dd>
+				</div>
+				<div className="grid grid-cols-2 gap-3">
+					<div>
+						<dt className="text-xs text-muted-foreground">Resource</dt>
+						<dd className="font-medium">
+							{scope === 'deployment'
+								? 'Deployment'
+								: source === 'stored'
+									? 'Stored'
+									: 'Hypothetical'}
+						</dd>
+					</div>
+					<div>
+						<dt className="text-xs text-muted-foreground">Authorization</dt>
+						<dd className="font-medium">
+							{expectedAllowed ? 'Allow' : 'Deny'}
+							{loginEnabled && expectedLoginOutcome === 'deny' ? ' (Conditional)' : ''}
+						</dd>
+					</div>
+				</div>
+				{loginEnabled ? (
+					<div>
+						<dt className="text-xs text-muted-foreground">Login</dt>
+						<dd className="font-medium">{title(expectedLoginOutcome)}</dd>
+					</div>
+				) : null}
+			</dl>
+
+			<div className="mt-5 border-t pt-4">
+				<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+					Stages to Run
+				</p>
+				<ol className="mt-3 space-y-2 text-sm">
+					<li className="flex items-center gap-2">
+						<span
+							className={`flex size-5 items-center justify-center rounded-full ${loginEnabled ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+						>
+							1
+						</span>
+						<span className={loginEnabled ? '' : 'text-muted-foreground'}>
+							Login Policy {loginEnabled ? '' : '(Skipped)'}
+						</span>
+					</li>
+					<li className="flex items-center gap-2">
+						<span className="flex size-5 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground">
+							2
+						</span>
+						Authorization
+						{loginEnabled && expectedLoginOutcome === 'deny' ? ' (Skipped on Deny)' : ''}
+					</li>
+					<li className="flex items-center gap-2">
+						<span className="flex size-5 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground">
+							3
+						</span>
+						Expectation Check
+					</li>
+				</ol>
+			</div>
+
+			<div className="mt-5 flex flex-col gap-2">
+				<Button variant="primary" onPress={onRun} isDisabled={isPending} className="w-full">
+					<Play aria-hidden="true" className="size-4" />
+					{isPending ? 'Running…' : 'Run Scenario'}
+				</Button>
+				<Button onPress={onAddToSuite} isDisabled={isPending} className="w-full">
+					<Plus aria-hidden="true" className="size-4" /> Add to JSON Suite
+				</Button>
+			</div>
+			<p className="mt-3 text-center text-xs text-muted-foreground">
+				Each run creates 1 bounded audit event.
+			</p>
+		</aside>
+	);
+}
+
+function AnalyzerMessages({
+	formError,
+	requestError,
+	suiteNotice,
+	errorRef,
+}: {
+	formError: string | null;
+	requestError: Error | null;
+	suiteNotice: string | null;
+	errorRef: RefObject<HTMLDivElement | null>;
+}) {
+	return (
+		<div aria-live="polite" aria-atomic="true">
+			{formError ? (
+				<div
+					ref={errorRef}
+					tabIndex={-1}
+					role="alert"
+					className="mt-5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-3 text-sm text-destructive outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					<p className="font-medium">The scenario is not ready.</p>
+					<p>{formError}</p>
+				</div>
+			) : null}
+			{requestError ? (
+				<div
+					role="alert"
+					className="mt-5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-3 text-sm text-destructive"
+				>
+					<p className="font-medium">The analyzer request failed.</p>
+					<p>{requestError.message}</p>
+				</div>
+			) : null}
+			{suiteNotice ? (
+				<p className="mt-3 text-sm text-emerald-700 dark:text-emerald-400">{suiteNotice}</p>
+			) : null}
+		</div>
+	);
+}
+
+interface SuiteEditorProps {
+	suiteInfo: SuiteInfo;
+	maximumCases: number;
+	suiteText: string;
+	isPending: boolean;
+	fileInput: RefObject<HTMLInputElement | null>;
+	onSuiteTextChange: (value: string) => void;
+	onSuiteNoticeChange: (value: string | null) => void;
+	onError: (error: unknown, fallback: string) => void;
+	onRun: () => void;
+}
+
+function SuiteEditor({
+	suiteInfo,
+	maximumCases,
+	suiteText,
+	isPending,
+	fileInput,
+	onSuiteTextChange,
+	onSuiteNoticeChange,
+	onError,
+	onRun,
+}: SuiteEditorProps) {
+	return (
+		<details className="group mt-8 overflow-hidden rounded-xl border bg-card">
+			<summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+				<div className="flex min-w-0 items-center gap-3">
+					<FileJson aria-hidden="true" className="size-5 shrink-0 text-primary" />
+					<div className="min-w-0">
+						<h2 className="font-semibold">JSON Test Suite</h2>
+						<p className="text-xs text-muted-foreground">
+							{suiteInfo.valid
+								? `${suiteInfo.count} of ${maximumCases} local cases · Version 1`
+								: suiteInfo.message}
+						</p>
+					</div>
+				</div>
+				<ChevronDown
+					aria-hidden="true"
+					className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180 motion-reduce:transition-none"
+				/>
+			</summary>
+			<div className="border-t p-4">
+				<div className="flex flex-wrap items-center justify-between gap-3">
+					<p className="max-w-2xl text-sm text-muted-foreground">
+						Edit the exact portable suite contract, or import a version 1 file.
+					</p>
+					<div className="flex gap-1">
+						<Button variant="ghost" size="sm" onPress={() => fileInput.current?.click()}>
+							<Upload aria-hidden="true" className="size-4" /> Import JSON
+						</Button>
+						<Button
+							variant="ghost"
+							size="sm"
+							onPress={() =>
+								triggerDownload(
+									'policy-suite.json',
+									new Blob([suiteText], { type: 'application/json' }),
+								)
+							}
+						>
+							<Download aria-hidden="true" className="size-4" /> Export JSON
+						</Button>
+					</div>
+				</div>
+				<input
+					aria-label="Import JSON suite"
+					ref={fileInput}
+					type="file"
+					accept="application/json,.json"
+					className="hidden"
+					onChange={(event) => {
+						const file = event.target.files?.[0];
+						if (file) {
+							void file
+								.text()
+								.then((value) => {
+									const suite = parseSuite(value, { allowEmpty: true });
+									assertSuiteLimit(suite, maximumCases);
+									onSuiteTextChange(value);
+									onSuiteNoticeChange(`Imported ${file.name}.`);
+								})
+								.catch((error: unknown) => onError(error, 'The suite file could not be read.'));
+						}
+						event.target.value = '';
+					}}
+				/>
+				<div className="mt-4 flex gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+					<AlertTriangle aria-hidden="true" className="size-4 shrink-0" />
+					Exported suites can contain sensitive sample claims and subject context. Store them as
+					sensitive data.
+				</div>
+				<textarea
+					aria-label="JSON suite"
+					name="json-suite"
+					autoComplete="off"
+					spellCheck={false}
+					className={`${textAreaClass} mt-4 min-h-96`}
+					value={suiteText}
+					onChange={(event) => {
+						onSuiteTextChange(event.target.value);
+						onSuiteNoticeChange(null);
+					}}
+				/>
+				<div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+					<p
+						className={`text-xs ${suiteInfo.valid ? 'text-muted-foreground' : 'text-destructive'}`}
+					>
+						{suiteInfo.valid ? `${suiteInfo.count} cases ready locally` : suiteInfo.message}
+					</p>
+					<Button variant="primary" onPress={onRun} isDisabled={isPending || !suiteInfo.valid}>
+						<FileJson aria-hidden="true" className="size-4" />
+						{isPending
+							? 'Running…'
+							: `Run Suite (${suiteInfo.count} ${suiteInfo.count === 1 ? 'Case' : 'Cases'})`}
+					</Button>
+				</div>
+			</div>
+		</details>
+	);
+}
+
+interface BuildPolicyCaseInput {
+	caseName: string;
+	subjectId: string;
+	subjectEmail: string;
+	scope: Scope;
+	source: ResourceSource;
+	projectId: string;
+	notebookId: string;
+	sessionId: string;
+	sessionMode: SessionMode;
+	relationship: Relationship;
+	memberRole: MemberRole;
+	projectStatus: ProjectStatus;
+	requiredClassification: string;
+	requiredCompartments: string;
+	loginEnabled: boolean;
+	expectedLoginOutcome: LoginOutcome;
+	entitlements: Entitlement[];
+	idClaims: string;
+	userInfoClaims: string;
+	action: Action;
+	contextMode: ContextMode;
+	heldClassification: string;
+	heldCompartments: string;
+	expectedAllowed: boolean;
+	expectedDenialCategory: DenialCategory | '';
+}
+
+function buildPolicyCase(input: BuildPolicyCaseInput): PolicyCase {
+	if (!input.caseName.trim()) throw new Error('Enter a case name.');
+	if (!input.subjectId.trim()) throw new Error('Enter a subject ID.');
+	if (!input.subjectEmail.trim()) throw new Error('Enter a subject email.');
+	if (input.scope !== 'deployment' && input.source === 'stored' && !input.projectId) {
+		throw new Error('Select a stored project, or use a hypothetical resource.');
+	}
+	if (input.scope === 'session' && input.source === 'stored' && !input.sessionId.trim()) {
+		throw new Error('Enter the stored session ID.');
+	}
+	const labels = input.requiredClassification
+		? {
+				classification: input.requiredClassification,
+				compartments: list(input.requiredCompartments),
+			}
+		: undefined;
+	const resource: NonNullable<PolicyCase['authorization']>['resource'] =
+		input.scope === 'deployment'
+			? { source: 'synthetic', kind: 'deployment' }
+			: input.source === 'stored'
+				? {
+						source: input.source,
+						kind: input.scope,
+						project_id: input.projectId,
+						...(input.notebookId.trim() ? { notebook_id: input.notebookId.trim() } : {}),
+						...(input.sessionId.trim() ? { session_id: input.sessionId.trim() } : {}),
+						...(input.scope === 'session-start' ? { mode: input.sessionMode } : {}),
+					}
+				: {
+						source: input.source,
+						kind: input.scope,
+						project: {
+							owner: input.relationship === 'owner' ? input.subjectId.trim() : 'policy-owner',
+							members:
+								input.relationship === 'member'
+									? [{ user_id: input.subjectId.trim(), role: input.memberRole }]
+									: [],
+							status: input.projectStatus,
+							...(labels ? { security_labels: labels } : {}),
+						},
+						...(input.scope === 'session'
+							? { session: { mode: input.sessionMode, user_id: input.subjectId.trim() } }
+							: {}),
+						...(input.scope === 'session-start' ? { mode: input.sessionMode } : {}),
+					};
+	return {
+		id: `case-${Date.now()}`,
+		name: input.caseName.trim(),
+		...(input.loginEnabled
+			? {
+					login: {
+						identity: { id: input.subjectId.trim(), email: input.subjectEmail.trim() },
+						id_token_claims: parseObject(input.idClaims, 'ID-token claims'),
+						...(input.userInfoClaims.trim()
+							? {
+									user_info_claims: parseObject(input.userInfoClaims, 'UserInfo claims'),
+								}
+							: {}),
+						expected: {
+							outcome: input.expectedLoginOutcome,
+							...(input.expectedLoginOutcome === 'allow'
+								? { entitlements: input.entitlements }
+								: {}),
+						},
+					},
+				}
+			: {}),
+		authorization: {
+			subject: {
+				id: input.subjectId.trim(),
+				email: input.subjectEmail.trim(),
+				entitlement_source: input.loginEnabled ? 'login' : 'explicit',
+				...(!input.loginEnabled ? { entitlements: input.entitlements } : {}),
+			},
+			action: input.action,
+			resource,
+			context:
+				input.contextMode === 'live-self'
+					? { mode: 'live-self' }
+					: {
+							mode: 'synthetic',
+							value: input.heldClassification
+								? {
+										schemaVersion: 1,
+										classification: input.heldClassification,
+										compartments: list(input.heldCompartments),
+										policyVersion: 'policy-analyzer',
+										expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+									}
+								: null,
+						},
+			expected: {
+				allowed: input.expectedAllowed,
+				...(!input.expectedAllowed && input.expectedDenialCategory
+					? { denial_category: input.expectedDenialCategory }
+					: {}),
+			},
+		},
+	};
+}
+
 export default function AdminPolicyAnalyzerPage() {
 	const { data: metadata } = usePolicyAnalyzerMetadataQuery();
 	const { data: users } = useAdminUsersQuery();
@@ -467,7 +1487,7 @@ export default function AdminPolicyAnalyzerPage() {
 		[action, metadata.actions],
 	);
 	const scope = actionRule?.scope ?? 'project';
-	const suiteInfo = useMemo(() => {
+	const suiteInfo = useMemo<SuiteInfo>(() => {
 		try {
 			const suite = parseSuite(deferredSuiteText, { allowEmpty: true });
 			assertSuiteLimit(suite, metadata.max_cases);
@@ -493,97 +1513,33 @@ export default function AdminPolicyAnalyzerPage() {
 	}
 
 	function buildCase(): PolicyCase {
-		if (!caseName.trim()) throw new Error('Enter a case name.');
-		if (!subjectId.trim()) throw new Error('Enter a subject ID.');
-		if (!subjectEmail.trim()) throw new Error('Enter a subject email.');
-		if (scope !== 'deployment' && source === 'stored' && !projectId) {
-			throw new Error('Select a stored project, or use a hypothetical resource.');
-		}
-		if (scope === 'session' && source === 'stored' && !sessionId.trim()) {
-			throw new Error('Enter the stored session ID.');
-		}
-		const labels = requiredClassification
-			? { classification: requiredClassification, compartments: list(requiredCompartments) }
-			: undefined;
-		const resource: NonNullable<PolicyCase['authorization']>['resource'] =
-			scope === 'deployment'
-				? { source: 'synthetic', kind: 'deployment' }
-				: source === 'stored'
-					? {
-							source,
-							kind: scope,
-							project_id: projectId,
-							...(notebookId.trim() ? { notebook_id: notebookId.trim() } : {}),
-							...(sessionId.trim() ? { session_id: sessionId.trim() } : {}),
-							...(scope === 'session-start' ? { mode: sessionMode } : {}),
-						}
-					: {
-							source,
-							kind: scope,
-							project: {
-								owner: relationship === 'owner' ? subjectId.trim() : 'policy-owner',
-								members:
-									relationship === 'member'
-										? [{ user_id: subjectId.trim(), role: memberRole }]
-										: [],
-								status: projectStatus,
-								...(labels ? { security_labels: labels } : {}),
-							},
-							...(scope === 'session'
-								? { session: { mode: sessionMode, user_id: subjectId.trim() } }
-								: {}),
-							...(scope === 'session-start' ? { mode: sessionMode } : {}),
-						};
-		return {
-			id: `case-${Date.now()}`,
-			name: caseName.trim(),
-			...(loginEnabled
-				? {
-						login: {
-							identity: { id: subjectId.trim(), email: subjectEmail.trim() },
-							id_token_claims: parseObject(idClaims, 'ID-token claims'),
-							...(userInfoClaims.trim()
-								? { user_info_claims: parseObject(userInfoClaims, 'UserInfo claims') }
-								: {}),
-							expected: {
-								outcome: expectedLoginOutcome,
-								...(expectedLoginOutcome === 'allow' ? { entitlements } : {}),
-							},
-						},
-					}
-				: {}),
-			authorization: {
-				subject: {
-					id: subjectId.trim(),
-					email: subjectEmail.trim(),
-					entitlement_source: loginEnabled ? 'login' : 'explicit',
-					...(!loginEnabled ? { entitlements } : {}),
-				},
-				action,
-				resource,
-				context:
-					contextMode === 'live-self'
-						? { mode: 'live-self' }
-						: {
-								mode: 'synthetic',
-								value: heldClassification
-									? {
-											schemaVersion: 1,
-											classification: heldClassification,
-											compartments: list(heldCompartments),
-											policyVersion: 'policy-analyzer',
-											expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
-										}
-									: null,
-							},
-				expected: {
-					allowed: expectedAllowed,
-					...(!expectedAllowed && expectedDenialCategory
-						? { denial_category: expectedDenialCategory }
-						: {}),
-				},
-			},
-		};
+		return buildPolicyCase({
+			caseName,
+			subjectId,
+			subjectEmail,
+			scope,
+			source,
+			projectId,
+			notebookId,
+			sessionId,
+			sessionMode,
+			relationship,
+			memberRole,
+			projectStatus,
+			requiredClassification,
+			requiredCompartments,
+			loginEnabled,
+			expectedLoginOutcome,
+			entitlements,
+			idClaims,
+			userInfoClaims,
+			action,
+			contextMode,
+			heldClassification,
+			heldCompartments,
+			expectedAllowed,
+			expectedDenialCategory,
+		});
 	}
 
 	function runOne() {
@@ -634,698 +1590,109 @@ export default function AdminPolicyAnalyzerPage() {
 				</div>
 			</PageHeader>
 
-			<div className="mb-6 grid gap-3 sm:grid-cols-3">
-				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
-					<ShieldCheck aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
-					<div>
-						<p className="text-sm font-medium">Deterministic</p>
-						<p className="text-xs text-muted-foreground">No generated reasoning</p>
-					</div>
-				</div>
-				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
-					<LockKeyhole aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
-					<div>
-						<p className="text-sm font-medium">Read-Only</p>
-						<p className="text-xs text-muted-foreground">No policy or access changes</p>
-					</div>
-				</div>
-				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
-					<Braces aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
-					<div>
-						<p className="text-sm font-medium">Versioned</p>
-						<p className="text-xs text-muted-foreground">Portable version 1 suites</p>
-					</div>
-				</div>
-			</div>
-
-			<div className="mb-6 flex flex-wrap gap-2" aria-label="Analyzer capabilities">
-				<Chip>
-					Login Policy: {metadata.capabilities.login_policy ? 'Available' : 'Not Configured'}
-				</Chip>
-				<Chip>
-					Resource Security:{' '}
-					{metadata.capabilities.resource_security ? 'Available' : 'Not Configured'}
-				</Chip>
-				<Chip>{metadata.max_cases} Cases Maximum</Chip>
-			</div>
+			<AnalyzerOverview metadata={metadata} />
 
 			<div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_19rem]">
 				<main className="flex min-w-0 flex-col gap-5">
-					<StepCard
-						number={1}
-						title="Choose the Subject"
-						description="Select a known user or enter a hypothetical identity."
-					>
-						<div className="grid gap-3 sm:grid-cols-2">
-							<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-								Known User
-								<select
-									name="known-user"
-									autoComplete="off"
-									className={inputClass}
-									value={users.some((entry) => entry.id === subjectId) ? subjectId : ''}
-									onChange={(event) => {
-										if (event.target.value) selectUser(event.target.value);
-									}}
-								>
-									<option value="">Hypothetical user</option>
-									{users.map((entry) => (
-										<option key={entry.id} value={entry.id}>
-											{entry.name} · {entry.email}
-										</option>
-									))}
-								</select>
-							</label>
-							<TextField label="Subject ID" value={subjectId} onChange={setSubjectId} />
-							<TextField label="Subject Email" value={subjectEmail} onChange={setSubjectEmail} />
-							<TextField label="Case Name" value={caseName} onChange={setCaseName} />
-						</div>
-
-						<AdvancedSection
-							title="Entitlements & Standing"
-							summary={`${entitlements.length} selected`}
-						>
-							<p className="mb-3 text-xs text-muted-foreground">
-								{loginEnabled
-									? 'Select the exact normalized entitlements expected from login. An allowed login passes them to authorization.'
-									: 'Explicit entitlements affect deployment standing and default roles.'}
-							</p>
-							<div className="grid gap-2 sm:grid-cols-2">
-								{metadata.entitlements.map((entitlement) => (
-									<label
-										key={entitlement}
-										className="flex min-h-9 items-center gap-2 rounded-md px-2 text-sm hover:bg-muted/50"
-									>
-										<input
-											type="checkbox"
-											aria-label={entitlement}
-											checked={entitlements.includes(entitlement)}
-											onChange={(event) =>
-												setEntitlements((current) =>
-													event.target.checked
-														? [...current, entitlement]
-														: current.filter((item) => item !== entitlement),
-												)
-											}
-										/>
-										<code translate="no" className="break-all">
-											{entitlement}
-										</code>
-									</label>
-								))}
-							</div>
-						</AdvancedSection>
-
-						<div className="mt-4 rounded-lg border bg-muted/20 p-3">
-							<label
-								aria-label="Evaluate the login policy"
-								className="flex items-start gap-3 text-sm"
-							>
-								<input
-									type="checkbox"
-									aria-label="Evaluate the login policy"
-									className="mt-1"
-									checked={loginEnabled}
-									disabled={!metadata.capabilities.login_policy}
-									onChange={(event) => setLoginEnabled(event.target.checked)}
-								/>
-								<span>
-									<span className="font-medium">Evaluate the Login Policy</span>
-									<span className="mt-0.5 block text-xs text-muted-foreground">
-										{metadata.capabilities.login_policy
-											? 'Use sample claims and pass allowed entitlements to authorization.'
-											: 'No login policy is configured for this deployment.'}
-									</span>
-								</span>
-							</label>
-							{loginEnabled ? (
-								<div className="mt-4 grid gap-3 border-t pt-4 sm:grid-cols-2">
-									<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-										Expected Login Decision
-										<select
-											name="expected-login-decision"
-											autoComplete="off"
-											className={inputClass}
-											value={expectedLoginOutcome}
-											onChange={(event) =>
-												setExpectedLoginOutcome(event.target.value as 'allow' | 'deny')
-											}
-										>
-											<option value="allow">Allow</option>
-											<option value="deny">Deny</option>
-										</select>
-									</label>
-									<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground sm:col-span-2">
-										ID-Token Claims
-										<textarea
-											aria-label="ID-token claims"
-											name="id-token-claims"
-											autoComplete="off"
-											spellCheck={false}
-											className={textAreaClass}
-											rows={6}
-											value={idClaims}
-											onChange={(event) => setIdClaims(event.target.value)}
-										/>
-									</label>
-									<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground sm:col-span-2">
-										UserInfo Claims <span className="font-normal">(Optional)</span>
-										<textarea
-											aria-label="UserInfo claims"
-											name="userinfo-claims"
-											autoComplete="off"
-											spellCheck={false}
-											className={textAreaClass}
-											rows={4}
-											placeholder={'{\n  "department": "analytics"\n}'}
-											value={userInfoClaims}
-											onChange={(event) => setUserInfoClaims(event.target.value)}
-										/>
-									</label>
-								</div>
-							) : null}
-						</div>
-					</StepCard>
-
-					<StepCard
-						number={2}
-						title="Choose the Action & Resource"
-						description="The selected action controls which resource fields and rules apply."
-					>
-						<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-							Action
-							<select
-								name="authorization-action"
-								autoComplete="off"
-								className={inputClass}
-								value={action}
-								onChange={(event) => setAction(event.target.value as Action)}
-							>
-								{metadata.actions.map((entry) => (
-									<option key={entry.action} value={entry.action}>
-										{entry.action}
-									</option>
-								))}
-							</select>
-						</label>
-						<div className="mt-3 flex gap-2 rounded-lg border border-primary/15 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
-							<Info aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
-							<p>
-								Scope: <code translate="no">{scope}</code>
-								{actionRule?.minimum_role ? ` · Minimum role: ${actionRule.minimum_role}` : ''}
-								{actionRule?.requires_super_admin ? ' · Requires super admin' : ''}
-								{actionRule?.denied_as ? ` · Denial appears as ${actionRule.denied_as}` : ''}
-							</p>
-						</div>
-
-						{scope !== 'deployment' ? (
-							<>
-								<fieldset className="mt-4">
-									<legend className="text-xs font-medium text-muted-foreground">
-										Resource Source
-									</legend>
-									<div className="mt-1.5 grid grid-cols-2 gap-2">
-										{(['synthetic', 'stored'] as const).map((value) => (
-											<label
-												key={value}
-												className={`flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border px-3 text-sm ${
-													source === value
-														? 'border-primary bg-primary/5 text-primary'
-														: 'hover:bg-muted/50'
-												}`}
-											>
-												<input
-													type="radio"
-													aria-label={value === 'synthetic' ? 'Hypothetical' : 'Stored resource'}
-													name="resource-source"
-													checked={source === value}
-													onChange={() => setSource(value)}
-												/>
-												{value === 'synthetic' ? 'Hypothetical' : 'Stored Resource'}
-											</label>
-										))}
-									</div>
-								</fieldset>
-
-								{source === 'stored' ? (
-									<div className="mt-4 grid gap-3 sm:grid-cols-2">
-										<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-											Project
-											<select
-												name="stored-project"
-												autoComplete="off"
-												className={inputClass}
-												value={projectId}
-												onChange={(event) => setProjectId(event.target.value)}
-											>
-												<option value="">Select a project…</option>
-												{(projects.data ?? []).map((project) => (
-													<option key={project.id} value={project.id}>
-														{project.name}
-													</option>
-												))}
-											</select>
-										</label>
-										<TextField
-											label="Notebook ID (Optional)"
-											value={notebookId}
-											onChange={setNotebookId}
-										/>
-										{scope === 'session' ? (
-											<TextField label="Session ID" value={sessionId} onChange={setSessionId} />
-										) : null}
-									</div>
-								) : (
-									<div className="mt-4 grid gap-3 sm:grid-cols-2">
-										<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-											Subject Relationship
-											<select
-												name="subject-relationship"
-												autoComplete="off"
-												className={inputClass}
-												value={relationship}
-												onChange={(event) =>
-													setRelationship(event.target.value as typeof relationship)
-												}
-											>
-												<option value="owner">Project Owner</option>
-												<option value="member">Project Member</option>
-												<option value="none">No Relationship</option>
-											</select>
-										</label>
-										{relationship === 'member' ? (
-											<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-												Member Role
-												<select
-													name="member-role"
-													autoComplete="off"
-													className={inputClass}
-													value={memberRole}
-													onChange={(event) =>
-														setMemberRole(event.target.value as typeof memberRole)
-													}
-												>
-													{MEMBER_ROLES.map((role) => (
-														<option key={role} value={role}>
-															{title(role)}
-														</option>
-													))}
-												</select>
-											</label>
-										) : null}
-									</div>
-								)}
-
-								{scope === 'session-start' || (scope === 'session' && source === 'synthetic') ? (
-									<label className="mt-3 flex max-w-xs flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-										Session Mode
-										<select
-											name="session-mode"
-											autoComplete="off"
-											className={inputClass}
-											value={sessionMode}
-											onChange={(event) => setSessionMode(event.target.value as SessionMode)}
-										>
-											<option value="edit">Edit</option>
-											<option value="run">Run</option>
-										</select>
-									</label>
-								) : null}
-
-								{source === 'synthetic' ? (
-									<AdvancedSection
-										title="Resource Lifecycle & Labels"
-										summary={requiredClassification || title(projectStatus)}
-									>
-										<div className="grid gap-3 sm:grid-cols-2">
-											<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-												Project Status
-												<select
-													name="project-status"
-													autoComplete="off"
-													className={inputClass}
-													value={projectStatus}
-													onChange={(event) =>
-														setProjectStatus(event.target.value as typeof projectStatus)
-													}
-												>
-													<option value="active">Active</option>
-													<option value="deleted">Deleted</option>
-												</select>
-											</label>
-											<TextField
-												label="Required Classification"
-												placeholder={`${metadata.classification_order[0] ?? 'LEVEL_1'}…`}
-												value={requiredClassification}
-												onChange={setRequiredClassification}
-											/>
-											<TextField
-												label="Required Compartments"
-												placeholder="team-a, project-b…"
-												value={requiredCompartments}
-												onChange={setRequiredCompartments}
-											/>
-										</div>
-										{metadata.classification_order.length > 0 ? (
-											<div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-												<span>Configured order:</span>
-												{metadata.classification_order.map((classification) => (
-													<Chip key={classification}>{classification}</Chip>
-												))}
-											</div>
-										) : null}
-									</AdvancedSection>
-								) : null}
-							</>
-						) : (
-							<p className="mt-3 text-sm text-muted-foreground">
-								This deployment-scoped action does not require a project or session resource.
-							</p>
-						)}
-					</StepCard>
-
-					<StepCard
-						number={3}
-						title="Set the Expected Result"
-						description="A scenario passes only when the actual decision matches this expectation."
-					>
-						<div className="grid gap-3 sm:grid-cols-2">
-							<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-								Expected Authorization Decision
-								<select
-									name="expected-authorization-decision"
-									autoComplete="off"
-									className={inputClass}
-									value={expectedAllowed ? 'allow' : 'deny'}
-									onChange={(event) => setExpectedAllowed(event.target.value === 'allow')}
-								>
-									<option value="allow">Allow</option>
-									<option value="deny">Deny</option>
-								</select>
-							</label>
-							{!expectedAllowed ? (
-								<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-									Expected Denial Category <span className="font-normal">(Optional)</span>
-									<select
-										name="expected-denial-category"
-										autoComplete="off"
-										className={inputClass}
-										value={expectedDenialCategory}
-										onChange={(event) =>
-											setExpectedDenialCategory(event.target.value as DenialCategory | '')
-										}
-									>
-										<option value="">Any denial category</option>
-										{DENIAL_CATEGORIES.map((category) => (
-											<option key={category} value={category}>
-												{title(category)}
-											</option>
-										))}
-									</select>
-								</label>
-							) : null}
-						</div>
-						{loginEnabled && expectedLoginOutcome === 'deny' ? (
-							<div className="mt-3 flex gap-2 rounded-lg border border-primary/15 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
-								<Info aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
-								<p>
-									A denied login skips authorization. The authorization expectation applies only if
-									the login policy unexpectedly allows this subject.
-								</p>
-							</div>
-						) : null}
-
-						{metadata.capabilities.resource_security ? (
-							<AdvancedSection
-								title="Subject Security Context"
-								summary={contextMode === 'live-self' ? 'Live self' : heldClassification || 'None'}
-							>
-								<div className="grid gap-3 sm:grid-cols-2">
-									<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
-										Context Source
-										<select
-											name="context-source"
-											autoComplete="off"
-											className={inputClass}
-											value={contextMode}
-											onChange={(event) => setContextMode(event.target.value as typeof contextMode)}
-										>
-											<option value="synthetic">Synthetic Context</option>
-											<option value="live-self" disabled={!metadata.capabilities.live_self_context}>
-												Live Context for Signed-In Admin
-											</option>
-										</select>
-									</label>
-									{contextMode === 'synthetic' ? (
-										<>
-											<TextField
-												label="Held Classification"
-												placeholder={`${metadata.classification_order.at(-1) ?? 'LEVEL_3'}…`}
-												value={heldClassification}
-												onChange={setHeldClassification}
-											/>
-											<TextField
-												label="Held Compartments"
-												placeholder="team-a, project-b…"
-												value={heldCompartments}
-												onChange={setHeldCompartments}
-											/>
-										</>
-									) : (
-										<p className="self-end text-xs text-muted-foreground">
-											Live context is available only for the signed-in admin.
-										</p>
-									)}
-								</div>
-							</AdvancedSection>
-						) : null}
-					</StepCard>
+					<SubjectStep
+						metadata={metadata}
+						users={users}
+						subjectId={subjectId}
+						subjectEmail={subjectEmail}
+						caseName={caseName}
+						entitlements={entitlements}
+						loginEnabled={loginEnabled}
+						expectedLoginOutcome={expectedLoginOutcome}
+						idClaims={idClaims}
+						userInfoClaims={userInfoClaims}
+						onSelectUser={selectUser}
+						onSubjectIdChange={setSubjectId}
+						onSubjectEmailChange={setSubjectEmail}
+						onCaseNameChange={setCaseName}
+						setEntitlements={setEntitlements}
+						onLoginEnabledChange={setLoginEnabled}
+						onExpectedLoginOutcomeChange={setExpectedLoginOutcome}
+						onIdClaimsChange={setIdClaims}
+						onUserInfoClaimsChange={setUserInfoClaims}
+					/>
+					<ResourceStep
+						metadata={metadata}
+						projects={projects.data ?? []}
+						action={action}
+						actionRule={actionRule}
+						scope={scope}
+						source={source}
+						projectId={projectId}
+						notebookId={notebookId}
+						sessionId={sessionId}
+						relationship={relationship}
+						memberRole={memberRole}
+						sessionMode={sessionMode}
+						projectStatus={projectStatus}
+						requiredClassification={requiredClassification}
+						requiredCompartments={requiredCompartments}
+						onActionChange={setAction}
+						onSourceChange={setSource}
+						onProjectIdChange={setProjectId}
+						onNotebookIdChange={setNotebookId}
+						onSessionIdChange={setSessionId}
+						onRelationshipChange={setRelationship}
+						onMemberRoleChange={setMemberRole}
+						onSessionModeChange={setSessionMode}
+						onProjectStatusChange={setProjectStatus}
+						onRequiredClassificationChange={setRequiredClassification}
+						onRequiredCompartmentsChange={setRequiredCompartments}
+					/>
+					<ExpectedResultStep
+						metadata={metadata}
+						expectedAllowed={expectedAllowed}
+						expectedDenialCategory={expectedDenialCategory}
+						loginEnabled={loginEnabled}
+						expectedLoginOutcome={expectedLoginOutcome}
+						contextMode={contextMode}
+						heldClassification={heldClassification}
+						heldCompartments={heldCompartments}
+						onExpectedAllowedChange={setExpectedAllowed}
+						onExpectedDenialCategoryChange={setExpectedDenialCategory}
+						onContextModeChange={setContextMode}
+						onHeldClassificationChange={setHeldClassification}
+						onHeldCompartmentsChange={setHeldCompartments}
+					/>
 				</main>
-
-				<aside className="min-w-0 self-start rounded-xl border bg-card p-4 shadow-xs xl:sticky xl:top-4">
-					<h2 className="font-semibold">Scenario Summary</h2>
-					<dl className="mt-4 space-y-3 text-sm">
-						<div>
-							<dt className="text-xs text-muted-foreground">Subject</dt>
-							<dd className="truncate font-medium" title={subjectEmail}>
-								{subjectEmail}
-							</dd>
-						</div>
-						<div>
-							<dt className="text-xs text-muted-foreground">Action</dt>
-							<dd>
-								<code translate="no" className="break-all font-medium">
-									{action}
-								</code>
-							</dd>
-						</div>
-						<div className="grid grid-cols-2 gap-3">
-							<div>
-								<dt className="text-xs text-muted-foreground">Resource</dt>
-								<dd className="font-medium">
-									{scope === 'deployment'
-										? 'Deployment'
-										: source === 'stored'
-											? 'Stored'
-											: 'Hypothetical'}
-								</dd>
-							</div>
-							<div>
-								<dt className="text-xs text-muted-foreground">Authorization</dt>
-								<dd className="font-medium">
-									{expectedAllowed ? 'Allow' : 'Deny'}
-									{loginEnabled && expectedLoginOutcome === 'deny' ? ' (Conditional)' : ''}
-								</dd>
-							</div>
-						</div>
-						{loginEnabled ? (
-							<div>
-								<dt className="text-xs text-muted-foreground">Login</dt>
-								<dd className="font-medium">{title(expectedLoginOutcome)}</dd>
-							</div>
-						) : null}
-					</dl>
-
-					<div className="mt-5 border-t pt-4">
-						<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-							Stages to Run
-						</p>
-						<ol className="mt-3 space-y-2 text-sm">
-							<li className="flex items-center gap-2">
-								<span
-									className={`flex size-5 items-center justify-center rounded-full ${loginEnabled ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
-								>
-									1
-								</span>
-								<span className={loginEnabled ? '' : 'text-muted-foreground'}>
-									Login Policy {loginEnabled ? '' : '(Skipped)'}
-								</span>
-							</li>
-							<li className="flex items-center gap-2">
-								<span className="flex size-5 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground">
-									2
-								</span>
-								Authorization
-								{loginEnabled && expectedLoginOutcome === 'deny' ? ' (Skipped on Deny)' : ''}
-							</li>
-							<li className="flex items-center gap-2">
-								<span className="flex size-5 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground">
-									3
-								</span>
-								Expectation Check
-							</li>
-						</ol>
-					</div>
-
-					<div className="mt-5 flex flex-col gap-2">
-						<Button
-							variant="primary"
-							onPress={runOne}
-							isDisabled={run.isPending}
-							className="w-full"
-						>
-							<Play aria-hidden="true" className="size-4" />
-							{run.isPending ? 'Running…' : 'Run Scenario'}
-						</Button>
-						<Button onPress={addToSuite} isDisabled={run.isPending} className="w-full">
-							<Plus aria-hidden="true" className="size-4" /> Add to JSON Suite
-						</Button>
-					</div>
-					<p className="mt-3 text-center text-xs text-muted-foreground">
-						Each run creates 1 bounded audit event.
-					</p>
-				</aside>
+				<ScenarioSummary
+					subjectEmail={subjectEmail}
+					action={action}
+					scope={scope}
+					source={source}
+					expectedAllowed={expectedAllowed}
+					loginEnabled={loginEnabled}
+					expectedLoginOutcome={expectedLoginOutcome}
+					isPending={run.isPending}
+					onRun={runOne}
+					onAddToSuite={addToSuite}
+				/>
 			</div>
 
-			<div aria-live="polite" aria-atomic="true">
-				{formError ? (
-					<div
-						ref={errorRef}
-						tabIndex={-1}
-						role="alert"
-						className="mt-5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-3 text-sm text-destructive outline-none focus-visible:ring-2 focus-visible:ring-ring"
-					>
-						<p className="font-medium">The scenario is not ready.</p>
-						<p>{formError}</p>
-					</div>
-				) : null}
-				{run.error ? (
-					<div
-						role="alert"
-						className="mt-5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-3 text-sm text-destructive"
-					>
-						<p className="font-medium">The analyzer request failed.</p>
-						<p>{run.error.message}</p>
-					</div>
-				) : null}
-				{suiteNotice ? (
-					<p className="mt-3 text-sm text-emerald-700 dark:text-emerald-400">{suiteNotice}</p>
-				) : null}
-			</div>
+			<AnalyzerMessages
+				formError={formError}
+				requestError={run.error}
+				suiteNotice={suiteNotice}
+				errorRef={errorRef}
+			/>
 
 			{run.data ? <ResultCard result={run.data} /> : null}
 
-			<details className="group mt-8 overflow-hidden rounded-xl border bg-card">
-				<summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
-					<div className="flex min-w-0 items-center gap-3">
-						<FileJson aria-hidden="true" className="size-5 shrink-0 text-primary" />
-						<div className="min-w-0">
-							<h2 className="font-semibold">JSON Test Suite</h2>
-							<p className="text-xs text-muted-foreground">
-								{suiteInfo.valid
-									? `${suiteInfo.count} of ${metadata.max_cases} local cases · Version 1`
-									: suiteInfo.message}
-							</p>
-						</div>
-					</div>
-					<ChevronDown
-						aria-hidden="true"
-						className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180 motion-reduce:transition-none"
-					/>
-				</summary>
-				<div className="border-t p-4">
-					<div className="flex flex-wrap items-center justify-between gap-3">
-						<p className="max-w-2xl text-sm text-muted-foreground">
-							Edit the exact portable suite contract, or import a version 1 file.
-						</p>
-						<div className="flex gap-1">
-							<Button variant="ghost" size="sm" onPress={() => fileInput.current?.click()}>
-								<Upload aria-hidden="true" className="size-4" /> Import JSON
-							</Button>
-							<Button
-								variant="ghost"
-								size="sm"
-								onPress={() =>
-									triggerDownload(
-										'policy-suite.json',
-										new Blob([suiteText], { type: 'application/json' }),
-									)
-								}
-							>
-								<Download aria-hidden="true" className="size-4" /> Export JSON
-							</Button>
-						</div>
-					</div>
-					<input
-						aria-label="Import JSON suite"
-						ref={fileInput}
-						type="file"
-						accept="application/json,.json"
-						className="hidden"
-						onChange={(event) => {
-							const file = event.target.files?.[0];
-							if (file) {
-								void file
-									.text()
-									.then((value) => {
-										const suite = parseSuite(value, { allowEmpty: true });
-										assertSuiteLimit(suite, metadata.max_cases);
-										setSuiteText(value);
-										setSuiteNotice(`Imported ${file.name}.`);
-									})
-									.catch((error: unknown) =>
-										reportError(error, 'The suite file could not be read.'),
-									);
-							}
-							event.target.value = '';
-						}}
-					/>
-					<div className="mt-4 flex gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
-						<AlertTriangle aria-hidden="true" className="size-4 shrink-0" />
-						Exported suites can contain sensitive sample claims and subject context. Store them as
-						sensitive data.
-					</div>
-					<textarea
-						aria-label="JSON suite"
-						name="json-suite"
-						autoComplete="off"
-						spellCheck={false}
-						className={`${textAreaClass} mt-4 min-h-96`}
-						value={suiteText}
-						onChange={(event) => {
-							setSuiteText(event.target.value);
-							setSuiteNotice(null);
-						}}
-					/>
-					<div className="mt-3 flex flex-wrap items-center justify-between gap-3">
-						<p
-							className={`text-xs ${suiteInfo.valid ? 'text-muted-foreground' : 'text-destructive'}`}
-						>
-							{suiteInfo.valid ? `${suiteInfo.count} cases ready locally` : suiteInfo.message}
-						</p>
-						<Button
-							variant="primary"
-							onPress={runSuite}
-							isDisabled={run.isPending || !suiteInfo.valid}
-						>
-							<FileJson aria-hidden="true" className="size-4" />
-							{run.isPending
-								? 'Running…'
-								: `Run Suite (${suiteInfo.count} ${suiteInfo.count === 1 ? 'Case' : 'Cases'})`}
-						</Button>
-					</div>
-				</div>
-			</details>
+			<SuiteEditor
+				suiteInfo={suiteInfo}
+				maximumCases={metadata.max_cases}
+				suiteText={suiteText}
+				isPending={run.isPending}
+				fileInput={fileInput}
+				onSuiteTextChange={setSuiteText}
+				onSuiteNoticeChange={setSuiteNotice}
+				onError={reportError}
+				onRun={runSuite}
+			/>
 		</PageContainer>
 	);
 }

--- a/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.tsx
+++ b/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.tsx
@@ -1,0 +1,1331 @@
+import { useDeferredValue, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+	AlertTriangle,
+	Braces,
+	CheckCircle2,
+	ChevronDown,
+	Download,
+	FileJson,
+	Info,
+	LockKeyhole,
+	Play,
+	Plus,
+	ShieldCheck,
+	Upload,
+	XCircle,
+} from 'lucide-react';
+import { Button, Chip, PageContainer, PageHeader, TextField } from '@/components/ui';
+import {
+	useAdminUsersQuery,
+	useEvaluatePolicySuite,
+	usePolicyAnalyzerMetadataQuery,
+	useProjectPickerQuery,
+} from '@/api/hooks';
+import { useAuth } from '@/context/AuthContext';
+import { triggerDownload } from '@/lib/download';
+import type { PolicySuiteResult, PolicySuiteV1 } from '@/types';
+
+type PolicyCase = PolicySuiteV1['cases'][number];
+type Action = NonNullable<PolicyCase['authorization']>['action'];
+type Entitlement = NonNullable<
+	NonNullable<PolicyCase['authorization']>['subject']['entitlements']
+>[number];
+type DenialCategory = NonNullable<
+	NonNullable<PolicyCase['authorization']>['expected']['denial_category']
+>;
+type SessionMode = NonNullable<NonNullable<PolicyCase['authorization']>['resource']['mode']>;
+
+const DENIAL_CATEGORIES: readonly DenialCategory[] = [
+	'lifecycle',
+	'visibility',
+	'role',
+	'session',
+	'standing',
+	'constraint',
+];
+const MEMBER_ROLES = ['viewer', 'editor', 'manager', 'admin'] as const;
+const INITIAL_SUITE = JSON.stringify(
+	{ schema_version: 1, name: 'Policy suite', cases: [] },
+	null,
+	2,
+);
+const inputClass =
+	'h-9 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+const textAreaClass =
+	'w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs text-foreground shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
+
+function parseObject(value: string, label: string): Record<string, unknown> {
+	const parsed: unknown = JSON.parse(value);
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		throw new Error(`${label} must be a JSON object.`);
+	}
+	return parsed as Record<string, unknown>;
+}
+
+function parseSuite(value: string, options?: { allowEmpty?: boolean }): PolicySuiteV1 {
+	const parsed: unknown = JSON.parse(value);
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		throw new Error('The suite must be a JSON object.');
+	}
+	const candidate = parsed as { schema_version?: unknown; cases?: unknown };
+	if (candidate.schema_version !== 1) throw new Error('Use suite schema version 1.');
+	if (!Array.isArray(candidate.cases)) throw new Error('The suite must contain a cases array.');
+	if (!options?.allowEmpty && candidate.cases.length === 0) {
+		throw new Error('Add at least 1 case before you run the suite.');
+	}
+	return parsed as PolicySuiteV1;
+}
+
+function assertSuiteLimit(suite: PolicySuiteV1, maximum: number): void {
+	if (suite.cases.length > maximum) {
+		throw new Error(`A suite can contain at most ${maximum} cases.`);
+	}
+}
+
+function list(value: string): string[] {
+	return [
+		...new Set(
+			value
+				.split(',')
+				.map((item) => item.trim())
+				.filter(Boolean),
+		),
+	];
+}
+
+function title(value: string): string {
+	return value
+		.split('-')
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
+function traceText(code: string): string {
+	const known: Record<string, string> = {
+		action_rule_loaded: 'Loaded the production rule for this action.',
+		project_active: 'The project is active, so evaluation can continue.',
+		project_deleted: 'The project is deleted, so authorization stops.',
+		resource_unlabeled: 'No resource labels apply to this decision.',
+		baseline_denied: 'Role or session policy denied access before label evaluation.',
+		resource_constraints_satisfied: 'The subject context satisfies every resource label.',
+		resource_constraints_constraint: 'The subject context does not satisfy the resource labels.',
+		resource_constraints_missing_context: 'A valid subject context is required for this resource.',
+		resource_constraints_unavailable: 'The constraint policy did not return a trusted decision.',
+		session_rule_satisfied: 'The session rule permits this action.',
+		session_rule_denied: 'The session rule denies this action.',
+		session_start_satisfied: 'The role and viewer mode permit this session mode.',
+		session_start_denied: 'The role or viewer mode denies this session mode.',
+		super_admin_standing_satisfied: 'The subject has the required deployment standing.',
+		super_admin_standing_missing: 'The subject lacks the required deployment standing.',
+		deployment_standing_satisfied: 'The deployment rule permits this action.',
+		deployment_standing_missing: 'The deployment rule denies this action.',
+		authorization_allowed: 'The final authorization decision allows the action.',
+	};
+	if (known[code]) return known[code];
+	if (code.startsWith('effective_role_')) {
+		return `The effective role comes from ${code.slice('effective_role_'.length).replaceAll('-', ' ')}.`;
+	}
+	if (code.startsWith('authorization_denied_')) {
+		return `The final decision denies the action because of ${code.slice('authorization_denied_'.length)} policy.`;
+	}
+	return code.replaceAll('_', ' ');
+}
+
+function problemText(code: string): string {
+	const messages: Record<string, string> = {
+		login_policy_unavailable:
+			'No login policy is configured. Disable the login stage and run again.',
+		login_policy_timeout:
+			'The login policy timed out. Reduce policy work or increase its configured timeout.',
+		login_policy_error:
+			'The login policy failed. Check the policy module logs for the bounded error.',
+		login_policy_invalid_result:
+			'The login policy returned an invalid contract result. Fix the module output.',
+		linked_login_stage_required: 'Login-derived entitlements require a login stage in this case.',
+		live_context_requires_self:
+			'Live context is limited to the signed-in admin. Use synthetic context for another subject.',
+		stored_resource_inaccessible:
+			'The stored resource is missing or not readable by the signed-in admin. Use a hypothetical resource instead.',
+		stored_notebook_session_mismatch:
+			'The selected notebook does not own this session. Clear the notebook or select the matching one.',
+	};
+	return messages[code] ?? code.replaceAll('_', ' ');
+}
+
+function StepCard({
+	number,
+	title: heading,
+	description,
+	children,
+}: {
+	number: number;
+	title: string;
+	description: string;
+	children: ReactNode;
+}) {
+	return (
+		<section className="rounded-xl border bg-card p-5 shadow-xs">
+			<header className="mb-5 flex gap-3">
+				<span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary tabular-nums">
+					{number}
+				</span>
+				<div className="min-w-0">
+					<h2 className="font-semibold text-pretty">{heading}</h2>
+					<p className="mt-0.5 text-sm text-muted-foreground text-pretty">{description}</p>
+				</div>
+			</header>
+			{children}
+		</section>
+	);
+}
+
+function AdvancedSection({
+	title: heading,
+	summary,
+	children,
+}: {
+	title: string;
+	summary: string;
+	children: ReactNode;
+}) {
+	return (
+		<details className="group mt-4 overflow-hidden rounded-lg border bg-muted/15">
+			<summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+				<span className="min-w-0">
+					<span className="font-medium">{heading}</span>
+					<span className="ml-2 text-xs text-muted-foreground">{summary}</span>
+				</span>
+				<ChevronDown
+					aria-hidden="true"
+					className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180 motion-reduce:transition-none"
+				/>
+			</summary>
+			<div className="border-t px-3 py-4">{children}</div>
+		</details>
+	);
+}
+
+function ResultCard({ result }: { result: PolicySuiteResult }) {
+	const singleCase = result.summary.case_count === 1;
+	return (
+		<section
+			className="mt-8 flex flex-col gap-4"
+			aria-label="Policy analysis result"
+			aria-live="polite"
+		>
+			<div
+				className={`flex flex-wrap items-center justify-between gap-3 rounded-xl border p-4 ${
+					result.valid
+						? 'border-emerald-600/30 bg-emerald-500/5'
+						: 'border-destructive/30 bg-destructive/5'
+				}`}
+			>
+				<div className="flex items-center gap-3">
+					{result.valid ? (
+						<CheckCircle2 aria-hidden="true" className="size-6 text-emerald-600" />
+					) : (
+						<XCircle aria-hidden="true" className="size-6 text-destructive" />
+					)}
+					<div>
+						<h2 className="font-semibold text-balance">
+							{singleCase ? 'Scenario' : 'Suite'} {result.valid ? 'Passed' : 'Failed'}
+						</h2>
+						<p className="text-sm text-muted-foreground">
+							{result.valid
+								? 'The policy result matches every expectation.'
+								: 'Review the expected and actual results below.'}
+						</p>
+					</div>
+				</div>
+				<p className="text-sm tabular-nums">
+					<span className="font-medium text-emerald-700 dark:text-emerald-400">
+						{result.summary.passed} passed
+					</span>
+					<span className="text-muted-foreground"> · </span>
+					<span className={result.summary.failed > 0 ? 'font-medium text-destructive' : ''}>
+						{result.summary.failed} failed
+					</span>
+				</p>
+			</div>
+
+			{result.cases.map((entry) => {
+				const expectedAllowed = entry.authorization?.assertion.expected.allowed === true;
+				const expectedCategory = entry.authorization?.assertion.expected.denial_category;
+				const actualAllowed = entry.authorization?.decision.allowed;
+				const expectedEntitlements = entry.login?.assertion.expected.entitlements;
+				const expectedEntitlementList = Array.isArray(expectedEntitlements)
+					? expectedEntitlements.filter((value): value is string => typeof value === 'string')
+					: [];
+				return (
+					<article key={entry.id} className="overflow-hidden rounded-xl border bg-card">
+						<header className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
+							<div className="min-w-0">
+								<h3 className="truncate font-medium">{entry.name}</h3>
+								<code translate="no" className="break-all text-xs text-muted-foreground">
+									{entry.id}
+								</code>
+							</div>
+							<Chip className={entry.valid ? 'text-emerald-700' : 'text-destructive'}>
+								{entry.valid ? 'Passed' : 'Failed'}
+							</Chip>
+						</header>
+						<div className="flex flex-col gap-5 p-4">
+							{entry.login ? (
+								<section aria-label="Login policy result">
+									<div className="flex flex-wrap items-center gap-2">
+										<h4 className="text-sm font-medium">Login Policy</h4>
+										<Chip>{title(entry.login.outcome)}</Chip>
+										<Chip
+											className={
+												entry.login.assertion.passed ? 'text-emerald-700' : 'text-destructive'
+											}
+										>
+											Expectation {entry.login.assertion.passed ? 'Matched' : 'Mismatched'}
+										</Chip>
+									</div>
+									<p className="mt-2 text-sm text-muted-foreground tabular-nums">
+										Expected{' '}
+										<strong className="text-foreground">
+											{title(String(entry.login.assertion.expected.outcome))}
+										</strong>
+										{' · '}Received{' '}
+										<strong className="text-foreground">{title(entry.login.outcome)}</strong>
+										{' · '}
+										{entry.login.duration_ms} ms
+									</p>
+									{entry.login.outcome === 'allow' || expectedEntitlementList.length > 0 ? (
+										<div className="mt-3 grid gap-3 rounded-lg bg-muted/30 p-3 sm:grid-cols-2">
+											<div>
+												<p className="mb-1.5 text-xs text-muted-foreground">
+													Expected Entitlements
+												</p>
+												<div className="flex flex-wrap gap-1.5">
+													{expectedEntitlementList.length > 0 ? (
+														expectedEntitlementList.map((entitlement) => (
+															<Chip key={entitlement}>{entitlement}</Chip>
+														))
+													) : (
+														<span className="text-xs">None</span>
+													)}
+												</div>
+											</div>
+											<div>
+												<p className="mb-1.5 text-xs text-muted-foreground">
+													Received Entitlements
+												</p>
+												<div className="flex flex-wrap gap-1.5">
+													{entry.login.entitlements.length > 0 ? (
+														entry.login.entitlements.map((entitlement) => (
+															<Chip key={entitlement}>{entitlement}</Chip>
+														))
+													) : (
+														<span className="text-xs">None</span>
+													)}
+												</div>
+											</div>
+										</div>
+									) : null}
+								</section>
+							) : null}
+
+							{entry.authorization ? (
+								<section aria-label="Authorization result">
+									<div className="flex flex-wrap items-center gap-2">
+										<h4 className="text-sm font-medium">Authorization</h4>
+										<Chip>{actualAllowed ? 'Allowed' : 'Denied'}</Chip>
+										<Chip>{title(entry.authorization.presentation)}</Chip>
+										{entry.authorization.decision.role ? (
+											<Chip>{title(entry.authorization.decision.role)} Role</Chip>
+										) : null}
+									</div>
+									<div
+										className={`mt-3 rounded-lg border px-3 py-2 text-sm ${
+											entry.authorization.assertion.passed
+												? 'border-emerald-600/20 bg-emerald-500/5'
+												: 'border-destructive/30 bg-destructive/5'
+										}`}
+									>
+										Expected{' '}
+										<strong>
+											{expectedAllowed ? 'Allow' : 'Deny'}
+											{typeof expectedCategory === 'string' ? ` (${title(expectedCategory)})` : ''}
+										</strong>
+										{' · '}Received{' '}
+										<strong>
+											{actualAllowed ? 'Allow' : 'Deny'}
+											{entry.authorization.decision.category
+												? ` (${title(entry.authorization.decision.category)})`
+												: ''}
+										</strong>
+									</div>
+									<ol className="mt-4 flex flex-col gap-2" aria-label="Decision trace">
+										{entry.authorization.trace.map((step) => (
+											<li key={`${step.stage}-${step.code}`} className="flex gap-3 text-sm">
+												{step.status === 'passed' ? (
+													<CheckCircle2
+														aria-hidden="true"
+														className="mt-0.5 size-4 shrink-0 text-emerald-600"
+													/>
+												) : step.status === 'failed' ? (
+													<XCircle
+														aria-hidden="true"
+														className="mt-0.5 size-4 shrink-0 text-destructive"
+													/>
+												) : (
+													<span
+														aria-hidden="true"
+														className="mt-2 size-1.5 shrink-0 rounded-full bg-muted-foreground"
+													/>
+												)}
+												<div className="min-w-0 flex-1">
+													<div className="flex flex-wrap items-baseline gap-x-2">
+														<span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+															{step.stage}
+														</span>
+														<p className="break-words">{traceText(step.code)}</p>
+													</div>
+													{step.details ? (
+														<details className="mt-1">
+															<summary className="cursor-pointer text-xs text-muted-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+																View Structured Evidence
+															</summary>
+															<pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-2 text-xs whitespace-pre-wrap break-all">
+																{JSON.stringify(step.details, null, 2)}
+															</pre>
+														</details>
+													) : null}
+												</div>
+											</li>
+										))}
+									</ol>
+								</section>
+							) : entry.login?.outcome === 'deny' ? (
+								<p className="rounded-lg border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+									Authorization was skipped because the login policy denied this subject.
+								</p>
+							) : null}
+
+							{entry.errors.length > 0 ? (
+								<div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-3 text-sm text-destructive">
+									<p className="font-medium">The analyzer could not complete this case.</p>
+									<ul className="mt-1 list-disc space-y-1 pl-5">
+										{entry.errors.map((error) => (
+											<li key={`${error.stage}-${error.code}`}>{problemText(error.code)}</li>
+										))}
+									</ul>
+								</div>
+							) : null}
+						</div>
+					</article>
+				);
+			})}
+		</section>
+	);
+}
+
+export default function AdminPolicyAnalyzerPage() {
+	const { data: metadata } = usePolicyAnalyzerMetadataQuery();
+	const { data: users } = useAdminUsersQuery();
+	const projects = useProjectPickerQuery(true);
+	const { user } = useAuth();
+	const run = useEvaluatePolicySuite();
+	const fileInput = useRef<HTMLInputElement>(null);
+	const errorRef = useRef<HTMLDivElement>(null);
+	const firstUser = user ?? users[0];
+	const [caseName, setCaseName] = useState('Policy check');
+	const [subjectId, setSubjectId] = useState(firstUser?.id ?? 'test-user');
+	const [subjectEmail, setSubjectEmail] = useState(firstUser?.email ?? 'test@example.com');
+	const [action, setAction] = useState<Action>('project.read');
+	const [source, setSource] = useState<'stored' | 'synthetic'>('synthetic');
+	const [projectId, setProjectId] = useState('');
+	const [notebookId, setNotebookId] = useState('');
+	const [sessionId, setSessionId] = useState('');
+	const [expectedAllowed, setExpectedAllowed] = useState(true);
+	const [expectedDenialCategory, setExpectedDenialCategory] = useState<DenialCategory | ''>('');
+	const [entitlements, setEntitlements] = useState<Entitlement[]>([]);
+	const [loginEnabled, setLoginEnabled] = useState(false);
+	const [expectedLoginOutcome, setExpectedLoginOutcome] = useState<'allow' | 'deny'>('allow');
+	const [idClaims, setIdClaims] = useState('{\n  "groups": []\n}');
+	const [userInfoClaims, setUserInfoClaims] = useState('');
+	const [contextMode, setContextMode] = useState<'synthetic' | 'live-self'>('synthetic');
+	const [relationship, setRelationship] = useState<'owner' | 'member' | 'none'>('owner');
+	const [memberRole, setMemberRole] = useState<(typeof MEMBER_ROLES)[number]>('viewer');
+	const [projectStatus, setProjectStatus] = useState<'active' | 'deleted'>('active');
+	const [sessionMode, setSessionMode] = useState<SessionMode>('edit');
+	const [heldClassification, setHeldClassification] = useState('');
+	const [heldCompartments, setHeldCompartments] = useState('');
+	const [requiredClassification, setRequiredClassification] = useState('');
+	const [requiredCompartments, setRequiredCompartments] = useState('');
+	const [formError, setFormError] = useState<string | null>(null);
+	const [suiteNotice, setSuiteNotice] = useState<string | null>(null);
+	const [suiteText, setSuiteText] = useState(() => INITIAL_SUITE);
+	const deferredSuiteText = useDeferredValue(suiteText);
+
+	const actionRule = useMemo(
+		() => metadata.actions.find((entry) => entry.action === action),
+		[action, metadata.actions],
+	);
+	const scope = actionRule?.scope ?? 'project';
+	const suiteInfo = useMemo(() => {
+		try {
+			const suite = parseSuite(deferredSuiteText, { allowEmpty: true });
+			assertSuiteLimit(suite, metadata.max_cases);
+			return { valid: true as const, count: suite.cases.length };
+		} catch (error) {
+			return {
+				valid: false as const,
+				count: 0,
+				message: error instanceof Error ? error.message : 'The suite is invalid.',
+			};
+		}
+	}, [deferredSuiteText, metadata.max_cases]);
+
+	function selectUser(id: string) {
+		const selected = users.find((entry) => entry.id === id);
+		setSubjectId(id);
+		if (selected) setSubjectEmail(selected.email);
+	}
+
+	function reportError(error: unknown, fallback: string) {
+		setFormError(error instanceof Error ? error.message : fallback);
+		requestAnimationFrame(() => errorRef.current?.focus());
+	}
+
+	function buildCase(): PolicyCase {
+		if (!caseName.trim()) throw new Error('Enter a case name.');
+		if (!subjectId.trim()) throw new Error('Enter a subject ID.');
+		if (!subjectEmail.trim()) throw new Error('Enter a subject email.');
+		if (scope !== 'deployment' && source === 'stored' && !projectId) {
+			throw new Error('Select a stored project, or use a hypothetical resource.');
+		}
+		if (scope === 'session' && source === 'stored' && !sessionId.trim()) {
+			throw new Error('Enter the stored session ID.');
+		}
+		const labels = requiredClassification
+			? { classification: requiredClassification, compartments: list(requiredCompartments) }
+			: undefined;
+		const resource: NonNullable<PolicyCase['authorization']>['resource'] =
+			scope === 'deployment'
+				? { source: 'synthetic', kind: 'deployment' }
+				: source === 'stored'
+					? {
+							source,
+							kind: scope,
+							project_id: projectId,
+							...(notebookId.trim() ? { notebook_id: notebookId.trim() } : {}),
+							...(sessionId.trim() ? { session_id: sessionId.trim() } : {}),
+							...(scope === 'session-start' ? { mode: sessionMode } : {}),
+						}
+					: {
+							source,
+							kind: scope,
+							project: {
+								owner: relationship === 'owner' ? subjectId.trim() : 'policy-owner',
+								members:
+									relationship === 'member'
+										? [{ user_id: subjectId.trim(), role: memberRole }]
+										: [],
+								status: projectStatus,
+								...(labels ? { security_labels: labels } : {}),
+							},
+							...(scope === 'session'
+								? { session: { mode: sessionMode, user_id: subjectId.trim() } }
+								: {}),
+							...(scope === 'session-start' ? { mode: sessionMode } : {}),
+						};
+		return {
+			id: `case-${Date.now()}`,
+			name: caseName.trim(),
+			...(loginEnabled
+				? {
+						login: {
+							identity: { id: subjectId.trim(), email: subjectEmail.trim() },
+							id_token_claims: parseObject(idClaims, 'ID-token claims'),
+							...(userInfoClaims.trim()
+								? { user_info_claims: parseObject(userInfoClaims, 'UserInfo claims') }
+								: {}),
+							expected: {
+								outcome: expectedLoginOutcome,
+								...(expectedLoginOutcome === 'allow' ? { entitlements } : {}),
+							},
+						},
+					}
+				: {}),
+			authorization: {
+				subject: {
+					id: subjectId.trim(),
+					email: subjectEmail.trim(),
+					entitlement_source: loginEnabled ? 'login' : 'explicit',
+					...(!loginEnabled ? { entitlements } : {}),
+				},
+				action,
+				resource,
+				context:
+					contextMode === 'live-self'
+						? { mode: 'live-self' }
+						: {
+								mode: 'synthetic',
+								value: heldClassification
+									? {
+											schemaVersion: 1,
+											classification: heldClassification,
+											compartments: list(heldCompartments),
+											policyVersion: 'policy-analyzer',
+											expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+										}
+									: null,
+							},
+				expected: {
+					allowed: expectedAllowed,
+					...(!expectedAllowed && expectedDenialCategory
+						? { denial_category: expectedDenialCategory }
+						: {}),
+				},
+			},
+		};
+	}
+
+	function runOne() {
+		try {
+			setFormError(null);
+			setSuiteNotice(null);
+			run.mutate({ schema_version: 1, cases: [buildCase()] });
+		} catch (error) {
+			reportError(error, 'The scenario is invalid.');
+		}
+	}
+
+	function addToSuite() {
+		try {
+			const suite = parseSuite(suiteText, { allowEmpty: true });
+			if (suite.cases.length >= metadata.max_cases) {
+				throw new Error(`A suite can contain at most ${metadata.max_cases} cases.`);
+			}
+			setSuiteText(JSON.stringify({ ...suite, cases: [...suite.cases, buildCase()] }, null, 2));
+			setFormError(null);
+			setSuiteNotice('Added the scenario to the local JSON suite.');
+		} catch (error) {
+			reportError(error, 'The suite is invalid.');
+		}
+	}
+
+	function runSuite() {
+		try {
+			const suite = parseSuite(suiteText);
+			assertSuiteLimit(suite, metadata.max_cases);
+			setFormError(null);
+			setSuiteNotice(null);
+			run.mutate(suite);
+		} catch (error) {
+			reportError(error, 'The suite is not valid JSON.');
+		}
+	}
+
+	return (
+		<PageContainer contentClassName="max-w-6xl">
+			<PageHeader>
+				<div>
+					<h1 className="text-2xl font-semibold tracking-tight text-balance">Policy Analyzer</h1>
+					<p className="mt-1 max-w-3xl text-sm text-muted-foreground text-pretty">
+						Test a policy decision without changing access. The analyzer runs the production login
+						and authorization evaluators, then compares the result with your expectation.
+					</p>
+				</div>
+			</PageHeader>
+
+			<div className="mb-6 grid gap-3 sm:grid-cols-3">
+				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
+					<ShieldCheck aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+					<div>
+						<p className="text-sm font-medium">Deterministic</p>
+						<p className="text-xs text-muted-foreground">No generated reasoning</p>
+					</div>
+				</div>
+				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
+					<LockKeyhole aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+					<div>
+						<p className="text-sm font-medium">Read-Only</p>
+						<p className="text-xs text-muted-foreground">No policy or access changes</p>
+					</div>
+				</div>
+				<div className="flex gap-3 rounded-lg border bg-card px-3 py-3">
+					<Braces aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+					<div>
+						<p className="text-sm font-medium">Versioned</p>
+						<p className="text-xs text-muted-foreground">Portable version 1 suites</p>
+					</div>
+				</div>
+			</div>
+
+			<div className="mb-6 flex flex-wrap gap-2" aria-label="Analyzer capabilities">
+				<Chip>
+					Login Policy: {metadata.capabilities.login_policy ? 'Available' : 'Not Configured'}
+				</Chip>
+				<Chip>
+					Resource Security:{' '}
+					{metadata.capabilities.resource_security ? 'Available' : 'Not Configured'}
+				</Chip>
+				<Chip>{metadata.max_cases} Cases Maximum</Chip>
+			</div>
+
+			<div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_19rem]">
+				<main className="flex min-w-0 flex-col gap-5">
+					<StepCard
+						number={1}
+						title="Choose the Subject"
+						description="Select a known user or enter a hypothetical identity."
+					>
+						<div className="grid gap-3 sm:grid-cols-2">
+							<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+								Known User
+								<select
+									name="known-user"
+									autoComplete="off"
+									className={inputClass}
+									value={users.some((entry) => entry.id === subjectId) ? subjectId : ''}
+									onChange={(event) => {
+										if (event.target.value) selectUser(event.target.value);
+									}}
+								>
+									<option value="">Hypothetical user</option>
+									{users.map((entry) => (
+										<option key={entry.id} value={entry.id}>
+											{entry.name} · {entry.email}
+										</option>
+									))}
+								</select>
+							</label>
+							<TextField label="Subject ID" value={subjectId} onChange={setSubjectId} />
+							<TextField label="Subject Email" value={subjectEmail} onChange={setSubjectEmail} />
+							<TextField label="Case Name" value={caseName} onChange={setCaseName} />
+						</div>
+
+						<AdvancedSection
+							title="Entitlements & Standing"
+							summary={`${entitlements.length} selected`}
+						>
+							<p className="mb-3 text-xs text-muted-foreground">
+								{loginEnabled
+									? 'Select the exact normalized entitlements expected from login. An allowed login passes them to authorization.'
+									: 'Explicit entitlements affect deployment standing and default roles.'}
+							</p>
+							<div className="grid gap-2 sm:grid-cols-2">
+								{metadata.entitlements.map((entitlement) => (
+									<label
+										key={entitlement}
+										className="flex min-h-9 items-center gap-2 rounded-md px-2 text-sm hover:bg-muted/50"
+									>
+										<input
+											type="checkbox"
+											aria-label={entitlement}
+											checked={entitlements.includes(entitlement)}
+											onChange={(event) =>
+												setEntitlements((current) =>
+													event.target.checked
+														? [...current, entitlement]
+														: current.filter((item) => item !== entitlement),
+												)
+											}
+										/>
+										<code translate="no" className="break-all">
+											{entitlement}
+										</code>
+									</label>
+								))}
+							</div>
+						</AdvancedSection>
+
+						<div className="mt-4 rounded-lg border bg-muted/20 p-3">
+							<label
+								aria-label="Evaluate the login policy"
+								className="flex items-start gap-3 text-sm"
+							>
+								<input
+									type="checkbox"
+									aria-label="Evaluate the login policy"
+									className="mt-1"
+									checked={loginEnabled}
+									disabled={!metadata.capabilities.login_policy}
+									onChange={(event) => setLoginEnabled(event.target.checked)}
+								/>
+								<span>
+									<span className="font-medium">Evaluate the Login Policy</span>
+									<span className="mt-0.5 block text-xs text-muted-foreground">
+										{metadata.capabilities.login_policy
+											? 'Use sample claims and pass allowed entitlements to authorization.'
+											: 'No login policy is configured for this deployment.'}
+									</span>
+								</span>
+							</label>
+							{loginEnabled ? (
+								<div className="mt-4 grid gap-3 border-t pt-4 sm:grid-cols-2">
+									<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+										Expected Login Decision
+										<select
+											name="expected-login-decision"
+											autoComplete="off"
+											className={inputClass}
+											value={expectedLoginOutcome}
+											onChange={(event) =>
+												setExpectedLoginOutcome(event.target.value as 'allow' | 'deny')
+											}
+										>
+											<option value="allow">Allow</option>
+											<option value="deny">Deny</option>
+										</select>
+									</label>
+									<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground sm:col-span-2">
+										ID-Token Claims
+										<textarea
+											aria-label="ID-token claims"
+											name="id-token-claims"
+											autoComplete="off"
+											spellCheck={false}
+											className={textAreaClass}
+											rows={6}
+											value={idClaims}
+											onChange={(event) => setIdClaims(event.target.value)}
+										/>
+									</label>
+									<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground sm:col-span-2">
+										UserInfo Claims <span className="font-normal">(Optional)</span>
+										<textarea
+											aria-label="UserInfo claims"
+											name="userinfo-claims"
+											autoComplete="off"
+											spellCheck={false}
+											className={textAreaClass}
+											rows={4}
+											placeholder={'{\n  "department": "analytics"\n}'}
+											value={userInfoClaims}
+											onChange={(event) => setUserInfoClaims(event.target.value)}
+										/>
+									</label>
+								</div>
+							) : null}
+						</div>
+					</StepCard>
+
+					<StepCard
+						number={2}
+						title="Choose the Action & Resource"
+						description="The selected action controls which resource fields and rules apply."
+					>
+						<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+							Action
+							<select
+								name="authorization-action"
+								autoComplete="off"
+								className={inputClass}
+								value={action}
+								onChange={(event) => setAction(event.target.value as Action)}
+							>
+								{metadata.actions.map((entry) => (
+									<option key={entry.action} value={entry.action}>
+										{entry.action}
+									</option>
+								))}
+							</select>
+						</label>
+						<div className="mt-3 flex gap-2 rounded-lg border border-primary/15 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+							<Info aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+							<p>
+								Scope: <code translate="no">{scope}</code>
+								{actionRule?.minimum_role ? ` · Minimum role: ${actionRule.minimum_role}` : ''}
+								{actionRule?.requires_super_admin ? ' · Requires super admin' : ''}
+								{actionRule?.denied_as ? ` · Denial appears as ${actionRule.denied_as}` : ''}
+							</p>
+						</div>
+
+						{scope !== 'deployment' ? (
+							<>
+								<fieldset className="mt-4">
+									<legend className="text-xs font-medium text-muted-foreground">
+										Resource Source
+									</legend>
+									<div className="mt-1.5 grid grid-cols-2 gap-2">
+										{(['synthetic', 'stored'] as const).map((value) => (
+											<label
+												key={value}
+												className={`flex min-h-11 cursor-pointer items-center gap-2 rounded-lg border px-3 text-sm ${
+													source === value
+														? 'border-primary bg-primary/5 text-primary'
+														: 'hover:bg-muted/50'
+												}`}
+											>
+												<input
+													type="radio"
+													aria-label={value === 'synthetic' ? 'Hypothetical' : 'Stored resource'}
+													name="resource-source"
+													checked={source === value}
+													onChange={() => setSource(value)}
+												/>
+												{value === 'synthetic' ? 'Hypothetical' : 'Stored Resource'}
+											</label>
+										))}
+									</div>
+								</fieldset>
+
+								{source === 'stored' ? (
+									<div className="mt-4 grid gap-3 sm:grid-cols-2">
+										<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+											Project
+											<select
+												name="stored-project"
+												autoComplete="off"
+												className={inputClass}
+												value={projectId}
+												onChange={(event) => setProjectId(event.target.value)}
+											>
+												<option value="">Select a project…</option>
+												{(projects.data ?? []).map((project) => (
+													<option key={project.id} value={project.id}>
+														{project.name}
+													</option>
+												))}
+											</select>
+										</label>
+										<TextField
+											label="Notebook ID (Optional)"
+											value={notebookId}
+											onChange={setNotebookId}
+										/>
+										{scope === 'session' ? (
+											<TextField label="Session ID" value={sessionId} onChange={setSessionId} />
+										) : null}
+									</div>
+								) : (
+									<div className="mt-4 grid gap-3 sm:grid-cols-2">
+										<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+											Subject Relationship
+											<select
+												name="subject-relationship"
+												autoComplete="off"
+												className={inputClass}
+												value={relationship}
+												onChange={(event) =>
+													setRelationship(event.target.value as typeof relationship)
+												}
+											>
+												<option value="owner">Project Owner</option>
+												<option value="member">Project Member</option>
+												<option value="none">No Relationship</option>
+											</select>
+										</label>
+										{relationship === 'member' ? (
+											<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+												Member Role
+												<select
+													name="member-role"
+													autoComplete="off"
+													className={inputClass}
+													value={memberRole}
+													onChange={(event) =>
+														setMemberRole(event.target.value as typeof memberRole)
+													}
+												>
+													{MEMBER_ROLES.map((role) => (
+														<option key={role} value={role}>
+															{title(role)}
+														</option>
+													))}
+												</select>
+											</label>
+										) : null}
+									</div>
+								)}
+
+								{scope === 'session-start' || (scope === 'session' && source === 'synthetic') ? (
+									<label className="mt-3 flex max-w-xs flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+										Session Mode
+										<select
+											name="session-mode"
+											autoComplete="off"
+											className={inputClass}
+											value={sessionMode}
+											onChange={(event) => setSessionMode(event.target.value as SessionMode)}
+										>
+											<option value="edit">Edit</option>
+											<option value="run">Run</option>
+										</select>
+									</label>
+								) : null}
+
+								{source === 'synthetic' ? (
+									<AdvancedSection
+										title="Resource Lifecycle & Labels"
+										summary={requiredClassification || title(projectStatus)}
+									>
+										<div className="grid gap-3 sm:grid-cols-2">
+											<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+												Project Status
+												<select
+													name="project-status"
+													autoComplete="off"
+													className={inputClass}
+													value={projectStatus}
+													onChange={(event) =>
+														setProjectStatus(event.target.value as typeof projectStatus)
+													}
+												>
+													<option value="active">Active</option>
+													<option value="deleted">Deleted</option>
+												</select>
+											</label>
+											<TextField
+												label="Required Classification"
+												placeholder={`${metadata.classification_order[0] ?? 'LEVEL_1'}…`}
+												value={requiredClassification}
+												onChange={setRequiredClassification}
+											/>
+											<TextField
+												label="Required Compartments"
+												placeholder="team-a, project-b…"
+												value={requiredCompartments}
+												onChange={setRequiredCompartments}
+											/>
+										</div>
+										{metadata.classification_order.length > 0 ? (
+											<div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+												<span>Configured order:</span>
+												{metadata.classification_order.map((classification) => (
+													<Chip key={classification}>{classification}</Chip>
+												))}
+											</div>
+										) : null}
+									</AdvancedSection>
+								) : null}
+							</>
+						) : (
+							<p className="mt-3 text-sm text-muted-foreground">
+								This deployment-scoped action does not require a project or session resource.
+							</p>
+						)}
+					</StepCard>
+
+					<StepCard
+						number={3}
+						title="Set the Expected Result"
+						description="A scenario passes only when the actual decision matches this expectation."
+					>
+						<div className="grid gap-3 sm:grid-cols-2">
+							<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+								Expected Authorization Decision
+								<select
+									name="expected-authorization-decision"
+									autoComplete="off"
+									className={inputClass}
+									value={expectedAllowed ? 'allow' : 'deny'}
+									onChange={(event) => setExpectedAllowed(event.target.value === 'allow')}
+								>
+									<option value="allow">Allow</option>
+									<option value="deny">Deny</option>
+								</select>
+							</label>
+							{!expectedAllowed ? (
+								<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+									Expected Denial Category <span className="font-normal">(Optional)</span>
+									<select
+										name="expected-denial-category"
+										autoComplete="off"
+										className={inputClass}
+										value={expectedDenialCategory}
+										onChange={(event) =>
+											setExpectedDenialCategory(event.target.value as DenialCategory | '')
+										}
+									>
+										<option value="">Any denial category</option>
+										{DENIAL_CATEGORIES.map((category) => (
+											<option key={category} value={category}>
+												{title(category)}
+											</option>
+										))}
+									</select>
+								</label>
+							) : null}
+						</div>
+						{loginEnabled && expectedLoginOutcome === 'deny' ? (
+							<div className="mt-3 flex gap-2 rounded-lg border border-primary/15 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+								<Info aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-primary" />
+								<p>
+									A denied login skips authorization. The authorization expectation applies only if
+									the login policy unexpectedly allows this subject.
+								</p>
+							</div>
+						) : null}
+
+						{metadata.capabilities.resource_security ? (
+							<AdvancedSection
+								title="Subject Security Context"
+								summary={contextMode === 'live-self' ? 'Live self' : heldClassification || 'None'}
+							>
+								<div className="grid gap-3 sm:grid-cols-2">
+									<label className="flex flex-col gap-1.5 text-xs font-medium text-muted-foreground">
+										Context Source
+										<select
+											name="context-source"
+											autoComplete="off"
+											className={inputClass}
+											value={contextMode}
+											onChange={(event) => setContextMode(event.target.value as typeof contextMode)}
+										>
+											<option value="synthetic">Synthetic Context</option>
+											<option value="live-self" disabled={!metadata.capabilities.live_self_context}>
+												Live Context for Signed-In Admin
+											</option>
+										</select>
+									</label>
+									{contextMode === 'synthetic' ? (
+										<>
+											<TextField
+												label="Held Classification"
+												placeholder={`${metadata.classification_order.at(-1) ?? 'LEVEL_3'}…`}
+												value={heldClassification}
+												onChange={setHeldClassification}
+											/>
+											<TextField
+												label="Held Compartments"
+												placeholder="team-a, project-b…"
+												value={heldCompartments}
+												onChange={setHeldCompartments}
+											/>
+										</>
+									) : (
+										<p className="self-end text-xs text-muted-foreground">
+											Live context is available only for the signed-in admin.
+										</p>
+									)}
+								</div>
+							</AdvancedSection>
+						) : null}
+					</StepCard>
+				</main>
+
+				<aside className="min-w-0 self-start rounded-xl border bg-card p-4 shadow-xs xl:sticky xl:top-4">
+					<h2 className="font-semibold">Scenario Summary</h2>
+					<dl className="mt-4 space-y-3 text-sm">
+						<div>
+							<dt className="text-xs text-muted-foreground">Subject</dt>
+							<dd className="truncate font-medium" title={subjectEmail}>
+								{subjectEmail}
+							</dd>
+						</div>
+						<div>
+							<dt className="text-xs text-muted-foreground">Action</dt>
+							<dd>
+								<code translate="no" className="break-all font-medium">
+									{action}
+								</code>
+							</dd>
+						</div>
+						<div className="grid grid-cols-2 gap-3">
+							<div>
+								<dt className="text-xs text-muted-foreground">Resource</dt>
+								<dd className="font-medium">
+									{scope === 'deployment'
+										? 'Deployment'
+										: source === 'stored'
+											? 'Stored'
+											: 'Hypothetical'}
+								</dd>
+							</div>
+							<div>
+								<dt className="text-xs text-muted-foreground">Authorization</dt>
+								<dd className="font-medium">
+									{expectedAllowed ? 'Allow' : 'Deny'}
+									{loginEnabled && expectedLoginOutcome === 'deny' ? ' (Conditional)' : ''}
+								</dd>
+							</div>
+						</div>
+						{loginEnabled ? (
+							<div>
+								<dt className="text-xs text-muted-foreground">Login</dt>
+								<dd className="font-medium">{title(expectedLoginOutcome)}</dd>
+							</div>
+						) : null}
+					</dl>
+
+					<div className="mt-5 border-t pt-4">
+						<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+							Stages to Run
+						</p>
+						<ol className="mt-3 space-y-2 text-sm">
+							<li className="flex items-center gap-2">
+								<span
+									className={`flex size-5 items-center justify-center rounded-full ${loginEnabled ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'}`}
+								>
+									1
+								</span>
+								<span className={loginEnabled ? '' : 'text-muted-foreground'}>
+									Login Policy {loginEnabled ? '' : '(Skipped)'}
+								</span>
+							</li>
+							<li className="flex items-center gap-2">
+								<span className="flex size-5 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground">
+									2
+								</span>
+								Authorization
+								{loginEnabled && expectedLoginOutcome === 'deny' ? ' (Skipped on Deny)' : ''}
+							</li>
+							<li className="flex items-center gap-2">
+								<span className="flex size-5 items-center justify-center rounded-full bg-primary text-xs text-primary-foreground">
+									3
+								</span>
+								Expectation Check
+							</li>
+						</ol>
+					</div>
+
+					<div className="mt-5 flex flex-col gap-2">
+						<Button
+							variant="primary"
+							onPress={runOne}
+							isDisabled={run.isPending}
+							className="w-full"
+						>
+							<Play aria-hidden="true" className="size-4" />
+							{run.isPending ? 'Running…' : 'Run Scenario'}
+						</Button>
+						<Button onPress={addToSuite} isDisabled={run.isPending} className="w-full">
+							<Plus aria-hidden="true" className="size-4" /> Add to JSON Suite
+						</Button>
+					</div>
+					<p className="mt-3 text-center text-xs text-muted-foreground">
+						Each run creates 1 bounded audit event.
+					</p>
+				</aside>
+			</div>
+
+			<div aria-live="polite" aria-atomic="true">
+				{formError ? (
+					<div
+						ref={errorRef}
+						tabIndex={-1}
+						role="alert"
+						className="mt-5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-3 text-sm text-destructive outline-none focus-visible:ring-2 focus-visible:ring-ring"
+					>
+						<p className="font-medium">The scenario is not ready.</p>
+						<p>{formError}</p>
+					</div>
+				) : null}
+				{run.error ? (
+					<div
+						role="alert"
+						className="mt-5 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-3 text-sm text-destructive"
+					>
+						<p className="font-medium">The analyzer request failed.</p>
+						<p>{run.error.message}</p>
+					</div>
+				) : null}
+				{suiteNotice ? (
+					<p className="mt-3 text-sm text-emerald-700 dark:text-emerald-400">{suiteNotice}</p>
+				) : null}
+			</div>
+
+			{run.data ? <ResultCard result={run.data} /> : null}
+
+			<details className="group mt-8 overflow-hidden rounded-xl border bg-card">
+				<summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+					<div className="flex min-w-0 items-center gap-3">
+						<FileJson aria-hidden="true" className="size-5 shrink-0 text-primary" />
+						<div className="min-w-0">
+							<h2 className="font-semibold">JSON Test Suite</h2>
+							<p className="text-xs text-muted-foreground">
+								{suiteInfo.valid
+									? `${suiteInfo.count} of ${metadata.max_cases} local cases · Version 1`
+									: suiteInfo.message}
+							</p>
+						</div>
+					</div>
+					<ChevronDown
+						aria-hidden="true"
+						className="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-180 motion-reduce:transition-none"
+					/>
+				</summary>
+				<div className="border-t p-4">
+					<div className="flex flex-wrap items-center justify-between gap-3">
+						<p className="max-w-2xl text-sm text-muted-foreground">
+							Edit the exact portable suite contract, or import a version 1 file.
+						</p>
+						<div className="flex gap-1">
+							<Button variant="ghost" size="sm" onPress={() => fileInput.current?.click()}>
+								<Upload aria-hidden="true" className="size-4" /> Import JSON
+							</Button>
+							<Button
+								variant="ghost"
+								size="sm"
+								onPress={() =>
+									triggerDownload(
+										'policy-suite.json',
+										new Blob([suiteText], { type: 'application/json' }),
+									)
+								}
+							>
+								<Download aria-hidden="true" className="size-4" /> Export JSON
+							</Button>
+						</div>
+					</div>
+					<input
+						aria-label="Import JSON suite"
+						ref={fileInput}
+						type="file"
+						accept="application/json,.json"
+						className="hidden"
+						onChange={(event) => {
+							const file = event.target.files?.[0];
+							if (file) {
+								void file
+									.text()
+									.then((value) => {
+										const suite = parseSuite(value, { allowEmpty: true });
+										assertSuiteLimit(suite, metadata.max_cases);
+										setSuiteText(value);
+										setSuiteNotice(`Imported ${file.name}.`);
+									})
+									.catch((error: unknown) =>
+										reportError(error, 'The suite file could not be read.'),
+									);
+							}
+							event.target.value = '';
+						}}
+					/>
+					<div className="mt-4 flex gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+						<AlertTriangle aria-hidden="true" className="size-4 shrink-0" />
+						Exported suites can contain sensitive sample claims and subject context. Store them as
+						sensitive data.
+					</div>
+					<textarea
+						aria-label="JSON suite"
+						name="json-suite"
+						autoComplete="off"
+						spellCheck={false}
+						className={`${textAreaClass} mt-4 min-h-96`}
+						value={suiteText}
+						onChange={(event) => {
+							setSuiteText(event.target.value);
+							setSuiteNotice(null);
+						}}
+					/>
+					<div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+						<p
+							className={`text-xs ${suiteInfo.valid ? 'text-muted-foreground' : 'text-destructive'}`}
+						>
+							{suiteInfo.valid ? `${suiteInfo.count} cases ready locally` : suiteInfo.message}
+						</p>
+						<Button
+							variant="primary"
+							onPress={runSuite}
+							isDisabled={run.isPending || !suiteInfo.valid}
+						>
+							<FileJson aria-hidden="true" className="size-4" />
+							{run.isPending
+								? 'Running…'
+								: `Run Suite (${suiteInfo.count} ${suiteInfo.count === 1 ? 'Case' : 'Cases'})`}
+						</Button>
+					</div>
+				</div>
+			</details>
+		</PageContainer>
+	);
+}

--- a/packages/web/src/components/ui/Button.test.tsx
+++ b/packages/web/src/components/ui/Button.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Button } from './Button';
+
+describe('Button', () => {
+	it('transitions the disabled opacity change', () => {
+		render(<Button isDisabled>Save</Button>);
+
+		expect(screen.getByRole('button', { name: 'Save' })).toHaveClass(
+			'transition-[color,background-color,border-color,box-shadow,transform,opacity]',
+		);
+	});
+});

--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -6,7 +6,7 @@ import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium shadow-xs transition-[color,background-color,border-color,box-shadow,transform] cursor-pointer active:translate-y-px disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:min-h-11 motion-reduce:transition-none',
+	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium shadow-xs transition-[color,background-color,border-color,box-shadow,transform,opacity] cursor-pointer active:translate-y-px disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:min-h-11 motion-reduce:transition-none',
 	{
 		variants: {
 			variant: {

--- a/packages/web/src/components/ui/Button.tsx
+++ b/packages/web/src/components/ui/Button.tsx
@@ -6,7 +6,7 @@ import { cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium shadow-xs transition-all cursor-pointer active:translate-y-px disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:min-h-11',
+	'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium shadow-xs transition-[color,background-color,border-color,box-shadow,transform] cursor-pointer active:translate-y-px disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background max-md:min-h-11 motion-reduce:transition-none',
 	{
 		variants: {
 			variant: {

--- a/packages/web/src/components/ui/PageLayout.tsx
+++ b/packages/web/src/components/ui/PageLayout.tsx
@@ -1,13 +1,22 @@
 import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
 
 /**
  * Centered, scrollable page body shared by the list views. Wraps content in the
  * standard max-width column.
  */
-export function PageContainer({ children }: { children: ReactNode }) {
+export function PageContainer({
+	children,
+	className,
+	contentClassName,
+}: {
+	children: ReactNode;
+	className?: string;
+	contentClassName?: string;
+}) {
 	return (
-		<div className="flex flex-1 justify-center overflow-y-auto p-8 max-md:p-3">
-			<div className="w-full max-w-3xl pb-8 max-md:pb-5">{children}</div>
+		<div className={cn('flex flex-1 justify-center overflow-y-auto p-8 max-md:p-3', className)}>
+			<div className={cn('w-full max-w-3xl pb-8 max-md:pb-5', contentClassName)}>{children}</div>
 		</div>
 	);
 }

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -120,6 +120,10 @@ export type AdminUser = ClientAdminUser;
 /** Redacted deployment configuration for the super-admin settings page. */
 export type DeploymentConfig = ClientDeploymentConfig;
 export type SandboxStartupReport = ClientSandboxStartupReport;
+export type PolicyAnalyzerMetadata = components['schemas']['PolicyAnalyzerMetadata'];
+export type PolicySuiteResult = components['schemas']['PolicySuiteResult'];
+export type PolicySuiteV1 =
+	paths['/api/v1/admin/policy-analyzer/evaluate']['post']['requestBody']['content']['application/json'];
 export type ApiResponse<T> = ClientApiResponse<T>;
 export type ApiError = ClientApiError;
 export type User = ClientUser;


### PR DESCRIPTION
Adds a deterministic, read-only policy analyzer for super admins. It runs the production login and authorization evaluators, returns bounded decision traces, supports stored and hypothetical resources, and audits each request without sensitive inputs.

Adds a staged Admin Policy workflow with progressive disclosure, expected-versus-actual explanations, browser-local versioned JSON suites, documentation, generated OpenAPI and client types, and coverage across core, API, and web.