### PR TITLE
feat(web): add notebook share menu

### DIFF
--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -53,6 +53,7 @@ import type { Theme } from '@/context/ThemeContext';
 import { canManageProject } from '@/lib/roles';
 import { SurfaceMenu } from './SurfaceMenu';
 import type { SecondarySurfaceFrame } from './SurfaceMenu';
+import { ShareMenu } from './ShareMenu';
 
 const SURFACE_TAB_ICONS = {
 	vscode: Code2,
@@ -444,12 +445,14 @@ function useNotebookPageModel({ variant = 'edit' }: { variant?: 'edit' | 'app' }
 		!!sourceProvider &&
 		(capabilities?.source_control?.change_request_providers.includes(sourceProvider) ?? false) &&
 		canManageProject(project.your_role);
+	const canRunApp = !isViewer || (capabilities?.viewer_session_modes ?? []).includes('app');
 	return {
 		appStale,
 		applicationTabs,
 		author,
 		backToProject,
 		canOpenChangeRequest,
+		canRunApp,
 		canRetryWithDefault,
 		capabilities,
 		closeSecondaryFrame,
@@ -519,6 +522,7 @@ function renderNotebookPage(model: ReturnType<typeof useNotebookPageModel>) {
 		author,
 		backToProject,
 		canOpenChangeRequest,
+		canRunApp,
 		canRetryWithDefault,
 		capabilities,
 		closeSecondaryFrame,
@@ -636,6 +640,9 @@ function renderNotebookPage(model: ReturnType<typeof useNotebookPageModel>) {
 					</span>
 				)}
 				<div className="ml-auto flex items-center gap-2">
+					{!isApp && (
+						<ShareMenu projectId={pid!} notebookId={nid!} title={title} canRunApp={canRunApp} />
+					)}
 					<ChangeRequestActions
 						projectId={pid!}
 						notebookId={nid!}

--- a/packages/web/src/components/NotebookPage/ShareMenu.test.tsx
+++ b/packages/web/src/components/NotebookPage/ShareMenu.test.tsx
@@ -1,0 +1,91 @@
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { ShareMenu } from './ShareMenu';
+
+function LocationProbe() {
+	return <output data-testid="location">{useLocation().pathname}</output>;
+}
+
+function renderMenu({ canRunApp = true }: { canRunApp?: boolean } = {}) {
+	const wrapper = ({ children }: { children: ReactNode }) => (
+		<MemoryRouter initialEntries={['/projects/proj-1/notebooks/nb-1']}>{children}</MemoryRouter>
+	);
+	return render(
+		<Routes>
+			<Route
+				path="*"
+				element={
+					<>
+						<ShareMenu
+							projectId="proj-1"
+							notebookId="nb-1"
+							title="Forecast"
+							canRunApp={canRunApp}
+						/>
+						<LocationProbe />
+					</>
+				}
+			/>
+		</Routes>,
+		{ wrapper },
+	);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	Reflect.deleteProperty(navigator, 'clipboard');
+});
+
+describe('ShareMenu', () => {
+	it('opens the latest static outputs', async () => {
+		const user = userEvent.setup();
+		renderMenu();
+
+		await user.click(screen.getByRole('button', { name: 'Share notebook' }));
+		await user.click(screen.getByRole('menuitem', { name: 'View static outputs' }));
+
+		expect(screen.getByTestId('location')).toHaveTextContent(
+			'/projects/proj-1/notebooks/nb-1/snapshot',
+		);
+	});
+
+	it('opens the shared app', async () => {
+		const user = userEvent.setup();
+		renderMenu();
+
+		await user.click(screen.getByRole('button', { name: 'Share notebook' }));
+		await user.click(screen.getByRole('menuitem', { name: 'Run as app' }));
+
+		expect(screen.getByTestId('location')).toHaveTextContent('/projects/proj-1/notebooks/nb-1/app');
+	});
+
+	it('copies the canonical notebook URL', async () => {
+		const user = userEvent.setup();
+		const writeText = vi.fn(() => Promise.resolve());
+		Object.defineProperty(navigator, 'clipboard', {
+			value: { writeText },
+			configurable: true,
+		});
+		renderMenu();
+
+		await user.click(screen.getByRole('button', { name: 'Share notebook' }));
+		await user.click(screen.getByRole('menuitem', { name: 'Copy URL' }));
+
+		expect(writeText).toHaveBeenCalledWith(
+			new URL('/projects/proj-1/notebooks/nb-1', window.location.origin).toString(),
+		);
+	});
+
+	it('hides app sharing when the viewer cannot start apps', async () => {
+		const user = userEvent.setup();
+		renderMenu({ canRunApp: false });
+
+		await user.click(screen.getByRole('button', { name: 'Share notebook' }));
+
+		expect(screen.queryByRole('menuitem', { name: 'Run as app' })).toBeNull();
+		expect(screen.getByRole('menuitem', { name: 'View static outputs' })).toBeInTheDocument();
+	});
+});

--- a/packages/web/src/components/NotebookPage/ShareMenu.tsx
+++ b/packages/web/src/components/NotebookPage/ShareMenu.tsx
@@ -1,0 +1,61 @@
+import { Camera, Copy, Play, Share2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { DropdownMenu } from '@/components/ui';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { withBasePath } from '@/lib/basePath';
+
+interface ShareMenuProps {
+	projectId: string;
+	notebookId: string;
+	title: string;
+	canRunApp: boolean;
+}
+
+export function ShareMenu({ projectId, notebookId, title, canRunApp }: ShareMenuProps) {
+	const navigate = useNavigate();
+	const { copy } = useCopyToClipboard();
+	const notebookPath = `/projects/${projectId}/notebooks/${notebookId}`;
+
+	const handleAction = (action: string) => {
+		if (action === 'static-outputs') {
+			void navigate(`${notebookPath}/snapshot`, { state: { title } });
+		} else if (action === 'run-app') {
+			void navigate(`${notebookPath}/app`, { state: { title } });
+		} else if (action === 'copy-url') {
+			const url = new URL(withBasePath(notebookPath), window.location.origin).toString();
+			void copy(url).then((copied) => copied && toast.success('Notebook URL copied'));
+		}
+	};
+
+	return (
+		<DropdownMenu
+			label="Share notebook"
+			icon={<Share2 className="size-3.5" />}
+			triggerClassName="h-[26px] w-7 rounded-md border border-input hover:border-primary hover:bg-transparent hover:text-primary max-md:h-11 max-md:w-11"
+			options={[
+				{
+					id: 'static-outputs',
+					label: 'View static outputs',
+					icon: <Camera className="size-3.5" />,
+				},
+				...(canRunApp
+					? [
+							{
+								id: 'run-app',
+								label: 'Run as app',
+								icon: <Play className="size-3.5" />,
+							},
+						]
+					: []),
+				{
+					id: 'copy-url',
+					label: 'Copy URL',
+					icon: <Copy className="size-3.5" />,
+					separatorBefore: true,
+				},
+			]}
+			onAction={handleAction}
+		/>
+	);
+}


### PR DESCRIPTION
Adds an icon-only Share menu to the notebook header with actions for viewing the latest static outputs, running the notebook as an app, and copying its canonical URL. App sharing follows the existing viewer capability gate, and canonical links avoid exposing session-specific sandbox URLs.