### PR TITLE
fix(web): keep notebook startup feedback visible

### DIFF
--- a/packages/api/src/routes/sessions.appMode.races.test.ts
+++ b/packages/api/src/routes/sessions.appMode.races.test.ts
@@ -59,6 +59,27 @@ describe('Session routes (app mode) — deletion, provisioning and cap races', (
 		return { compute: fakeComputeFrom(instance), calls: fake.calls, entered, release };
 	}
 
+	it.each(['app', 'edit'] as const)(
+		'coalesces a second %s create while the first kernel is still starting',
+		async (mode) => {
+			const { compute, calls, entered, release } = pausableCompute();
+			const api = createTestApi({ bucket, userId: ACTOR, compute }).request;
+
+			const firstPending = api('POST', sessionsPath(), { mode });
+			await entered;
+			const second = await expectOk<any>(await api('POST', sessionsPath(), { mode }));
+
+			expect(second).toMatchObject({ status: 'starting', reused: true });
+			expect(second.sandbox_url).toBeUndefined();
+
+			release();
+			const first = await expectOk<any>(await firstPending);
+			expect(second.session_id).toBe(first.session_id);
+			expect(calls.startProcess).toHaveLength(1);
+			expect(await createServices(bucket).sessions.listSessions(nid)).toHaveLength(1);
+		},
+	);
+
 	it('deleting the notebook during app provisioning cannot resurrect the app or its claim', async () => {
 		const { compute, calls, entered, release } = pausableCompute();
 		const api = createTestApi({ bucket, userId: ACTOR, compute });

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -508,6 +508,28 @@ describe('NotebookPage viewer modes', () => {
 		expect(screen.queryByText(/won't be saved/)).toBeNull();
 	});
 
+	it.each([
+		{ variant: 'edit' as const, message: 'Starting sandbox...' },
+		{ variant: 'app' as const, message: 'Starting app...' },
+	])(
+		'keeps $variant startup feedback visible after receiving a starting session',
+		async (testCase) => {
+			makeFetch({
+				role: 'editor',
+				session: runningSession({
+					mode: testCase.variant === 'app' ? 'app' : undefined,
+					status: 'starting',
+					sandbox_url: undefined,
+				}),
+			});
+			const { container } = renderPage(testCase.variant);
+
+			expect(await screen.findByRole('button', { name: 'Stop' })).toBeEnabled();
+			expect(screen.getByText(testCase.message)).toBeInTheDocument();
+			expect(container.querySelector('iframe')).toBeNull();
+		},
+	);
+
 	it('stops a viewer ephemeral session without a shared-sandbox warning', async () => {
 		const user = userEvent.setup();
 		const fetch = makeFetch({

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -794,8 +794,8 @@ function renderNotebookPage(model: ReturnType<typeof useNotebookPageModel>) {
 				</div>
 			)}
 
-			{!session &&
-				(isProvisioning || resolvingMode || (!isApp && !isViewer && !editorDecisionReady)) &&
+			{(isProvisioning ||
+				(!session && (resolvingMode || (!isApp && !isViewer && !editorDecisionReady)))) &&
 				!showEditorStateFailure &&
 				!showIdentityStateFailure &&
 				!showEditorChoice && (


### PR DESCRIPTION
Keep notebook startup feedback visible when a concurrent create returns an existing starting session before its sandbox URL is available.

Cover edit and app UI states plus route-level coalescing to verify concurrent callers share one session and one kernel process.