### PR TITLE
feat(core): name the sandbox owner to compute adapters

### DIFF
--- a/packages/api/src/routes/changeRequestPublishing.ts
+++ b/packages/api/src/routes/changeRequestPublishing.ts
@@ -1,4 +1,4 @@
-import { ConflictError, NotFoundError, UnavailableError } from '@marimo-hub/core';
+import { ConflictError, NotFoundError, sessionOwner, UnavailableError } from '@marimo-hub/core';
 import type {
 	AuthSubject,
 	GitSourceRevision,
@@ -129,7 +129,7 @@ export async function prepareProposal(input: PrepareProposalInput): Promise<Prep
 			notebookId: input.notebookId,
 			proposalId: input.proposalId,
 			session,
-			sandbox: input.deps.compute.create(session.sandbox_id),
+			sandbox: input.deps.compute.create(session.sandbox_id, { owner: sessionOwner(session) }),
 			workdir: input.deps.sandbox.workdir,
 			author: input.author,
 			targetProposalId: input.targetProposalId,

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -664,6 +664,15 @@ describe('Session routes', () => {
 		expect(notifier.attempts).toBe(attemptsBeforeTakeover);
 	});
 
+	it('names the holder as owner when reconnecting to inspect editor activity', async () => {
+		const otherCompute = makeFakeCompute();
+		const exclusiveOwner = exclusiveApi(ACTOR);
+		const exclusiveOther = exclusiveApi(STRANGER, otherCompute);
+		await expectOk<ApiSession>(await exclusiveOwner('POST', sessionsPath()));
+		await expectOk<EditorState>(await exclusiveOther('GET', editorSessionPath()));
+		expect(otherCompute.lastCreateOptions?.owner).toEqual({ projectId: pid, userId: ACTOR });
+	});
+
 	it('does not fail a takeover when notification delivery fails', async () => {
 		const notifier = new MemoryNotifier();
 		notifier.failNext();

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -46,6 +46,7 @@ import {
 	SessionId,
 	sessionMode,
 	sessionModePolicy,
+	sessionOwner,
 	SubdomainExposure,
 	UnavailableError,
 	EditSessionOwnedError,
@@ -807,7 +808,10 @@ async function inspectEditorActivity(deps: ApiDeps, session: Session) {
 		return { state: 'unknown' as const };
 	}
 	const basePath = kernelBasePathFromUrl(session.sandbox_url);
-	const active = await kernelActiveConnections(deps.compute.create(session.sandbox_id), basePath);
+	const active = await kernelActiveConnections(
+		deps.compute.create(session.sandbox_id, { owner: sessionOwner(session) }),
+		basePath,
+	);
 	const checkedAt = new Date().toISOString();
 	if (active === null) return { state: 'unknown' as const, checked_at: checkedAt };
 	await deps.services.sessions
@@ -1611,7 +1615,8 @@ export async function startNotebookSession(input: {
 					observer.tag('provision_used_fallback', usedFallback);
 					({ clientUrl, originUrl } = await sandboxExposure.finalize(url, exposureCtx));
 				},
-				compensate: () => compute.create(sandboxId).destroy(),
+				compensate: () =>
+					compute.create(sandboxId, { owner: { projectId: pid, userId: user.id } }).destroy(),
 			})
 			.step('mark_running', async () => {
 				if (

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1559,6 +1559,7 @@ export async function startNotebookSession(input: {
 							return provisioner.provision({
 								sandboxId,
 								projectId: pid,
+								userId: user.id,
 								notebookId: nid,
 								hostname,
 								bucket: sandbox.bucket,

--- a/packages/core/src/ports/sandbox.ts
+++ b/packages/core/src/ports/sandbox.ts
@@ -1,4 +1,4 @@
-import type { SandboxId } from '../ids';
+import type { ProjectId, SandboxId, UserId } from '../ids';
 import type { Millis } from '../duration';
 import type { Timings } from '../timing';
 
@@ -259,6 +259,15 @@ export interface SandboxUserHome {
 	path: string;
 }
 
+/**
+ * Who a sandbox is for. Adapters that partition compute per tenant (an Armada
+ * queue, a Kubernetes namespace) key on it; the rest ignore it.
+ */
+export interface SandboxOwner {
+	projectId: ProjectId;
+	userId?: UserId;
+}
+
 export interface CreateSandboxOptions {
 	/**
 	 * May the adapter reconnect to an existing sandbox with this id instead of
@@ -282,6 +291,12 @@ export interface CreateSandboxOptions {
 	 * later provider-side backstop; it is not the graceful lifecycle enforcement.
 	 */
 	sessionIdleTimeoutMs?: Millis;
+	/**
+	 * Who the sandbox is for, on every call where the caller holds a session
+	 * record. Absent where it holds only an id (orphan reconciliation), so an
+	 * adapter that keys on it must remember what it learned or look it up.
+	 */
+	owner?: SandboxOwner;
 }
 
 export interface SandboxProvider {

--- a/packages/core/src/services/content/filesystemSnapshots.ts
+++ b/packages/core/src/services/content/filesystemSnapshots.ts
@@ -13,7 +13,7 @@ import type { NotebookService } from './NotebookService';
 
 type CreateOrRestoreSandboxOptions = Pick<
 	CreateSandboxOptions,
-	'image' | 'resources' | 'userHome' | 'sessionIdleTimeoutMs'
+	'image' | 'resources' | 'userHome' | 'sessionIdleTimeoutMs' | 'owner'
 >;
 
 /**
@@ -73,6 +73,7 @@ export function createOrRestoreSandbox(
 		...(options.sessionIdleTimeoutMs !== undefined
 			? { sessionIdleTimeoutMs: options.sessionIdleTimeoutMs }
 			: {}),
+		...(options.owner ? { owner: options.owner } : {}),
 	};
 	// reuse: false — this id is brand new, so the adapter's reconnect lookup can
 	// never match and would just cost a round-trip on the critical path.

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -219,6 +219,7 @@ export { ReconciliationService } from './runtime/ReconciliationService';
 export type { ActiveSandboxSource, ReconcileResult } from './runtime/ReconciliationService';
 export { SandboxDiagnosticLease } from './runtime/SandboxDiagnosticLease';
 export { kernelActiveConnections, SessionLifecycleService } from './runtime/sessionLifecycle';
+export { sessionOwner } from './runtime/sessionOwner';
 export type {
 	ConnectionProbe,
 	SessionLifecycleConfig,

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Millis } from '../../duration';
-import { createNotebookId, createProjectId, createSandboxId, createVersionId } from '../../ids';
+import {
+	createNotebookId,
+	createProjectId,
+	createSandboxId,
+	createVersionId,
+	UserId,
+} from '../../ids';
 import { paths } from '../../paths';
 import {
 	ACTOR,
@@ -117,6 +123,23 @@ describe('SandboxProvisioner', () => {
 			expect(calls.startProcess[0].cmd).not.toContain('--asset-url');
 			// Binds all interfaces so the external ingress can reach the kernel.
 			expect(calls.startProcess[0].cmd).toContain('--host 0.0.0.0');
+		});
+
+		it('names the owner to the provider, project and user', async () => {
+			const { instance } = makeFakeSandbox();
+			const compute = fakeComputeFrom(instance);
+			const userId = UserId.parse('user_owner');
+
+			await new SandboxProvisioner(compute).provision({
+				sandboxId,
+				projectId,
+				userId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+			});
+
+			expect(compute.lastCreateOptions?.owner).toEqual({ projectId, userId });
 		});
 
 		it('runs resolved launch setup before starting the kernel', async () => {
@@ -300,7 +323,11 @@ describe('SandboxProvisioner', () => {
 				image: 'ghcr.io/marimo/custom:1',
 			});
 
-			expect(compute.lastCreateOptions).toEqual({ reuse: false, image: 'ghcr.io/marimo/custom:1' });
+			expect(compute.lastCreateOptions).toEqual({
+				reuse: false,
+				owner: { projectId },
+				image: 'ghcr.io/marimo/custom:1',
+			});
 		});
 
 		it('forwards a user home to sandbox creation', async () => {
@@ -318,7 +345,7 @@ describe('SandboxProvisioner', () => {
 				userHome,
 			});
 
-			expect(compute.lastCreateOptions).toEqual({ reuse: false, userHome });
+			expect(compute.lastCreateOptions).toEqual({ reuse: false, owner: { projectId }, userHome });
 		});
 
 		it('destroys the sandbox when a sessionEnv promise rejects (fail-closed creds)', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -218,6 +218,11 @@ export interface ProvisionOptions {
 	resources?: ComputeResources;
 	/** Personal directory selected for an owner-isolated editor sandbox. */
 	userHome?: SandboxUserHome;
+	/**
+	 * The user the session is for. With `projectId` it names the sandbox's owner
+	 * to adapters that partition compute per tenant.
+	 */
+	userId?: UserId;
 	/** Control-plane idle deadline used by providers to derive an orphan backstop. */
 	sessionIdleTimeoutMs?: Millis;
 	/**
@@ -610,6 +615,10 @@ export class SandboxProvisioner {
 				resources: options.resources,
 				userHome: options.userHome,
 				sessionIdleTimeoutMs: options.sessionIdleTimeoutMs,
+				owner: {
+					projectId: options.projectId,
+					...(options.userId ? { userId: options.userId } : {}),
+				},
 			},
 		);
 		const createMs = Date.now() - createStart;
@@ -651,6 +660,10 @@ export class SandboxProvisioner {
 				resources: options.resources,
 				userHome: options.userHome,
 				sessionIdleTimeoutMs: options.sessionIdleTimeoutMs,
+				owner: {
+					projectId: options.projectId,
+					...(options.userId ? { userId: options.userId } : {}),
+				},
 			},
 		);
 		const createMs = Date.now() - createStart;

--- a/packages/core/src/services/runtime/SessionRetirer.ts
+++ b/packages/core/src/services/runtime/SessionRetirer.ts
@@ -1,5 +1,6 @@
 import type { Bucket } from '../../ports/bucket';
 import type { SandboxProvider } from '../../ports/sandbox';
+import { sessionOwner } from './sessionOwner';
 import type { Session } from '../../schema';
 import { Millis } from '../../duration';
 import { ConflictError } from '../../errors';
@@ -197,7 +198,7 @@ export class SessionRetirer {
 		} = { assertLease: async () => {}, advanceLease: async () => {} },
 	): Promise<void> {
 		if (!session.sandbox_id || session.sandbox_reclaimed_at) return;
-		const sandbox = this.deps.compute.create(session.sandbox_id);
+		const sandbox = this.deps.compute.create(session.sandbox_id, { owner: sessionOwner(session) });
 		await this.stopSecondarySurfaces(sandbox, session);
 		if (!session.takeover_capture_completed_at) {
 			const persisted = await this.provisioner.captureSession(
@@ -259,7 +260,9 @@ export class SessionRetirer {
 			if (!(await this.teardownSandbox(session))) return false;
 		} else if (session.sandbox_id) {
 			try {
-				await this.deps.compute.create(session.sandbox_id).destroy();
+				await this.deps.compute
+					.create(session.sandbox_id, { owner: sessionOwner(session) })
+					.destroy();
 			} catch {
 				return false;
 			}
@@ -278,7 +281,7 @@ export class SessionRetirer {
 	 */
 	private async teardownSandbox(session: Session, captureBeforeDestroy = true): Promise<boolean> {
 		if (!session.sandbox_id) return true;
-		const sandbox = this.deps.compute.create(session.sandbox_id);
+		const sandbox = this.deps.compute.create(session.sandbox_id, { owner: sessionOwner(session) });
 		await this.stopSecondarySurfaces(sandbox, session);
 		let persisted = false;
 		if (captureBeforeDestroy) {

--- a/packages/core/src/services/runtime/sessionLifecycle.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.ts
@@ -5,6 +5,7 @@ import { mapWithConcurrency } from '../../concurrency';
 import { Millis } from '../../duration';
 import type { NotebookId, SessionId } from '../../ids';
 import type { SandboxInstance, SandboxProvider } from '../../ports/sandbox';
+import { sessionOwner } from './sessionOwner';
 import { createSlidingWindowBudget } from '../../rateLimit';
 import type { Session } from '../../schema';
 import type { NotebookService } from '../content/NotebookService';
@@ -177,7 +178,7 @@ export class SessionLifecycleService {
 		};
 
 		await mapWithConcurrency(candidates, SESSION_SWEEP_CONCURRENCY, async (s) => {
-			const sandbox = this.compute.create(s.sandbox_id!);
+			const sandbox = this.compute.create(s.sandbox_id!, { owner: sessionOwner(s) });
 
 			const heartbeatStale =
 				now - Date.parse(s.last_heartbeat) > this.cfg.idleTimeoutMsByMode[sessionMode(s)];

--- a/packages/core/src/services/runtime/sessionOwner.ts
+++ b/packages/core/src/services/runtime/sessionOwner.ts
@@ -1,0 +1,11 @@
+import type { SandboxOwner } from '../../ports/sandbox';
+import type { Session } from '../../schema';
+
+/**
+ * The owner a session record names, for adapters that partition compute per
+ * tenant. Passed on every `create` that starts from a record, so an adapter
+ * can find the sandbox's partition again after a restart.
+ */
+export function sessionOwner(session: Pick<Session, 'project_id' | 'user_id'>): SandboxOwner {
+	return { projectId: session.project_id, userId: session.user_id };
+}


### PR DESCRIPTION
## Summary

Compute adapters that partition compute per tenant, such as an Armada queue per team or a Kubernetes namespace per project, had no way to know whose sandbox they were creating. `CreateSandboxOptions` carried the image, resources and user home, but not the project or user the session belongs to, so such an adapter could only put every sandbox in one partition.

This adds `owner?: { projectId, userId? }` to `CreateSandboxOptions` and passes it on every `create` that starts from something the hub knows:

- The provisioner sends the project from its options and the user from the session route, which now hands `userId` to `provision`.
- The session sweep and the retirer send both from the session record, through one `sessionOwner` helper.
- The reconciler's orphan path and the data-preview sandbox pass nothing, since they hold no record.

The field is optional. Every adapter that ignores it is unchanged. An adapter that keys on it must tolerate its absence, which is why the partition has to be remembered or looked up rather than derived on every call; the doc comment on the field says so.

The first consumer is the Armada adapter in `marimohub-compute-armada`, which maps the owner to a queue so that Armada's per-queue fair share applies per team or per user.

## Verification

- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm build`

For docs-only changes:

- [ ] `pnpm --filter @marimo-hub/docs test`
- [ ] `pnpm --filter @marimo-hub/docs build`

A new test in `SandboxProvisioner.test.ts` asserts the owner reaches the provider with both ids. Two existing exact-equality assertions on the create options were extended with the new field.

## Notes

- Docs updated or not needed: not needed. The field is part of the adapter port, documented by its doc comment; no operator-facing configuration changes.
- Security impact: none new. The owner ids are already known to the hub and already stored on the session record; they are now also handed to the compute adapter the operator chose to load. No new external input, and an adapter that partitions on them gains a way to enforce tenant separation rather than lose one.

Hope this is reasonable to add @mscolnick.
