### PR TITLE
feat(runtime): authenticate marimo kernels

### DIFF
--- a/apps/docs/.vitepress/wizard/generate.ts
+++ b/apps/docs/.vitepress/wizard/generate.ts
@@ -327,7 +327,7 @@ export function validateSelection(sel: WizardSelection): SelectionWarning[] {
 				level: 'danger',
 				title: 'Kubernetes kernel traffic is plaintext',
 				message:
-					'Disabled ingress TLS exposes tokenless kernel traffic. Use a TLS secret or the ingress controller default in production.',
+					'Disabled ingress TLS exposes kernel access tokens and traffic. Use a TLS secret or the ingress controller default in production.',
 			});
 		}
 	}

--- a/apps/server/src/sandboxProxyWs.test.ts
+++ b/apps/server/src/sandboxProxyWs.test.ts
@@ -5,10 +5,9 @@ import { PassThrough } from 'node:stream';
 import type { Duplex } from 'node:stream';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { createInitializedBucket, makeTestDeps } from '@marimo-hub/api/testing';
-import type { ApiDeps } from '@marimo-hub/api';
 import { createServices, ProxyExposure, signProxyToken } from '@marimo-hub/core';
 import type { Authenticator, ProjectId, UserId } from '@marimo-hub/core';
-import { ACTOR, MemoryBucket } from '@marimo-hub/core/testing';
+import { ACTOR, MemoryBucket, TEST_KERNEL_AUTH_TOKEN } from '@marimo-hub/core/testing';
 import { attachSandboxProxyUpgrade } from './sandboxProxyWs';
 
 const SECRET = 'a-test-signing-secret-at-least-32-bytes-long!!';
@@ -37,7 +36,17 @@ function authAs(userId: UserId | null): Authenticator {
 	};
 }
 
-async function runningProxySession(origin: string, authorizationExpiresAt: string) {
+async function runningProxySession(
+	origin: string,
+	options: {
+		authorizationExpiresAt?: string;
+		kernelAuthToken?: string | null;
+	} = {},
+) {
+	const authorizationExpiresAt =
+		options.authorizationExpiresAt ?? new Date(Date.now() + 60_000).toISOString();
+	const kernelAuthToken =
+		options.kernelAuthToken === undefined ? TEST_KERNEL_AUTH_TOKEN : options.kernelAuthToken;
 	const bucket = await createInitializedBucket();
 	const services = createServices(bucket);
 	const project = await services.projects.createProject({ name: 'Owned', description: 'd' }, ACTOR);
@@ -52,6 +61,7 @@ async function runningProxySession(origin: string, authorizationExpiresAt: strin
 		project_id: pid,
 		user_id: ACTOR,
 		authorization_expires_at: authorizationExpiresAt,
+		...(kernelAuthToken !== null ? { kernel_auth_token: kernelAuthToken } : {}),
 	});
 	await services.sessions.setRunning(pid, session.session_id, '/proxy/x/', false, origin);
 	const token = await signProxyToken(pid, session.session_id, SECRET);
@@ -65,7 +75,7 @@ async function runningProxySession(origin: string, authorizationExpiresAt: strin
 			exposure: new ProxyExposure(SECRET),
 		},
 	});
-	return { deps, token };
+	return { deps, token, services, session };
 }
 
 /** Collect bytes written to a client socket, in flowing mode. */
@@ -128,10 +138,7 @@ describe('attachSandboxProxyUpgrade', () => {
 	});
 
 	it('rejects a suspended user with the suspension-specific WebSocket status', async () => {
-		const { deps, token } = await runningProxySession(
-			'http://127.0.0.1:1',
-			new Date(Date.now() + 60_000).toISOString(),
-		);
+		const { deps, token } = await runningProxySession('http://127.0.0.1:1');
 		await deps.services.identities.upsert({
 			id: ACTOR,
 			email: `${ACTOR}@example.com`,
@@ -152,10 +159,9 @@ describe('attachSandboxProxyUpgrade', () => {
 	it('rejects when authorization expires between request validation and the upstream dial', async () => {
 		const now = Date.now();
 		const deadline = now + 1000;
-		const { deps, token } = await runningProxySession(
-			'http://127.0.0.1:1',
-			new Date(deadline).toISOString(),
-		);
+		const { deps, token } = await runningProxySession('http://127.0.0.1:1', {
+			authorizationExpiresAt: new Date(deadline).toISOString(),
+		});
 		const nowSpy = vi.spyOn(Date, 'now').mockReturnValueOnce(now).mockReturnValue(deadline);
 		const server = fakeUpgradeServer();
 		attachSandboxProxyUpgrade(server, deps);
@@ -170,10 +176,7 @@ describe('attachSandboxProxyUpgrade', () => {
 	});
 
 	it('returns 502 when the upstream dial fails before authorization expires', async () => {
-		const { deps, token } = await runningProxySession(
-			'http://127.0.0.1:1',
-			new Date(Date.now() + 60_000).toISOString(),
-		);
+		const { deps, token } = await runningProxySession('http://127.0.0.1:1');
 		const server = fakeUpgradeServer();
 		attachSandboxProxyUpgrade(server, deps);
 		const socket = new PassThrough();
@@ -205,50 +208,14 @@ describe('attachSandboxProxyUpgrade', () => {
 		afterAll(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
 
 		it('relays a non-upgrade upstream response and closes the client socket', async () => {
-			const bucket = await createInitializedBucket();
-			const services = createServices(bucket);
-			const project = await services.projects.createProject(
-				{ name: 'Owned', description: 'd' },
-				ACTOR,
-			);
-			const pid = project.id as ProjectId;
-			const notebook = await services.notebooks.createNotebook(
-				pid,
-				{ title: 'NB', description: 'd', code: 'import marimo as mo' },
-				ACTOR,
-			);
-			const session = await services.sessions.createSession({
-				notebook_id: notebook.id,
-				project_id: pid,
-				user_id: ACTOR,
-				authorization_expires_at: new Date(Date.now() + 60_000).toISOString(),
-			});
-			await services.sessions.setRunning(
-				pid,
-				session.session_id,
-				'/proxy/x/',
-				false,
-				upstreamOrigin,
-			);
-			const token = await signProxyToken(pid, session.session_id, SECRET);
-
-			const deps: ApiDeps = makeTestDeps(bucket, {
-				authenticator: authAs(ACTOR),
-				sandbox: {
-					bucket: { name: 'test', endpoint: '' },
-					hostname: 'localhost',
-					workdir: '/workspace',
-					persistWorkspace: 'source',
-					exposure: new ProxyExposure(SECRET),
-				},
-			});
+			const { deps, token } = await runningProxySession(upstreamOrigin);
 			const server = fakeUpgradeServer();
 			attachSandboxProxyUpgrade(server, deps);
 
 			const socket = new PassThrough();
 			const out = collect(socket);
-			// Hub credentials ride the browser's upgrade request; the kernel (and the
-			// notebook code that can read its request headers) must never see them.
+			// Hub credentials ride the browser's upgrade request. Replace them with the
+			// kernel-scoped credential before notebook code can read the headers.
 			const req = fakeIncomingMessage(`/proxy/${token}/`);
 			req.headers.cookie = 'hub_session=secret';
 			req.headers.authorization = 'Bearer mhub_pat_secret';
@@ -261,51 +228,37 @@ describe('attachSandboxProxyUpgrade', () => {
 			expect(out.text()).toMatch(/^HTTP\/1\.1 404/);
 			expect(lastUpstreamHeaders).toBeDefined();
 			expect(lastUpstreamHeaders!.cookie).toBeUndefined();
-			expect(lastUpstreamHeaders!.authorization).toBeUndefined();
+			expect(lastUpstreamHeaders!.authorization).toBe(`Bearer ${TEST_KERNEL_AUTH_TOKEN}`);
 			expect(lastUpstreamHeaders!['cf-access-jwt-assertion']).toBeUndefined();
 			expect(lastUpstreamHeaders!['x-custom']).toBe('passes');
 		});
 
-		it('dials a strip-prefix surface at the path beneath its proxy prefix', async () => {
-			const bucket = await createInitializedBucket();
-			const services = createServices(bucket);
-			const project = await services.projects.createProject(
-				{ name: 'Owned', description: 'd' },
-				ACTOR,
-			);
-			const pid = project.id as ProjectId;
-			const notebook = await services.notebooks.createNotebook(
-				pid,
-				{ title: 'NB', description: 'd', code: 'import marimo as mo' },
-				ACTOR,
-			);
-			const session = await services.sessions.createSession({
-				notebook_id: notebook.id,
-				project_id: pid,
-				user_id: ACTOR,
+		it('strips caller credentials without adding authorization for a legacy kernel', async () => {
+			const { deps, token } = await runningProxySession(upstreamOrigin, {
+				kernelAuthToken: null,
 			});
-			await services.sessions.setRunning(
-				pid,
-				session.session_id,
-				'/proxy/x/',
-				false,
-				'http://kernel',
-			);
-			await services.sessions.setSurfaceState(pid, session.session_id, 'vscode', {
+			const server = fakeUpgradeServer();
+			attachSandboxProxyUpgrade(server, deps);
+			const socket = new PassThrough();
+			const req = fakeIncomingMessage(`/proxy/${token}/`);
+			req.headers.cookie = 'hub_session=secret';
+			req.headers.authorization = 'Bearer caller-secret';
+			lastUpstreamHeaders = undefined;
+
+			server.listeners[0](req, socket, Buffer.alloc(0));
+
+			await vi.waitFor(() => expect(socket.destroyed).toBe(true));
+			expect(lastUpstreamHeaders).toBeDefined();
+			expect(lastUpstreamHeaders!.cookie).toBeUndefined();
+			expect(lastUpstreamHeaders!.authorization).toBeUndefined();
+		});
+
+		it('dials a strip-prefix surface at the path beneath its proxy prefix', async () => {
+			const { deps, token, services, session } = await runningProxySession('http://kernel');
+			await services.sessions.setSurfaceState(session.project_id, session.session_id, 'vscode', {
 				status: 'ready',
 				origin_url: upstreamOrigin,
 				proxy_path: 'strip-prefix',
-			});
-			const token = await signProxyToken(pid, session.session_id, SECRET);
-			const deps: ApiDeps = makeTestDeps(bucket, {
-				authenticator: authAs(ACTOR),
-				sandbox: {
-					bucket: { name: 'test', endpoint: '' },
-					hostname: 'localhost',
-					workdir: '/workspace',
-					persistWorkspace: 'source',
-					exposure: new ProxyExposure(SECRET),
-				},
 			});
 			const server = fakeUpgradeServer();
 			attachSandboxProxyUpgrade(server, deps);
@@ -313,26 +266,28 @@ describe('attachSandboxProxyUpgrade', () => {
 			const socket = new PassThrough();
 			const out = collect(socket);
 			lastUpstreamUrl = undefined;
-			server.listeners[0](
-				fakeIncomingMessage(`/surface-proxy/${token}/vscode/stable/out.js?v=1`),
-				socket,
-				Buffer.alloc(0),
-			);
+			lastUpstreamHeaders = undefined;
+			const req = fakeIncomingMessage(`/surface-proxy/${token}/vscode/stable/out.js?v=1`);
+			req.headers.authorization = 'Bearer caller-secret';
+			server.listeners[0](req, socket, Buffer.alloc(0));
 
 			await vi.waitFor(() => expect(socket.destroyed).toBe(true));
 			expect(out.text()).toMatch(/^HTTP\/1\.1 404/);
 			expect(lastUpstreamUrl).toBe('/stable/out.js?v=1');
+			expect(lastUpstreamHeaders!.authorization).toBeUndefined();
 		});
 
-		it('strips Set-Cookie from a successful upgrade handshake', async () => {
+		it('authenticates a successful kernel upgrade and strips Set-Cookie', async () => {
 			// The 101's headers are relayed verbatim, on the app's own origin — so a
 			// kernel cookie would overwrite the caller's hub session.
 			const upgrader = createServer();
 			// An upgraded socket detaches from the server, so keep it to close by hand.
 			let upstreamSocket: Duplex | undefined;
 			let receivedClientHead = '';
-			upgrader.on('upgrade', (_req, socket) => {
+			let receivedAuthorization: string | undefined;
+			upgrader.on('upgrade', (req, socket) => {
 				upstreamSocket = socket;
+				receivedAuthorization = req.headers.authorization;
 				socket.on('data', (chunk) => {
 					receivedClientHead += chunk.toString();
 				});
@@ -347,42 +302,7 @@ describe('attachSandboxProxyUpgrade', () => {
 			const upgraderOrigin = `http://127.0.0.1:${(upgrader.address() as AddressInfo).port}`;
 
 			try {
-				const bucket = await createInitializedBucket();
-				const services = createServices(bucket);
-				const project = await services.projects.createProject(
-					{ name: 'Owned', description: 'd' },
-					ACTOR,
-				);
-				const pid = project.id as ProjectId;
-				const notebook = await services.notebooks.createNotebook(
-					pid,
-					{ title: 'NB', description: 'd', code: 'import marimo as mo' },
-					ACTOR,
-				);
-				const session = await services.sessions.createSession({
-					notebook_id: notebook.id,
-					project_id: pid,
-					user_id: ACTOR,
-				});
-				await services.sessions.setRunning(
-					pid,
-					session.session_id,
-					'/proxy/x/',
-					false,
-					upgraderOrigin,
-				);
-				const token = await signProxyToken(pid, session.session_id, SECRET);
-
-				const deps: ApiDeps = makeTestDeps(bucket, {
-					authenticator: authAs(ACTOR),
-					sandbox: {
-						bucket: { name: 'test', endpoint: '' },
-						hostname: 'localhost',
-						workdir: '/workspace',
-						persistWorkspace: 'source',
-						exposure: new ProxyExposure(SECRET),
-					},
-				});
+				const { deps, token } = await runningProxySession(upgraderOrigin);
 				const server = fakeUpgradeServer();
 				attachSandboxProxyUpgrade(server, deps);
 
@@ -394,6 +314,7 @@ describe('attachSandboxProxyUpgrade', () => {
 				server.listeners[0](req, socket, Buffer.from('client-head'));
 
 				await vi.waitFor(() => expect(out.text()).toMatch(/^HTTP\/1\.1 101/));
+				expect(receivedAuthorization).toBe(`Bearer ${TEST_KERNEL_AUTH_TOKEN}`);
 				expect(out.text().toLowerCase()).not.toContain('set-cookie');
 				await vi.waitFor(() => expect(receivedClientHead).toBe('client-head'));
 			} finally {
@@ -408,10 +329,9 @@ describe('attachSandboxProxyUpgrade', () => {
 			const stalledOrigin = `http://127.0.0.1:${(stalled.address() as AddressInfo).port}`;
 
 			try {
-				const { deps, token } = await runningProxySession(
-					stalledOrigin,
-					new Date(Date.now() + 250).toISOString(),
-				);
+				const { deps, token } = await runningProxySession(stalledOrigin, {
+					authorizationExpiresAt: new Date(Date.now() + 250).toISOString(),
+				});
 				const server = fakeUpgradeServer();
 				attachSandboxProxyUpgrade(server, deps);
 				const socket = new PassThrough();
@@ -437,10 +357,7 @@ describe('attachSandboxProxyUpgrade', () => {
 			const stalledOrigin = `http://127.0.0.1:${(stalled.address() as AddressInfo).port}`;
 
 			try {
-				const { deps, token } = await runningProxySession(
-					stalledOrigin,
-					new Date(Date.now() + 60_000).toISOString(),
-				);
+				const { deps, token } = await runningProxySession(stalledOrigin);
 				const server = fakeUpgradeServer();
 				attachSandboxProxyUpgrade(server, deps);
 				const socket = new PassThrough();
@@ -472,41 +389,8 @@ describe('attachSandboxProxyUpgrade', () => {
 			const upgraderOrigin = `http://127.0.0.1:${(upgrader.address() as AddressInfo).port}`;
 
 			try {
-				const bucket = await createInitializedBucket();
-				const services = createServices(bucket);
-				const project = await services.projects.createProject(
-					{ name: 'Owned', description: 'd' },
-					ACTOR,
-				);
-				const pid = project.id as ProjectId;
-				const notebook = await services.notebooks.createNotebook(
-					pid,
-					{ title: 'NB', description: 'd', code: 'import marimo as mo' },
-					ACTOR,
-				);
-				const session = await services.sessions.createSession({
-					notebook_id: notebook.id,
-					project_id: pid,
-					user_id: ACTOR,
-					authorization_expires_at: new Date(Date.now() + 1500).toISOString(),
-				});
-				await services.sessions.setRunning(
-					pid,
-					session.session_id,
-					'/proxy/x/',
-					false,
-					upgraderOrigin,
-				);
-				const token = await signProxyToken(pid, session.session_id, SECRET);
-				const deps = makeTestDeps(bucket, {
-					authenticator: authAs(ACTOR),
-					sandbox: {
-						bucket: { name: 'test', endpoint: '' },
-						hostname: 'localhost',
-						workdir: '/workspace',
-						persistWorkspace: 'source',
-						exposure: new ProxyExposure(SECRET),
-					},
+				const { deps, token } = await runningProxySession(upgraderOrigin, {
+					authorizationExpiresAt: new Date(Date.now() + 1500).toISOString(),
 				});
 				const server = fakeUpgradeServer();
 				attachSandboxProxyUpgrade(server, deps);

--- a/apps/server/src/sandboxProxyWs.ts
+++ b/apps/server/src/sandboxProxyWs.ts
@@ -79,7 +79,14 @@ export function attachSandboxProxyUpgrade(server: UpgradeServer, deps: ApiDeps):
 					if (CREDENTIAL_HEADERS.has(key.toLowerCase())) continue;
 					forwarded[key] = value;
 				}
-				const headers = { ...forwarded, host: target.host, origin: target.origin };
+				const headers = {
+					...forwarded,
+					host: target.host,
+					origin: target.origin,
+					...(decision.kernelAuthToken
+						? { authorization: `Bearer ${decision.kernelAuthToken}` }
+						: {}),
+				};
 				const proxyReq = lib.request({
 					protocol: target.protocol,
 					hostname: target.hostname,

--- a/development_docs/architecture.md
+++ b/development_docs/architecture.md
@@ -221,10 +221,10 @@ differences:
 Under the default `MARIMOHUB_VIEWER_MODE=static`, viewers cannot start, open,
 or reach an app: session create, heartbeat, and stop require editor+, the
 proxy re-authorizes every HTTP request (WebSockets at each upgrade — an
-established socket lives until it closes) in `proxy` exposure, and — because in
-`subdomain` exposure the kernel URL itself is the access capability (kernels
-run `--no-token`; see docs/security.md) — the session read projections
-(list/get) withhold `sandbox_url` from callers the kernel gates would reject.
+established socket lives until it closes) in `proxy` exposure. In `subdomain`
+exposure, the kernel URL contains marimo's per-session access token. The session
+read projections (list/get) withhold `sandbox_url` from callers the kernel gates
+would reject.
 The UI says so rather than dangling an unopenable indicator. The reason is
 credential exposure: app sandboxes keep WIF credentials and integration
 secrets injected (apps commonly exist to query project data), and `marimo run`

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -66,10 +66,10 @@ every request; the UI simply hides what the caller cannot do. How kernel
 traffic itself is gated depends on the
 [sandbox exposure mode](./security.md): under `proxy` exposure every kernel
 request (and each WebSocket handshake) re-checks the caller's role; under
-`subdomain` exposure (the default) the kernel URL is itself the access
-capability — it is only revealed to admitted callers, but whoever already
-holds it can keep using the running app. Revoking a member or downgrading
-`MARIMOHUB_VIEWER_MODE` always stops new admissions; under `subdomain`
+`subdomain` exposure (the default) the kernel URL carries marimo's per-session
+access token. The API reveals it only to admitted callers, but someone who
+already holds the URL can keep using the running app. Revoking a member or
+downgrading `MARIMOHUB_VIEWER_MODE` always stops new admissions; under `subdomain`
 exposure, stop or restart the app to cut off someone already holding its URL.
 Membership still applies: under `MARIMOHUB_DEFAULT_ROLE=none`, a non-member
 gets nothing from `applications` — only explicit members with at least the

--- a/docs/deploying/kubernetes.md
+++ b/docs/deploying/kubernetes.md
@@ -104,8 +104,7 @@ kubectl -n marimo-kernels get pods,svc,ingress \
 5. Restart all API and maintenance replicas.
 6. Remove the Ingress RBAC rule.
 
-If a session survives the change, its tokenless Ingress stays public and becomes
-orphaned.
+If a session survives the change, its Ingress stays public and becomes orphaned.
 :::
 
 See [Configuration → Compute → Kubernetes](../configuration.md#compute) for every
@@ -208,8 +207,10 @@ with the
 - Kernel Pods are **bare Pods** (no Deployment/restart): a node failure ends the
   session. That matches the ephemeral one-kernel-per-session model; a `Failed` Pod
   is treated as terminal.
-- marimo runs **tokenless** behind marimohub's own auth (the provisioner passes
-  `--no-token`); do not expose `*.<hostname>` without marimohub in front.
+- marimo uses an independent token for each interactive session. Keep
+  `*.<hostname>` behind TLS and do not publish session URLs.
+- Complete a server rollout promptly. During a mixed-version rollout, an old
+  proxy replica cannot authenticate to a kernel that a new replica started.
 - In subdomain exposure, the Ingress/TLS scheme is cluster-specific. Confirm
   your ingress controller honours per-host rules and the wildcard certificate.
 - A subdomain-mode Ingress route is created but not waited on, so the kernel

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -113,8 +113,14 @@ So your image must provide:
    pre-installed base.
 
 No marimo entrypoint or `CMD` is required — marimohub supplies the launch command.
-The repository images use `--token` in their default `CMD`. A bare `docker run`
-prints marimo's generated token. Use that token to open the editor.
+The repository images use a generated token in their quiet default `CMD`. For a
+standalone check, publish the port and read the token from the container:
+
+```sh
+cid=$(docker run -d -p 127.0.0.1:2718:2718 IMAGE)
+token=$(docker exec "$cid" cat /tmp/.marimohub-kernel-token)
+printf 'http://127.0.0.1:2718/?access_token=%s\n' "$token"
+```
 
 > **Don't set `UV_COMPILE_BYTECODE` in your image.** Compile bytecode at build with
 > the `--compile-bytecode` flag (fast imports for the pre-installed base). The

--- a/docs/sandbox-image.md
+++ b/docs/sandbox-image.md
@@ -68,8 +68,13 @@ reusing the image's pre-installed environment. With cwd `/workspace`:
 
 ```sh
 uv sync --inexact --no-install-package marimo --no-compile-bytecode --no-build   # add the notebook's deps (skipped when it declares none)
-uv run --no-sync marimo edit notebook.py --headless --no-token --host 0.0.0.0 --port 2718
+uv run --no-sync marimo --quiet edit notebook.py --headless --token --token-password-file /tmp/.marimohub-kernel-token --host 0.0.0.0 --port 2718
 ```
+
+The provisioner creates the password file after it writes other session
+credentials. The file is outside `/workspace`, so workspace snapshots cannot
+capture it. Custom images must use a marimo version that supports
+`--token-password-file`. The supported 0.23.10 and 0.24.x images provide it.
 
 During the sync, `--no-install-package marimo` keeps the image's pinned marimo
 version even if the notebook declares another version. `--no-build` permits only
@@ -108,6 +113,8 @@ So your image must provide:
    pre-installed base.
 
 No marimo entrypoint or `CMD` is required — marimohub supplies the launch command.
+The repository images use `--token` in their default `CMD`. A bare `docker run`
+prints marimo's generated token. Use that token to open the editor.
 
 > **Don't set `UV_COMPILE_BYTECODE` in your image.** Compile bytecode at build with
 > the `--compile-bytecode` flag (fast imports for the pre-installed base). The

--- a/docs/security.md
+++ b/docs/security.md
@@ -35,12 +35,12 @@ MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=sandboxes.example.net
 `sandboxes.hub.example.com` or `hub.example.com` for kernels is rejected at boot.
 :::
 
-The kernel URL is **not authenticated by the hub** — the per-session sandbox id
-is the only capability. Don't expose the kernel hostname beyond the iframe.
-Because the URL is the capability, the session API shows `sandbox_url` only to
-callers who could reach that kernel: editors, the owner of an ephemeral viewer
-session, and — when the [viewer mode](/apps#who-can-do-what) grants apps —
-viewers, for the shared app only.
+The kernel URL is **not authenticated by the hub**. It includes marimo's
+per-session `access_token` query parameter. marimo exchanges the token for its
+session cookie. Do not expose the kernel hostname or copy the URL outside the
+iframe. The session API shows `sandbox_url` only to callers who can reach that
+kernel: editors, the owner of an ephemeral viewer session, and viewers of the
+shared app when the [viewer mode](/apps#who-can-do-what) grants access.
 
 ### `proxy`: forwarded through the app
 
@@ -68,7 +68,8 @@ server; the Cloudflare Workers deployment uses `subdomain`.
 Kubernetes proxy mode uses each kernel's internal Service URL. It does not query,
 create, or delete Ingresses. Before you change from subdomain exposure, complete
 the required [session drain](/deploying/kubernetes#changing-from-subdomain-to-proxy).
-An old tokenless Ingress otherwise stays public and becomes orphaned.
+A session Ingress from an earlier release otherwise stays public and becomes
+orphaned.
 
 Note the interaction with [notebook apps](/apps): the same-origin risk you
 acknowledge is that notebook-authored JS can script the control plane as
@@ -77,13 +78,32 @@ can be — from editors opening their own notebooks to any viewer opening a
 shared app someone else wrote. Combine proxy mode with viewer apps only if you
 trust every notebook author in the deployment.
 
-## Kernels run tokenless
+## Native kernel authentication
 
-The provisioner launches marimo with `--no-token`, so the kernel has no auth of
-its own. In `proxy` mode the hub's auth + per-session check front it; in
-`subdomain` mode only the high-entropy sandbox id on an isolated domain does.
-Never expose the kernel hostname directly — keep marimohub (and your ingress, for
-the `kubernetes`/`coreweave` backends) in front.
+The provisioner generates an independent 256-bit token for each interactive
+session. It writes the token to a reserved file outside the workspace and starts
+marimo with global `--quiet` plus `--token --token-password-file`. Quiet mode suppresses
+marimo's token-bearing startup URL, and captured failure output redacts an
+`access_token` value as a second safeguard. The token does not appear in the
+process command or server logs. Scheduled jobs do not start a server and do not
+use a token.
+
+In `subdomain` mode, the client URL delivers the token to marimo. In `proxy`
+mode, the hub replaces caller credentials with the kernel token after it
+authorizes the request. This replacement applies to kernel HTTP requests and
+WebSocket upgrades. The hub does not send the token to VS Code or OpenCode.
+
+Keep marimohub and your ingress in front of kernels. Native authentication
+limits access after a hostname or origin leak, but it does not replace TLS,
+origin isolation, or hub authorization.
+
+::: warning Complete rolling upgrades promptly
+An old proxy replica cannot authenticate to a kernel that a new replica starts.
+An old lifecycle replica also cannot read that kernel's connection count. A
+mixed-version rollout can therefore return temporary 401 responses and report
+unknown connection counts. Complete the server rollout promptly. New replicas
+remain compatible with sessions started without a token by an earlier release.
+:::
 
 ## Secondary editor surfaces
 

--- a/docs/setup/compute/docker.md
+++ b/docs/setup/compute/docker.md
@@ -9,7 +9,7 @@
 MARIMOHUB_COMPUTE_BACKEND=docker
 MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_DOCKER_HOST=localhost         # hostname used in the kernel URL
-MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=127.0.0.1    # keep tokenless kernel ports on loopback
+MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=127.0.0.1    # keep kernel ports on loopback
 # MARIMOHUB_COMPUTE_DOCKER_NETWORK=marimo         # optional network to attach kernels to
 ```
 
@@ -23,9 +23,9 @@ so kernel traffic goes through the hub's authentication and per-session
 authorization.
 
 ::: danger Direct kernel exposure
-Kernels run without their own authentication token. If you deliberately publish
-them directly on a trusted, isolated network, set
-`MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=0.0.0.0` **and** set
+Kernels use a per-session bearer token, but their URLs carry that token during
+login. If you deliberately publish them directly on a trusted, isolated network,
+set `MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=0.0.0.0` **and** set
 `MARIMOHUB_COMPUTE_DOCKER_HOST` to the server hostname browsers can reach.
 Never expose those ports to the public internet.
 :::

--- a/docs/setup/compute/podman.md
+++ b/docs/setup/compute/podman.md
@@ -10,7 +10,7 @@
 MARIMOHUB_COMPUTE_BACKEND=podman
 MARIMOHUB_COMPUTE_IMAGE=ghcr.io/orgname/marimo-sandbox:latest
 MARIMOHUB_COMPUTE_PODMAN_HOST=localhost         # hostname used in the kernel URL
-MARIMOHUB_COMPUTE_PODMAN_BIND_HOST=127.0.0.1    # keep tokenless kernel ports on loopback
+MARIMOHUB_COMPUTE_PODMAN_BIND_HOST=127.0.0.1    # keep kernel ports on loopback
 # MARIMOHUB_COMPUTE_PODMAN_NETWORK=marimohub      # optional network to attach kernels to
 ```
 
@@ -20,9 +20,9 @@ so kernel traffic goes through the hub's authentication and per-session
 authorization.
 
 ::: danger Direct kernel exposure
-Kernels run without their own authentication token. If you deliberately publish
-them directly on a trusted, isolated network, set
-`MARIMOHUB_COMPUTE_PODMAN_BIND_HOST=0.0.0.0` **and** set
+Kernels use a per-session bearer token, but their URLs carry that token during
+login. If you deliberately publish them directly on a trusted, isolated network,
+set `MARIMOHUB_COMPUTE_PODMAN_BIND_HOST=0.0.0.0` **and** set
 `MARIMOHUB_COMPUTE_PODMAN_HOST` to the server hostname browsers can reach.
 Never expose those ports to the public internet.
 :::

--- a/examples/sandbox-image/Dockerfile
+++ b/examples/sandbox-image/Dockerfile
@@ -65,7 +65,6 @@ ENV VIRTUAL_ENV=/opt/marimohub/venv \
 USER appuser
 WORKDIR /workspace
 
-# Not used in production (the provisioner supplies the launch command); lets a bare
-# `docker run` start a kernel for a sanity check, straight from the pre-installed
-# env. `--convert` opens a plain Python file too.
-CMD ["uv", "run", "--no-sync", "marimo", "edit", "notebook.py", "--convert", "--headless", "--token", "--host", "0.0.0.0", "--port", "2718"]
+# Not used in production; the provisioner supplies its own launch command and token.
+# The standalone command keeps its generated credential in the container filesystem.
+CMD ["sh", "-lc", "umask 077; python3 -c \"import secrets; print('mhub_kernel_' + secrets.token_urlsafe(32))\" > /tmp/.marimohub-kernel-token; exec uv run --no-sync marimo --quiet edit notebook.py --convert --headless --token --token-password-file /tmp/.marimohub-kernel-token --host 0.0.0.0 --port 2718"]

--- a/examples/sandbox-image/Dockerfile
+++ b/examples/sandbox-image/Dockerfile
@@ -68,4 +68,4 @@ WORKDIR /workspace
 # Not used in production (the provisioner supplies the launch command); lets a bare
 # `docker run` start a kernel for a sanity check, straight from the pre-installed
 # env. `--convert` opens a plain Python file too.
-CMD ["uv", "run", "--no-sync", "marimo", "edit", "notebook.py", "--convert", "--headless", "--no-token", "--host", "0.0.0.0", "--port", "2718"]
+CMD ["uv", "run", "--no-sync", "marimo", "edit", "notebook.py", "--convert", "--headless", "--token", "--host", "0.0.0.0", "--port", "2718"]

--- a/examples/sandbox-image/acceptance-test.sh
+++ b/examples/sandbox-image/acceptance-test.sh
@@ -8,7 +8,7 @@
 #
 # The launch flow mirrors the active strategy in
 # packages/core/src/services/runtime/marimoLaunch.ts (`uv-sync-edit`): checked
-# `uv sync`, followed by `uv run --no-sync marimo edit`.
+# `uv sync`, followed by `uv run --no-sync marimo --quiet edit`.
 #
 # Usage:  acceptance-test.sh [IMAGE_TAG] [CONTEXT_DIR]
 #   IMAGE_TAG    tag to build/test          (default: marimo-sandbox:acceptance)
@@ -21,6 +21,8 @@ set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 IMAGE="${1:-marimo-sandbox:acceptance}"
 CONTEXT="${2:-$HERE}"
+KERNEL_TOKEN="mhub_kernel_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+KERNEL_TOKEN_FILE="/tmp/.marimohub-kernel-token"
 
 # --- tiny test harness -------------------------------------------------------
 PASS=0
@@ -52,10 +54,14 @@ run_detached() { # echoes container id; $@ = args after image
 # Poll the kernel's published port until it serves a page (mirrors the
 # provisioner's waitForPort). marimo redirects `/` (303 → /auth/login) so we
 # follow redirects (-L) and require a final 200. Fails after ~90s.
-wait_http_200() { # $1 = host port
-	local port="$1" i code
+wait_http_200() { # $1 = host port; $2 = optional bearer token
+	local port="$1" token="${2:-}" i code
 	for i in $(seq 1 90); do
-		code="$(curl -sSL -o /dev/null -w '%{http_code}' "http://127.0.0.1:${port}/" 2>/dev/null || true)"
+		if [ -n "$token" ]; then
+			code="$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" "http://127.0.0.1:${port}/api/status/connections" 2>/dev/null || true)"
+		else
+			code="$(curl -sSL -o /dev/null -w '%{http_code}' "http://127.0.0.1:${port}/" 2>/dev/null || true)"
+		fi
 		[ "$code" = "200" ] && return 0
 		sleep 1
 	done
@@ -117,14 +123,16 @@ TOML
 # Start marimo via the active `uv-sync-edit` launch flow (mirrors marimoLaunch.ts),
 # detached, logging to /tmp/m.log.
 launch_kernel() { # $1 = container id
+	docker exec "$1" sh -lc "printf '%s' '$KERNEL_TOKEN' > '$KERNEL_TOKEN_FILE'"
 	docker exec "$1" sh -lc '
 		cd /workspace
 		[ ! -s pyproject.toml ] || uv sync --inexact --no-install-package marimo --no-compile-bytecode --no-build
 	'
 	docker exec -d "$1" sh -lc '
 		cd /workspace
-		uv run --no-sync marimo edit notebook.py \
-			--convert --headless --no-token --host 0.0.0.0 --port 2718 >/tmp/m.log 2>&1
+		uv run --no-sync marimo --quiet edit notebook.py \
+			--convert --headless --token --token-password-file /tmp/.marimohub-kernel-token \
+			--host 0.0.0.0 --port 2718 >/tmp/m.log 2>&1
 	'
 }
 
@@ -205,8 +213,12 @@ echo "==> 3. Kernel serves via the uv-sync-edit launch flow"
 cid="$(run_detached -p 127.0.0.1:2718:2718 "$IMAGE" sleep infinity)"
 provision_notebook "$cid"
 launch_kernel "$cid"
-wait_http_200 2718 || { docker exec "$cid" sh -lc 'tail -20 /tmp/m.log' || true; fail "kernel did not serve HTTP 200 on 2718"; }
-ok "marimo kernel serves HTTP 200 via uv sync + uv run"
+wait_http_200 2718 "$KERNEL_TOKEN" || { docker exec "$cid" sh -lc 'tail -20 /tmp/m.log' || true; fail "kernel did not serve authenticated HTTP 200 on 2718"; }
+unauth_code="$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:2718/api/status/connections")"
+[ "$unauth_code" = "401" ] || fail "kernel accepted an unauthenticated status request (HTTP $unauth_code)"
+auth_code="$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $KERNEL_TOKEN" "http://127.0.0.1:2718/api/status/connections")"
+[ "$auth_code" = "200" ] || fail "kernel rejected its configured token (HTTP $auth_code)"
+ok "marimo kernel rejects unauthenticated requests and accepts its configured token"
 docker rm -f "$cid" >/dev/null 2>&1
 
 # --- 4. --convert rescues a non-marimo python file (no pyproject) ------------
@@ -214,7 +226,7 @@ echo "==> 4. --convert opens a non-marimo file"
 cid="$(run_detached -p 127.0.0.1:2719:2718 "$IMAGE" sleep infinity)"
 docker exec "$cid" sh -lc 'cd /workspace && printf "import marimo\n" > notebook.py'
 launch_kernel "$cid"
-wait_http_200 2719 || { docker exec "$cid" sh -lc 'tail -20 /tmp/m.log' || true; fail "--convert did not open the non-marimo file"; }
+wait_http_200 2719 "$KERNEL_TOKEN" || { docker exec "$cid" sh -lc 'tail -20 /tmp/m.log' || true; fail "--convert did not open the non-marimo file"; }
 ok "--convert serves a plain Python file with no pyproject (HTTP 200)"
 docker rm -f "$cid" >/dev/null 2>&1
 

--- a/examples/sandbox-image/acceptance-test.sh
+++ b/examples/sandbox-image/acceptance-test.sh
@@ -22,6 +22,7 @@ HERE="$(cd "$(dirname "$0")" && pwd)"
 IMAGE="${1:-marimo-sandbox:acceptance}"
 CONTEXT="${2:-$HERE}"
 KERNEL_TOKEN="mhub_kernel_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+WRONG_KERNEL_TOKEN="mhub_kernel_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 KERNEL_TOKEN_FILE="/tmp/.marimohub-kernel-token"
 
 # --- tiny test harness -------------------------------------------------------
@@ -51,9 +52,9 @@ run_detached() { # echoes container id; $@ = args after image
 	echo "$cid"
 }
 
-# Poll the kernel's published port until it serves a page (mirrors the
-# provisioner's waitForPort). marimo redirects `/` (303 → /auth/login) so we
-# follow redirects (-L) and require a final 200. Fails after ~90s.
+# Poll the kernel's published port (mirrors the provisioner's waitForPort). With
+# a token, probe the authenticated connection endpoint directly. Without one,
+# follow the root redirect and require a final 200. Fails after ~90s.
 wait_http_200() { # $1 = host port; $2 = optional bearer token
 	local port="$1" token="${2:-}" i code
 	for i in $(seq 1 90); do
@@ -63,6 +64,19 @@ wait_http_200() { # $1 = host port; $2 = optional bearer token
 			code="$(curl -sSL -o /dev/null -w '%{http_code}' "http://127.0.0.1:${port}/" 2>/dev/null || true)"
 		fi
 		[ "$code" = "200" ] && return 0
+		sleep 1
+	done
+	return 1
+}
+
+read_kernel_token() { # $1 = container id
+	local cid="$1" token i
+	for i in $(seq 1 30); do
+		token="$(docker exec "$cid" sh -lc "cat '$KERNEL_TOKEN_FILE'" 2>/dev/null || true)"
+		if [ -n "$token" ]; then
+			echo "$token"
+			return 0
+		fi
 		sleep 1
 	done
 	return 1
@@ -214,11 +228,13 @@ cid="$(run_detached -p 127.0.0.1:2718:2718 "$IMAGE" sleep infinity)"
 provision_notebook "$cid"
 launch_kernel "$cid"
 wait_http_200 2718 "$KERNEL_TOKEN" || { docker exec "$cid" sh -lc 'tail -20 /tmp/m.log' || true; fail "kernel did not serve authenticated HTTP 200 on 2718"; }
-unauth_code="$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:2718/api/status/connections")"
+unauth_code="$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:2718/api/status/connections" 2>/dev/null || true)"
 [ "$unauth_code" = "401" ] || fail "kernel accepted an unauthenticated status request (HTTP $unauth_code)"
-auth_code="$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $KERNEL_TOKEN" "http://127.0.0.1:2718/api/status/connections")"
+wrong_auth_code="$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $WRONG_KERNEL_TOKEN" "http://127.0.0.1:2718/api/status/connections" 2>/dev/null || true)"
+[ "$wrong_auth_code" = "401" ] || fail "kernel accepted an incorrect bearer token (HTTP $wrong_auth_code)"
+auth_code="$(curl -sS -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $KERNEL_TOKEN" "http://127.0.0.1:2718/api/status/connections" 2>/dev/null || true)"
 [ "$auth_code" = "200" ] || fail "kernel rejected its configured token (HTTP $auth_code)"
-ok "marimo kernel rejects unauthenticated requests and accepts its configured token"
+ok "marimo kernel rejects missing and incorrect credentials and accepts its configured token"
 docker rm -f "$cid" >/dev/null 2>&1
 
 # --- 4. --convert rescues a non-marimo python file (no pyproject) ------------
@@ -233,8 +249,11 @@ docker rm -f "$cid" >/dev/null 2>&1
 # --- 5. bare `docker run` (default CMD) serves -------------------------------
 echo "==> 5. Default CMD (bare docker run)"
 cid="$(run_detached -p 127.0.0.1:2720:2718 "$IMAGE")"
-wait_http_200 2720 || { docker logs "$cid" 2>&1 | tail -20 || true; fail "default CMD did not serve HTTP 200"; }
-ok "bare 'docker run' starts a kernel (HTTP 200)"
+default_token="$(read_kernel_token "$cid" || true)"
+[ -n "$default_token" ] || fail "default CMD did not create its kernel token file"
+wait_http_200 2720 "$default_token" || { docker logs "$cid" 2>&1 | tail -20 || true; fail "default CMD did not serve authenticated HTTP 200"; }
+! docker logs "$cid" 2>&1 | grep -q 'access_token=' || fail "default CMD exposed its kernel token in container logs"
+ok "bare 'docker run' starts an authenticated kernel without logging its token"
 docker rm -f "$cid" >/dev/null 2>&1
 
 echo

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -75,7 +75,7 @@ RUN echo 'export PATH=$VIRTUAL_ENV/bin:$PATH' > /etc/profile.d/venv-path.sh
 USER appuser
 WORKDIR /workspace
 
-CMD ["uv", "run", "--no-sync", "marimo", "edit", "notebook.py", "--convert", "--headless", "--no-token", "--host", "0.0.0.0", "--port", "2718"]
+CMD ["uv", "run", "--no-sync", "marimo", "edit", "notebook.py", "--convert", "--headless", "--token", "--host", "0.0.0.0", "--port", "2718"]
 
 FROM base AS vscode
 

--- a/images/marimo-sandbox/Dockerfile
+++ b/images/marimo-sandbox/Dockerfile
@@ -75,7 +75,7 @@ RUN echo 'export PATH=$VIRTUAL_ENV/bin:$PATH' > /etc/profile.d/venv-path.sh
 USER appuser
 WORKDIR /workspace
 
-CMD ["uv", "run", "--no-sync", "marimo", "edit", "notebook.py", "--convert", "--headless", "--token", "--host", "0.0.0.0", "--port", "2718"]
+CMD ["sh", "-lc", "umask 077; python3 -c \"import secrets; print('mhub_kernel_' + secrets.token_urlsafe(32))\" > /tmp/.marimohub-kernel-token; exec uv run --no-sync marimo --quiet edit notebook.py --convert --headless --token --token-password-file /tmp/.marimohub-kernel-token --host 0.0.0.0 --port 2718"]
 
 FROM base AS vscode
 

--- a/internal/schemas/bucket.yml
+++ b/internal/schemas/bucket.yml
@@ -2921,6 +2921,9 @@ components:
               type: string
         sandbox_id:
           type: string
+        kernel_auth_token:
+          type: string
+          pattern: ^mhub_kernel_[A-Za-z0-9_-]{43}$
         sandbox_url:
           type: string
         compute_profile:

--- a/packages/api/src/mcp/createMcpApp.test.ts
+++ b/packages/api/src/mcp/createMcpApp.test.ts
@@ -5,6 +5,8 @@ import {
 	expandTokenGrantPreset,
 	OAuthAuthorizationId,
 	paths,
+	ProjectId,
+	SessionId,
 	UserId,
 } from '@marimo-hub/core';
 import type { AuthenticatedPrincipal, TokenGrant } from '@marimo-hub/core';
@@ -53,9 +55,11 @@ describe('MCP OAuth app', () => {
 	it('discovers OAuth and exchanges browser consent for a PAT', async () => {
 		const { instance, calls } = makeFakeSandbox();
 		const compute = fakeComputeFrom(instance);
+		const kernelAuthorizations: (string | null)[] = [];
 		compute.proxy = async (request) => {
 			const path = new URL(request.url).pathname;
 			if (path.endsWith('/api/sessions')) {
+				kernelAuthorizations.push(request.headers.get('Authorization'));
 				return new Response(
 					JSON.stringify({
 						'kernel-one': { filename: '/workspace/renamed.py', path: '/workspace/renamed.py' },
@@ -64,6 +68,7 @@ describe('MCP OAuth app', () => {
 				);
 			}
 			if (path.endsWith('/api/kernel/execute')) {
+				kernelAuthorizations.push(request.headers.get('Authorization'));
 				return new Response(
 					'event: stdout\ndata: {"data":"2\\n"}\n\n' +
 						'event: done\ndata: {"success":true,"output":{"mimetype":"text/plain","data":"2"}}\n\n',
@@ -308,6 +313,14 @@ describe('MCP OAuth app', () => {
 				},
 			},
 		});
+		const storedSession = await deps.services.sessions.getSession(
+			ProjectId.parse(projectId),
+			SessionId.parse(launchResult.result.structuredContent.session_id),
+		);
+		expect(kernelAuthorizations).toEqual([
+			`Bearer ${storedSession.kernel_auth_token}`,
+			`Bearer ${storedSession.kernel_auth_token}`,
+		]);
 
 		const otherClientId = await registerClient(app, 'https://other.example/callback');
 		const unrelatedRevocation = await app.request('/revoke', {

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -435,12 +435,16 @@ export function createMcpServer(
 				const labels = await assertSessionNotebookVisible(deps, project, session, principal);
 				await assertSessionAccess(project, session, principal, deps, labels);
 				const baseUrl = kernelBaseUrl(session);
+				const kernelRequest = {
+					fetchImpl: kernelFetch(deps),
+					kernelAuthToken: session.kernel_auth_token,
+				};
 				const discoveryTimeoutMs = deadlineAt - Date.now();
 				if (discoveryTimeoutMs <= 0) return kernelDiscoveryTimeout(input.timeout_seconds);
 				let kernelSessions;
 				try {
 					kernelSessions = await withDeadline(
-						(signal) => listKernelSessions(baseUrl, { fetchImpl: kernelFetch(deps), signal }),
+						(signal) => listKernelSessions(baseUrl, { ...kernelRequest, signal }),
 						{
 							timeoutMs: discoveryTimeoutMs,
 							timeoutError: () => new KernelDiscoveryTimeoutError(),
@@ -474,7 +478,7 @@ export function createMcpServer(
 						maxStderrBytes: 256 * 1024,
 						maxOutputBytes: 1024 * 1024,
 					},
-					{ fetchImpl: kernelFetch(deps), timeoutMs: executionTimeoutMs },
+					{ ...kernelRequest, timeoutMs: executionTimeoutMs },
 				);
 				const data = {
 					project_id: project.id,

--- a/packages/api/src/routes/sessions.appMode.test.ts
+++ b/packages/api/src/routes/sessions.appMode.test.ts
@@ -306,7 +306,7 @@ describe('Session routes (app mode)', () => {
 		await expectOk<any>(await api.request('POST', sessionsPath(), { mode: 'app' }));
 
 		expect(fake.calls.mountBucket).toHaveLength(0);
-		expect(fake.calls.startProcess[0].cmd).toContain('marimo run');
+		expect(fake.calls.startProcess[0].cmd).toContain('marimo --quiet run');
 		expect(fake.calls.startProcess[0].cmd).not.toContain('--convert');
 	});
 
@@ -425,8 +425,8 @@ describe('Session routes (app mode)', () => {
 		});
 
 		it('read projections withhold the kernel URL from callers the kernel gates would reject', async () => {
-			// In subdomain exposure the URL IS the kernel capability (`--no-token`),
-			// so list/get must not hand it to a viewer who couldn't reach the kernel.
+			// In subdomain exposure the URL carries the kernel token, so list/get must
+			// not hand it to a viewer who could not reach the kernel.
 			const edit = await expectOk<any>(await owner('POST', sessionsPath()));
 			const app = await expectOk<any>(await owner('POST', sessionsPath(), { mode: 'app' }));
 

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -4,6 +4,8 @@ import {
 	createNotebookId,
 	createProjectId,
 	createServices,
+	KERNEL_AUTH_TOKEN_FILE,
+	KERNEL_AUTH_TOKEN_PATTERN,
 	Millis,
 	paths,
 } from '@marimo-hub/core';
@@ -330,6 +332,34 @@ describe('Session routes', () => {
 		expect(data.reused).toBe(false);
 		// A healthy session carries no failure reason.
 		expect(data.error).toBeUndefined();
+	});
+
+	it('stores a kernel token without exposing it in the session response or command', async () => {
+		const { instance, calls } = makeFakeSandbox();
+		const request = createTestApi({
+			bucket,
+			userId: ACTOR,
+			compute: fakeComputeFrom(instance),
+		}).request;
+
+		const data = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+		const stored = await createServices(bucket).sessions.getSession(
+			pid,
+			data.session_id as SessionId,
+		);
+		expect(stored.kernel_auth_token).toMatch(KERNEL_AUTH_TOKEN_PATTERN);
+		expect(data).not.toHaveProperty('kernel_auth_token');
+
+		const url = new URL(data.sandbox_url!);
+		expect(url.searchParams.get('access_token')).toBe(stored.kernel_auth_token);
+		expect(calls.writeFile).toContainEqual({
+			path: KERNEL_AUTH_TOKEN_FILE,
+			content: stored.kernel_auth_token,
+		});
+		expect(calls.startProcess[0].cmd).toContain(
+			`--token --token-password-file '${KERNEL_AUTH_TOKEN_FILE}'`,
+		);
+		expect(calls.startProcess[0].cmd).not.toContain(stored.kernel_auth_token!);
 	});
 
 	it('uses the configured sandbox startup timeout to bound the kernel port wait', async () => {

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -21,6 +21,7 @@ import type {
 import {
 	BadRequestError,
 	ConflictError,
+	createKernelAuthToken,
 	createSandboxId,
 	DomainError,
 	marimoAiContributor,
@@ -53,6 +54,7 @@ import {
 	TakeoverInProgressError,
 	TakeoverRetirementError,
 	kernelActiveConnections,
+	kernelBasePathFromUrl,
 	joinUrlPath,
 	SECONDARY_SURFACE_IDS,
 	SurfaceForbiddenError,
@@ -437,12 +439,11 @@ function publicSurfaces(s: Session, can: { attach: boolean; surface: boolean }) 
 /**
  * Project a stored Session onto the public Session response envelope, carrying
  * the caller's evaluated grants (`sessionGrantsFor`). `sandbox_url` rides on
- * `can.attach`: in `subdomain` exposure the URL is the kernel capability
- * itself (kernels run `--no-token`), so listing it to a caller the kernel
- * gates would reject hands them the kernel. Exposes `user_id` (who started it)
- * for the collaborative "started by" UI — visible only to users who can
- * already list the project's sessions. Internal infra fields (`sandbox_id`,
- * `used_fallback`) stay private.
+ * `can.attach`: in `subdomain` exposure the URL carries the kernel token, so
+ * listing it to a caller the kernel gates would reject hands them the kernel.
+ * `user_id` supports the collaborative "started by" UI and is visible only to
+ * users who can list the project's sessions. Internal infrastructure fields
+ * (`sandbox_id`, `used_fallback`) stay private.
  */
 export function toSessionResponse(
 	s: Session,
@@ -805,12 +806,7 @@ async function inspectEditorActivity(deps: ApiDeps, session: Session) {
 	if (session.status !== 'running' || !session.sandbox_id) {
 		return { state: 'unknown' as const };
 	}
-	let basePath = '';
-	try {
-		basePath = session.sandbox_url ? new URL(session.sandbox_url).pathname.replace(/\/$/, '') : '';
-	} catch {
-		basePath = '';
-	}
+	const basePath = kernelBasePathFromUrl(session.sandbox_url);
 	const active = await kernelActiveConnections(deps.compute.create(session.sandbox_id), basePath);
 	const checkedAt = new Date().toISOString();
 	if (active === null) return { state: 'unknown' as const, checked_at: checkedAt };
@@ -1335,6 +1331,7 @@ export async function startNotebookSession(input: {
 	await enforceSessionCap(deps, mode, pid, user.id, temporaryToRetire?.session_id);
 
 	const sandboxId = createSandboxId();
+	const kernelAuthToken = createKernelAuthToken();
 
 	const restoreFilesystemSnapshot =
 		!ephemeral && workspacePolicy.restoreFilesystemSnapshot
@@ -1385,6 +1382,7 @@ export async function startNotebookSession(input: {
 					project_id: pid,
 					user_id: user.id,
 					sandbox_id: sandboxId,
+					kernel_auth_token: kernelAuthToken,
 					compute_profile: appliedComputeProfile.name,
 					compute_resources: appliedComputeProfile.resources,
 					compute_from_snapshot: restoreFilesystemSnapshot !== undefined,
@@ -1448,6 +1446,7 @@ export async function startNotebookSession(input: {
 						projectId: pid,
 						notebookId: nid,
 						sandboxId,
+						kernelAuthToken,
 						appBaseUrl,
 					};
 					// WIF + integrations share `sandboxEnv.ts` with the job runner, so the
@@ -1568,6 +1567,7 @@ export async function startNotebookSession(input: {
 								assetUrl: sandbox.assetUrl,
 								startupTimeoutMs: sandbox.startupTimeoutMs,
 								baseUrl,
+								kernelAuthToken,
 								// A second editor writes the notebook file, so marimo must reload it.
 								marimoWatch:
 									mode === 'edit' && SECONDARY_SURFACE_IDS.some((id) => sandbox.surfaces?.[id]),

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -5,6 +5,7 @@ import { gzipSync } from 'node:zlib';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	createServices,
+	KERNEL_AUTH_TOKEN_PATTERN,
 	ProjectId,
 	ProxyExposure,
 	signProxyToken,
@@ -17,6 +18,7 @@ import {
 	localResourceSecurity,
 	makeFakeCompute,
 	makeSubjectContext,
+	TEST_KERNEL_AUTH_TOKEN,
 	uid,
 } from '@marimo-hub/core/testing';
 import type { MemoryBucket } from '@marimo-hub/core/testing';
@@ -74,6 +76,7 @@ describe('authorizeProxyRequest', () => {
 			notebook_id: notebook.id,
 			project_id: pid,
 			user_id: ACTOR,
+			kernel_auth_token: TEST_KERNEL_AUTH_TOKEN,
 		});
 		sessionId = session.session_id;
 		// Mark running with a server-reachable origin (proxy-mode provisioning).
@@ -327,7 +330,25 @@ describe('authorizeProxyRequest', () => {
 			kind: 'forward',
 			targetUrl: `${ORIGIN}/proxy/${token}/assets/app.js?v=1`,
 			sessionId,
+			kernelAuthToken: TEST_KERNEL_AUTH_TOKEN,
 		});
+	});
+
+	it('forwards legacy tokenless sessions without a kernel credential', async () => {
+		const services = createServices(bucket);
+		const current = await services.sessions.getSession(pid, sessionId as never);
+		const legacy = await services.sessions.createSession({
+			notebook_id: current.notebook_id,
+			project_id: pid,
+			user_id: ACTOR,
+		});
+		await services.sessions.setRunning(pid, legacy.session_id, '/proxy/legacy/', false, ORIGIN);
+		const legacyProxyToken = await signProxyToken(pid, legacy.session_id, SECRET);
+
+		const allowed = await authorizeProxyRequest(req(`/proxy/${legacyProxyToken}/`), deps(ACTOR));
+
+		expect(allowed).toMatchObject({ kind: 'forward', sessionId: legacy.session_id });
+		expect(allowed).not.toHaveProperty('kernelAuthToken');
 	});
 
 	it('authorizes a VS Code surface separately and strips the code-server proxy prefix', async () => {
@@ -344,6 +365,7 @@ describe('authorizeProxyRequest', () => {
 			targetUrl: 'http://vscode.internal:8443/stable/out.js?v=1',
 			sessionId,
 		});
+		expect(allowed).not.toHaveProperty('kernelAuthToken');
 
 		const denied = await authorizeProxyRequest(req(path), {
 			...deps(STRANGER),
@@ -593,9 +615,11 @@ describe('forwardHttp', () => {
 	let server: Server;
 	let origin: string;
 	let flakyHits: number;
+	let flakyAuthorizations: (string | undefined)[];
 
 	beforeEach(() => {
 		flakyHits = 0;
+		flakyAuthorizations = [];
 	});
 
 	beforeAll(async () => {
@@ -604,6 +628,7 @@ describe('forwardHttp', () => {
 				// First connection dies mid-request (a closed keep-alive socket, from
 				// the client's perspective); subsequent attempts succeed.
 				flakyHits++;
+				flakyAuthorizations.push(req.headers.authorization);
 				if (flakyHits === 1) {
 					req.socket.destroy();
 					return;
@@ -676,6 +701,7 @@ describe('forwardHttp', () => {
 				new Request('https://hub/x'),
 				`${deadOrigin}/proxy/tok/down`,
 				'sess-123',
+				TEST_KERNEL_AUTH_TOKEN,
 			);
 			expect(res.status).toBe(502);
 			expect(await res.json()).toEqual({
@@ -708,6 +734,7 @@ describe('forwardHttp', () => {
 				// the token-bearing target URL, and no token.
 				const line = JSON.stringify(e);
 				expect(line).not.toContain('/proxy/tok');
+				expect(line).not.toContain(TEST_KERNEL_AUTH_TOKEN);
 				expect(line).not.toContain('fetch failed');
 			}
 		} finally {
@@ -716,13 +743,22 @@ describe('forwardHttp', () => {
 		}
 	});
 
-	it('retries a GET once when the connection drops, and succeeds on the fresh connection', async () => {
+	it('keeps kernel authentication on a retried GET', async () => {
 		const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		try {
-			const res = await forwardHttp(new Request('https://hub/x'), `${origin}/flaky`);
+			const res = await forwardHttp(
+				new Request('https://hub/x'),
+				`${origin}/flaky`,
+				'sess-123',
+				TEST_KERNEL_AUTH_TOKEN,
+			);
 			expect(res.status).toBe(200);
 			expect(await res.text()).toBe('recovered');
 			expect(flakyHits).toBe(2);
+			expect(flakyAuthorizations).toEqual([
+				`Bearer ${TEST_KERNEL_AUTH_TOKEN}`,
+				`Bearer ${TEST_KERNEL_AUTH_TOKEN}`,
+			]);
 		} finally {
 			logSpy.mockRestore();
 		}
@@ -768,7 +804,7 @@ describe('forwardHttp', () => {
 		}
 	});
 
-	it('strips hub credentials (Cookie/Authorization/CF-Access) before the kernel sees the request', async () => {
+	it('replaces hub credentials with the kernel token before forwarding', async () => {
 		// Notebook code can read request headers (mo.app_meta().request) — the
 		// caller's hub session cookie / PAT / Access assertion must never reach it.
 		const req = new Request('https://hub.example.com/proxy/tok/api', {
@@ -781,14 +817,20 @@ describe('forwardHttp', () => {
 				'x-custom': 'passes',
 			},
 		});
-		const res = await forwardHttp(req, `${origin}/echo`);
+		const res = await forwardHttp(req, `${origin}/echo`, 'sess-123', TEST_KERNEL_AUTH_TOKEN);
 		const seen = (await res.json()) as Record<string, string>;
 		expect(seen.cookie).toBeUndefined();
-		expect(seen.authorization).toBeUndefined();
+		expect(seen.authorization).toBe(`Bearer ${TEST_KERNEL_AUTH_TOKEN}`);
 		expect(seen['cf-access-jwt-assertion']).toBeUndefined();
 		expect(seen['cf-access-client-id']).toBeUndefined();
 		expect(seen['cf-access-client-secret']).toBeUndefined();
 		expect(seen['x-custom']).toBe('passes');
+	});
+
+	it('forwards no authorization header for a legacy tokenless session', async () => {
+		const res = await forwardHttp(new Request('https://hub/x'), `${origin}/echo`);
+		const seen = (await res.json()) as Record<string, string>;
+		expect(seen.authorization).toBeUndefined();
 	});
 
 	it('strips Set-Cookie from the kernel response', async () => {
@@ -836,7 +878,9 @@ describe('create-session in proxy mode', () => {
 		expect(data.sandbox_url).toBe(`https://hub.example.com/marimohub/proxy/${token}/`);
 		// The server-reachable origin is persisted on the record but never in the response.
 		expect(data).not.toHaveProperty('sandbox_origin_url');
+		expect(data).not.toHaveProperty('kernel_auth_token');
 		const stored = await services.sessions.getSession(pid, data.session_id as never);
 		expect(stored.sandbox_origin_url).toBe('https://sandbox.example/kernel');
+		expect(stored.kernel_auth_token).toMatch(KERNEL_AUTH_TOKEN_PATTERN);
 	});
 });

--- a/packages/api/src/sandboxProxy.ts
+++ b/packages/api/src/sandboxProxy.ts
@@ -36,6 +36,7 @@ export type ProxyDecision =
 			kind: 'forward';
 			targetUrl: string;
 			sessionId: string;
+			kernelAuthToken?: string;
 			authorizationDeadline?: number;
 	  };
 
@@ -241,6 +242,9 @@ export async function authorizeProxyRequest(
 		kind: 'forward',
 		targetUrl,
 		sessionId,
+		...(kernelMatch && session.kernel_auth_token
+			? { kernelAuthToken: session.kernel_auth_token }
+			: {}),
 		...(effectiveDeadline !== undefined ? { authorizationDeadline: effectiveDeadline } : {}),
 	};
 }
@@ -259,9 +263,10 @@ const HOP_BY_HOP = new Set([
 ]);
 
 /**
- * Hub credentials must never reach the kernel: it runs `--no-token` and needs
- * none, and notebook code can read request headers (`mo.app_meta().request`) —
- * forwarding them would hand every caller's credential to the notebook author.
+ * Hub credentials must never reach the kernel. Notebook code can read request
+ * headers (`mo.app_meta().request`), so forwarding them would expose each
+ * caller's credential to the notebook author. The proxy adds only the
+ * session-scoped marimo token after this filter.
  * `cf-access-jwt-assertion` is exactly that under the Cloudflare Access
  * authenticator (it is the whole proof of identity), and the `cf-access-client-*`
  * service-token pair mints one. Access's `CF_Authorization` cookie is covered by
@@ -282,7 +287,7 @@ export const CREDENTIAL_HEADERS = new Set([
  */
 export const UNSAFE_RESPONSE_HEADERS = new Set(['set-cookie', 'set-cookie2']);
 
-function requestHeaders(request: Request, targetUrl: string): Headers {
+function requestHeaders(request: Request, targetUrl: string, kernelAuthToken?: string): Headers {
 	const out = new Headers();
 	request.headers.forEach((value, key) => {
 		const k = key.toLowerCase();
@@ -291,6 +296,7 @@ function requestHeaders(request: Request, targetUrl: string): Headers {
 	// marimo validates a request's Origin against its own host; present the kernel
 	// origin so the proxied request reads as same-origin (Host is set by `fetch`).
 	out.set('origin', new URL(targetUrl).origin);
+	if (kernelAuthToken) out.set('authorization', `Bearer ${kernelAuthToken}`);
 	return out;
 }
 
@@ -327,10 +333,11 @@ export async function forwardHttp(
 	request: Request,
 	targetUrl: string,
 	sessionId?: string,
+	kernelAuthToken?: string,
 ): Promise<Response> {
 	const init: RequestInit = {
 		method: request.method,
-		headers: requestHeaders(request, targetUrl),
+		headers: requestHeaders(request, targetUrl, kernelAuthToken),
 		redirect: 'manual',
 	};
 	const retryable = request.method === 'GET' || request.method === 'HEAD';
@@ -405,6 +412,6 @@ export function sandboxProxyMiddleware(deps: ApiDeps): MiddlewareHandler<HonoEnv
 		if (decision.kind === 'reject') {
 			return fail(c, decision.code, decision.message, decision.status);
 		}
-		return forwardHttp(c.req.raw, decision.targetUrl, decision.sessionId);
+		return forwardHttp(c.req.raw, decision.targetUrl, decision.sessionId, decision.kernelAuthToken);
 	};
 }

--- a/packages/api/src/schema-conformance.test.ts
+++ b/packages/api/src/schema-conformance.test.ts
@@ -142,6 +142,7 @@ describe('schema conformance: api response shapes vs core public shapes', () => 
 		const internalSessionFields = [
 			'runtime',
 			'sandbox_id',
+			'kernel_auth_token',
 			'sandbox_origin_url',
 			'used_fallback',
 			'expires_at',

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -1203,9 +1203,8 @@ export const SessionResponseSchema = z
 		/**
 		 * The kernel URL the browser embeds. Absent while `starting`, and absent
 		 * from list/get projections for callers who may not reach this kernel: in
-		 * `subdomain` exposure the URL itself is the access capability (the kernel
-		 * runs `--no-token`), so it is shown only to callers the kernel gates
-		 * would admit.
+		 * `subdomain` exposure the URL contains the kernel token, so it is shown
+		 * only to callers the kernel gates would admit.
 		 */
 		sandbox_url: z.string().optional(),
 		started_at: dt(),

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -35,8 +35,8 @@
  * caveat the Modal/CoreWeave adapters carry): the Ingress host scheme and TLS are
  * cluster/ingress-controller specific. The returned URL requires `ingressClassName`,
  * a matching `*.{host}` DNS record, and TLS from either a named wildcard secret or
- * the controller's default certificate; marimo must run tokenless behind marimohub's own auth
- * (the provisioner passes `--no-token`); and the in-pod port wait assumes
+ * the controller's default certificate. Kernel URLs and bearer tokens require TLS. The in-pod
+ * port wait assumes
  * `python3` is on the image PATH (see `portWaitCommand`).
  */
 import {

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -35,8 +35,8 @@
  * caveat the Modal/CoreWeave adapters carry): the Ingress host scheme and TLS are
  * cluster/ingress-controller specific. The returned URL requires `ingressClassName`,
  * a matching `*.{host}` DNS record, and TLS from either a named wildcard secret or
- * the controller's default certificate. Kernel URLs and bearer tokens require TLS. The in-pod
- * port wait assumes
+ * the controller's default certificate. Token-protected deployments must enable TLS;
+ * `ingressTlsMode: 'disabled'` is suitable only for isolated development. The in-pod port wait assumes
  * `python3` is on the image PATH (see `portWaitCommand`).
  */
 import {

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -18,7 +18,7 @@ import {
 	CONTRACT_VISIBLE_FILE,
 } from '@marimo-hub/core/testing/compute-contract';
 import { buildMarimoLaunch } from '@marimo-hub/core';
-import { LocalCompute, prepareMarimoCommand, rewriteWorkspace } from './index';
+import { LocalCompute, prepareMarimoCommand, rewriteSandboxPaths, rewriteWorkspace } from './index';
 
 const compute = new LocalCompute();
 const created: SandboxId[] = [];
@@ -161,7 +161,7 @@ describe('prepareMarimoCommand (pure)', () => {
 		const command = [...plan.setup.map(({ command }) => command), plan.start].join(' && ');
 		const prepared = prepareMarimoCommand(command, '0.0.0.0');
 		expect(prepared.split(' && ').slice(0, -1)).toEqual(command.split(' && ').slice(0, -1));
-		expect(prepared).toContain('uv run --with marimo --no-sync marimo edit');
+		expect(prepared).toContain('uv run --with marimo --no-sync marimo --quiet edit');
 		expect(prepared.match(/--with marimo/g)).toHaveLength(1);
 		// The strategy's own --host must not be doubled by the bind-host append.
 		expect(prepared.match(/--host/g)).toHaveLength(1);
@@ -252,6 +252,17 @@ describe('rewriteWorkspace (pure)', () => {
 
 	it('leaves commands without /workspace untouched', () => {
 		expect(rewriteWorkspace('echo hello', '/root')).toBe('echo hello');
+	});
+});
+
+describe('rewriteSandboxPaths (pure)', () => {
+	it('maps the kernel token file into the sandbox root', () => {
+		expect(
+			rewriteSandboxPaths(
+				"marimo edit --token-password-file '/tmp/.marimohub-kernel-token'",
+				'/root',
+			),
+		).toBe("marimo edit --token-password-file '/root/tmp/.marimohub-kernel-token'");
 	});
 });
 

--- a/packages/compute-local/src/index.ts
+++ b/packages/compute-local/src/index.ts
@@ -12,8 +12,8 @@
  * it has no isolation and is not safe for shared/production use.
  *
  * Two impedance mismatches with the provider-agnostic core are handled here:
- *  - core hardcodes the workspace at `/workspace`; each sandbox gets a private
- *    root and `/workspace` is rewritten to `<root>/workspace`.
+ *  - core uses sandbox-absolute workspace and control-file paths; each sandbox
+ *    gets a private root and those paths are rewritten beneath it.
  *  - core hardcodes `--port 2718`; we allocate a real free port per sandbox and
  *    map the logical port (2718) → the real port so multiple kernels coexist.
  */
@@ -33,7 +33,7 @@ import {
 	WRITE_CONCURRENCY,
 } from '@marimo-hub/compute-commons';
 import { Utf8TailBuffer } from '@marimo-hub/compute-commons/node';
-import { SURFACE_STATE_ROOT } from '@marimo-hub/core';
+import { KERNEL_AUTH_TOKEN_FILE, SURFACE_STATE_ROOT } from '@marimo-hub/core';
 import type { SandboxId } from '@marimo-hub/core';
 import type {
 	ActiveSandbox,
@@ -182,6 +182,12 @@ export function rewriteWorkspace(cmd: string, root: string): string {
 	return cmd.replaceAll(WORKSPACE, path.join(root, WORKSPACE));
 }
 
+export function rewriteSandboxPaths(cmd: string, root: string): string {
+	return rewriteWorkspace(cmd, root)
+		.replaceAll(SURFACE_STATE_ROOT, path.join(root, SURFACE_STATE_ROOT.slice(1)))
+		.replaceAll(KERNEL_AUTH_TOKEN_FILE, path.join(root, KERNEL_AUTH_TOKEN_FILE.slice(1)));
+}
+
 /**
  * Scan from `start` for the end of the current shell command, i.e. the first
  * top-level (outside single/double quotes) separator — `&&`, `||`, `|`, `;`, or
@@ -321,12 +327,9 @@ class LocalSandboxInstance implements SandboxInstance {
 		}
 	}
 
-	/** Rewrite `/workspace` and surface-state references in a shell command to the real root. */
+	/** Map sandbox-absolute paths in a shell command beneath the local sandbox root. */
 	private rewriteCmd(cmd: string): string {
-		return rewriteWorkspace(cmd, this.root).replaceAll(
-			SURFACE_STATE_ROOT,
-			path.join(this.root, SURFACE_STATE_ROOT.slice(1)),
-		);
+		return rewriteSandboxPaths(cmd, this.root);
 	}
 
 	/** Adjust a `uv run … marimo …` command for local execution (see {@link prepareMarimoCommand}). */

--- a/packages/core/src/ports/sandboxExposure.ts
+++ b/packages/core/src/ports/sandboxExposure.ts
@@ -7,8 +7,8 @@ import type { NotebookId, ProjectId, SandboxId, SessionId } from '../ids';
  *
  * - `subdomain` — the kernel is reached DIRECTLY at the compute adapter's public
  *   URL on an isolated sandbox domain (`<id>.sandbox.example.com`). True
- *   cross-origin isolation; not authenticated by the hub (the unguessable sandbox
- *   id is the capability). The default mode.
+ *   cross-origin isolation; not authenticated by the hub. marimo authenticates
+ *   the client with the per-session kernel token. The default mode.
  * - `proxy` — all kernel traffic is forwarded THROUGH the app at
  *   `…/proxy/<token>/…`, so it passes through the hub's auth + per-session
  *   authorization. Same-origin with the app (XSS-capable); for trusted
@@ -22,6 +22,8 @@ export interface ExposureContext {
 	projectId: ProjectId;
 	notebookId: NotebookId;
 	sandboxId: SandboxId;
+	/** Independent credential used by marimo's native authentication. */
+	kernelAuthToken: string;
 	/** The app's public base URL, which may include a path prefix. */
 	appBaseUrl: string;
 }

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -26,6 +26,8 @@ import {
 	UserId,
 } from './ids';
 
+export const KERNEL_AUTH_TOKEN_PATTERN = /^mhub_kernel_[A-Za-z0-9_-]{43}$/;
+
 // --- Schema versioning ---
 //
 // Only the immutable / append-only objects carry `schema_version`: snapshots,
@@ -841,6 +843,8 @@ export const SessionSchema = z.looseObject({
 	connections_checked_at: z.iso.datetime().optional(),
 	runtime: RuntimeSchema.optional(),
 	sandbox_id: SandboxIdSchema.optional(),
+	/** Plaintext, session-scoped credential for marimo. Never expose it as a response field. */
+	kernel_auth_token: z.string().regex(KERNEL_AUTH_TOKEN_PATTERN).optional(),
 	sandbox_url: z.string().optional(),
 	compute_profile: z.string().optional(),
 	compute_resources: ComputeResourceRecordSchema.optional(),

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -311,6 +311,8 @@ export type {
 	SessionScopedAction,
 } from './authorization/actions';
 export { signProxyToken, verifyProxyToken } from './runtime/proxyToken';
+export { createKernelAuthToken, KERNEL_AUTH_TOKEN_FILE } from './runtime/kernelAuth';
+export { kernelBasePathFromUrl } from './runtime/sandboxExposure';
 export { resolveBaseImage } from './runtime/resolveBaseImage';
 export { resolveComputeProfile, toComputeResourceRecord } from './runtime/resolveComputeProfile';
 export type { ComputeProfileConfig, ResolvedComputeProfile } from './runtime/resolveComputeProfile';
@@ -333,7 +335,6 @@ export type {
 	KernelSession,
 	SseEvent,
 } from './runtime/kernelExecute';
-export { kernelBasePath } from './runtime/sessionLifecycle';
 export { runPreflight } from './runtime/preflight';
 export type {
 	CheckOutcome,

--- a/packages/core/src/services/runtime/SandboxProvisioner.test.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.test.ts
@@ -11,6 +11,7 @@ import {
 	makeLocalSource,
 	MemoryBucket,
 	setupTestEnv,
+	TEST_KERNEL_AUTH_TOKEN,
 } from '../../testing';
 import type {
 	ExecResult,
@@ -21,6 +22,7 @@ import type {
 import type { NotebookService } from '../content/NotebookService';
 import { SandboxProvisioner } from './SandboxProvisioner';
 import type { BucketConfig, WorkspaceLoadStrategies } from './SandboxProvisioner';
+import { KERNEL_AUTH_TOKEN_FILE } from './kernelAuth';
 
 const MOUNT_PATH = '/workspace';
 
@@ -105,7 +107,7 @@ describe('SandboxProvisioner', () => {
 
 			expect(calls.startProcess).toHaveLength(1);
 			expect(calls.startProcess[0].options?.cwd).toBe(MOUNT_PATH);
-			expect(calls.startProcess[0].cmd).toContain('marimo edit');
+			expect(calls.startProcess[0].cmd).toContain('marimo --quiet edit');
 			expect(calls.startProcess[0].cmd).toContain('2718');
 			expect(calls.waitForPort).toEqual([2718]);
 			expect(calls.exposePort[0].port).toBe(2718);
@@ -144,7 +146,7 @@ describe('SandboxProvisioner', () => {
 			expect(cmd).toContain('--no-install-package marimo');
 			expect(cmd).not.toContain('MARIMOHUB_MARIMO_VERSION');
 			expect(cmd).not.toContain('marimo==');
-			expect(calls.startProcess[0].cmd).toContain("marimo edit 'apps/dash.py'");
+			expect(calls.startProcess[0].cmd).toContain("marimo --quiet edit 'apps/dash.py'");
 			expect(calls.startProcess[0].cmd).not.toContain('uv sync');
 		});
 
@@ -607,6 +609,31 @@ describe('SandboxProvisioner', () => {
 			expect((failure as Error).message).not.toContain('startup timeout');
 		});
 
+		it('redacts a token-bearing startup URL from captured kernel output', async () => {
+			const { instance } = makeFakeSandbox({
+				failWaitForPort: new Error('process exited before the port opened'),
+				logs: {
+					stdout: `Open http://localhost:2718/?access_token=${TEST_KERNEL_AUTH_TOKEN}&mode=edit`,
+					stderr: '',
+				},
+			});
+
+			const failure = await new SandboxProvisioner(fakeComputeFrom(instance))
+				.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					kernelAuthToken: TEST_KERNEL_AUTH_TOKEN,
+				})
+				.catch((error: Error) => error);
+
+			expect(failure).toBeInstanceOf(Error);
+			expect((failure as Error).message).toContain('access_token=[REDACTED]&mode=edit');
+			expect((failure as Error).message).not.toContain(TEST_KERNEL_AUTH_TOKEN);
+		});
+
 		it('injects sessionEnv (files + env) BEFORE starting the kernel', async () => {
 			const { instance, calls } = makeFakeSandbox();
 			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
@@ -631,6 +658,110 @@ describe('SandboxProvisioner', () => {
 			]);
 			// Env + token file must land before the kernel process starts.
 			expect(calls.sequence).toEqual(['writeFiles', 'setEnvVars', 'startProcess']);
+		});
+
+		it('writes the kernel token after other files and launches marimo with its path', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			await provisioner.provision({
+				sandboxId,
+				projectId,
+				notebookId,
+				hostname: 'localhost',
+				bucket: bucketConfig,
+				kernelAuthToken: TEST_KERNEL_AUTH_TOKEN,
+				sessionEnv: { files: [{ path: '/creds', content: 'credential' }] },
+			});
+
+			expect(calls.writeFile).toEqual([
+				{ path: '/creds', content: 'credential' },
+				{ path: KERNEL_AUTH_TOKEN_FILE, content: TEST_KERNEL_AUTH_TOKEN },
+			]);
+			expect(calls.sequence).toEqual(['writeFiles', 'writeFiles', 'startProcess']);
+			expect(calls.startProcess[0].cmd).toContain(
+				`--token --token-password-file '${KERNEL_AUTH_TOKEN_FILE}'`,
+			);
+			expect(calls.startProcess[0].cmd).not.toContain(TEST_KERNEL_AUTH_TOKEN);
+		});
+
+		it('destroys the sandbox without starting marimo when the token file cannot be written', async () => {
+			const { instance, calls } = makeFakeSandbox();
+			const writeFiles = instance.writeFiles.bind(instance);
+			instance.writeFiles = async (files) => {
+				await writeFiles(files);
+				if (files.some(({ path }) => path === KERNEL_AUTH_TOKEN_FILE)) {
+					throw new Error('token file write denied');
+				}
+			};
+
+			const failure = await new SandboxProvisioner(fakeComputeFrom(instance))
+				.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					kernelAuthToken: TEST_KERNEL_AUTH_TOKEN,
+					sessionEnv: { files: [{ path: '/creds', content: 'credential' }] },
+				})
+				.catch((error: Error) => error);
+			expect(failure).toBeInstanceOf(Error);
+			expect((failure as Error).message).toContain('injecting session credentials');
+			expect((failure as Error).message).not.toContain(TEST_KERNEL_AUTH_TOKEN);
+			expect(calls.writeFiles.map(([file]) => file.path)).toEqual([
+				'/creds',
+				KERNEL_AUTH_TOKEN_FILE,
+			]);
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
+		});
+
+		it.each(['', 'not-a-kernel-token'])(
+			'rejects an invalid supplied kernel token without starting marimo: %j',
+			async (kernelAuthToken) => {
+				const { instance, calls } = makeFakeSandbox();
+
+				await expect(
+					new SandboxProvisioner(fakeComputeFrom(instance)).provision({
+						sandboxId,
+						projectId,
+						notebookId,
+						hostname: 'localhost',
+						bucket: bucketConfig,
+						kernelAuthToken,
+					}),
+				).rejects.toThrow('injecting session credentials');
+				expect(calls.writeFiles).toHaveLength(0);
+				expect(calls.startProcess).toHaveLength(0);
+				expect(calls.destroy).toBe(1);
+			},
+		);
+
+		it.each([
+			KERNEL_AUTH_TOKEN_FILE,
+			'/tmp/./.marimohub-kernel-token',
+			'/tmp/credentials/../.marimohub-kernel-token',
+			'//tmp//.marimohub-kernel-token',
+			'/tmp/.marimohub-kernel-token/',
+			'/../../tmp/.marimohub-kernel-token',
+		])('rejects a session file that targets the reserved kernel token path: %s', async (path) => {
+			const { instance, calls } = makeFakeSandbox();
+			const provisioner = new SandboxProvisioner(fakeComputeFrom(instance));
+
+			await expect(
+				provisioner.provision({
+					sandboxId,
+					projectId,
+					notebookId,
+					hostname: 'localhost',
+					bucket: bucketConfig,
+					kernelAuthToken: TEST_KERNEL_AUTH_TOKEN,
+					sessionEnv: { files: [{ path, content: 'overwrite' }] },
+				}),
+			).rejects.toThrow('injecting session credentials');
+			expect(calls.startProcess).toHaveLength(0);
+			expect(calls.destroy).toBe(1);
 		});
 
 		it('injects sessionEnv defaults with onlyIfUnset, before the kernel starts', async () => {
@@ -896,7 +1027,7 @@ describe('SandboxProvisioner', () => {
 
 				expect(calls.exec).toHaveLength(1);
 				expect(calls.exec[0]).toContain('uv sync');
-				expect(calls.startProcess[0].cmd).toContain('marimo edit');
+				expect(calls.startProcess[0].cmd).toContain('marimo --quiet edit');
 				expect(calls.startProcess[0].cmd).not.toContain('uv sync');
 			});
 		});
@@ -1087,7 +1218,7 @@ describe('SandboxProvisioner', () => {
 			expect(result.usedFallback).toBe(true);
 			expect(calls.mountBucket).toHaveLength(0);
 			expect(calls.writeFiles.flat().some((f) => f.path.endsWith('apps/my_app.py'))).toBe(true);
-			expect(calls.startProcess[0].cmd).toContain("marimo edit 'apps/my_app.py'");
+			expect(calls.startProcess[0].cmd).toContain("marimo --quiet edit 'apps/my_app.py'");
 		});
 
 		it('restores a packed synced workspace without listing or fetching individual files', async () => {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -11,7 +11,6 @@ import { workspaceSourcePolicy } from '../../integrations/remoteWorkspace';
 import type { WorkspaceLoadMode } from '../../integrations/remoteWorkspace';
 import { logEvent } from '../../logs';
 import { paths } from '../../paths';
-import { KERNEL_AUTH_TOKEN_PATTERN } from '../../schema';
 import { logOperationalError } from '../../operationalLog';
 import type {
 	ComputeResources,
@@ -28,7 +27,7 @@ import type { Timings } from '../../timing';
 import { captureFilesystemSnapshot, createOrRestoreSandbox } from '../content/filesystemSnapshots';
 import { buildMarimoLaunch, DEFAULT_LAUNCH_STRATEGY } from './marimoLaunch';
 import type { MarimoLaunchMode, MarimoLaunchPlan, MarimoLaunchStrategyName } from './marimoLaunch';
-import { KERNEL_AUTH_TOKEN_FILE } from './kernelAuth';
+import { assertValidKernelAuthToken, KERNEL_AUTH_TOKEN_FILE } from './kernelAuth';
 import { shellQuote } from './shell';
 import type { NotebookService } from '../content/NotebookService';
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
@@ -578,9 +577,7 @@ async function writeSessionFiles(
 	files: NonNullable<SessionEnv['files']>,
 	kernelAuthToken?: string,
 ): Promise<void> {
-	if (kernelAuthToken !== undefined && !KERNEL_AUTH_TOKEN_PATTERN.test(kernelAuthToken)) {
-		throw new Error('Invalid kernel authentication token');
-	}
+	if (kernelAuthToken !== undefined) assertValidKernelAuthToken(kernelAuthToken);
 	if (
 		kernelAuthToken !== undefined &&
 		files.some(({ path }) => normalizeAbsoluteSandboxPath(path) === KERNEL_AUTH_TOKEN_FILE)

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -11,6 +11,7 @@ import { workspaceSourcePolicy } from '../../integrations/remoteWorkspace';
 import type { WorkspaceLoadMode } from '../../integrations/remoteWorkspace';
 import { logEvent } from '../../logs';
 import { paths } from '../../paths';
+import { KERNEL_AUTH_TOKEN_PATTERN } from '../../schema';
 import { logOperationalError } from '../../operationalLog';
 import type {
 	ComputeResources,
@@ -27,6 +28,7 @@ import type { Timings } from '../../timing';
 import { captureFilesystemSnapshot, createOrRestoreSandbox } from '../content/filesystemSnapshots';
 import { buildMarimoLaunch, DEFAULT_LAUNCH_STRATEGY } from './marimoLaunch';
 import type { MarimoLaunchMode, MarimoLaunchPlan, MarimoLaunchStrategyName } from './marimoLaunch';
+import { KERNEL_AUTH_TOKEN_FILE } from './kernelAuth';
 import { shellQuote } from './shell';
 import type { NotebookService } from '../content/NotebookService';
 import { captureWorkspace, readSessionArtifacts, restoreWorkspace } from './sandboxFiles';
@@ -229,6 +231,8 @@ export interface ProvisionOptions {
 	 * credential resolution overlaps the (dominant) sandbox create.
 	 */
 	sessionEnv?: SessionEnv | Promise<SessionEnv | undefined>;
+	/** Interactive marimo credential. Scheduled-job preparation omits it. */
+	kernelAuthToken?: string;
 	/** Workspace-relative notebook file marimo should open. Defaults to `notebook.py`. */
 	entryNotebook?: string;
 	/** Per-source launch strategy (see launchStrategy.ts). Defaults to the project-managed env. */
@@ -319,6 +323,7 @@ function formatKernelLogs(stdout: string, stderr: string): string {
 	return [stdout, stderr]
 		.filter((value) => value.trim())
 		.join('\n')
+		.replaceAll(/([?&]access_token=)[A-Za-z0-9_-]+/g, '$1[REDACTED]')
 		.trim();
 }
 
@@ -555,6 +560,37 @@ function loadCounters(load: WorkspaceLoadResult): Record<string, number> {
 		if (load.archiveBytes !== undefined) counters.files_archive_bytes = load.archiveBytes;
 	}
 	return counters;
+}
+
+function normalizeAbsoluteSandboxPath(value: string): string {
+	if (!value.startsWith('/')) return value;
+	const segments: string[] = [];
+	for (const segment of value.split('/')) {
+		if (!segment || segment === '.') continue;
+		if (segment === '..') segments.pop();
+		else segments.push(segment);
+	}
+	return `/${segments.join('/')}`;
+}
+
+async function writeSessionFiles(
+	sandbox: SandboxInstance,
+	files: NonNullable<SessionEnv['files']>,
+	kernelAuthToken?: string,
+): Promise<void> {
+	if (kernelAuthToken !== undefined && !KERNEL_AUTH_TOKEN_PATTERN.test(kernelAuthToken)) {
+		throw new Error('Invalid kernel authentication token');
+	}
+	if (
+		kernelAuthToken !== undefined &&
+		files.some(({ path }) => normalizeAbsoluteSandboxPath(path) === KERNEL_AUTH_TOKEN_FILE)
+	) {
+		throw new Error(`Session credentials cannot write reserved path ${KERNEL_AUTH_TOKEN_FILE}`);
+	}
+	if (files.length > 0) await sandbox.writeFiles(files);
+	if (kernelAuthToken !== undefined) {
+		await sandbox.writeFiles([{ path: KERNEL_AUTH_TOKEN_FILE, content: kernelAuthToken }]);
+	}
 }
 
 export class SandboxProvisioner {
@@ -897,16 +933,15 @@ export class SandboxProvisioner {
 		time: TimeSandboxPhase,
 	): Promise<void> {
 		const sessionEnv = await options.sessionEnv;
-		if (!sessionEnv) return;
+		const kernelAuthToken = options.kernelAuthToken;
+		if (!sessionEnv && kernelAuthToken === undefined) return;
 		await time(async () => {
 			try {
-				// The credential files go in one write; env vars are a separate channel, so
-				// the round-trips overlap.
-				const files = sessionEnv.files ?? [];
-				const vars = sessionEnv.vars;
-				const defaults = sessionEnv.defaults;
+				const files = sessionEnv?.files ?? [];
+				const vars = sessionEnv?.vars;
+				const defaults = sessionEnv?.defaults;
 				await Promise.all([
-					files.length > 0 ? sandbox.writeFiles(files) : undefined,
+					writeSessionFiles(sandbox, files, kernelAuthToken),
 					vars && Object.keys(vars).length > 0 ? sandbox.setEnvVars(vars) : undefined,
 					defaults && Object.keys(defaults).length > 0
 						? sandbox.setEnvVars(defaults, { onlyIfUnset: true })
@@ -933,6 +968,8 @@ export class SandboxProvisioner {
 					mode: options.launchMode,
 					assetUrl: options.assetUrl,
 					baseUrl: options.baseUrl,
+					tokenPasswordFile:
+						options.kernelAuthToken !== undefined ? KERNEL_AUTH_TOKEN_FILE : undefined,
 					watch: options.marimoWatch,
 				},
 				options.launchStrategy,

--- a/packages/core/src/services/runtime/SessionService.test.ts
+++ b/packages/core/src/services/runtime/SessionService.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ACTOR, advanceTime, expectNotFound, MemoryBucket, restoreClock, uid } from '../../testing';
+import {
+	ACTOR,
+	advanceTime,
+	expectNotFound,
+	MemoryBucket,
+	restoreClock,
+	TEST_KERNEL_AUTH_TOKEN,
+	uid,
+} from '../../testing';
 import { ConflictError, PreconditionFailedError } from '../../errors';
 import { createNotebookId, createProjectId, createVersionId } from '../../ids';
 import type { SessionId } from '../../ids';
@@ -30,6 +38,21 @@ describe('SessionService', () => {
 			expect(session.notebook_id).toBe(notebookId);
 			expect(session.project_id).toBe(projectId);
 			expect(session.session_id).toMatch(/^sess-/);
+			expect(session.kernel_auth_token).toBeUndefined();
+		});
+
+		it('persists an interactive kernel token', async () => {
+			const session = await sessions.createSession({
+				notebook_id: notebookId,
+				project_id: projectId,
+				user_id: ACTOR,
+				kernel_auth_token: TEST_KERNEL_AUTH_TOKEN,
+			});
+
+			expect(session.kernel_auth_token).toBe(TEST_KERNEL_AUTH_TOKEN);
+			expect((await sessions.getSession(projectId, session.session_id)).kernel_auth_token).toBe(
+				TEST_KERNEL_AUTH_TOKEN,
+			);
 		});
 
 		it('rejects a source version at or before the prune cutoff', async () => {

--- a/packages/core/src/services/runtime/SessionService.test.ts
+++ b/packages/core/src/services/runtime/SessionService.test.ts
@@ -55,6 +55,21 @@ describe('SessionService', () => {
 			);
 		});
 
+		it.each(['', 'not-a-kernel-token'])(
+			'rejects an invalid kernel token before persisting the session: %j',
+			async (kernelAuthToken) => {
+				await expect(
+					sessions.createSession({
+						notebook_id: notebookId,
+						project_id: projectId,
+						user_id: ACTOR,
+						kernel_auth_token: kernelAuthToken,
+					}),
+				).rejects.toThrow('Invalid kernel authentication token');
+				expect(await sessions.listSessions(notebookId)).toEqual([]);
+			},
+		);
+
 		it('rejects a source version at or before the prune cutoff', async () => {
 			const sourceVersion = createVersionId();
 			await sessions.advanceVersionPruneCutoff(projectId, notebookId, sourceVersion);

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -51,6 +51,7 @@ export interface CreateSessionInput {
 	user_id: UserId;
 	runtime?: { python_version?: string; marimo_version?: string };
 	sandbox_id?: SandboxId;
+	kernel_auth_token?: string;
 	sandbox_url?: string;
 	compute_profile?: string;
 	compute_resources?: Session['compute_resources'];
@@ -163,6 +164,7 @@ export class SessionService {
 				: {}),
 			runtime: input.runtime,
 			sandbox_id: input.sandbox_id,
+			kernel_auth_token: input.kernel_auth_token,
 			sandbox_url: input.sandbox_url,
 			compute_profile: input.compute_profile,
 			compute_resources: input.compute_resources,

--- a/packages/core/src/services/runtime/SessionService.ts
+++ b/packages/core/src/services/runtime/SessionService.ts
@@ -34,6 +34,7 @@ import {
 } from '../../schema';
 import type { EditorClaim, Session, SurfaceState } from '../../schema';
 import type { SurfaceId } from './surfaces/types';
+import { assertValidKernelAuthToken } from './kernelAuth';
 import {
 	ACTIVE_STATUSES,
 	isTerminal,
@@ -142,6 +143,9 @@ export class SessionService {
 	}
 
 	async createSession(input: CreateSessionInput): Promise<Session> {
+		if (input.kernel_auth_token !== undefined) {
+			assertValidKernelAuthToken(input.kernel_auth_token);
+		}
 		const sessionId = input.session_id ?? createSessionId();
 		const now = new Date().toISOString();
 

--- a/packages/core/src/services/runtime/kernelAuth.test.ts
+++ b/packages/core/src/services/runtime/kernelAuth.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { KERNEL_AUTH_TOKEN_PATTERN } from '../../schema';
+import { createKernelAuthToken } from './kernelAuth';
+
+describe('createKernelAuthToken', () => {
+	afterEach(() => vi.restoreAllMocks());
+
+	it('creates independent 256-bit URL-safe credentials', () => {
+		const tokens = new Set(Array.from({ length: 100 }, () => createKernelAuthToken()));
+		expect(tokens.size).toBe(100);
+		for (const token of tokens) {
+			expect(token).toMatch(KERNEL_AUTH_TOKEN_PATTERN);
+		}
+	});
+
+	it('fills all 32 random bytes with the platform cryptographic source', () => {
+		const random = vi.spyOn(crypto, 'getRandomValues');
+
+		createKernelAuthToken();
+
+		expect(random).toHaveBeenCalledOnce();
+		expect(random.mock.calls[0][0]).toBeInstanceOf(Uint8Array);
+		expect(random.mock.calls[0][0]).toHaveLength(32);
+	});
+
+	it('fails instead of substituting a weak token when the cryptographic source fails', () => {
+		vi.spyOn(crypto, 'getRandomValues').mockImplementationOnce(() => {
+			throw new Error('entropy unavailable');
+		});
+
+		expect(() => createKernelAuthToken()).toThrow('entropy unavailable');
+	});
+});

--- a/packages/core/src/services/runtime/kernelAuth.ts
+++ b/packages/core/src/services/runtime/kernelAuth.ts
@@ -1,4 +1,5 @@
 import { toBase64Url } from '../../internal/base64url';
+import { KERNEL_AUTH_TOKEN_PATTERN } from '../../schema';
 
 export const KERNEL_AUTH_TOKEN_FILE = '/tmp/.marimohub-kernel-token';
 
@@ -7,4 +8,10 @@ const TOKEN_PREFIX = 'mhub_kernel_';
 
 export function createKernelAuthToken(): string {
 	return `${TOKEN_PREFIX}${toBase64Url(crypto.getRandomValues(new Uint8Array(TOKEN_BYTES)))}`;
+}
+
+export function assertValidKernelAuthToken(token: string): void {
+	if (!KERNEL_AUTH_TOKEN_PATTERN.test(token)) {
+		throw new Error('Invalid kernel authentication token');
+	}
 }

--- a/packages/core/src/services/runtime/kernelAuth.ts
+++ b/packages/core/src/services/runtime/kernelAuth.ts
@@ -1,0 +1,10 @@
+import { toBase64Url } from '../../internal/base64url';
+
+export const KERNEL_AUTH_TOKEN_FILE = '/tmp/.marimohub-kernel-token';
+
+const TOKEN_BYTES = 32;
+const TOKEN_PREFIX = 'mhub_kernel_';
+
+export function createKernelAuthToken(): string {
+	return `${TOKEN_PREFIX}${toBase64Url(crypto.getRandomValues(new Uint8Array(TOKEN_BYTES)))}`;
+}

--- a/packages/core/src/services/runtime/kernelExecute.test.ts
+++ b/packages/core/src/services/runtime/kernelExecute.test.ts
@@ -48,6 +48,29 @@ describe('kernel execution', () => {
 		await expect(listKernelSessions('https://kernel', { fetchImpl })).resolves.toEqual([
 			{ id: 'one', path: '/notebook.py' },
 		]);
+		expect(new Headers(fetchImpl.mock.calls[0][1]?.headers).has('Authorization')).toBe(false);
+	});
+
+	it('authenticates kernel discovery and execution when a token is present', async () => {
+		const authorizations: (string | null)[] = [];
+		const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			authorizations.push(new Headers(init?.headers).get('Authorization'));
+			return String(input).endsWith('/api/sessions')
+				? new Response(JSON.stringify([{ id: 'one' }]))
+				: sse('event: done\ndata: {"success":true}\n\n');
+		});
+
+		await listKernelSessions('https://kernel', {
+			fetchImpl,
+			kernelAuthToken: 'secret-token',
+		});
+		await executeInKernel(
+			'https://kernel',
+			{ sessionId: 'one', code: '1+1' },
+			{ fetchImpl, kernelAuthToken: 'secret-token' },
+		);
+
+		expect(authorizations).toEqual(['Bearer secret-token', 'Bearer secret-token']);
 	});
 
 	it('normalizes marimo session maps keyed by session id', async () => {

--- a/packages/core/src/services/runtime/kernelExecute.ts
+++ b/packages/core/src/services/runtime/kernelExecute.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { Session } from '../../schema';
-import { kernelBasePath } from './sessionLifecycle';
+import { kernelBasePathFromUrl } from './sandboxExposure';
 
 export interface KernelSession {
 	id: string;
@@ -53,7 +53,19 @@ export function kernelBaseUrl(session: Session): string {
 	const endpoint = session.sandbox_origin_url ?? session.sandbox_url;
 	if (!endpoint) throw new Error('Session has no sandbox URL');
 	const origin = new URL(endpoint).origin;
-	return `${origin}${kernelBasePath(session)}`;
+	return `${origin}${kernelBasePathFromUrl(session.sandbox_url)}`;
+}
+
+interface KernelRequestOptions {
+	fetchImpl?: typeof fetch;
+	kernelAuthToken?: string;
+	signal?: AbortSignal;
+}
+
+function kernelRequestHeaders(headers: Record<string, string>, kernelAuthToken?: string): Headers {
+	const result = new Headers(headers);
+	if (kernelAuthToken) result.set('Authorization', `Bearer ${kernelAuthToken}`);
+	return result;
 }
 
 async function responseDetail(response: Response): Promise<string> {
@@ -80,10 +92,10 @@ async function assertKernelResponse(response: Response, contentType?: string): P
 
 export async function listKernelSessions(
 	baseUrl: string,
-	options: { fetchImpl?: typeof fetch; signal?: AbortSignal } = {},
+	options: KernelRequestOptions = {},
 ): Promise<KernelSession[]> {
 	const response = await (options.fetchImpl ?? globalThis.fetch)(`${baseUrl}/api/sessions`, {
-		headers: { Accept: 'application/json' },
+		headers: kernelRequestHeaders({ Accept: 'application/json' }, options.kernelAuthToken),
 		signal: options.signal,
 	});
 	await assertKernelResponse(response);
@@ -186,7 +198,7 @@ export async function executeInKernel(
 		maxStderrBytes?: number;
 		maxOutputBytes?: number;
 	},
-	options: { fetchImpl?: typeof fetch; timeoutMs?: number; signal?: AbortSignal } = {},
+	options: KernelRequestOptions & { timeoutMs?: number } = {},
 ): Promise<KernelExecuteResult> {
 	const controller = new AbortController();
 	let timedOut = false;
@@ -208,11 +220,14 @@ export async function executeInKernel(
 			`${baseUrl}/api/kernel/execute`,
 			{
 				method: 'POST',
-				headers: {
-					Accept: 'text/event-stream',
-					'Content-Type': 'application/json',
-					'Marimo-Session-Id': input.sessionId,
-				},
+				headers: kernelRequestHeaders(
+					{
+						Accept: 'text/event-stream',
+						'Content-Type': 'application/json',
+						'Marimo-Session-Id': input.sessionId,
+					},
+					options.kernelAuthToken,
+				),
 				body: JSON.stringify({ code: input.code }),
 				signal: controller.signal,
 			},

--- a/packages/core/src/services/runtime/marimoLaunch.test.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.test.ts
@@ -8,13 +8,14 @@ const BASE: MarimoLaunchParams = {
 	host: '0.0.0.0',
 	assetUrl: 'https://cdn.example.com/assets',
 	baseUrl: '/proxy/tok',
+	tokenPasswordFile: '/tmp/.marimohub-kernel-token',
 };
 
 describe('buildMarimoLaunch', () => {
 	it('defaults to edit mode', () => {
 		const { start } = buildMarimoLaunch(BASE);
-		expect(start).toContain('marimo edit');
-		expect(start).not.toContain('marimo run');
+		expect(start).toContain('marimo --quiet edit');
+		expect(start).not.toContain('marimo --quiet run');
 	});
 
 	it('edit keeps --convert and --asset-url', () => {
@@ -35,7 +36,7 @@ describe('buildMarimoLaunch', () => {
 	for (const file of ['docs/page.md', 'page.markdown', 'reports/q3.qmd']) {
 		it(`edit drops --convert for ${file}`, () => {
 			const { start } = buildMarimoLaunch({ ...BASE, mode: 'edit', notebookFile: file });
-			expect(start).toContain('marimo edit');
+			expect(start).toContain('marimo --quiet edit');
 			expect(start).not.toContain('--convert');
 		});
 	}
@@ -47,9 +48,11 @@ describe('buildMarimoLaunch', () => {
 
 	it('app drops --convert but keeps host/port/asset-url/base-url', () => {
 		const { start } = buildMarimoLaunch({ ...BASE, mode: 'app' });
-		expect(start).toContain('marimo run');
+		expect(start).toContain('marimo --quiet run');
 		expect(start).not.toContain('--convert');
-		expect(start).toContain('--headless --no-token --host 0.0.0.0 --port 2718');
+		expect(start).toContain(
+			"--headless --token --token-password-file '/tmp/.marimohub-kernel-token' --host 0.0.0.0 --port 2718",
+		);
 		// A hidden-but-real option on `marimo run` — the CDN fast path applies to apps.
 		expect(start).toContain('--asset-url="https://cdn.example.com/assets"');
 		expect(start).toContain('--base-url="/proxy/tok"');
@@ -67,6 +70,28 @@ describe('buildMarimoLaunch', () => {
 		expect(uvPrefix(run.start)).toBe(uvPrefix(edit.start));
 	});
 
+	it('keeps the token value out of the launch command', () => {
+		const { start } = buildMarimoLaunch({
+			...BASE,
+			tokenPasswordFile: '/tmp/token-file',
+		});
+		expect(start).toContain("--token-password-file '/tmp/token-file'");
+		expect(start).not.toContain('mhub_kernel_secret');
+	});
+
+	it('retains tokenless launches for legacy callers without a token file', () => {
+		const { start } = buildMarimoLaunch({ ...BASE, tokenPasswordFile: undefined });
+		expect(start).toContain('marimo --quiet edit');
+		expect(start).toContain('--no-token');
+		expect(start).not.toContain('--token-password-file');
+	});
+
+	it('rejects an explicitly empty token file path instead of launching tokenless', () => {
+		expect(() => buildMarimoLaunch({ ...BASE, tokenPasswordFile: '' })).toThrow(
+			'Token password file path cannot be empty',
+		);
+	});
+
 	it('job creates its output directory before exporting', () => {
 		const { setup, start } = buildMarimoLaunch({ ...BASE, mode: 'job' });
 
@@ -75,6 +100,9 @@ describe('buildMarimoLaunch', () => {
 			command: "mkdir -p '__marimo__'",
 		});
 		expect(start).toContain('marimo export html');
+		expect(start).not.toContain('--quiet');
+		expect(start).not.toContain('--token');
+		expect(start).not.toContain('--no-token');
 	});
 
 	it('job does not establish a session-artifact contract for custom entries', () => {
@@ -90,12 +118,11 @@ describe('buildMarimoLaunch', () => {
 		expect(setup.at(-1)?.command).toBe("mkdir -p '__marimo__'");
 	});
 
-	// Every strategy must honor the mode — a new strategy hardcoding `marimo
-	// edit` would silently break app sessions.
+	// Every strategy must honor the mode and suppress the token-bearing startup URL.
 	for (const [name, strategy] of Object.entries(MARIMO_LAUNCH_STRATEGIES)) {
-		it(`strategy ${name} emits the mode's subcommand`, () => {
-			expect(strategy({ ...BASE, mode: 'edit' }).start).toContain('marimo edit');
-			expect(strategy({ ...BASE, mode: 'app' }).start).toContain('marimo run');
+		it(`strategy ${name} emits a quiet interactive subcommand`, () => {
+			expect(strategy({ ...BASE, mode: 'edit' }).start).toContain('marimo --quiet edit');
+			expect(strategy({ ...BASE, mode: 'app' }).start).toContain('marimo --quiet run');
 		});
 	}
 

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -22,6 +22,8 @@ export interface MarimoLaunchParams {
 	outputFile?: string;
 	/** Optional CDN base for the frontend, passed as --asset-url. */
 	assetUrl?: string;
+	/** File containing marimo's session token. Jobs and legacy tokenless launches omit it. */
+	tokenPasswordFile?: string;
 	/**
 	 * Optional path prefix marimo serves under, passed as `--base-url`. Set in
 	 * `proxy` exposure mode (e.g. `/proxy/<token>`) so the kernel's asset and
@@ -46,10 +48,15 @@ export interface MarimoSetupStep {
 export type MarimoLaunchStrategy = (params: MarimoLaunchParams) => MarimoLaunchPlan;
 
 /** Flags both subcommands accept, spelled identically. */
-const commonFlags = ({ host, port, assetUrl, baseUrl }: MarimoLaunchParams) => {
+const commonFlags = ({ host, port, assetUrl, baseUrl, tokenPasswordFile }: MarimoLaunchParams) => {
 	const assetUrlArg = assetUrl ? ` --asset-url="${assetUrl}"` : '';
 	const baseUrlArg = baseUrl ? ` --base-url="${baseUrl}"` : '';
-	return `--headless --no-token --host ${host} --port ${port}${assetUrlArg}${baseUrlArg}`;
+	if (tokenPasswordFile === '') throw new Error('Token password file path cannot be empty');
+	const tokenArg =
+		tokenPasswordFile !== undefined
+			? `--token --token-password-file ${shellQuote(tokenPasswordFile)}`
+			: '--no-token';
+	return `--headless ${tokenArg} --host ${host} --port ${port}${assetUrlArg}${baseUrlArg}`;
 };
 
 interface ModeLaunch {
@@ -92,10 +99,14 @@ const LAUNCH_MODES: Record<MarimoLaunchMode, ModeLaunch> = {
 	},
 };
 
-/** The mode-dependent tail of every strategy: `marimo <subcommand> <file> <flags>`. */
+/** The mode-dependent tail of every strategy: `marimo <global flags> <subcommand> …`. */
 function marimoCommand(p: MarimoLaunchParams, extraFlags = ''): string {
-	const { subcommand, flags } = LAUNCH_MODES[p.mode ?? 'edit'];
-	return `marimo ${subcommand} ${extraFlags}${shellQuote(p.notebookFile)} ${flags(p)}`;
+	const mode = p.mode ?? 'edit';
+	const { subcommand, flags } = LAUNCH_MODES[mode];
+	// marimo's startup URL contains access_token. Suppress it before sandbox
+	// adapters capture process output; jobs do not start an authenticated server.
+	const globalFlags = mode === 'job' ? '' : '--quiet ';
+	return `marimo ${globalFlags}${subcommand} ${extraFlags}${shellQuote(p.notebookFile)} ${flags(p)}`;
 }
 
 // Sync only when the notebook declares real deps; an empty one just gets a

--- a/packages/core/src/services/runtime/sandboxExposure.test.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { NotebookId, ProjectId, SandboxId, SessionId } from '../../ids';
+import { TEST_KERNEL_AUTH_TOKEN } from '../../testing';
 import { signProxyToken } from './proxyToken';
-import { ProxyExposure, SubdomainExposure } from './sandboxExposure';
+import { kernelBasePathFromUrl, ProxyExposure, SubdomainExposure } from './sandboxExposure';
 
 const SECRET = 'a-test-signing-secret-at-least-32-bytes-long!!';
 const ctx = {
@@ -9,6 +10,7 @@ const ctx = {
 	projectId: 'proj-1' as ProjectId,
 	notebookId: 'nb-1' as NotebookId,
 	sandboxId: 'sbx-1' as SandboxId,
+	kernelAuthToken: TEST_KERNEL_AUTH_TOKEN,
 	appBaseUrl: 'https://hub.example.com',
 };
 
@@ -19,10 +21,22 @@ describe('SubdomainExposure', () => {
 		expect(await exposure.prepare(ctx)).toEqual({});
 	});
 
-	it('uses the adapter URL as-is and records no origin', async () => {
+	it('adds the kernel token to the adapter URL and records no origin', async () => {
 		const result = await exposure.finalize('https://sbx-1.sandbox.example.net', ctx);
-		expect(result).toEqual({ clientUrl: 'https://sbx-1.sandbox.example.net' });
+		expect(result).toEqual({
+			clientUrl: `https://sbx-1.sandbox.example.net/?access_token=${TEST_KERNEL_AUTH_TOKEN}`,
+		});
 		expect(result.originUrl).toBeUndefined();
+	});
+
+	it('preserves provider query parameters and fragments', async () => {
+		const result = await exposure.finalize(
+			'https://sandbox.example.net/open?provider=one&provider=two&empty=#notebook',
+			ctx,
+		);
+		expect(result.clientUrl).toBe(
+			`https://sandbox.example.net/open?provider=one&provider=two&empty=&access_token=${TEST_KERNEL_AUTH_TOKEN}#notebook`,
+		);
 	});
 });
 
@@ -71,4 +85,15 @@ describe('ProxyExposure', () => {
 			expect(result.clientUrl).toBe(`https://hub.example.com/marimohub/proxy/${token}/`);
 		},
 	);
+});
+
+describe('kernelBasePathFromUrl', () => {
+	it.each([
+		[undefined, ''],
+		['not a url', ''],
+		['https://kernel.example/', ''],
+		['https://hub.example/proxy/token///?access_token=secret', '/proxy/token'],
+	])('extracts the marimo base path from %s', (url, expected) => {
+		expect(kernelBasePathFromUrl(url)).toBe(expected);
+	});
 });

--- a/packages/core/src/services/runtime/sandboxExposure.test.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.test.ts
@@ -38,6 +38,16 @@ describe('SubdomainExposure', () => {
 			`https://sandbox.example.net/open?provider=one&provider=two&empty=&access_token=${TEST_KERNEL_AUTH_TOKEN}#notebook`,
 		);
 	});
+
+	it.each([
+		'https://sandbox.example.net/?access_token=provider-credential',
+		'https://sandbox.example.net/?access_token=',
+		'https://sandbox.example.net/?%61ccess_token=provider-credential',
+	])('rejects an adapter URL containing the reserved token parameter: %s', async (url) => {
+		await expect(exposure.finalize(url, ctx)).rejects.toThrow(
+			'Sandbox exposure URL contains reserved access_token query parameter',
+		);
+	});
 });
 
 describe('ProxyExposure', () => {

--- a/packages/core/src/services/runtime/sandboxExposure.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.ts
@@ -34,6 +34,9 @@ export class SubdomainExposure implements SandboxExposure {
 
 	async finalize(exposedUrl: string, ctx: ExposureContext): Promise<ExposureResult> {
 		const url = new URL(exposedUrl);
+		if (url.searchParams.has('access_token')) {
+			throw new Error('Sandbox exposure URL contains reserved access_token query parameter');
+		}
 		url.searchParams.set('access_token', ctx.kernelAuthToken);
 		return { clientUrl: url.toString() };
 	}

--- a/packages/core/src/services/runtime/sandboxExposure.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.ts
@@ -11,9 +11,18 @@ import type {
 import { joinUrlPath } from '../../url';
 import { signProxyToken } from './proxyToken';
 
+export function kernelBasePathFromUrl(sandboxUrl?: string): string {
+	if (!sandboxUrl) return '';
+	try {
+		return new URL(sandboxUrl).pathname.replace(/\/+$/, '');
+	} catch {
+		return '';
+	}
+}
+
 /**
- * `subdomain` (default) — the compute adapter's `exposePort()` URL is used as-is;
- * the browser reaches the kernel directly on its isolated domain. No proxying, no
+ * `subdomain` (default) — the browser reaches the kernel directly on its isolated
+ * domain. The adapter URL carries marimo's access token. There is no proxying or
  * marimo base path.
  */
 export class SubdomainExposure implements SandboxExposure {
@@ -23,8 +32,10 @@ export class SubdomainExposure implements SandboxExposure {
 		return {};
 	}
 
-	async finalize(exposedUrl: string, _ctx: ExposureContext): Promise<ExposureResult> {
-		return { clientUrl: exposedUrl };
+	async finalize(exposedUrl: string, ctx: ExposureContext): Promise<ExposureResult> {
+		const url = new URL(exposedUrl);
+		url.searchParams.set('access_token', ctx.kernelAuthToken);
+		return { clientUrl: url.toString() };
 	}
 }
 

--- a/packages/core/src/services/runtime/sessionAuthz.ts
+++ b/packages/core/src/services/runtime/sessionAuthz.ts
@@ -20,7 +20,7 @@ export interface SessionActor {
 /**
  * `attach` — reach the session's kernel: proxy/WS traffic, keep-alive
  * heartbeats, and seeing `sandbox_url` (in `subdomain` exposure the URL is
- * the capability). `stop` — terminate or restart it.
+ * a bearer capability). `stop` — terminate or restart it.
  */
 export type SessionAction = 'attach' | 'stop' | 'surface';
 

--- a/packages/core/src/services/runtime/sessionLifecycle.test.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.test.ts
@@ -594,9 +594,30 @@ describe('SessionLifecycleService', () => {
 describe('kernelActiveConnections', () => {
 	const sandboxWith = (exec: SandboxInstance['exec']) => ({ exec }) as SandboxInstance;
 
-	it('parses the active connection count', async () => {
-		const sandbox = sandboxWith(async () => ({ success: true, stdout: '3\n', stderr: '' }));
+	it('authenticates the probe and keeps a missing-file fallback', async () => {
+		let command = '';
+		const sandbox = sandboxWith(async (cmd) => {
+			command = cmd;
+			return { success: true, stdout: '3\n', stderr: '' };
+		});
 		expect(await kernelActiveConnections(sandbox)).toBe(3);
+		expect(command).toContain('p.exists()');
+		expect(command).toContain('"Authorization":"Bearer "+p.read_text().strip()');
+		expect(command).toContain('if p.exists() else {}');
+	});
+
+	it('shell-quotes an unexpected base path', async () => {
+		let command = '';
+		const sandbox = sandboxWith(async (cmd) => {
+			command = cmd;
+			return { success: true, stdout: '0\n', stderr: '' };
+		});
+		const basePath = `/proxy/'";touch /tmp/probe-injection;#`;
+
+		expect(await kernelActiveConnections(sandbox, basePath)).toBe(0);
+		expect(command).toMatch(/^python3 -c '/);
+		expect(command).toContain(`'\\''`);
+		expect(command).not.toContain(`-c "`);
 	});
 
 	it('returns null when the exec fails', async () => {

--- a/packages/core/src/services/runtime/sessionLifecycle.ts
+++ b/packages/core/src/services/runtime/sessionLifecycle.ts
@@ -12,6 +12,9 @@ import { SandboxProvisioner } from './SandboxProvisioner';
 import { SessionRetirer } from './SessionRetirer';
 import { isTerminal, sessionMode, sessionModePolicy, sessionPersistsEdits } from './sessionState';
 import type { SessionService } from './SessionService';
+import { KERNEL_AUTH_TOKEN_FILE } from './kernelAuth';
+import { kernelBasePathFromUrl } from './sandboxExposure';
+import { shellQuote } from './shell';
 
 const SESSION_SWEEP_CONCURRENCY = 8;
 /** Cadence for informational connection counts; reap decisions always probe immediately. */
@@ -29,8 +32,8 @@ export const RECLAIM_PROVISION_GRACE_MS = Millis.minutes(15);
 
 /**
  * Ask the marimo kernel how many websocket connections (editors) it has, via an
- * `exec` INSIDE the sandbox — exposure-mode-independent (works for `subdomain`
- * and `proxy`) and needs no auth (the kernel runs with `--no-token`).
+ * `exec` inside the sandbox. The probe reads the session token file when it is
+ * present and remains compatible with legacy tokenless kernels.
  *
  * `basePath` is the prefix marimo serves under (its `--base-url`, e.g.
  * `/proxy/<token>` in proxy exposure) — the status endpoint exists ONLY under
@@ -46,10 +49,14 @@ export async function kernelActiveConnections(
 	basePath = '',
 ): Promise<number | null> {
 	try {
-		const res = await sandbox.exec(
-			`python3 -c "import json,urllib.request;` +
-				`print(json.load(urllib.request.urlopen('http://127.0.0.1:${MARIMO_PORT}${basePath}/api/status/connections',timeout=3))['active'])"`,
-		);
+		const url = `http://127.0.0.1:${MARIMO_PORT}${basePath}/api/status/connections`;
+		const script =
+			'import json,pathlib,urllib.request;' +
+			`p=pathlib.Path(${JSON.stringify(KERNEL_AUTH_TOKEN_FILE)});` +
+			'h={"Authorization":"Bearer "+p.read_text().strip()} if p.exists() else {};' +
+			`r=urllib.request.Request(${JSON.stringify(url)},headers=h);` +
+			'print(json.load(urllib.request.urlopen(r,timeout=3))["active"])';
+		const res = await sandbox.exec(`python3 -c ${shellQuote(script)}`);
 		if (!res.success) return null;
 		// Whole output or nothing — `parseInt` would read 2 out of "2garbage", and a
 		// half-parsed answer must count as unknown rather than steer reaping. The
@@ -69,21 +76,6 @@ export type ConnectionProbe = (
 	sandbox: SandboxInstance,
 	basePath?: string,
 ) => Promise<number | null>;
-
-/**
- * The kernel's serving prefix, recovered from the session's client URL:
- * `/proxy/<token>` under proxy exposure (where the URL's path IS marimo's
- * `--base-url`), empty under subdomain exposure (kernel at root).
- */
-export function kernelBasePath(s: Session): string {
-	if (!s.sandbox_url) return '';
-	try {
-		return new URL(s.sandbox_url).pathname.replace(/\/$/, '');
-	} catch {
-		return '';
-	}
-}
-
 export interface SessionLifecycleConfig {
 	/** Reap after a stale heartbeat and no connections. */
 	idleTimeoutMsByMode: Record<SessionMode, number>;
@@ -211,7 +203,7 @@ export class SessionLifecycleService {
 				connectionCountCheck &&
 				this.connectionProbeBudget.consume(s.session_id, now);
 			if (this.cfg.connectionAware && (reapCandidate || connectionCountDue)) {
-				active = await this.probe(sandbox, kernelBasePath(s));
+				active = await this.probe(sandbox, kernelBasePathFromUrl(s.sandbox_url));
 				// A null probe is "unknown" — leave the last stamp rather than write a
 				// lie. An unchanged count is skipped too: no CAS/ETag churn against
 				// heartbeats for the steady state.

--- a/packages/core/src/testing/fixtures.ts
+++ b/packages/core/src/testing/fixtures.ts
@@ -29,6 +29,7 @@ import type {
 
 export const ACTOR = UserId.parse('user_01HXY00000000000000000000');
 export const NOW = '2025-03-05T14:00:00.000Z';
+export const TEST_KERNEL_AUTH_TOKEN = `mhub_kernel_${'a'.repeat(43)}`;
 
 /** Brand a string as a UserId in tests (user ids are opaque, so any value works). */
 export const uid = (s: string): UserId => UserId.parse(s);

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -508,6 +508,23 @@ describe('NotebookPage viewer modes', () => {
 		expect(screen.queryByText(/won't be saved/)).toBeNull();
 	});
 
+	it('preserves the complete kernel URL when it adds marimo display parameters', async () => {
+		makeFetch({
+			role: 'editor',
+			session: runningSession({
+				sandbox_url:
+					'https://sandbox.example/kernel?provider=one&access_token=kernel-secret#notebook',
+			}),
+		});
+		const { container } = renderPage();
+
+		await waitFor(() => expect(container.querySelector('iframe')).not.toBeNull());
+		expect(container.querySelector('iframe')).toHaveAttribute(
+			'src',
+			'https://sandbox.example/kernel?provider=one&access_token=kernel-secret&theme=light#notebook',
+		);
+	});
+
 	it.each([
 		{ variant: 'edit' as const, message: 'Starting sandbox...' },
 		{ variant: 'app' as const, message: 'Starting app...' },


### PR DESCRIPTION
Enables native marimo token authentication for every new interactive edit and app session while preserving compatibility with already-running tokenless sessions. Scheduled jobs remain unchanged.

- Generates and persists an independent 256-bit URL-safe token per session without exposing it in API response fields.
- Delivers tokens through subdomain URLs or authenticated proxy HTTP and WebSocket forwarding, isolated from secondary surfaces.
- Stores credentials in a reserved sandbox file, authenticates connection probes, and fails closed on path collisions or invalid tokens.
- Suppresses token-bearing marimo startup URLs with global `--quiet` and defensively redacts captured `access_token` values.
- Updates schemas, supported images, operational documentation, and edge-case and unhappy-path coverage.

Mixed-version rollouts can temporarily return 401 responses when old proxy replicas reach newly authenticated kernels, so server rollout should complete promptly.