### PR TITLE
feat(web): add dedicated MCP setup dialog

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -25,8 +25,7 @@ The MCP server URL adds `/mcp` to this value:
 https://hub.example.com/mcp
 ```
 
-OAuth discovery uses the base URL to publish stable, absolute URLs. The API
-tokens dialog shows the MCP URL.
+OAuth discovery uses the base URL to publish stable, absolute URLs. The MCP dialog in the user menu shows the MCP URL and client setup instructions.
 
 ## Connect a client
 

--- a/packages/web/src/components/Account/ApiTokensDialog.tsx
+++ b/packages/web/src/components/Account/ApiTokensDialog.tsx
@@ -10,12 +10,7 @@ import {
 	TextField,
 	WriteOnceWarning,
 } from '@/components/ui';
-import {
-	useApiTokensQuery,
-	useCapabilitiesQuery,
-	useCreateScopedApiToken,
-	useRevokeApiToken,
-} from '@/api/hooks';
+import { useApiTokensQuery, useCreateScopedApiToken, useRevokeApiToken } from '@/api/hooks';
 import { useDialogTarget } from '@/hooks/useDialogTarget';
 import { formatDuration, formatRelative } from '@/lib/time';
 import type { ApiToken, ApiTokenCreated } from '@/types';
@@ -23,7 +18,6 @@ import { TokenGrantEditor } from './TokenGrantEditor';
 import { tokenGrantFromDraft } from './tokenGrantDraft';
 import type { TokenGrantDraft } from './tokenGrantDraft';
 import { TOKEN_GRANT_PRESETS } from '@marimo-hub/core/token-grants';
-import { DOCS_MCP_URL } from '@/lib/links';
 
 export interface ApiTokensDialogProps {
 	isOpen: boolean;
@@ -72,7 +66,6 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 	const { data: tokens } = useApiTokensQuery(isOpen);
 	const createToken = useCreateScopedApiToken();
 	const revokeToken = useRevokeApiToken();
-	const { data: capabilities } = useCapabilitiesQuery(isOpen);
 
 	const [name, setName] = useState('');
 	const [expiresInDays, setExpiresInDays] = useState('');
@@ -138,20 +131,6 @@ export function ApiTokensDialog({ isOpen, onClose }: ApiTokensDialogProps) {
 					<code className="text-xs">Authorization: Bearer …</code>. Tokens cannot manage other
 					tokens.
 				</p>
-				{capabilities?.mcp.available && capabilities.mcp.url ? (
-					<div className="flex flex-col gap-2 rounded-md border p-3">
-						<span className="text-xs font-semibold">MCP server URL</span>
-						<CopyField label="MCP server URL" value={capabilities.mcp.url} hideLabel />
-						<a
-							href={DOCS_MCP_URL}
-							target="_blank"
-							rel="noreferrer"
-							className="text-xs text-primary underline-offset-2 hover:underline"
-						>
-							How to connect an MCP client
-						</a>
-					</div>
-				) : null}
 
 				{created && (
 					<div className="flex flex-col gap-2 rounded-md border p-3">

--- a/packages/web/src/components/Account/McpDialog.tsx
+++ b/packages/web/src/components/Account/McpDialog.tsx
@@ -1,0 +1,158 @@
+import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
+import { useCapabilitiesQuery } from '@/api/hooks';
+import { Button, CopyField, DialogModal, LinkButton } from '@/components/ui';
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
+import { DOCS_MCP_URL } from '@/lib/links';
+
+const clients = ['Cursor', 'Claude', 'Codex', 'OpenCode', 'Other'] as const;
+const panelClassName =
+	'flex flex-col gap-3 pt-4 outline-none focus-visible:ring-2 focus-visible:ring-ring';
+
+function OpenCodeConfig({ url }: { url: string }) {
+	const { copied, copy } = useCopyToClipboard();
+	const config = JSON.stringify({ mcp: { marimohub: { type: 'remote', url } } }, null, 2);
+	return (
+		<div className="flex flex-col gap-2">
+			<textarea
+				aria-label="OpenCode configuration"
+				readOnly
+				value={config}
+				rows={8}
+				onFocus={(event) => event.target.select()}
+				className="w-full resize-none rounded-md border border-input bg-muted/40 p-3 font-mono text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring"
+			/>
+			<Button className="self-end" size="sm" onPress={() => void copy(config)}>
+				{copied ? 'Copied' : 'Copy configuration'}
+			</Button>
+		</div>
+	);
+}
+
+export function McpDialog({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+	const { data: capabilities, isPending, isError } = useCapabilitiesQuery(isOpen);
+	const url = capabilities?.mcp?.available ? capabilities.mcp.url : null;
+	// Single quotes keep URL characters from being interpreted by POSIX shells.
+	const shellUrl = url ? `'${url.replaceAll("'", "'\\''")}'` : '';
+	const cursorConfig = url
+		? btoa(
+				Array.from(new TextEncoder().encode(JSON.stringify({ url })), (byte) =>
+					String.fromCharCode(byte),
+				).join(''),
+			)
+		: '';
+
+	return (
+		<DialogModal isOpen={isOpen} onClose={onClose} title="Connect with MCP" width="lg">
+			<div className="flex flex-col gap-4 text-sm">
+				<p className="text-muted-foreground">
+					Connect your AI tools to read, edit, and run your marimohub notebooks.
+				</p>
+				{url ? (
+					<>
+						<CopyField label="MCP server URL" value={url} />
+						<Tabs defaultSelectedKey="Cursor">
+							<TabList aria-label="MCP client" className="flex overflow-x-auto border-b">
+								{clients.map((client) => (
+									<Tab
+										key={client}
+										id={client}
+										className="shrink-0 cursor-pointer border-b-2 border-transparent px-3 py-2 text-sm text-muted-foreground outline-none selected:border-primary selected:text-foreground focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+									>
+										{client}
+									</Tab>
+								))}
+							</TabList>
+							<TabPanel id="Cursor" className={panelClassName}>
+								<p>Add the server to Cursor, then connect it to sign in.</p>
+								<LinkButton
+									className="self-start"
+									variant="primary"
+									to={`cursor://anysphere.cursor-deeplink/mcp/install?name=marimohub&config=${encodeURIComponent(cursorConfig)}`}
+								>
+									Add to Cursor
+								</LinkButton>
+								<p className="text-muted-foreground">
+									For manual setup, add a remote MCP server in Cursor settings with the URL above.
+								</p>
+							</TabPanel>
+							<TabPanel id="Claude" className={panelClassName}>
+								<p>Run this command in your terminal to add the server to Claude Code:</p>
+								<CopyField
+									label="Claude Code command"
+									value={`claude mcp add --transport http --scope user marimohub ${shellUrl}`}
+									hideLabel
+								/>
+								<p>
+									In Claude Code, run <code>/mcp</code> and select marimohub to authenticate.
+								</p>
+								<p className="text-muted-foreground">
+									For Claude web or desktop, add a custom connector in Settings → Connectors with
+									the URL above.
+								</p>
+							</TabPanel>
+							<TabPanel id="Codex" className={panelClassName}>
+								<p>Run this command in your terminal to add the server:</p>
+								<CopyField
+									label="Codex command"
+									value={`codex mcp add marimohub --url ${shellUrl}`}
+									hideLabel
+								/>
+								<p>Then sign in through your browser:</p>
+								<CopyField
+									label="Codex login command"
+									value="codex mcp login marimohub"
+									hideLabel
+								/>
+							</TabPanel>
+							<TabPanel id="OpenCode" className={panelClassName}>
+								<p>
+									Merge this server configuration into your <code>opencode.json</code>:
+								</p>
+								<OpenCodeConfig url={url} />
+								<p>Then run this command to sign in:</p>
+								<CopyField
+									label="OpenCode login command"
+									value="opencode mcp auth marimohub"
+									hideLabel
+								/>
+							</TabPanel>
+							<TabPanel id="Other" className={panelClassName}>
+								<p>
+									Add a remote MCP server named <code>marimohub</code> with the URL above.
+								</p>
+								<p>
+									Select Streamable HTTP as the transport and OAuth as the authentication method.
+									Connect the server to sign in through your browser.
+								</p>
+								<p className="text-muted-foreground">
+									Your client must support OAuth with dynamic client registration. Manually created
+									API tokens cannot authenticate to this MCP server.
+								</p>
+							</TabPanel>
+						</Tabs>
+						<p className="border-t pt-4 text-xs text-muted-foreground">
+							When you sign in, choose which actions and projects the client can access. You can
+							revoke access from API tokens.
+						</p>
+					</>
+				) : (
+					<output className="text-muted-foreground">
+						{isError
+							? 'Could not load MCP settings. Close this dialog and try again.'
+							: isPending
+								? 'Loading MCP settings…'
+								: 'MCP is not available on this deployment.'}
+					</output>
+				)}
+				<a
+					href={DOCS_MCP_URL}
+					target="_blank"
+					rel="noreferrer"
+					className="text-xs text-primary underline-offset-2 hover:underline"
+				>
+					MCP documentation
+				</a>
+			</div>
+		</DialogModal>
+	);
+}

--- a/packages/web/src/components/Header/Header.test.tsx
+++ b/packages/web/src/components/Header/Header.test.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from '@/context/ThemeContext';
 import { installMatchMedia, jsonOk, renderWithClient } from '@/test/render';
 import { Header } from './Header';
 
+const MCP_URL = 'https://hub.example.com/team/mcp';
+
 const USER = { id: 'usr-123', email: 'ada@example.com' };
 
 function LocationProbe() {
@@ -18,14 +20,17 @@ function LocationProbe() {
  * be stubbed afterwards or the copy silently succeeds against user-event's stub.
  */
 function setup(
-	writeText: () => Promise<void> = () => Promise.resolve(),
+	writeText: (value: string) => Promise<void> = () => Promise.resolve(),
 	me: Record<string, unknown> = USER,
+	mcpAvailable = false,
 ) {
 	installMatchMedia(false);
 	vi.stubGlobal(
 		'fetch',
 		vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 			const url = String(input);
+			if (url === '/api/v1/capabilities')
+				return jsonOk({ mcp: { available: mcpAvailable, url: mcpAvailable ? MCP_URL : null } });
 			if (url === '/api/v1/me') return jsonOk(me);
 			if (url === '/api/v1/me/tokens') return jsonOk([]);
 			if (url === '/api/v1/projects') return jsonOk({ items: [], next_cursor: null });
@@ -133,7 +138,7 @@ describe('Header', () => {
 	});
 
 	it('opens the API tokens dialog from the menu', async () => {
-		const { user } = setup();
+		const { user } = setup(undefined, USER, true);
 		expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 		await openUserMenu(user);
 
@@ -142,6 +147,50 @@ describe('Header', () => {
 		await waitFor(() =>
 			expect(screen.getByRole('heading', { name: 'API tokens' })).toBeInTheDocument(),
 		);
+		expect(screen.queryByLabelText('MCP server URL')).not.toBeInTheDocument();
+	});
+
+	it('connects clients from the dedicated MCP dialog', async () => {
+		const { user, clipboard } = setup(undefined, USER, true);
+		await openUserMenu(user);
+		await user.click(await screen.findByRole('menuitem', { name: 'MCP' }));
+		expect(await screen.findByRole('heading', { name: 'Connect with MCP' })).toBeInTheDocument();
+		const installLink = new URL(
+			screen.getByRole('link', { name: 'Add to Cursor' }).getAttribute('href')!,
+		);
+		expect(installLink.protocol).toBe('cursor:');
+		expect(installLink.searchParams.get('name')).toBe('marimohub');
+		expect(JSON.parse(atob(installLink.searchParams.get('config')!))).toEqual({ url: MCP_URL });
+		await user.click(screen.getByRole('button', { name: 'Copy mcp server url' }));
+		expect(clipboard).toHaveBeenLastCalledWith(MCP_URL);
+
+		await user.click(screen.getByRole('tab', { name: 'Claude' }));
+		await user.click(screen.getByRole('button', { name: 'Copy claude code command' }));
+		expect(clipboard).toHaveBeenLastCalledWith(
+			`claude mcp add --transport http --scope user marimohub '${MCP_URL}'`,
+		);
+
+		await user.click(screen.getByRole('tab', { name: 'Codex' }));
+		expect(screen.getByLabelText('Codex command')).toHaveValue(
+			`codex mcp add marimohub --url '${MCP_URL}'`,
+		);
+		expect(screen.getByLabelText('Codex login command')).toHaveValue('codex mcp login marimohub');
+
+		await user.click(screen.getByRole('tab', { name: 'OpenCode' }));
+		await user.click(screen.getByRole('button', { name: 'Copy configuration' }));
+		expect(JSON.parse(clipboard.mock.calls.at(-1)![0])).toEqual({
+			mcp: { marimohub: { type: 'remote', url: MCP_URL } },
+		});
+		await user.click(screen.getByRole('tab', { name: 'OpenCode' }));
+		await user.keyboard('{ArrowRight}');
+		expect(screen.getByRole('tab', { name: 'Other' })).toHaveAttribute('aria-selected', 'true');
+		expect(screen.getByRole('tabpanel')).toHaveTextContent('Streamable HTTP');
+	});
+
+	it('hides MCP when the deployment does not support it', async () => {
+		const { user } = setup();
+		await openUserMenu(user);
+		expect(screen.queryByRole('menuitem', { name: 'MCP' })).not.toBeInTheDocument();
 	});
 
 	it('toggles the theme', async () => {

--- a/packages/web/src/components/Header/Header.tsx
+++ b/packages/web/src/components/Header/Header.tsx
@@ -1,12 +1,14 @@
 import { Link, useNavigate } from 'react-router-dom';
 import { MenuTrigger, Button, Popover, Menu, MenuItem, Separator } from 'react-aria-components';
-import { ChevronDown, Copy, KeyRound, Moon, Puzzle, Shield, Sun } from 'lucide-react';
+import { ChevronDown, Copy, KeyRound, Moon, Plug, Puzzle, Shield, Sun } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@/context/AuthContext';
 import { useTheme } from '@/context/ThemeContext';
 import { Brand, UserAvatar } from '@/components/ui';
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard';
 import { useDisclosure } from '@/hooks/useDisclosure';
+import { useCapabilitiesQuery } from '@/api/hooks';
+import { McpDialog } from '@/components/Account/McpDialog';
 import { ApiTokensDialog } from '@/components/Account/ApiTokensDialog';
 import { OrgIntegrationsDialog } from '@/components/Project/ProjectIntegrationsDialog';
 
@@ -15,6 +17,8 @@ export function Header() {
 	const { user, signOut } = useAuth();
 	const { theme, toggleTheme } = useTheme();
 	const tokensDialog = useDisclosure();
+	const mcpDialog = useDisclosure();
+	const { data: capabilities } = useCapabilitiesQuery(!!user);
 	const orgIntegrationsDialog = useDisclosure();
 	const { copy } = useCopyToClipboard();
 
@@ -61,6 +65,7 @@ export function Header() {
 									else if (key === 'copy-id') {
 										void copy(user.id).then((ok) => ok && toast.success('User id copied'));
 									} else if (key === 'api-tokens') tokensDialog.open();
+									else if (key === 'mcp') mcpDialog.open();
 									else if (key === 'org-integrations') orgIntegrationsDialog.open();
 									else if (key === 'admin') void navigate('/admin/users');
 								}}
@@ -90,6 +95,15 @@ export function Header() {
 									<KeyRound className="size-3.5" />
 									API tokens
 								</MenuItem>
+								{capabilities?.mcp?.available && capabilities.mcp.url ? (
+									<MenuItem
+										id="mcp"
+										className="flex cursor-pointer items-center gap-2 px-3 py-2 text-[13px] outline-none transition-colors focus:bg-muted max-md:min-h-11"
+									>
+										<Plug className="size-3.5" />
+										MCP
+									</MenuItem>
+								) : null}
 								{user.is_super_admin && (
 									<MenuItem
 										id="org-integrations"
@@ -122,6 +136,7 @@ export function Header() {
 			</div>
 
 			<ApiTokensDialog isOpen={tokensDialog.isOpen} onClose={tokensDialog.close} />
+			<McpDialog isOpen={mcpDialog.isOpen} onClose={mcpDialog.close} />
 			<OrgIntegrationsDialog
 				isOpen={orgIntegrationsDialog.isOpen}
 				onClose={orgIntegrationsDialog.close}


### PR DESCRIPTION
Move MCP setup out of API tokens into a dedicated dialog beside it in the user menu. Add tabs for Cursor, Claude, Codex, OpenCode, and other clients, with a Cursor install link, copyable commands and configuration, and OAuth instructions.

Show the menu item only when MCP is available, and update the documentation to point to the new dialog.
