### PR TITLE
feat(compute-kubernetes): expose secondary surface ports

### DIFF
--- a/charts/marimohub/values.yaml
+++ b/charts/marimohub/values.yaml
@@ -52,6 +52,8 @@ compute:
   profileOverride: none
 
 surfaces:
+  # On the kubernetes compute backend, enabling a surface needs the sandbox Ingress
+  # wildcard host/cert to also cover the per-port `{id}-{port}.{host}` subdomain.
   # Use a published `-vscode`, `-opencode`, or `-tools` sandbox image tag.
   sandboxImage: ''
   vscode:

--- a/docs/setup/compute/kubernetes.md
+++ b/docs/setup/compute/kubernetes.md
@@ -6,7 +6,9 @@ the cluster is ready:
 1. **Bake the client in:** `pnpm add @kubernetes/client-node` (bring-your-own
    dependency) and rebuild your server image.
 2. **Grant RBAC:** marimohub's ServiceAccount needs `pods` and `services` in the
-   kernel namespace. Subdomain exposure also needs `ingresses`.
+   kernel namespace (`services` includes `update`, so a reconnect can reconcile
+   the Service's ports — add it when upgrading). Subdomain exposure also needs
+   `ingresses`.
 3. **For subdomain exposure, configure ingress + TLS:** an ingress controller, a
    `*.{host}` DNS record, and either a matching wildcard TLS secret or an
    ingress-controller default certificate so each `{id}.{host}` kernel URL is

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -42,10 +42,14 @@ another surface.
 ## Availability
 
 The compute adapter must expose multiple ports from one sandbox. The `local`,
-`e2b`, `cloudflare`, and `coreweave` adapters support this feature. Configuration
-fails for other adapters. Docker, Podman, Kubernetes, and Modal need create-time
+`e2b`, `cloudflare`, `coreweave`, and `kubernetes` adapters support this feature.
+Configuration fails for other adapters. Docker, Podman, and Modal need create-time
 port reservation support. W&B runs on the CoreWeave adapter but is not yet wired
 to reserve surface ports.
+
+On kubernetes with subdomain exposure each port gets its own `{id}-{port}.{host}`
+Ingress host, so the `*.{host}` wildcard DNS record and TLS certificate must cover
+it.
 
 Port 2718 belongs to marimo. Each secondary surface must use a unique port. If
 an image lacks a required binary, only that surface becomes unavailable.

--- a/examples/kubernetes/rbac.yaml
+++ b/examples/kubernetes/rbac.yaml
@@ -24,8 +24,13 @@ metadata:
   namespace: marimo-kernels
 rules:
   - apiGroups: ['']
-    resources: ['pods', 'services']
+    resources: ['pods']
     verbs: ['create', 'get', 'list', 'watch', 'delete']
+  # `update` on services: a reconnect reconciles the Service so it picks up
+  # newly reserved surface ports rather than 409-ing on the re-create.
+  - apiGroups: ['']
+    resources: ['services']
+    verbs: ['create', 'get', 'list', 'watch', 'update', 'delete']
   - apiGroups: ['']
     resources: ['pods/exec']
     verbs: ['create', 'get']

--- a/packages/compute-coreweave/src/index.test.ts
+++ b/packages/compute-coreweave/src/index.test.ts
@@ -1168,6 +1168,11 @@ computeContract(
 				},
 				startImpl: async (command) => contractLaunchProcess(command) ?? fakeProcess(),
 			}),
+			{ ...baseConfig, extraPorts: [8443] },
 		),
-	{ mountFallsBack: true, semantics: { failingCommand: 'mh-contract-fail', launch: {} } },
+	{
+		mountFallsBack: true,
+		secondaryPort: 8443,
+		semantics: { failingCommand: 'mh-contract-fail', launch: {} },
+	},
 );

--- a/packages/compute-e2b/src/index.test.ts
+++ b/packages/compute-e2b/src/index.test.ts
@@ -903,6 +903,7 @@ computeContract(
 	},
 	{
 		mountFallsBack: true,
+		secondaryPort: 8443,
 		semantics: {
 			failingCommand: 'mh-contract-fail',
 			launch: {},

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -10,6 +10,8 @@ const k8sMock = vi.hoisted(() => {
 	const core = {
 		createNamespacedPod: vi.fn(),
 		createNamespacedService: vi.fn(),
+		readNamespacedService: vi.fn(),
+		replaceNamespacedService: vi.fn(),
 		readNamespacedPod: vi.fn(),
 		listNamespacedEvent: vi.fn(),
 		deleteNamespacedService: vi.fn(),
@@ -69,6 +71,8 @@ beforeEach(() => {
 	for (const fn of [
 		k8sMock.core.createNamespacedPod,
 		k8sMock.core.createNamespacedService,
+		k8sMock.core.readNamespacedService,
+		k8sMock.core.replaceNamespacedService,
 		k8sMock.core.readNamespacedPod,
 		k8sMock.core.listNamespacedEvent,
 		k8sMock.core.deleteNamespacedService,
@@ -270,6 +274,47 @@ describe('createK8sClient', () => {
 					finalizers: ['controller.example/finalizer'],
 				}),
 				spec: expect.objectContaining({ tls: [{}] }),
+			}),
+		});
+	});
+
+	it('reconciles an existing managed service so a reconnect gains new surface ports', async () => {
+		k8sMock.core.createNamespacedService.mockRejectedValueOnce({ code: 409 });
+		k8sMock.core.readNamespacedService.mockResolvedValueOnce({
+			metadata: {
+				name: 'mh-sb',
+				resourceVersion: '9',
+				labels: { [MANAGED_BY_LABEL]: MANAGED_BY_VALUE },
+			},
+			spec: { clusterIP: '10.0.0.7', clusterIPs: ['10.0.0.7'], ports: [{ port: 2718 }] },
+		});
+		const client = createK8sClient({ namespace: 'kernels' });
+
+		await client.ensure({
+			name: 'mh-sb',
+			sandboxId: SANDBOX_ID,
+			image: 'kernel-image:v1',
+			ports: [
+				{ port: 2718, host: 'sb.example.com' },
+				{ port: 8443, host: 'sb-8443.example.com' },
+			],
+			namespace: 'kernels',
+		});
+
+		expect(k8sMock.core.readNamespacedService).toHaveBeenCalledWith({
+			name: 'mh-sb',
+			namespace: 'kernels',
+		});
+		expect(k8sMock.core.replaceNamespacedService).toHaveBeenCalledWith({
+			name: 'mh-sb',
+			namespace: 'kernels',
+			body: expect.objectContaining({
+				metadata: expect.objectContaining({ resourceVersion: '9' }),
+				spec: expect.objectContaining({
+					// clusterIP carried forward (immutable); ports now include the surface.
+					clusterIP: '10.0.0.7',
+					ports: [expect.objectContaining({ port: 2718 }), expect.objectContaining({ port: 8443 })],
+				}),
 			}),
 		});
 	});

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -95,9 +95,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: 'sb.example.com',
 				image: 'kernel-image:v1',
-				port: 2718,
+				ports: [{ port: 2718, host: 'sb.example.com' }],
 				namespace: 'kernels',
 				ingressClassName: 'nginx',
 				ingressAnnotations: {
@@ -131,7 +130,7 @@ describe('createK8sClient', () => {
 						image: 'kernel-image:v1',
 						// Pinned tag → cached nodes skip the registry round-trip.
 						imagePullPolicy: 'IfNotPresent',
-						ports: [{ containerPort: 2718 }],
+						ports: [{ containerPort: 2718, name: 'kernel' }],
 						resources: {
 							requests: { cpu: '2', memory: '4Gi' },
 							limits: { 'nvidia.com/gpu': '1' },
@@ -157,14 +156,70 @@ describe('createK8sClient', () => {
 		expect(k8sMock.net.replaceNamespacedIngress).not.toHaveBeenCalled();
 	});
 
+	it('names every port and routes a rule per hosted port with multiple surfaces', async () => {
+		const client = createK8sClient({ namespace: 'kernels' });
+		await client.ensure({
+			name: 'mh-sb',
+			sandboxId: SANDBOX_ID,
+			image: 'kernel-image:v1',
+			ports: [
+				{ port: 2718, host: 'sb-2718.example.com' },
+				{ port: 8443, host: 'sb-8443.example.com' },
+			],
+			namespace: 'kernels',
+			ingressClassName: 'nginx',
+			tlsSecretName: 'wildcard-cert',
+		});
+
+		const pod = k8sMock.core.createNamespacedPod.mock.calls[0]?.[0].body;
+		expect(pod.spec.containers[0].ports).toEqual([
+			{ containerPort: 2718, name: 'kernel' },
+			{ containerPort: 8443, name: 'port-8443' },
+		]);
+		const service = k8sMock.core.createNamespacedService.mock.calls[0]?.[0].body;
+		expect(service.spec.ports).toEqual([
+			{ name: 'kernel', port: 2718, targetPort: 2718, protocol: 'TCP' },
+			{ name: 'port-8443', port: 8443, targetPort: 8443, protocol: 'TCP' },
+		]);
+		const ingress = k8sMock.net.createNamespacedIngress.mock.calls[0]?.[0].body;
+		expect(ingress.spec.tls).toEqual([
+			{ hosts: ['sb-2718.example.com', 'sb-8443.example.com'], secretName: 'wildcard-cert' },
+		]);
+		expect(ingress.spec.rules).toEqual([
+			{
+				host: 'sb-2718.example.com',
+				http: {
+					paths: [
+						{
+							path: '/',
+							pathType: 'Prefix',
+							backend: { service: { name: 'mh-sb', port: { number: 2718 } } },
+						},
+					],
+				},
+			},
+			{
+				host: 'sb-8443.example.com',
+				http: {
+					paths: [
+						{
+							path: '/',
+							pathType: 'Prefix',
+							backend: { service: { name: 'mh-sb', port: { number: 8443 } } },
+						},
+					],
+				},
+			},
+		]);
+	});
+
 	it('preserves the legacy default alias for the ingress-controller certificate', async () => {
 		const client = createK8sClient({ namespace: 'kernels' });
 		await client.ensure({
 			name: 'mh-sb',
 			sandboxId: SANDBOX_ID,
-			host: 'sb.example.com',
 			image: 'kernel-image:v1',
-			port: 2718,
+			ports: [{ port: 2718, host: 'sb.example.com' }],
 			namespace: 'kernels',
 			ingressTlsMode: 'default',
 		});
@@ -190,9 +245,8 @@ describe('createK8sClient', () => {
 		await client.ensure({
 			name: 'mh-sb',
 			sandboxId: SANDBOX_ID,
-			host: 'sb.example.com',
 			image: 'kernel-image:v1',
-			port: 2718,
+			ports: [{ port: 2718, host: 'sb.example.com' }],
 			namespace: 'kernels',
 			ingressAnnotations: { 'route.openshift.io/termination': 'edge' },
 			ingressTlsMode: 'controller-default',
@@ -231,9 +285,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: 'sb.example.com',
 				image: 'kernel-image:v1',
-				port: 2718,
+				ports: [{ port: 2718, host: 'sb.example.com' }],
 				namespace: 'kernels',
 			}),
 		).rejects.toThrow(/unmanaged Ingress/);
@@ -251,9 +304,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: 'sb.example.com',
 				image: 'kernel-image:v1',
-				port: 2718,
+				ports: [{ port: 2718, host: 'sb.example.com' }],
 				namespace: 'kernels',
 			}),
 		).rejects.toThrow(/has no resourceVersion/);
@@ -284,9 +336,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: 'sb.example.com',
 				image: 'kernel-image:v1',
-				port: 2718,
+				ports: [{ port: 2718, host: 'sb.example.com' }],
 				namespace: 'kernels',
 			}),
 		).resolves.toEqual({ createdPod: true });
@@ -310,9 +361,8 @@ describe('createK8sClient', () => {
 		await client.ensure({
 			name: 'mh-sb',
 			sandboxId: SANDBOX_ID,
-			host: 'sb.example.com',
 			image: 'kernel-image:v1',
-			port: 2718,
+			ports: [{ port: 2718, host: 'sb.example.com' }],
 			namespace: 'kernels',
 			ingressTlsMode: 'disabled',
 		});
@@ -332,9 +382,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: 'sb.example.com',
 				image: 'kernel-image:v1',
-				port: 2718,
+				ports: [{ port: 2718, host: 'sb.example.com' }],
 				namespace: 'kernels',
 				ingressAnnotations: { [key]: 'value' },
 			}),
@@ -350,9 +399,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: 'sb.example.com',
 				image: 'kernel-image:v1',
-				port: 2718,
+				ports: [{ port: 2718, host: 'sb.example.com' }],
 				namespace: 'kernels',
 				ingressAnnotations: { name: 'x'.repeat(256 * 1024) },
 			}),
@@ -365,9 +413,8 @@ describe('createK8sClient', () => {
 		await client.ensure({
 			name: 'mh-sb',
 			sandboxId: SANDBOX_ID,
-			host: 'sb.example.com',
 			image: 'kernel-image:v1',
-			port: 2718,
+			ports: [{ port: 2718, host: 'sb.example.com' }],
 			namespace: 'kernels',
 			ingressTlsMode: 'disabled',
 		});
@@ -382,9 +429,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: 'sb.example.com',
 				image: 'kernel-image:v1',
-				port: 2718,
+				ports: [{ port: 2718, host: 'sb.example.com' }],
 				namespace: 'kernels',
 				ingressTlsMode: 'secret',
 			}),
@@ -400,9 +446,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: '',
 				image: 'kernel-image',
-				port: 2718,
+				ports: [{ port: 2718, host: '' }],
 				namespace: 'default',
 			}),
 		).resolves.toEqual({ createdPod: true });
@@ -415,9 +460,8 @@ describe('createK8sClient', () => {
 		await client.ensure({
 			name: 'mh-sb',
 			sandboxId: SANDBOX_ID,
-			host: '',
 			image: 'kernel-image:v1',
-			port: 2718,
+			ports: [{ port: 2718, host: '' }],
 			namespace: 'default',
 			imagePullPolicy: 'Always',
 		});
@@ -433,9 +477,8 @@ describe('createK8sClient', () => {
 		await client.ensure({
 			name: 'mh-sb',
 			sandboxId: SANDBOX_ID,
-			host: '',
 			image: 'ghcr.io/marimo-team/marimo:latest',
-			port: 2718,
+			ports: [{ port: 2718, host: '' }],
 			namespace: 'default',
 		});
 		const pod = k8sMock.core.createNamespacedPod.mock.calls[0]?.[0].body;
@@ -455,9 +498,8 @@ describe('createK8sClient', () => {
 		await client.ensure({
 			name: 'mh-sb',
 			sandboxId: SANDBOX_ID,
-			host: '',
 			image: 'kernel-image',
-			port: 2718,
+			ports: [{ port: 2718, host: '' }],
 			namespace: 'default',
 			resources: {
 				cpu: '2',
@@ -701,9 +743,8 @@ describe('createK8sClient', () => {
 			client.ensure({
 				name: 'mh-sb',
 				sandboxId: SANDBOX_ID,
-				host: '',
 				image: 'kernel-image',
-				port: 2718,
+				ports: [{ port: 2718, host: '' }],
 				namespace: 'kernels',
 			}),
 		).rejects.toMatchObject({ code: 403 });

--- a/packages/compute-kubernetes/src/client.ts
+++ b/packages/compute-kubernetes/src/client.ts
@@ -311,6 +311,43 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 		}
 	}
 
+	async function reconcileService(core: K8s.CoreV1Api, desired: V1Service): Promise<void> {
+		try {
+			await core.createNamespacedService({ namespace, body: desired });
+			return;
+		} catch (err) {
+			if (!hasCode(err, 409)) throw err;
+		}
+
+		const metadata = desired.metadata;
+		const name = metadata?.name;
+		if (!metadata || !name) throw new Error('Cannot reconcile a Service without a name');
+		const desiredLabels = metadata.labels;
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const existing = await core.readNamespacedService({ name, namespace });
+			if (existing.metadata?.labels?.[MANAGED_BY_LABEL] !== MANAGED_BY_VALUE) {
+				throw new Error(`Refusing to replace unmanaged Service "${name}"`);
+			}
+			const resourceVersion = existing.metadata.resourceVersion;
+			if (!resourceVersion) throw new Error(`Service "${name}" has no resourceVersion`);
+			metadata.resourceVersion = resourceVersion;
+			metadata.labels = { ...existing.metadata.labels, ...desiredLabels };
+			metadata.finalizers = existing.metadata.finalizers;
+			metadata.ownerReferences = existing.metadata.ownerReferences;
+			// clusterIP is immutable; a replace must carry the assigned value forward.
+			if (desired.spec) {
+				desired.spec.clusterIP = existing.spec?.clusterIP;
+				desired.spec.clusterIPs = existing.spec?.clusterIPs;
+			}
+			try {
+				await core.replaceNamespacedService({ name, namespace, body: desired });
+				return;
+			} catch (err) {
+				if (!hasCode(err, 409) || attempt === 2) throw err;
+			}
+		}
+	}
+
 	return {
 		async ensure(o: EnsureSandboxOptions): Promise<{ createdPod: boolean }> {
 			const pod = podManifest(o);
@@ -318,11 +355,12 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 			const ingress = o.ports.some((p) => p.host) ? ingressManifest(o) : undefined;
 			const { core, net } = await apis();
 			// Order-independent: k8s is declarative (a Service's selector / an
-			// Ingress's backend need not pre-exist), so the creates fan out.
+			// Ingress's backend need not pre-exist), so the creates fan out. The
+			// Service and Ingress reconcile so a reconnect picks up newly reserved
+			// surface ports rather than swallowing the create conflict.
 			const [createdPod] = await Promise.all([
 				createTolerant(() => core.createNamespacedPod({ namespace, body: pod })),
-				createTolerant(() => core.createNamespacedService({ namespace, body: service })),
-				// No hosted port → no Ingress (the URL will be unroutable; documented).
+				reconcileService(core, service),
 				ingress ? reconcileIngress(net, ingress) : undefined,
 			]);
 			return { createdPod };

--- a/packages/compute-kubernetes/src/client.ts
+++ b/packages/compute-kubernetes/src/client.ts
@@ -27,6 +27,7 @@ import {
 	defaultImagePullPolicy,
 	MANAGED_BY_LABEL,
 	MANAGED_BY_VALUE,
+	portName,
 	resolveIngressTlsMode,
 	SANDBOX_ID_ANNOTATION,
 	validateIngressAnnotations,
@@ -126,7 +127,7 @@ function podManifest(o: EnsureSandboxOptions): V1Pod {
 					// Keep-alive: the Pod idles while we exec marimo into it (see
 					// startProcess). Mirrors the CoreWeave "main process is keep-alive".
 					command: ['sh', '-c', 'sleep infinity'],
-					ports: [{ containerPort: o.port }],
+					ports: o.ports.map((p, i) => ({ containerPort: p.port, name: portName(i, p.port) })),
 					resources: buildResources(o.resources),
 				},
 			],
@@ -143,7 +144,13 @@ function serviceManifest(o: EnsureSandboxOptions): V1Service {
 		},
 		spec: {
 			selector: { [SANDBOX_NAME_LABEL]: o.name },
-			ports: [{ port: o.port, targetPort: o.port, protocol: 'TCP' }],
+			// A Service with more than one port requires a unique name on each.
+			ports: o.ports.map((p, i) => ({
+				name: portName(i, p.port),
+				port: p.port,
+				targetPort: p.port,
+				protocol: 'TCP',
+			})),
 		},
 	};
 }
@@ -153,7 +160,8 @@ function ingressTls(o: EnsureSandboxOptions): V1IngressTLS[] | undefined {
 	if (mode === 'disabled') return undefined;
 	if (mode === 'controller-default') return [{}];
 	if (!o.tlsSecretName) throw new Error('Ingress TLS mode "secret" requires a TLS secret name');
-	return [{ hosts: [o.host], secretName: o.tlsSecretName }];
+	const hosts = [...new Set(o.ports.filter((p) => p.host).map((p) => p.host))];
+	return [{ hosts, secretName: o.tlsSecretName }];
 }
 
 function ingressManifest(o: EnsureSandboxOptions): V1Ingress {
@@ -167,20 +175,20 @@ function ingressManifest(o: EnsureSandboxOptions): V1Ingress {
 		spec: {
 			ingressClassName: o.ingressClassName,
 			tls: ingressTls(o),
-			rules: [
-				{
-					host: o.host,
+			rules: o.ports
+				.filter((p) => p.host)
+				.map((p) => ({
+					host: p.host,
 					http: {
 						paths: [
 							{
 								path: '/',
 								pathType: 'Prefix',
-								backend: { service: { name: o.name, port: { number: o.port } } },
+								backend: { service: { name: o.name, port: { number: p.port } } },
 							},
 						],
 					},
-				},
-			],
+				})),
 		},
 	};
 }
@@ -307,14 +315,14 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 		async ensure(o: EnsureSandboxOptions): Promise<{ createdPod: boolean }> {
 			const pod = podManifest(o);
 			const service = serviceManifest(o);
-			const ingress = o.host ? ingressManifest(o) : undefined;
+			const ingress = o.ports.some((p) => p.host) ? ingressManifest(o) : undefined;
 			const { core, net } = await apis();
 			// Order-independent: k8s is declarative (a Service's selector / an
 			// Ingress's backend need not pre-exist), so the creates fan out.
 			const [createdPod] = await Promise.all([
 				createTolerant(() => core.createNamespacedPod({ namespace, body: pod })),
 				createTolerant(() => core.createNamespacedService({ namespace, body: service })),
-				// No host configured → no Ingress (the URL will be unroutable; documented).
+				// No hosted port → no Ingress (the URL will be unroutable; documented).
 				ingress ? reconcileIngress(net, ingress) : undefined,
 			]);
 			return { createdPod };

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -200,15 +200,33 @@ describe('KubernetesCompute', () => {
 			});
 		});
 
-		it('rejects a custom subdomain template without {port} when surfaces are set', () => {
+		it('rejects a subdomain template whose ports share one Ingress host', () => {
+			const world = makeWorld();
+			// {port} absent from the host, and {port} only in the path, both collide.
+			for (const hostnameTemplate of ['https://{id}.{host}', 'https://{id}.{host}/{port}']) {
+				expect(() =>
+					makeCompute(world, { ...baseConfig, surfacePorts: [8443], hostnameTemplate }),
+				).toThrow(/distinct destination/);
+			}
+		});
+
+		it('rejects a proxy template with a hardcoded port when surfaces are set', () => {
 			const world = makeWorld();
 			expect(() =>
 				makeCompute(world, {
 					...baseConfig,
+					exposureMode: 'proxy',
 					surfacePorts: [8443],
-					hostnameTemplate: 'https://{id}.{host}',
+					hostnameTemplate: 'http://mh-{id}.ns.svc.cluster.local:2718',
 				}),
-			).toThrow(/\{port\}/);
+			).toThrow(/distinct destination/);
+		});
+
+		it('accepts the proxy default template, which carries {port} per destination', () => {
+			const world = makeWorld();
+			expect(() =>
+				makeCompute(world, { ...baseConfig, exposureMode: 'proxy', surfacePorts: [8443] }),
+			).not.toThrow();
 		});
 
 		it('reserves each surface port with its own per-port Ingress host', async () => {

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -191,6 +191,61 @@ describe('KubernetesCompute', () => {
 		).not.toThrow();
 	});
 
+	describe('secondary surface ports', () => {
+		it('advertises multiPort exactly when surface ports are configured', () => {
+			const world = makeWorld();
+			expect(makeCompute(world, baseConfig).capabilities).toEqual({ multiPort: false });
+			expect(makeCompute(world, { ...baseConfig, surfacePorts: [8443] }).capabilities).toEqual({
+				multiPort: true,
+			});
+		});
+
+		it('rejects a custom subdomain template without {port} when surfaces are set', () => {
+			const world = makeWorld();
+			expect(() =>
+				makeCompute(world, {
+					...baseConfig,
+					surfacePorts: [8443],
+					hostnameTemplate: 'https://{id}.{host}',
+				}),
+			).toThrow(/\{port\}/);
+		});
+
+		it('reserves each surface port with its own per-port Ingress host', async () => {
+			const world = makeWorld();
+			await makeCompute(world, { ...baseConfig, surfacePorts: [8443] })
+				.create(SANDBOX_ID)
+				.exec('true');
+			expect(world.ensured[0].ports).toEqual([
+				{ port: 2718, host: 'sb-abc-2718.hub.example.com' },
+				{ port: 8443, host: 'sb-abc-8443.hub.example.com' },
+			]);
+		});
+
+		it('exposes distinct URLs per port and honours the port argument', async () => {
+			const world = makeWorld();
+			const inst = makeCompute(world, { ...baseConfig, surfacePorts: [8443] }).create(SANDBOX_ID);
+			const kernel = await inst.exposePort(2718, { hostname: 'hub.example.com' });
+			const surface = await inst.exposePort(8443, { hostname: 'hub.example.com' });
+			expect(kernel.url).toBe('https://sb-abc-2718.hub.example.com');
+			expect(surface.url).toBe('https://sb-abc-8443.hub.example.com');
+			expect(kernel.url).not.toBe(surface.url);
+		});
+
+		it('exposes a surface port on the in-cluster Service in proxy mode', async () => {
+			const world = makeWorld();
+			const { url } = await makeCompute(world, {
+				...baseConfig,
+				exposureMode: 'proxy',
+				namespace: 'marimo-sandboxes',
+				surfacePorts: [8443],
+			})
+				.create(SANDBOX_ID)
+				.exposePort(8443, { hostname: 'hub.example.com' });
+			expect(url).toBe('http://mh-sb-abc.marimo-sandboxes.svc.cluster.local:8443');
+		});
+	});
+
 	describe('exec()', () => {
 		it('runs user commands in a login shell (profile-provided PATH keeps working)', async () => {
 			const world = makeWorld();
@@ -245,9 +300,8 @@ describe('KubernetesCompute', () => {
 				name: NAME,
 				sandboxId: SANDBOX_ID,
 				image: 'my-image',
-				port: 2718,
 				namespace: 'default',
-				host: 'sb-abc.hub.example.com',
+				ports: [{ port: 2718, host: 'sb-abc.hub.example.com' }],
 			});
 		});
 
@@ -701,7 +755,7 @@ describe('KubernetesCompute', () => {
 				url: 'http://mh-sb-abc-123.marimo-sandboxes.svc.cluster.local:2718',
 			});
 			expect(world.ensured).toHaveLength(1);
-			expect(world.ensured[0]?.host).toBe('');
+			expect(world.ensured[0]?.ports.every((p) => p.host === '')).toBe(true);
 
 			await inst.destroy();
 			expect(world.deleteIngress).toEqual([false]);
@@ -719,7 +773,7 @@ describe('KubernetesCompute', () => {
 				.exposePort(2718, { hostname: 'hub.example.com' });
 
 			expect(url).toBe('http://mh-sb-abc.marimo-sandboxes.svc.cluster.local:2718');
-			expect(world.ensured[0]?.host).toBe('');
+			expect(world.ensured[0]?.ports.every((p) => p.host === '')).toBe(true);
 		});
 
 		it('substitutes the Service name and namespace in a proxy template', async () => {
@@ -754,7 +808,7 @@ describe('KubernetesCompute', () => {
 			const inst = makeCompute(world, { ...baseConfig, hostname: undefined }).create(SANDBOX_ID);
 
 			await inst.exec('true');
-			expect(world.ensured[0]?.host).toBe('');
+			expect(world.ensured[0]?.ports.every((p) => p.host === '')).toBe(true);
 
 			await inst.destroy();
 			expect(world.deleteIngress).toEqual([true]);
@@ -1003,7 +1057,8 @@ computeContract(
 					return;
 				},
 			}),
+			{ ...baseConfig, surfacePorts: [8443] },
 		);
 	},
-	{ mountFallsBack: true, semantics: { failingCommand: 'false', launch: {} } },
+	{ mountFallsBack: true, secondaryPort: 8443, semantics: { failingCommand: 'false', launch: {} } },
 );

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -178,6 +178,74 @@ export function resourceName(id: SandboxId): string {
 	return `mh-${slug || 'sandbox'}`;
 }
 
+/** The hostname template in effect, applying the mode/surface-aware defaults. */
+function hostnameTemplate(config: KubernetesConfig): string {
+	if (config.hostnameTemplate) return config.hostnameTemplate;
+	if ((config.exposureMode ?? 'subdomain') === 'proxy')
+		return 'http://{name}.{namespace}.svc.cluster.local:{port}';
+	return (config.surfacePorts?.length ?? 0) > 0
+		? 'https://{id}-{port}.{host}'
+		: 'https://{id}.{host}';
+}
+
+function renderHostname(
+	template: string,
+	vars: { id: string; name: string; namespace: string; host: string; token: string; port: number },
+): string {
+	return template
+		.replaceAll('{id}', vars.id)
+		.replaceAll('{name}', vars.name)
+		.replaceAll('{namespace}', vars.namespace)
+		.replaceAll('{port}', String(vars.port))
+		.replaceAll('{host}', vars.host)
+		.replaceAll('{token}', vars.token);
+}
+
+/**
+ * The first pair of reserved ports that resolve to the SAME routing destination —
+ * the Ingress host in subdomain mode, the full origin (host:port) in proxy mode — or
+ * `undefined` when every port routes distinctly. A `{port}` that only lands in the
+ * path, or a proxy template with a hardcoded port, collides a surface onto the kernel.
+ * Checked against the rendered URL, not the template text, so `config` validation and
+ * live routing can never diverge.
+ */
+export function portRoutingCollision(
+	config: KubernetesConfig,
+): { ports: [number, number]; destination: string } | undefined {
+	const proxy = (config.exposureMode ?? 'subdomain') === 'proxy';
+	if (!proxy && !config.hostname) return undefined; // subdomain without a host is unroutable
+	const template = hostnameTemplate(config);
+	const ports = [config.kernelPort ?? DEFAULT_KERNEL_PORT, ...(config.surfacePorts ?? [])];
+	const byDestination = new Map<string, number>();
+	for (const port of ports) {
+		const url = new URL(
+			renderHostname(template, {
+				id: 'sandbox',
+				name: 'service',
+				namespace: 'namespace',
+				host: config.hostname || 'host.invalid',
+				token: '',
+				port,
+			}),
+		);
+		const destination = proxy ? url.origin : url.host;
+		const clash = byDestination.get(destination);
+		if (clash !== undefined) return { ports: [clash, port], destination };
+		byDestination.set(destination, port);
+	}
+	return undefined;
+}
+
+function assertDistinctPortRouting(config: KubernetesConfig): void {
+	const collision = portRoutingCollision(config);
+	if (collision) {
+		const [a, b] = collision.ports;
+		throw new Error(
+			`A kubernetes hostname template must route each reserved port to a distinct destination, but ports ${a} and ${b} both resolve to ${collision.destination}`,
+		);
+	}
+}
+
 let PROC_SEQ = 0;
 
 class KubernetesSandboxInstance implements SandboxInstance {
@@ -227,20 +295,14 @@ class KubernetesSandboxInstance implements SandboxInstance {
 	}
 
 	private urlFrom(hostname: string, token: string, port: number): string {
-		const template =
-			this.config.hostnameTemplate ??
-			(this.config.exposureMode === 'proxy'
-				? 'http://{name}.{namespace}.svc.cluster.local:{port}'
-				: this.surfacePorts.length > 0
-					? 'https://{id}-{port}.{host}'
-					: 'https://{id}.{host}');
-		return template
-			.replaceAll('{id}', String(this.id))
-			.replaceAll('{name}', this.name)
-			.replaceAll('{namespace}', this.namespace)
-			.replaceAll('{port}', String(port))
-			.replaceAll('{host}', hostname)
-			.replaceAll('{token}', token);
+		return renderHostname(hostnameTemplate(this.config), {
+			id: String(this.id),
+			name: this.name,
+			namespace: this.namespace,
+			host: hostname,
+			token,
+			port,
+		});
 	}
 
 	/**
@@ -622,18 +684,10 @@ export class KubernetesCompute implements SandboxProvider {
 	) {
 		const surfaced = (config.surfacePorts?.length ?? 0) > 0;
 		if ((config.exposureMode ?? 'subdomain') === 'subdomain' && config.hostname) {
-			const template =
-				config.hostnameTemplate ??
-				(surfaced ? 'https://{id}-{port}.{host}' : 'https://{id}.{host}');
 			const tlsMode = resolveIngressTlsMode(config.ingressTlsMode, config.tlsSecretName);
-			validateIngressTlsHostnameTemplate(template, tlsMode);
-			// Every port shares one host without {port}, colliding on the same Ingress.
-			if (surfaced && !template.includes('{port}')) {
-				throw new Error(
-					'A kubernetes subdomain hostname template with secondary surfaces must include {port} so each port gets a distinct Ingress host',
-				);
-			}
+			validateIngressTlsHostnameTemplate(hostnameTemplate(config), tlsMode);
 		}
+		if (surfaced) assertDistinctPortRouting(config);
 		this.capabilities = { multiPort: surfaced };
 		this.client = client;
 	}

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -187,6 +187,7 @@ class KubernetesSandboxInstance implements SandboxInstance {
 	private readonly image: string;
 	private readonly hostname: string;
 	private readonly kernelPort: number;
+	private readonly surfacePorts: readonly number[];
 	private readonly subdomainExposure: boolean;
 	private resolved = false;
 	private env: Record<string, string> = {};
@@ -206,27 +207,38 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		this.image = config.image ?? DEFAULT_IMAGE;
 		this.hostname = config.hostname ?? '';
 		this.kernelPort = config.kernelPort ?? DEFAULT_KERNEL_PORT;
+		this.surfacePorts = config.surfacePorts ?? [];
 		this.subdomainExposure = (config.exposureMode ?? 'subdomain') === 'subdomain';
 	}
 
-	/** The per-session Ingress host, or empty when this deployment does not manage one. */
-	private ingressHost(): string {
+	/** The per-session Ingress host for a port, or empty when none is managed. */
+	private ingressHostFor(port: number): string {
 		if (!this.subdomainExposure || !this.hostname) return '';
 		// Reuse the URL template, then keep just its host component.
-		return new URL(this.urlFrom(this.hostname, '')).host;
+		return new URL(this.urlFrom(this.hostname, '', port)).host;
 	}
 
-	private urlFrom(hostname: string, token: string): string {
+	/** Kernel first, then each reserved surface port, with its Ingress host. */
+	private portSpecs(): { port: number; host: string }[] {
+		return [
+			{ port: this.kernelPort, host: this.ingressHostFor(this.kernelPort) },
+			...this.surfacePorts.map((port) => ({ port, host: this.ingressHostFor(port) })),
+		];
+	}
+
+	private urlFrom(hostname: string, token: string, port: number): string {
 		const template =
 			this.config.hostnameTemplate ??
 			(this.config.exposureMode === 'proxy'
 				? 'http://{name}.{namespace}.svc.cluster.local:{port}'
-				: 'https://{id}.{host}');
+				: this.surfacePorts.length > 0
+					? 'https://{id}-{port}.{host}'
+					: 'https://{id}.{host}');
 		return template
 			.replaceAll('{id}', String(this.id))
 			.replaceAll('{name}', this.name)
 			.replaceAll('{namespace}', this.namespace)
-			.replaceAll('{port}', String(this.kernelPort))
+			.replaceAll('{port}', String(port))
 			.replaceAll('{host}', hostname)
 			.replaceAll('{token}', token);
 	}
@@ -244,9 +256,8 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		const { createdPod } = await this.client.ensure({
 			name: this.name,
 			sandboxId: this.id,
-			host: this.ingressHost(),
+			ports: this.portSpecs(),
 			image: this.image,
-			port: this.kernelPort,
 			namespace: this.namespace,
 			ingressClassName: this.config.ingressClassName,
 			ingressAnnotations: this.config.ingressAnnotations,
@@ -586,11 +597,11 @@ class KubernetesSandboxInstance implements SandboxInstance {
 		});
 	}
 
-	async exposePort(_port: number, options: ExposePortOptions): Promise<ExposePortResult> {
+	async exposePort(port: number, options: ExposePortOptions): Promise<ExposePortResult> {
 		// Prefer the deploy-time hostname for subdomain routing. Proxy mode's default
 		// template does not use it and resolves the Service inside the cluster.
 		await this.ensure();
-		return { url: this.urlFrom(this.hostname || options.hostname, options.token ?? '') };
+		return { url: this.urlFrom(this.hostname || options.hostname, options.token ?? '', port) };
 	}
 
 	async destroy(): Promise<void> {
@@ -602,18 +613,28 @@ class KubernetesSandboxInstance implements SandboxInstance {
 }
 
 export class KubernetesCompute implements SandboxProvider {
-	readonly capabilities = { multiPort: false } as const;
+	readonly capabilities: { multiPort: boolean };
 	private client?: K8sClient;
 
 	constructor(
 		private readonly config: KubernetesConfig,
 		client?: K8sClient,
 	) {
+		const surfaced = (config.surfacePorts?.length ?? 0) > 0;
 		if ((config.exposureMode ?? 'subdomain') === 'subdomain' && config.hostname) {
-			const template = config.hostnameTemplate ?? 'https://{id}.{host}';
+			const template =
+				config.hostnameTemplate ??
+				(surfaced ? 'https://{id}-{port}.{host}' : 'https://{id}.{host}');
 			const tlsMode = resolveIngressTlsMode(config.ingressTlsMode, config.tlsSecretName);
 			validateIngressTlsHostnameTemplate(template, tlsMode);
+			// Every port shares one host without {port}, colliding on the same Ingress.
+			if (surfaced && !template.includes('{port}')) {
+				throw new Error(
+					'A kubernetes subdomain hostname template with secondary surfaces must include {port} so each port gets a distinct Ingress host',
+				);
+			}
 		}
+		this.capabilities = { multiPort: surfaced };
 		this.client = client;
 	}
 

--- a/packages/compute-kubernetes/src/shared.ts
+++ b/packages/compute-kubernetes/src/shared.ts
@@ -120,6 +120,15 @@ export function defaultImagePullPolicy(image: string): ImagePullPolicy {
 	return !tag || tag === 'latest' ? 'Always' : 'IfNotPresent';
 }
 
+/**
+ * Pod/Service port name: `kernel` for the first (kernel) port, `port-<n>` after.
+ * Kubernetes requires a name on every Service port once a Service has more than
+ * one; must stay a DNS-1123 label (≤15 chars).
+ */
+export function portName(index: number, port: number): string {
+	return index === 0 ? 'kernel' : `port-${port}`;
+}
+
 export interface KubernetesResources {
 	/** CPU request/limit (e.g. `1`, `500m`). */
 	cpu?: string;
@@ -145,6 +154,12 @@ export interface KubernetesConfig {
 	hostname?: string;
 	/** Port marimo binds inside the Pod. Default 2718. */
 	kernelPort?: number;
+	/**
+	 * Secondary-surface ports reserved on every sandbox's Pod/Service/Ingress at
+	 * create time (subdomain exposure gives each its own `{id}-{port}` Ingress
+	 * host). Any present makes `multiPort` true.
+	 */
+	surfacePorts?: readonly number[];
 	/**
 	 * Template for the kernel URL. `{id}`, `{name}`, `{namespace}`, `{port}`, `{host}`,
 	 * and `{token}` are substituted. Subdomain exposure defaults to
@@ -184,10 +199,13 @@ export interface EnsureSandboxOptions {
 	name: string;
 	/** Verbatim `SandboxId`, stored in an annotation for `listActive()` mapping. */
 	sandboxId: SandboxId;
-	/** Ingress host for the kernel (`{id}.{host}`); the Ingress routes it to the Pod. */
-	host: string;
+	/**
+	 * Ports opened on the Pod/Service, kernel first. Each `host` is the Ingress
+	 * host that routes the port to the Pod; an empty `host` reserves the port with
+	 * no Ingress rule.
+	 */
+	ports: readonly { port: number; host: string }[];
 	image: string;
-	port: number;
 	namespace: string;
 	ingressClassName?: string;
 	ingressAnnotations?: Record<string, string>;
@@ -239,8 +257,9 @@ export interface K8sExecOptions {
  */
 export interface K8sClient {
 	/**
-	 * Create the Pod + Service and optional Ingress for a session if they don't already
-	 * exist. `createdPod` is false when the Pod pre-existed (a reconnect).
+	 * Create the Pod + Service and an Ingress rule per hosted port for a session if
+	 * they don't already exist. `createdPod` is false when the Pod pre-existed (a
+	 * reconnect).
 	 */
 	ensure(options: EnsureSandboxOptions): Promise<{ createdPod: boolean }>;
 	/** Pod phase + boot timestamps, or `undefined` if the Pod does not exist. */

--- a/packages/compute-local/src/index.test.ts
+++ b/packages/compute-local/src/index.test.ts
@@ -910,6 +910,7 @@ describe('LocalCompute process hygiene', () => {
 
 computeContract('LocalCompute', () => new LocalCompute(), {
 	mountFallsBack: true,
+	secondaryPort: 8443,
 	semantics: {
 		failingCommand: 'false',
 		absentFile: { path: '/workspace/contract-absent.txt', code: 'NOT_FOUND' },

--- a/packages/config/src/compute.test.ts
+++ b/packages/config/src/compute.test.ts
@@ -346,7 +346,7 @@ describe('makeCompute fail-fast', () => {
 		});
 	});
 
-	it('rejects a kubernetes subdomain template without {port} when surfaces are set', () => {
+	it('rejects a kubernetes subdomain template whose ports share a destination', () => {
 		const surfaces = surfacesFromEnv({ MARIMOHUB_SURFACES: 'marimo,vscode' });
 		const error = getConfigError(() =>
 			makeCompute(
@@ -358,7 +358,7 @@ describe('makeCompute fail-fast', () => {
 				{ surfaces },
 			),
 		);
-		expect(error.message).toMatch(/\{port\}/);
+		expect(error.message).toMatch(/both resolve to/);
 		expect(error.opts.variable).toBe('MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE');
 	});
 

--- a/packages/config/src/compute.test.ts
+++ b/packages/config/src/compute.test.ts
@@ -12,6 +12,7 @@ import {
 	resolveSandboxImages,
 	usesSandboxNativeObjectStorage,
 } from './compute';
+import { surfacesFromEnv } from './surfaces';
 import { ConfigError } from './errors';
 
 function getConfigError(run: () => unknown): ConfigError {
@@ -43,6 +44,7 @@ const configOf = (provider: unknown) =>
 				hostname?: string;
 				hostnameTemplate?: string;
 				ingressClassName?: string;
+				surfacePorts?: readonly number[];
 			};
 		}
 	).config;
@@ -326,6 +328,38 @@ describe('makeCompute fail-fast', () => {
 		expect(configOf(makeCompute({ MARIMOHUB_COMPUTE_BACKEND: 'kubernetes' }))).toMatchObject({
 			ingressTlsMode: 'controller-default',
 		});
+	});
+
+	it('reserves surface ports and advertises multiPort for kubernetes with a surface', () => {
+		const surfaces = surfacesFromEnv({ MARIMOHUB_SURFACES: 'marimo,vscode' });
+		const compute = makeCompute(
+			{
+				MARIMOHUB_COMPUTE_BACKEND: 'kubernetes',
+				MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: 'kernels.example.com',
+			},
+			{ surfaces },
+		);
+		expect(compute.capabilities).toEqual({ multiPort: true });
+		expect(configOf(compute)).toMatchObject({
+			surfacePorts: [8443],
+			hostnameTemplate: 'https://{id}-{port}.{host}',
+		});
+	});
+
+	it('rejects a kubernetes subdomain template without {port} when surfaces are set', () => {
+		const surfaces = surfacesFromEnv({ MARIMOHUB_SURFACES: 'marimo,vscode' });
+		const error = getConfigError(() =>
+			makeCompute(
+				{
+					MARIMOHUB_COMPUTE_BACKEND: 'kubernetes',
+					MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: 'kernels.example.com',
+					MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE: 'https://{id}.{host}',
+				},
+				{ surfaces },
+			),
+		);
+		expect(error.message).toMatch(/\{port\}/);
+		expect(error.opts.variable).toBe('MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE');
 	});
 
 	it('requires URL schemes that match the kubernetes ingress TLS mode', () => {

--- a/packages/config/src/compute.ts
+++ b/packages/config/src/compute.ts
@@ -448,7 +448,28 @@ export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 			const pullPolicy = env.MARIMOHUB_COMPUTE_KUBERNETES_IMAGE_PULL_POLICY;
 			const proxyExposure = opts?.sandboxExposureMode === 'proxy';
 			const ingressTlsMode = proxyExposure ? undefined : kubernetesIngressTlsMode(env);
-			const hostnameTemplate = env.MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE;
+			const ports = surfacePorts(opts?.surfaces);
+			const customTemplate = env.MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE;
+			// Each surface port needs its own subdomain, so the default becomes
+			// port-aware and a custom template must carry {port} or all ports collide.
+			if (
+				!proxyExposure &&
+				ports.length > 0 &&
+				customTemplate &&
+				!customTemplate.includes('{port}')
+			) {
+				throw new ConfigError(
+					`Invalid MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE for secondary surfaces: ${customTemplate} ` +
+						'(each surface port needs a distinct subdomain, so the template must include {port})',
+					{
+						variable: 'MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE',
+						remediation: 'Include {port} in the template, e.g. https://{id}-{port}.{host}.',
+					},
+				);
+			}
+			const hostnameTemplate =
+				customTemplate ??
+				(!proxyExposure && ports.length > 0 ? 'https://{id}-{port}.{host}' : undefined);
 			// Proxy exposure publishes no Ingress, so a template built on the public
 			// host (the subdomain default) would yield a URL with nothing behind it.
 			if (proxyExposure && hostnameTemplate && /\{host\}|\{token\}/.test(hostnameTemplate)) {
@@ -475,6 +496,7 @@ export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 				exposureMode: opts?.sandboxExposureMode,
 				namespace: env.MARIMOHUB_COMPUTE_KUBERNETES_NAMESPACE,
 				image: defaultImage,
+				surfacePorts: ports,
 				hostname: proxyExposure ? undefined : env.MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME,
 				hostnameTemplate,
 				ingressClassName: proxyExposure

--- a/packages/config/src/compute.ts
+++ b/packages/config/src/compute.ts
@@ -11,6 +11,7 @@ import { E2bCompute } from '@marimo-hub/compute-e2b';
 import {
 	KubernetesCompute,
 	parseIngressAnnotations,
+	portRoutingCollision,
 	resolveIngressTlsMode,
 	validateIngressTlsHostnameTemplate,
 } from '@marimo-hub/compute-kubernetes';
@@ -450,26 +451,33 @@ export function makeCompute(env: Env, opts?: ComputeOptions): SandboxProvider {
 			const ingressTlsMode = proxyExposure ? undefined : kubernetesIngressTlsMode(env);
 			const ports = surfacePorts(opts?.surfaces);
 			const customTemplate = env.MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE;
-			// Each surface port needs its own subdomain, so the default becomes
-			// port-aware and a custom template must carry {port} or all ports collide.
-			if (
-				!proxyExposure &&
-				ports.length > 0 &&
-				customTemplate &&
-				!customTemplate.includes('{port}')
-			) {
-				throw new ConfigError(
-					`Invalid MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE for secondary surfaces: ${customTemplate} ` +
-						'(each surface port needs a distinct subdomain, so the template must include {port})',
-					{
-						variable: 'MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE',
-						remediation: 'Include {port} in the template, e.g. https://{id}-{port}.{host}.',
-					},
-				);
-			}
+			// Each surface port needs its own subdomain, so the default becomes port-aware.
 			const hostnameTemplate =
 				customTemplate ??
 				(!proxyExposure && ports.length > 0 ? 'https://{id}-{port}.{host}' : undefined);
+			// Reject templates that route two ports to the same destination — {port} only
+			// in the path (subdomain) or a hardcoded port (proxy) collides a surface onto
+			// the kernel. Validated against rendered URLs, so it can't diverge from routing.
+			if (ports.length > 0) {
+				const collision = portRoutingCollision({
+					exposureMode: opts?.sandboxExposureMode,
+					hostname: proxyExposure ? undefined : env.MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME,
+					hostnameTemplate,
+					surfacePorts: ports,
+				});
+				if (collision) {
+					const [a, b] = collision.ports;
+					throw new ConfigError(
+						`Invalid MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE for secondary surfaces: ` +
+							`ports ${a} and ${b} both resolve to ${collision.destination}`,
+						{
+							variable: 'MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE',
+							remediation:
+								'Route each port to a distinct destination — include {port} in the subdomain host, e.g. https://{id}-{port}.{host}.',
+						},
+					);
+				}
+			}
 			// Proxy exposure publishes no Ingress, so a template built on the public
 			// host (the subdomain default) would yield a URL with nothing behind it.
 			if (proxyExposure && hostnameTemplate && /\{host\}|\{token\}/.test(hostnameTemplate)) {

--- a/packages/core/src/testing/computeContract.ts
+++ b/packages/core/src/testing/computeContract.ts
@@ -149,6 +149,12 @@ export interface ComputeContractOptions {
 	mountFallsBack?: boolean;
 	/** Hostname passed to `exposePort`; some adapters embed it in the URL. */
 	hostname?: string;
+	/**
+	 * A second port the provider was configured to expose. When set, the contract
+	 * asserts `capabilities.multiPort` and that `exposePort` honours its port
+	 * argument (a distinct, stable, parseable URL per port). URL-shape only.
+	 */
+	secondaryPort?: number;
 	semantics?: ComputeContractSemantics;
 }
 
@@ -282,6 +288,23 @@ export function computeContract(
 			expect(url).toBeTruthy();
 			expect(() => new URL(url)).not.toThrow();
 		});
+
+		if (opts.secondaryPort !== undefined) {
+			const secondaryPort = opts.secondaryPort;
+			it('a multiPort provider exposes a distinct, stable URL per port', async () => {
+				expect(provider.capabilities?.multiPort).toBe(true);
+				const inst = provider.create(CONTRACT_ID);
+				await inst.exec('true');
+				const kernel = await inst.exposePort(CONTRACT_LAUNCH_PORT, { hostname });
+				const secondary = await inst.exposePort(secondaryPort, { hostname });
+				expect(() => new URL(kernel.url)).not.toThrow();
+				expect(() => new URL(secondary.url)).not.toThrow();
+				// Catches an adapter that ignores its port argument.
+				expect(secondary.url).not.toBe(kernel.url);
+				const again = await inst.exposePort(secondaryPort, { hostname });
+				expect(again.url).toBe(secondary.url);
+			});
+		}
 
 		it('proxy() resolves to null or a Response (never throws)', async () => {
 			const res = await provider.proxy(new Request('http://kernel.example/'));


### PR DESCRIPTION
Brings the `kubernetes` compute adapter to the same multi-port bar `coreweave` already meets, so surfaces that need their own port (e.g. code-server) can run on it. Previously the adapter advertised `multiPort: false` and `exposePort` ignored its port argument.

- `KubernetesConfig.surfacePorts` reserves extra ports on the Pod/Service/Ingress at create time (named ports; one Ingress rule per host).
- `capabilities.multiPort` is derived from `surfacePorts`; `exposePort` honors its port argument.
- Under `subdomain` exposure with a surface enabled, the hostname template defaults to `https://{id}-{port}.{host}`. Single-port deployments keep `https://{id}.{host}` unchanged.

Reviewer note: the port-aware template adds a `-{port}` segment to the kernel host once a surface is enabled, so the existing `*.{host}` wildcard DNS/TLS must cover it. Happy to use a different scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
