### PR TITLE
fix(kubernetes): validate ingress hosts and preserve service IP families

### DIFF
--- a/charts/marimohub/values.yaml
+++ b/charts/marimohub/values.yaml
@@ -52,7 +52,7 @@ compute:
   profileOverride: none
 
 surfaces:
-  # On the kubernetes compute backend, enabling a surface needs the sandbox Ingress
+  # With kubernetes subdomain exposure, enabling a surface needs the sandbox Ingress
   # wildcard host/cert to also cover the per-port `{id}-{port}.{host}` subdomain.
   # Use a published `-vscode`, `-opencode`, or `-tools` sandbox image tag.
   sandboxImage: ''

--- a/packages/compute-kubernetes/src/client.test.ts
+++ b/packages/compute-kubernetes/src/client.test.ts
@@ -278,46 +278,68 @@ describe('createK8sClient', () => {
 		});
 	});
 
-	it('reconciles an existing managed service so a reconnect gains new surface ports', async () => {
-		k8sMock.core.createNamespacedService.mockRejectedValueOnce({ code: 409 });
-		k8sMock.core.readNamespacedService.mockResolvedValueOnce({
-			metadata: {
+	it.each([
+		{ clusterIPs: ['10.0.0.7'], ipFamilies: ['IPv4'], ipFamilyPolicy: 'SingleStack' },
+		{ clusterIPs: ['fd00::7'], ipFamilies: ['IPv6'], ipFamilyPolicy: 'SingleStack' },
+		{
+			clusterIPs: ['10.0.0.7', 'fd00::7'],
+			ipFamilies: ['IPv4', 'IPv6'],
+			ipFamilyPolicy: 'PreferDualStack',
+		},
+		{
+			clusterIPs: ['fd00::7', '10.0.0.7'],
+			ipFamilies: ['IPv6', 'IPv4'],
+			ipFamilyPolicy: 'RequireDualStack',
+		},
+	])(
+		'reconciles service ports while preserving $ipFamilyPolicy addresses and families $ipFamilies',
+		async ({ clusterIPs, ipFamilies, ipFamilyPolicy }) => {
+			const clusterIP = clusterIPs[0];
+			k8sMock.core.createNamespacedService.mockRejectedValueOnce({ code: 409 });
+			k8sMock.core.readNamespacedService.mockResolvedValueOnce({
+				metadata: {
+					name: 'mh-sb',
+					resourceVersion: '9',
+					labels: { [MANAGED_BY_LABEL]: MANAGED_BY_VALUE },
+				},
+				spec: { clusterIP, clusterIPs, ipFamilies, ipFamilyPolicy, ports: [{ port: 2718 }] },
+			});
+			const client = createK8sClient({ namespace: 'kernels' });
+
+			await client.ensure({
 				name: 'mh-sb',
-				resourceVersion: '9',
-				labels: { [MANAGED_BY_LABEL]: MANAGED_BY_VALUE },
-			},
-			spec: { clusterIP: '10.0.0.7', clusterIPs: ['10.0.0.7'], ports: [{ port: 2718 }] },
-		});
-		const client = createK8sClient({ namespace: 'kernels' });
+				sandboxId: SANDBOX_ID,
+				image: 'kernel-image:v1',
+				ports: [
+					{ port: 2718, host: 'sb.example.com' },
+					{ port: 8443, host: 'sb-8443.example.com' },
+				],
+				namespace: 'kernels',
+			});
 
-		await client.ensure({
-			name: 'mh-sb',
-			sandboxId: SANDBOX_ID,
-			image: 'kernel-image:v1',
-			ports: [
-				{ port: 2718, host: 'sb.example.com' },
-				{ port: 8443, host: 'sb-8443.example.com' },
-			],
-			namespace: 'kernels',
-		});
-
-		expect(k8sMock.core.readNamespacedService).toHaveBeenCalledWith({
-			name: 'mh-sb',
-			namespace: 'kernels',
-		});
-		expect(k8sMock.core.replaceNamespacedService).toHaveBeenCalledWith({
-			name: 'mh-sb',
-			namespace: 'kernels',
-			body: expect.objectContaining({
-				metadata: expect.objectContaining({ resourceVersion: '9' }),
-				spec: expect.objectContaining({
-					// clusterIP carried forward (immutable); ports now include the surface.
-					clusterIP: '10.0.0.7',
-					ports: [expect.objectContaining({ port: 2718 }), expect.objectContaining({ port: 8443 })],
+			expect(k8sMock.core.readNamespacedService).toHaveBeenCalledWith({
+				name: 'mh-sb',
+				namespace: 'kernels',
+			});
+			expect(k8sMock.core.replaceNamespacedService).toHaveBeenCalledWith({
+				name: 'mh-sb',
+				namespace: 'kernels',
+				body: expect.objectContaining({
+					metadata: expect.objectContaining({ resourceVersion: '9' }),
+					spec: expect.objectContaining({
+						clusterIP,
+						clusterIPs,
+						ipFamilies,
+						ipFamilyPolicy,
+						ports: [
+							expect.objectContaining({ port: 2718 }),
+							expect.objectContaining({ port: 8443 }),
+						],
+					}),
 				}),
-			}),
-		});
-	});
+			});
+		},
+	);
 
 	it('refuses to replace an unmanaged ingress', async () => {
 		k8sMock.net.createNamespacedIngress.mockRejectedValueOnce({ code: 409 });

--- a/packages/compute-kubernetes/src/client.ts
+++ b/packages/compute-kubernetes/src/client.ts
@@ -334,10 +334,12 @@ export function createK8sClient(config: KubernetesConfig): K8sClient {
 			metadata.labels = { ...existing.metadata.labels, ...desiredLabels };
 			metadata.finalizers = existing.metadata.finalizers;
 			metadata.ownerReferences = existing.metadata.ownerReferences;
-			// clusterIP is immutable; a replace must carry the assigned value forward.
+			// clusterIP is immutable; retain IP-family settings to avoid implicit stack changes.
 			if (desired.spec) {
 				desired.spec.clusterIP = existing.spec?.clusterIP;
 				desired.spec.clusterIPs = existing.spec?.clusterIPs;
+				desired.spec.ipFamilies = existing.spec?.ipFamilies;
+				desired.spec.ipFamilyPolicy = existing.spec?.ipFamilyPolicy;
 			}
 			try {
 				await core.replaceNamespacedService({ name, namespace, body: desired });

--- a/packages/compute-kubernetes/src/index.test.ts
+++ b/packages/compute-kubernetes/src/index.test.ts
@@ -191,6 +191,19 @@ describe('KubernetesCompute', () => {
 		).not.toThrow();
 	});
 
+	it.each([
+		'https://{id}.{host}:{port}',
+		'https://{id}-{port}.{host}:8443',
+		'https://{id}-{port}.{host}:443',
+	])('rejects an authority port in a subdomain template: %s', (hostnameTemplate) => {
+		const world = makeWorld();
+		for (const surfacePorts of [[], [8443]]) {
+			expect(() => makeCompute(world, { ...baseConfig, surfacePorts, hostnameTemplate })).toThrow(
+				/authority port/,
+			);
+		}
+	});
+
 	describe('secondary surface ports', () => {
 		it('advertises multiPort exactly when surface ports are configured', () => {
 			const world = makeWorld();

--- a/packages/compute-kubernetes/src/index.ts
+++ b/packages/compute-kubernetes/src/index.ts
@@ -56,7 +56,7 @@ import {
 import { Millis } from '@marimo-hub/core';
 import type { SandboxId, Timings } from '@marimo-hub/core';
 import { createK8sClient } from './client';
-import { resolveIngressTlsMode, validateIngressTlsHostnameTemplate } from './shared';
+import { resolveIngressTlsMode, validateIngressHostnameTemplate } from './shared';
 import type { K8sClient, K8sExecResult, K8sPodPhaseInfo, KubernetesConfig } from './shared';
 import { execResult, listFilesFailure, readFileFailure } from '@marimo-hub/core/ports';
 export * from './shared';
@@ -201,14 +201,7 @@ function renderHostname(
 		.replaceAll('{token}', vars.token);
 }
 
-/**
- * The first pair of reserved ports that resolve to the SAME routing destination —
- * the Ingress host in subdomain mode, the full origin (host:port) in proxy mode — or
- * `undefined` when every port routes distinctly. A `{port}` that only lands in the
- * path, or a proxy template with a hardcoded port, collides a surface onto the kernel.
- * Checked against the rendered URL, not the template text, so `config` validation and
- * live routing can never diverge.
- */
+/** Find collisions by Ingress DNS hostname (subdomain) or origin (proxy). */
 export function portRoutingCollision(
 	config: KubernetesConfig,
 ): { ports: [number, number]; destination: string } | undefined {
@@ -228,7 +221,7 @@ export function portRoutingCollision(
 				port,
 			}),
 		);
-		const destination = proxy ? url.origin : url.host;
+		const destination = proxy ? url.origin : url.hostname;
 		const clash = byDestination.get(destination);
 		if (clash !== undefined) return { ports: [clash, port], destination };
 		byDestination.set(destination, port);
@@ -685,7 +678,7 @@ export class KubernetesCompute implements SandboxProvider {
 		const surfaced = (config.surfacePorts?.length ?? 0) > 0;
 		if ((config.exposureMode ?? 'subdomain') === 'subdomain' && config.hostname) {
 			const tlsMode = resolveIngressTlsMode(config.ingressTlsMode, config.tlsSecretName);
-			validateIngressTlsHostnameTemplate(hostnameTemplate(config), tlsMode);
+			validateIngressHostnameTemplate(hostnameTemplate(config), tlsMode);
 		}
 		if (surfaced) assertDistinctPortRouting(config);
 		this.capabilities = { multiPort: surfaced };

--- a/packages/compute-kubernetes/src/shared.ts
+++ b/packages/compute-kubernetes/src/shared.ts
@@ -90,10 +90,17 @@ export function resolveIngressTlsMode(
 	return resolved as ResolvedIngressTlsMode;
 }
 
-export function validateIngressTlsHostnameTemplate(
+export function validateIngressHostnameTemplate(
 	template: string,
 	tlsMode: ResolvedIngressTlsMode,
 ): void {
+	// Inspect the raw authority: URL.port drops explicit default ports such as :443.
+	const host = /^[a-z][a-z\d+.-]*:\/\/([^/?#]*)/i.exec(template)?.[1]?.split('@').at(-1);
+	if (host?.includes(':')) {
+		throw new Error(
+			'Kubernetes subdomain hostname templates must not include an authority port; put {port} in the DNS hostname, e.g. https://{id}-{port}.{host}',
+		);
+	}
 	const scheme = /^([a-z][a-z\d+.-]*):\/\//i.exec(template)?.[1]?.toLowerCase();
 	if (tlsMode === 'disabled' && scheme !== 'http') {
 		throw new Error('Disabled Kubernetes ingress TLS requires an http:// hostname template');

--- a/packages/config/src/compute.test.ts
+++ b/packages/config/src/compute.test.ts
@@ -442,6 +442,26 @@ describe('makeCompute fail-fast', () => {
 		expect(error.opts.variable).toBe('MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE');
 	});
 
+	it.each([
+		'https://{id}.{host}:{port}',
+		'https://{id}-{port}.{host}:8443',
+		'https://{id}-{port}.{host}:443',
+	])('rejects a kubernetes subdomain template with an authority port: %s', (template) => {
+		const surfaces = surfacesFromEnv({ MARIMOHUB_SURFACES: 'marimo,vscode' });
+		const error = getConfigError(() =>
+			makeCompute(
+				{
+					MARIMOHUB_COMPUTE_BACKEND: 'kubernetes',
+					MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME: 'kernels.example.com',
+					MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE: template,
+				},
+				{ surfaces },
+			),
+		);
+		expect(error.message).toMatch(/authority port/);
+		expect(error.opts.variable).toBe('MARIMOHUB_COMPUTE_KUBERNETES_HOSTNAME_TEMPLATE');
+	});
+
 	it('requires URL schemes that match the kubernetes ingress TLS mode', () => {
 		const disabledError = getConfigError(() =>
 			makeCompute({

--- a/packages/config/src/compute.ts
+++ b/packages/config/src/compute.ts
@@ -14,7 +14,7 @@ import {
 	parseIngressAnnotations,
 	portRoutingCollision,
 	resolveIngressTlsMode,
-	validateIngressTlsHostnameTemplate,
+	validateIngressHostnameTemplate,
 } from '@marimo-hub/compute-kubernetes';
 import { parseBool, parseEnum, parseIntEnv, parseList, requiredVar } from './env';
 import type { Env } from './env';
@@ -108,7 +108,7 @@ function kubernetesIngressTlsMode(env: Env): 'disabled' | 'controller-default' |
 	const template = env[templateKey] ?? 'https://{id}.{host}';
 	try {
 		if (env.MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME) {
-			validateIngressTlsHostnameTemplate(template, mode);
+			validateIngressHostnameTemplate(template, mode);
 		}
 	} catch (cause) {
 		const detail = cause instanceof Error ? cause.message : 'invalid hostname template';
@@ -116,8 +116,8 @@ function kubernetesIngressTlsMode(env: Env): 'disabled' | 'controller-default' |
 			variable: templateKey,
 			remediation:
 				mode === 'disabled'
-					? 'Use an http:// hostname template with disabled TLS.'
-					: 'Use an https:// hostname template when Kubernetes ingress TLS is enabled.',
+					? 'Use an http:// hostname template without an authority port with disabled TLS.'
+					: 'Use an https:// hostname template without an authority port when Kubernetes ingress TLS is enabled.',
 		});
 	}
 	return mode;


### PR DESCRIPTION
Follow up on #312: reject authority ports in Kubernetes subdomain templates, preserve Service IP-family settings on reconnect, and scope the chart’s wildcard DNS/TLS comment to subdomain exposure. Includes regression coverage.

Verified: `pnpm check`, `pnpm typecheck`, `pnpm test`, and `pnpm build`.
