### PR TITLE
feat(release): attach a standalone Linux x64 server binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,10 @@ name: Release
 # Triggered by a semver tag, normally pushed by release-tag.yml when a
 # "release: X.Y.Z" PR is merged (see development_docs/releasing.md).
 # This publishes the container image and Helm chart to GHCR, builds native CLI
-# archives and binary wheels, and creates a GitHub release with checksums,
-# provenance, an SBOM, and a changelog generated from commits since the prior
-# tag. The chart version, appVersion, and image tag are pinned to the git tag.
+# archives and binary wheels plus a standalone Linux x64 server binary, and
+# creates a GitHub release with checksums, provenance, an SBOM, and a changelog
+# generated from commits since the prior tag. The chart version, appVersion,
+# and image tag are pinned to the git tag.
 #   helm upgrade --install marimohub oci://ghcr.io/marimo-team/charts/marimohub \
 #     --version 1.4.2 -n marimohub -f values.yaml
 on:
@@ -188,6 +189,46 @@ jobs:
             apps/cli/target/distrib/*.sum
           if-no-files-found: error
 
+  server-binary:
+    name: Build server binary (linux-x64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+        with:
+          version: 0.1.24
+          node-version-file: '.node-version'
+          sfw: true
+          cache: true
+          run-install: |
+            - args: ['--frozen-lockfile']
+
+      - name: Build web and server
+        run: vp run --fail-if-no-match --filter @marimo-hub/web --filter @marimo-hub/server build
+
+      # A Node single-executable (SEA): the runner's `node` with the server
+      # bundle and SPA injected as assets. See scripts/build-sea.mjs.
+      - name: Build binary
+        run: node scripts/build-sea.mjs --no-build
+
+      - name: Smoke test
+        run: scripts/smoke-sea.sh apps/server/dist/sea/marimohub-linux-x64 "${GITHUB_REF_NAME#v}"
+
+      - name: Checksum
+        working-directory: apps/server/dist/sea
+        run: sha256sum marimohub-linux-x64 > marimohub-linux-x64.sha256
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: marimohub-linux-x64
+          path: |
+            apps/server/dist/sea/marimohub-linux-x64
+            apps/server/dist/sea/marimohub-linux-x64.sha256
+          if-no-files-found: error
+
   image:
     name: Build & push image
     runs-on: ubuntu-latest
@@ -345,6 +386,40 @@ jobs:
           scripts/retry.sh gh release upload "$GITHUB_REF_NAME"
           release-assets/* --clobber
 
+  publish-server-binary:
+    name: Attach server binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # The CLI job creates the release; this only adds one more asset to it.
+    needs: [server-binary, publish-cli-release]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: marimohub-linux-x64
+          path: server-binary
+
+      - name: Verify checksum
+        working-directory: server-binary
+        run: sha256sum -c marimohub-linux-x64.sha256
+
+      - name: Attest server binary
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: server-binary/marimohub-linux-x64
+
+      - name: Attach server binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          scripts/retry.sh gh release upload "$GITHUB_REF_NAME"
+          server-binary/marimohub-linux-x64 server-binary/marimohub-linux-x64.sha256 --clobber
+
   cli-release-metadata:
     name: Publish CLI release metadata
     runs-on: ubuntu-latest
@@ -393,7 +468,17 @@ jobs:
     timeout-minutes: 5
     # Report the overall outcome once every release job has finished.
     needs:
-      [cli, cli-linux-x64, cli-installers, image, chart, publish-cli-release, cli-release-metadata]
+      [
+        cli,
+        cli-linux-x64,
+        cli-installers,
+        server-binary,
+        image,
+        chart,
+        publish-cli-release,
+        publish-server-binary,
+        cli-release-metadata,
+      ]
     if: always()
     steps:
       - name: Notify Slack - Release Success

--- a/apps/server/src/unavailableOptionalDependency.cjs
+++ b/apps/server/src/unavailableOptionalDependency.cjs
@@ -1,0 +1,6 @@
+// Bundled in place of optional native packages the server never ships
+// (see the `alias` map in vite.config.ts). Callers require these inside a
+// try/catch and fall back to pure JS; throwing here keeps that fallback while
+// leaving no bare `require()` in the bundle that Node would otherwise resolve
+// through every ancestor node_modules directory at runtime.
+throw new Error('optional dependency is not bundled with the marimohub server');

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite-plus';
 import { DUCKDB_EXTENSION_MANIFEST } from '../../packages/duckdb-wasm-runtime/src/extensionManifest';
 
@@ -20,6 +21,16 @@ export default defineConfig({
 		platform: 'node',
 		format: ['esm'],
 		dts: false,
+		// ws, node-fetch and pg probe for optional native packages with a guarded
+		// require(). Left unresolved, those become bare require() calls that Node
+		// resolves through every ancestor node_modules directory of wherever the
+		// bundle runs. Point them at a stub that throws so the fallback is taken.
+		alias: Object.fromEntries(
+			['bufferutil', 'utf-8-validate', 'encoding', 'pg-native'].map((name) => [
+				name,
+				fileURLToPath(new URL('./src/unavailableOptionalDependency.cjs', import.meta.url)),
+			]),
+		),
 		noExternal: [
 			/^@marimo-hub\//,
 			/^@modelcontextprotocol\//,

--- a/development_docs/releasing.md
+++ b/development_docs/releasing.md
@@ -22,6 +22,20 @@ Releases are cut via a PR, never by pushing to `main` or hand-pushing tags.
 The x86-64 Linux build uses a glibc 2.28 image. Each native archive contains
 shell completions and man pages.
 
+The release also attaches `marimohub-linux-x64`, a standalone server binary
+built with Node's single executable application (SEA) support by
+[`scripts/build-sea.mjs`](../scripts/build-sea.mjs). It is the runner's `node`
+with the server bundle and the SPA injected as assets; on first start it unpacks
+them to a cache directory and loads the bundle from there. The container image
+stays the primary distribution; the binary is a convenience for hosts without
+Node. It carries its own `.sha256` and a build provenance attestation (verify
+with `gh attestation verify marimohub-linux-x64 --repo marimo-team/marimohub`),
+but it is not in the CLI `SHA256SUMS` or SBOM, and the recovery workflow does
+not rebuild it.
+Build it locally with `pnpm build:sea` (outputs
+`apps/server/dist/sea/marimohub-<platform>-<arch>`) and check it with
+`scripts/smoke-sea.sh <binary>`.
+
 [`apps/cli/dist-workspace.toml`](../apps/cli/dist-workspace.toml) defines shell,
 PowerShell, Homebrew, and npm installers. It also defines the standalone
 `mohub-update` program. Run `dist plan --allow-dirty` from `apps/cli` to check

--- a/docs/deployment-options.md
+++ b/docs/deployment-options.md
@@ -36,6 +36,19 @@ MARIMOHUB_PERSIST_WORKSPACE=source
 - Everything is documented in [Configuration](./configuration.md).
 - Best for standard deployments (Docker, Podman, Kubernetes).
 
+The container image is the primary distribution. Each
+[GitHub release](https://github.com/marimo-team/marimohub/releases) also
+attaches `marimohub-linux-x64`, a standalone server binary for x86-64 Linux
+hosts without Node. It reads the same `MARIMOHUB_*` variables. On first start it
+unpacks its bundled files to `$TMPDIR/marimohub-sea/<build-id>`; set
+`MARIMOHUB_SEA_CACHE_DIR` to use a different directory.
+
+```bash
+curl -fsSLO https://github.com/marimo-team/marimohub/releases/latest/download/marimohub-linux-x64
+chmod +x marimohub-linux-x64
+./marimohub-linux-x64
+```
+
 ## 2. SDK / library composition (the complex case)
 
 Import the adapters you want and construct `createApi(deps)` by hand. Use this

--- a/docs/deployment-options.md
+++ b/docs/deployment-options.md
@@ -42,16 +42,22 @@ attaches `marimohub-linux-x64`, a standalone server binary for x86-64 Linux
 hosts without Node. It reads the same `MARIMOHUB_*` variables. On first start it
 unpacks its bundled files to `$XDG_CACHE_HOME/marimohub-sea/<build-id>`
 (default `~/.cache/marimohub-sea/<build-id>`); set `MARIMOHUB_SEA_CACHE_DIR` to
-use a different directory. The unpacked files are executed, so keep that
-directory on a path other users cannot write to anywhere along it (not under
-`/tmp`).
+use a different directory. The unpacked files are executed, so the binary
+refuses a cache directory that is a symlink, not owned by the current user, or
+reachable through a directory another user can write to. Do not put it under
+`/tmp`: Node also resolves optional modules through every ancestor
+`node_modules` directory.
+
+The example below is a throwaway configuration that keeps all state in memory.
+For a real deployment use the durable variables from the `.env` above.
 
 ```bash
 curl -fsSLO https://github.com/marimo-team/marimohub/releases/latest/download/marimohub-linux-x64
 chmod +x marimohub-linux-x64
 
 export MARIMOHUB_STORAGE_BACKEND=memory
-export MARIMOHUB_COMPUTE_BACKEND=subprocess
+export MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true
+export MARIMOHUB_COMPUTE_BACKEND=none
 export MARIMOHUB_AUTH_BACKEND=dev
 ./marimohub-linux-x64
 ```

--- a/docs/deployment-options.md
+++ b/docs/deployment-options.md
@@ -44,9 +44,8 @@ unpacks its bundled files to `$XDG_CACHE_HOME/marimohub-sea/<build-id>`
 (default `~/.cache/marimohub-sea/<build-id>`); set `MARIMOHUB_SEA_CACHE_DIR` to
 use a different directory. The unpacked files are executed, so the binary
 refuses a cache directory that is a symlink, not owned by the current user, or
-reachable through a directory another user can write to. Do not put it under
-`/tmp`: Node also resolves optional modules through every ancestor
-`node_modules` directory.
+reachable through a directory another user can write to, including sticky
+directories such as `/tmp`.
 
 The example below is a throwaway configuration that keeps all state in memory.
 For a real deployment use the durable variables from the `.env` above.

--- a/docs/deployment-options.md
+++ b/docs/deployment-options.md
@@ -40,8 +40,11 @@ The container image is the primary distribution. Each
 [GitHub release](https://github.com/marimo-team/marimohub/releases) also
 attaches `marimohub-linux-x64`, a standalone server binary for x86-64 Linux
 hosts without Node. It reads the same `MARIMOHUB_*` variables. On first start it
-unpacks its bundled files to `$TMPDIR/marimohub-sea-<uid>/<build-id>`; set
-`MARIMOHUB_SEA_CACHE_DIR` to use a different directory.
+unpacks its bundled files to `$XDG_CACHE_HOME/marimohub-sea/<build-id>`
+(default `~/.cache/marimohub-sea/<build-id>`); set `MARIMOHUB_SEA_CACHE_DIR` to
+use a different directory. The unpacked files are executed, so keep that
+directory on a path other users cannot write to anywhere along it (not under
+`/tmp`).
 
 ```bash
 curl -fsSLO https://github.com/marimo-team/marimohub/releases/latest/download/marimohub-linux-x64

--- a/docs/deployment-options.md
+++ b/docs/deployment-options.md
@@ -40,12 +40,16 @@ The container image is the primary distribution. Each
 [GitHub release](https://github.com/marimo-team/marimohub/releases) also
 attaches `marimohub-linux-x64`, a standalone server binary for x86-64 Linux
 hosts without Node. It reads the same `MARIMOHUB_*` variables. On first start it
-unpacks its bundled files to `$TMPDIR/marimohub-sea/<build-id>`; set
+unpacks its bundled files to `$TMPDIR/marimohub-sea-<uid>/<build-id>`; set
 `MARIMOHUB_SEA_CACHE_DIR` to use a different directory.
 
 ```bash
 curl -fsSLO https://github.com/marimo-team/marimohub/releases/latest/download/marimohub-linux-x64
 chmod +x marimohub-linux-x64
+
+export MARIMOHUB_STORAGE_BACKEND=memory
+export MARIMOHUB_COMPUTE_BACKEND=subprocess
+export MARIMOHUB_AUTH_BACKEND=dev
 ./marimohub-linux-x64
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"ready": "vp fmt && vp lint && pnpm typecheck && vp run -r test && vp run -r build",
 		"check": "vp check",
 		"typecheck": "vp run -r typecheck",
-		"test": "vp test tools/oxlint/anti-slop/index.test.ts --silent=passed-only --hideSkippedTests && vp run -r test --configLoader=runner --pool=threads --silent=passed-only --hideSkippedTests",
+		"test": "vp test tools/oxlint/anti-slop/index.test.ts scripts/sea/launcher.test.ts --silent=passed-only --hideSkippedTests && vp run -r test --configLoader=runner --pool=threads --silent=passed-only --hideSkippedTests",
 		"test:release-scripts": "bash scripts/release-helpers.test.sh",
 		"test:coverage": "pnpm test:coverage:root && pnpm test:coverage:web",
 		"test:coverage:root": "vp test --coverage",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"@oxlint/plugins": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
 		"oxlint": "catalog:",
+		"postject": "catalog:",
 		"react-doctor": "catalog:",
 		"vite-plus": "catalog:"
 	},

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"schemas:generate": "pnpm --filter @marimo-hub/api openapi:generate && pnpm --filter @marimo-hub/api cli:generate && pnpm --filter @marimo-hub/core schemas:generate && vp fmt internal/schemas && pnpm --filter @marimo-hub/client generate && pnpm --filter @marimo-hub/docs integrations:generate",
 		"build": "vp run -r build",
 		"cli:version-check": "node scripts/check-cli-version.mjs",
+		"build:sea": "node scripts/build-sea.mjs",
 		"release": "node scripts/release.mjs",
 		"prepare": "vp config"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ catalogs:
     pg-cursor:
       specifier: ^2.22.0
       version: 2.22.0
+    postject:
+      specifier: 1.0.0-alpha.6
+      version: 1.0.0-alpha.6
     react-aria-components:
       specifier: ^1.20.0
       version: 1.20.0
@@ -328,9 +331,12 @@ importers:
       oxlint:
         specifier: 'catalog:'
         version: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      postject:
+        specifier: 'catalog:'
+        version: 1.0.0-alpha.6
       react-doctor:
         specifier: 'catalog:'
-        version: 0.9.12(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(eslint@10.8.1(jiti@2.7.0))(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+        version: 0.9.12(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(eslint@10.8.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
@@ -1878,7 +1884,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)'
 
 packages:
 
@@ -5365,6 +5371,10 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
@@ -6987,6 +6997,11 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postject@1.0.0-alpha.6:
+    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
@@ -10738,6 +10753,49 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.24':
     optional: true
 
+  '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      es-module-lexer: 1.7.0
+      obug: 2.1.2
+      pixelmatch: 7.2.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)'
+      ws: 8.21.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(@voidzero-dev/vite-plus-test@0.1.24)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - yaml
+
   '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -11298,6 +11356,8 @@ snapshots:
   commander@14.0.3: {}
 
   commander@2.20.3: {}
+
+  commander@9.5.0: {}
 
   compare-versions@6.1.1: {}
 
@@ -13063,7 +13123,7 @@ snapshots:
       oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxlint@1.77.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.77.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.77.0
       '@oxlint/binding-android-arm64': 1.77.0
@@ -13084,6 +13144,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.77.0
       '@oxlint/binding-win32-ia32-msvc': 1.77.0
       '@oxlint/binding-win32-x64-msvc': 1.77.0
+      oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
   p-limit@3.1.0:
@@ -13214,6 +13275,10 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  postject@1.0.0-alpha.6:
+    dependencies:
+      commander: 9.5.0
+
   preact@10.29.2: {}
 
   prelude-ls@1.2.1: {}
@@ -13312,7 +13377,7 @@ snapshots:
       react-stately: 3.49.0(react@19.2.7)
       use-sync-external-store: 1.6.0(react@19.2.7)
 
-  react-doctor@0.9.12(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(eslint@10.8.1(jiti@2.7.0))(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  react-doctor@0.9.12(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(eslint@10.8.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@sentry/node': 10.70.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))
@@ -13324,7 +13389,7 @@ snapshots:
       jiti: 2.7.0
       magicast: 0.5.3
       oxc-resolver: 11.24.2
-      oxlint: 1.77.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.77.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-plugin-react-doctor: 0.9.12
       prompts: 2.4.2
       typescript: 5.9.3
@@ -14017,7 +14082,7 @@ snapshots:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
       '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       oxfmt: 0.52.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))
       oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,6 +88,7 @@ catalog:
   oxlint: 1.67.0
   pg: ^8.23.0
   pg-cursor: ^2.22.0
+  postject: 1.0.0-alpha.6
   react-aria-components: ^1.20.0
   react-doctor: 0.9.12
   simple-icons: ^16.27.0

--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+// Build a single-executable marimohub server with Node SEA.
+//
+//   node scripts/build-sea.mjs            # builds web + server first
+//   node scripts/build-sea.mjs --no-build # reuse existing dist/ output
+//
+// Output: apps/server/dist/sea/marimohub-<platform>-<arch> (plus the
+// intermediate blob/config). Targets the host platform: the executable is a
+// copy of the running `node` with the SEA blob injected, so cross-building
+// means running this on the target OS (or with a downloaded Node binary via
+// NODE_BINARY). Releases only ship marimohub-linux-x64; other platforms are
+// for local testing.
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+	cpSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const POSTJECT = 'postject@1.0.0-alpha.6';
+const SEA_FUSE = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
+
+const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const serverDist = join(repoRoot, 'apps/server/dist');
+const webDist = join(repoRoot, 'packages/web/dist');
+const outDir = join(serverDist, 'sea');
+const build = !process.argv.includes('--no-build');
+const nodeBinary = process.env.NODE_BINARY ?? process.execPath;
+
+const run = (cmd, args, opts = {}) => {
+	console.log(`$ ${cmd} ${args.join(' ')}`);
+	execFileSync(cmd, args, { stdio: 'inherit', cwd: repoRoot, ...opts });
+};
+
+const walk = (dir) =>
+	readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+		const full = join(dir, entry.name);
+		return entry.isDirectory() ? walk(full) : [full];
+	});
+
+if (build) {
+	run('pnpm', [
+		'exec',
+		'vp',
+		'run',
+		'--filter',
+		'@marimo-hub/web',
+		'--filter',
+		'@marimo-hub/server',
+		'build',
+	]);
+}
+for (const file of [join(serverDist, 'index.mjs'), join(webDist, 'index.html')]) {
+	if (!statSync(file, { throwIfNoEntry: false })?.isFile()) {
+		console.error(`missing ${file}; run without --no-build`);
+		process.exit(1);
+	}
+}
+
+rmSync(outDir, { recursive: true, force: true });
+
+// Every payload file becomes a named SEA asset; the launcher unpacks them by
+// the names listed in manifest.json. Keys are POSIX-style relative paths.
+const assets = {};
+const hash = createHash('sha256');
+const addTree = (root, prefix) => {
+	for (const file of walk(root).sort()) {
+		const key = `${prefix}/${relative(root, file).split('\\').join('/')}`;
+		assets[key] = file;
+		hash.update(key).update(readFileSync(file));
+	}
+};
+addTree(serverDist, 'dist');
+addTree(webDist, 'public');
+mkdirSync(outDir, { recursive: true });
+
+const version = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).version;
+const manifest = { version, buildId: hash.digest('hex').slice(0, 16), files: Object.keys(assets) };
+const manifestPath = join(outDir, 'manifest.json');
+writeFileSync(manifestPath, JSON.stringify(manifest));
+assets['manifest.json'] = manifestPath;
+
+const launcher = join(outDir, 'launcher.cjs');
+cpSync(join(repoRoot, 'scripts/sea/launcher.cjs'), launcher);
+
+const seaConfig = join(outDir, 'sea-config.json');
+const blob = join(outDir, 'sea.blob');
+writeFileSync(
+	seaConfig,
+	JSON.stringify(
+		{
+			main: launcher,
+			output: blob,
+			disableExperimentalSEAWarning: true,
+			assets,
+		},
+		null,
+		2,
+	),
+);
+
+run(nodeBinary, ['--experimental-sea-config', seaConfig]);
+
+const exe = join(
+	outDir,
+	`marimohub-${process.platform}-${process.arch}${process.platform === 'win32' ? '.exe' : ''}`,
+);
+cpSync(nodeBinary, exe);
+if (process.platform === 'darwin') run('codesign', ['--remove-signature', exe]);
+
+const postjectArgs = [exe, 'NODE_SEA_BLOB', blob, '--sentinel-fuse', SEA_FUSE];
+if (process.platform === 'darwin') postjectArgs.push('--macho-segment-name', 'NODE_SEA');
+run('npx', ['--yes', POSTJECT, ...postjectArgs]);
+
+if (process.platform === 'darwin') run('codesign', ['--sign', '-', exe]);
+
+const mb = (statSync(exe).size / 1024 / 1024).toFixed(0);
+console.log(
+	`\nbuilt ${exe} (${mb} MB, ${manifest.files.length} embedded files, build ${manifest.buildId})`,
+);

--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -5,11 +5,10 @@
 //   node scripts/build-sea.mjs --no-build # reuse existing dist/ output
 //
 // Output: apps/server/dist/sea/marimohub-<platform>-<arch> (plus the
-// intermediate blob/config). Targets the host platform: the executable is a
-// copy of the running `node` with the SEA blob injected, so cross-building
-// means running this on the target OS (or with a downloaded Node binary via
-// NODE_BINARY). Releases only ship marimohub-linux-x64; other platforms are
-// for local testing.
+// intermediate blob/config). Always targets the host: the executable is a copy
+// of the running `node` with the SEA blob injected, and there is no
+// cross-building, so run this on the target OS and architecture. Releases only
+// ship marimohub-linux-x64; other platforms are for local testing.
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
@@ -24,7 +23,6 @@ import {
 import { join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const POSTJECT = 'postject@1.0.0-alpha.6';
 const SEA_FUSE = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
 
 const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
@@ -32,7 +30,7 @@ const serverDist = join(repoRoot, 'apps/server/dist');
 const webDist = join(repoRoot, 'packages/web/dist');
 const outDir = join(serverDist, 'sea');
 const build = !process.argv.includes('--no-build');
-const nodeBinary = process.env.NODE_BINARY ?? process.execPath;
+const nodeBinary = process.execPath;
 
 const run = (cmd, args, opts = {}) => {
 	console.log(`$ ${cmd} ${args.join(' ')}`);
@@ -117,7 +115,7 @@ if (process.platform === 'darwin') run('codesign', ['--remove-signature', exe]);
 
 const postjectArgs = [exe, 'NODE_SEA_BLOB', blob, '--sentinel-fuse', SEA_FUSE];
 if (process.platform === 'darwin') postjectArgs.push('--macho-segment-name', 'NODE_SEA');
-run('npx', ['--yes', POSTJECT, ...postjectArgs]);
+run('pnpm', ['exec', 'postject', ...postjectArgs]);
 
 if (process.platform === 'darwin') run('codesign', ['--sign', '-', exe]);
 

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -13,11 +13,9 @@ const { pathToFileURL } = require('node:url');
 const manifest = JSON.parse(sea.getAsset('manifest.json', 'utf8'));
 
 const uid = process.getuid ? process.getuid() : null;
-// The bundle still `require()`s optional packages it does not ship (ws's
-// bufferutil, node-fetch's encoding), and Node resolves those through every
-// ancestor node_modules directory up to /. Under a shared tmpdir any local
-// user could plant /tmp/node_modules, so the default cache lives beneath the
-// user's own cache directory, whose ancestors only the user and root can write.
+// The unpacked bundle is executed, so the cache defaults to the user's own
+// cache directory, whose ancestors only the user and root can write. A shared
+// tmpdir would let any local user interfere with the path (see the checks below).
 let homeDir = null;
 try {
 	homeDir = os.homedir();
@@ -44,15 +42,16 @@ if (fs.lstatSync(cacheRoot).isSymbolicLink()) {
 	process.exit(1);
 }
 
-// The unpacked bundle is executed, so every directory on the path to it must
-// be one that no other user can rename or replace: owned by the current user
-// or root, and not group/world-writable. Checking only cacheRoot is not
-// enough, because whoever can write an ancestor can swap cacheRoot for a
-// symlink to a prepared tree between this check and the import below. Sticky
-// ancestors such as /tmp are tolerated: there, only the owner of an entry can
-// rename or unlink it. The resolved path is checked, and used from here on, so
-// an ancestor symlink maintained by root (/home -> /var/home) is allowed while
-// the import path itself contains no symlink component.
+// Every directory on the path to the unpacked bundle must be one no other user
+// can write: owned by the current user or root, and not group/world-writable.
+// Checking only cacheRoot is not enough, because whoever can write an ancestor
+// can swap cacheRoot for a symlink to a prepared tree between this check and
+// the import below. Sticky directories such as /tmp are rejected too: the
+// sticky bit stops renames, but a bundled module that still probes for an
+// optional package would resolve it through /tmp/node_modules. The resolved
+// path is checked, and used from here on, so an ancestor symlink maintained by
+// root (/home -> /var/home) is allowed while the import path itself contains
+// no symlink component.
 const resolvedRoot = fs.realpathSync(cacheRoot);
 const payloadDir = path.join(resolvedRoot, manifest.buildId);
 const readyMarker = path.join(payloadDir, '.ready');
@@ -73,8 +72,7 @@ for (let dir = resolvedRoot; ; dir = path.dirname(dir)) {
 		);
 		process.exit(1);
 	}
-	const sticky = dir !== resolvedRoot && st.mode & 0o1000;
-	if (st.mode & 0o022 && !sticky) {
+	if (st.mode & 0o022) {
 		console.error(
 			`${dir} is group or world-writable (mode ${(st.mode & 0o777).toString(8)}); refusing to use cache at ${cacheRoot}`,
 		);

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -1,0 +1,51 @@
+// SEA entrypoint. Node's single-executable loader only runs CommonJS and its
+// `require` resolves built-ins only, so the real (ESM) server bundle is shipped
+// as assets, unpacked to a per-build cache directory on first start, and then
+// loaded with a dynamic import. Once on disk, `import.meta.url` inside the
+// bundle resolves the worker scripts and DuckDB wasm files exactly as it does
+// in the container image.
+const sea = require('node:sea');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const manifest = JSON.parse(sea.getAsset('manifest.json', 'utf8'));
+
+const cacheRoot = process.env.MARIMOHUB_SEA_CACHE_DIR ?? path.join(os.tmpdir(), 'marimohub-sea');
+const payloadDir = path.join(cacheRoot, manifest.buildId);
+const readyMarker = path.join(payloadDir, '.ready');
+
+// The unpacked bundle is executed, so never load it from a directory another
+// user could have pre-populated (the default lives under the shared tmpdir).
+fs.mkdirSync(cacheRoot, { recursive: true, mode: 0o700 });
+if (process.getuid && fs.statSync(cacheRoot).uid !== process.getuid()) {
+	console.error(`${cacheRoot} is not owned by the current user; set MARIMOHUB_SEA_CACHE_DIR`);
+	process.exit(1);
+}
+
+if (!fs.existsSync(readyMarker)) {
+	// Unpack into a sibling temp dir and rename so a crash mid-extract, or two
+	// instances starting at once, never leave a half-written payload behind.
+	const staging = fs.mkdtempSync(path.join(cacheRoot, 'unpack-'));
+	for (const file of manifest.files) {
+		const target = path.join(staging, file);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, Buffer.from(sea.getRawAsset(file)));
+	}
+	fs.writeFileSync(path.join(staging, '.ready'), '');
+	try {
+		fs.renameSync(staging, payloadDir);
+	} catch (error) {
+		if (error.code !== 'ENOTEMPTY' && error.code !== 'EEXIST') throw error;
+		fs.rmSync(staging, { recursive: true, force: true });
+	}
+}
+
+process.env.MARIMOHUB_STATIC_ROOT ??= path.join(payloadDir, 'public');
+process.env.MARIMOHUB_VERSION ??= manifest.version;
+
+import(pathToFileURL(path.join(payloadDir, 'dist', 'index.mjs')).href).catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -81,6 +81,85 @@ for (let dir = resolvedRoot; ; dir = path.dirname(dir)) {
 	if (path.dirname(dir) === dir) break;
 }
 
+// Replacing a damaged payload directory runs under this lock so concurrent
+// starts never remove a payload a peer has just repaired. The lock is held
+// only across a marker check and one rename, so one older than a minute, or
+// one whose creator is gone, belongs to a crashed process and is broken.
+// Breaking a stale lock is an unlink by path, so two starts that observe the
+// same stale lock at the same instant could both proceed; that is safe because
+// the rename that moves the damaged tree aside succeeds for only one of them.
+const repairLock = path.join(resolvedRoot, `${manifest.buildId}.repair.lock`);
+const REPAIR_LOCK_STALE_MS = 60_000;
+const sleepSync = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+function isStaleRepairLock() {
+	let st;
+	let pid;
+	try {
+		st = fs.statSync(repairLock);
+		pid = Number(fs.readFileSync(repairLock, 'utf8'));
+	} catch (error) {
+		if (error.code === 'ENOENT') return false;
+		throw error;
+	}
+	if (Date.now() - st.mtimeMs > REPAIR_LOCK_STALE_MS) return true;
+	if (!Number.isInteger(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return false;
+	} catch (error) {
+		return error.code === 'ESRCH';
+	}
+}
+
+function acquireRepairLock() {
+	for (;;) {
+		try {
+			fs.writeFileSync(repairLock, String(process.pid), { flag: 'wx', mode: 0o600 });
+			return;
+		} catch (error) {
+			if (error.code !== 'EEXIST') throw error;
+		}
+		if (isStaleRepairLock()) {
+			fs.rmSync(repairLock, { force: true });
+			continue;
+		}
+		sleepSync(10);
+	}
+}
+
+// Moves `staging` into place. Returns false when a peer's identical payload
+// won the race, in which case `staging` has been discarded.
+function installPayload(staging) {
+	try {
+		fs.renameSync(staging, payloadDir);
+		return true;
+	} catch (error) {
+		if (error.code !== 'ENOTEMPTY' && error.code !== 'EEXIST') throw error;
+	}
+	if (fs.existsSync(readyMarker)) {
+		fs.rmSync(staging, { recursive: true, force: true });
+		return false;
+	}
+	// A payload directory without its marker is damaged (the rename is atomic,
+	// so only tampering or a partial delete gets here). Replace it rather than
+	// importing from it forever after. The damaged tree is moved aside before it
+	// is deleted: a recursive rm empties the directory first, and a peer's
+	// rename onto an empty directory succeeds, so deleting in place could
+	// strip a payload the peer just installed.
+	const damaged = `${staging}-damaged`;
+	acquireRepairLock();
+	try {
+		if (!fs.existsSync(readyMarker)) fs.renameSync(payloadDir, damaged);
+	} catch (error) {
+		if (error.code !== 'ENOENT') throw error;
+	} finally {
+		fs.rmSync(repairLock, { force: true });
+	}
+	fs.rmSync(damaged, { recursive: true, force: true });
+	return installPayload(staging);
+}
+
 if (!fs.existsSync(readyMarker)) {
 	// Unpack into a sibling temp dir and rename so a crash mid-extract, or two
 	// instances starting at once, never leave a half-written payload behind.
@@ -91,21 +170,7 @@ if (!fs.existsSync(readyMarker)) {
 		fs.writeFileSync(target, Buffer.from(sea.getRawAsset(file)));
 	}
 	fs.writeFileSync(path.join(staging, '.ready'), '');
-	try {
-		fs.renameSync(staging, payloadDir);
-	} catch (error) {
-		if (error.code !== 'ENOTEMPTY' && error.code !== 'EEXIST') throw error;
-		if (fs.existsSync(readyMarker)) {
-			// Another instance finished first; its payload is identical.
-			fs.rmSync(staging, { recursive: true, force: true });
-		} else {
-			// A payload directory without its marker is damaged (the rename is
-			// atomic, so only tampering or a partial delete gets here). Replace it
-			// rather than importing from it forever after.
-			fs.rmSync(payloadDir, { recursive: true, force: true });
-			fs.renameSync(staging, payloadDir);
-		}
-	}
+	installPayload(staging);
 }
 
 process.env.MARIMOHUB_STATIC_ROOT ??= path.join(payloadDir, 'public');

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -95,7 +95,16 @@ if (!fs.existsSync(readyMarker)) {
 		fs.renameSync(staging, payloadDir);
 	} catch (error) {
 		if (error.code !== 'ENOTEMPTY' && error.code !== 'EEXIST') throw error;
-		fs.rmSync(staging, { recursive: true, force: true });
+		if (fs.existsSync(readyMarker)) {
+			// Another instance finished first; its payload is identical.
+			fs.rmSync(staging, { recursive: true, force: true });
+		} else {
+			// A payload directory without its marker is damaged (the rename is
+			// atomic, so only tampering or a partial delete gets here). Replace it
+			// rather than importing from it forever after.
+			fs.rmSync(payloadDir, { recursive: true, force: true });
+			fs.renameSync(staging, payloadDir);
+		}
 	}
 }
 

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -13,11 +13,27 @@ const { pathToFileURL } = require('node:url');
 const manifest = JSON.parse(sea.getAsset('manifest.json', 'utf8'));
 
 const uid = process.getuid ? process.getuid() : null;
-const defaultCache =
-	uid !== null
-		? path.join(os.tmpdir(), `marimohub-sea-${uid}`)
-		: path.join(os.tmpdir(), 'marimohub-sea');
-const cacheRoot = process.env.MARIMOHUB_SEA_CACHE_DIR ?? defaultCache;
+// The bundle still `require()`s optional packages it does not ship (ws's
+// bufferutil, node-fetch's encoding), and Node resolves those through every
+// ancestor node_modules directory up to /. Under a shared tmpdir any local
+// user could plant /tmp/node_modules, so the default cache lives beneath the
+// user's own cache directory, whose ancestors only the user and root can write.
+let homeDir = null;
+try {
+	homeDir = os.homedir();
+} catch {
+	homeDir = null;
+}
+const cacheBase =
+	process.env.XDG_CACHE_HOME && path.isAbsolute(process.env.XDG_CACHE_HOME)
+		? process.env.XDG_CACHE_HOME
+		: homeDir && path.join(homeDir, '.cache');
+const cacheRoot =
+	process.env.MARIMOHUB_SEA_CACHE_DIR ?? (cacheBase ? path.join(cacheBase, 'marimohub-sea') : null);
+if (!cacheRoot) {
+	console.error('Cannot determine a cache directory; set MARIMOHUB_SEA_CACHE_DIR');
+	process.exit(1);
+}
 const payloadDir = path.join(cacheRoot, manifest.buildId);
 const readyMarker = path.join(payloadDir, '.ready');
 

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -34,34 +34,59 @@ if (!cacheRoot) {
 	console.error('Cannot determine a cache directory; set MARIMOHUB_SEA_CACHE_DIR');
 	process.exit(1);
 }
-const payloadDir = path.join(cacheRoot, manifest.buildId);
-const readyMarker = path.join(payloadDir, '.ready');
 
 fs.mkdirSync(cacheRoot, { recursive: true, mode: 0o700 });
 
-// Reject symlinks: an attacker in /tmp could plant one before the mkdir.
-const rootStat = fs.lstatSync(cacheRoot);
-if (rootStat.isSymbolicLink()) {
+// Reject a symlinked cacheRoot outright: in a sticky directory another user
+// could have planted it before the mkdir and can re-point it afterwards.
+if (fs.lstatSync(cacheRoot).isSymbolicLink()) {
 	console.error(`${cacheRoot} is a symlink; refusing to use it`);
 	process.exit(1);
 }
+
+// The unpacked bundle is executed, so every directory on the path to it must
+// be one that no other user can rename or replace: owned by the current user
+// or root, and not group/world-writable. Checking only cacheRoot is not
+// enough, because whoever can write an ancestor can swap cacheRoot for a
+// symlink to a prepared tree between this check and the import below. Sticky
+// ancestors such as /tmp are tolerated: there, only the owner of an entry can
+// rename or unlink it. The resolved path is checked, and used from here on, so
+// an ancestor symlink maintained by root (/home -> /var/home) is allowed while
+// the import path itself contains no symlink component.
+const resolvedRoot = fs.realpathSync(cacheRoot);
+const payloadDir = path.join(resolvedRoot, manifest.buildId);
+const readyMarker = path.join(payloadDir, '.ready');
+const rootStat = fs.lstatSync(resolvedRoot);
 if (uid !== null && rootStat.uid !== uid) {
 	console.error(`${cacheRoot} is not owned by the current user; set MARIMOHUB_SEA_CACHE_DIR`);
 	process.exit(1);
 }
-// Reject group/world-writable directories: another user could swap files
-// between the permission check and import.
-if (rootStat.mode & 0o022) {
-	console.error(
-		`${cacheRoot} is group or world-writable (mode ${(rootStat.mode & 0o777).toString(8)}); refusing to use it`,
-	);
-	process.exit(1);
+for (let dir = resolvedRoot; ; dir = path.dirname(dir)) {
+	const st = dir === resolvedRoot ? rootStat : fs.lstatSync(dir);
+	if (st.isSymbolicLink()) {
+		console.error(`${dir} is a symlink; refusing to use cache at ${cacheRoot}`);
+		process.exit(1);
+	}
+	if (uid !== null && st.uid !== uid && st.uid !== 0) {
+		console.error(
+			`${dir} is owned by uid ${st.uid}, not the current user or root; set MARIMOHUB_SEA_CACHE_DIR`,
+		);
+		process.exit(1);
+	}
+	const sticky = dir !== resolvedRoot && st.mode & 0o1000;
+	if (st.mode & 0o022 && !sticky) {
+		console.error(
+			`${dir} is group or world-writable (mode ${(st.mode & 0o777).toString(8)}); refusing to use cache at ${cacheRoot}`,
+		);
+		process.exit(1);
+	}
+	if (path.dirname(dir) === dir) break;
 }
 
 if (!fs.existsSync(readyMarker)) {
 	// Unpack into a sibling temp dir and rename so a crash mid-extract, or two
 	// instances starting at once, never leave a half-written payload behind.
-	const staging = fs.mkdtempSync(path.join(cacheRoot, 'unpack-'));
+	const staging = fs.mkdtempSync(path.join(resolvedRoot, 'unpack-'));
 	for (const file of manifest.files) {
 		const target = path.join(staging, file);
 		fs.mkdirSync(path.dirname(target), { recursive: true });

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -12,15 +12,33 @@ const { pathToFileURL } = require('node:url');
 
 const manifest = JSON.parse(sea.getAsset('manifest.json', 'utf8'));
 
-const cacheRoot = process.env.MARIMOHUB_SEA_CACHE_DIR ?? path.join(os.tmpdir(), 'marimohub-sea');
+const uid = process.getuid ? process.getuid() : null;
+const defaultCache =
+	uid !== null
+		? path.join(os.tmpdir(), `marimohub-sea-${uid}`)
+		: path.join(os.tmpdir(), 'marimohub-sea');
+const cacheRoot = process.env.MARIMOHUB_SEA_CACHE_DIR ?? defaultCache;
 const payloadDir = path.join(cacheRoot, manifest.buildId);
 const readyMarker = path.join(payloadDir, '.ready');
 
-// The unpacked bundle is executed, so never load it from a directory another
-// user could have pre-populated (the default lives under the shared tmpdir).
 fs.mkdirSync(cacheRoot, { recursive: true, mode: 0o700 });
-if (process.getuid && fs.statSync(cacheRoot).uid !== process.getuid()) {
+
+// Reject symlinks: an attacker in /tmp could plant one before the mkdir.
+const rootStat = fs.lstatSync(cacheRoot);
+if (rootStat.isSymbolicLink()) {
+	console.error(`${cacheRoot} is a symlink; refusing to use it`);
+	process.exit(1);
+}
+if (uid !== null && rootStat.uid !== uid) {
 	console.error(`${cacheRoot} is not owned by the current user; set MARIMOHUB_SEA_CACHE_DIR`);
+	process.exit(1);
+}
+// Reject group/world-writable directories: another user could swap files
+// between the permission check and import.
+if (rootStat.mode & 0o022) {
+	console.error(
+		`${cacheRoot} is group or world-writable (mode ${(rootStat.mode & 0o777).toString(8)}); refusing to use it`,
+	);
 	process.exit(1);
 }
 

--- a/scripts/sea/launcher.test.ts
+++ b/scripts/sea/launcher.test.ts
@@ -1,0 +1,155 @@
+import { spawn } from 'node:child_process';
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Runs the real launcher under plain `node`, with `node:sea` replaced by a
+// preload that serves a two-file payload. The unpacked entrypoint reports what
+// the launcher handed it, so a run's stdout tells us which payload was loaded.
+const launcher = fileURLToPath(new URL('./launcher.cjs', import.meta.url));
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const BUILD_ID = 'testbuild';
+const ENTRY = 'dist/index.mjs';
+const ENTRY_SOURCE = `console.log(JSON.stringify({
+	loaded: import.meta.url,
+	staticRoot: process.env.MARIMOHUB_STATIC_ROOT,
+	version: process.env.MARIMOHUB_VERSION,
+}));`;
+const STUB_SOURCE = `const Module = require('node:module');
+const manifest = ${JSON.stringify({ buildId: BUILD_ID, version: '0.0.0-test', files: [ENTRY, 'public/index.html'] })};
+const assets = { [${JSON.stringify(ENTRY)}]: ${JSON.stringify(ENTRY_SOURCE)}, 'public/index.html': '<div id="root"></div>' };
+const load = Module._load;
+Module._load = function (request, ...rest) {
+	if (request !== 'node:sea') return load.call(this, request, ...rest);
+	return {
+		getAsset: () => JSON.stringify(manifest),
+		getRawAsset: (name) => Buffer.from(assets[name]),
+	};
+};`;
+
+// Scratch trees live under node_modules/.cache rather than the OS tmpdir: the
+// launcher rejects anything below a world-writable directory such as /tmp.
+let scratch: string;
+let stub: string;
+
+interface Run {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+const runLauncher = (cacheDir: string): Promise<Run> =>
+	new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, ['-r', stub, launcher], {
+			env: { ...process.env, MARIMOHUB_SEA_CACHE_DIR: cacheDir },
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		let stdout = '';
+		let stderr = '';
+		child.stdout.on('data', (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on('data', (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+		child.on('error', reject);
+		child.on('close', (code) => {
+			resolve({ code, stdout, stderr });
+		});
+	});
+
+const loadedPayload = (run: Run) => {
+	expect(run.stderr).toBe('');
+	expect(run.code).toBe(0);
+	return JSON.parse(run.stdout) as { loaded: string; staticRoot: string; version: string };
+};
+
+const freshCache = (name: string) => join(mkdtempSync(join(scratch, `${name}-`)), 'cache');
+
+beforeAll(() => {
+	mkdirSync(join(repoRoot, 'node_modules/.cache'), { recursive: true });
+	scratch = mkdtempSync(join(repoRoot, 'node_modules/.cache/sea-launcher-'));
+	stub = join(scratch, 'sea-stub.cjs');
+	writeFileSync(stub, STUB_SOURCE);
+});
+
+afterAll(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform === 'win32')('SEA launcher', () => {
+	it('unpacks the payload on first start and reuses it afterwards', async () => {
+		const cache = freshCache('reuse');
+		const payloadDir = join(cache, BUILD_ID);
+
+		const first = loadedPayload(await runLauncher(cache));
+		expect(first.loaded).toBe(`file://${join(payloadDir, ENTRY)}`);
+		expect(first.staticRoot).toBe(join(payloadDir, 'public'));
+		expect(first.version).toBe('0.0.0-test');
+		expect(existsSync(join(payloadDir, '.ready'))).toBe(true);
+		expect(existsSync(join(payloadDir, 'public/index.html'))).toBe(true);
+		expect(readdirSync(cache)).toEqual([BUILD_ID]);
+
+		writeFileSync(join(payloadDir, 'marker'), '');
+		const second = loadedPayload(await runLauncher(cache));
+		expect(second.loaded).toBe(first.loaded);
+		expect(existsSync(join(payloadDir, 'marker'))).toBe(true);
+	});
+
+	it('leaves a single payload when two instances start at once', async () => {
+		const cache = freshCache('concurrent');
+		const runs = await Promise.all([runLauncher(cache), runLauncher(cache)]);
+		for (const run of runs) loadedPayload(run);
+		expect(readdirSync(cache)).toEqual([BUILD_ID]);
+		expect(existsSync(join(cache, BUILD_ID, '.ready'))).toBe(true);
+	});
+
+	it('replaces a payload directory that lost its ready marker', async () => {
+		const cache = freshCache('stale');
+		const payloadDir = join(cache, BUILD_ID);
+		mkdirSync(payloadDir, { recursive: true, mode: 0o700 });
+		writeFileSync(join(payloadDir, 'leftover'), '');
+
+		loadedPayload(await runLauncher(cache));
+		expect(existsSync(join(payloadDir, '.ready'))).toBe(true);
+		expect(existsSync(join(payloadDir, 'leftover'))).toBe(false);
+		expect(existsSync(join(payloadDir, ENTRY))).toBe(true);
+	});
+
+	it('refuses a cache root that is a symlink', async () => {
+		const base = mkdtempSync(join(scratch, 'symlink-'));
+		mkdirSync(join(base, 'real'), { mode: 0o700 });
+		symlinkSync(join(base, 'real'), join(base, 'cache'));
+
+		const run = await runLauncher(join(base, 'cache'));
+		expect(run.code).toBe(1);
+		expect(run.stderr).toContain('is a symlink');
+		expect(readdirSync(join(base, 'real'))).toEqual([]);
+	});
+
+	it.each([
+		['world-writable', 0o777],
+		['sticky world-writable', 0o1777],
+		['group-writable', 0o770],
+	])('refuses a cache below a %s ancestor', async (_label, mode) => {
+		const base = mkdtempSync(join(scratch, 'ancestor-'));
+		const ancestor = join(base, 'shared');
+		mkdirSync(ancestor);
+		chmodSync(ancestor, mode);
+
+		const run = await runLauncher(join(ancestor, 'cache'));
+		expect(run.code).toBe(1);
+		expect(run.stderr).toContain(`${ancestor} is group or world-writable`);
+		expect(existsSync(join(ancestor, 'cache', BUILD_ID))).toBe(false);
+	});
+});

--- a/scripts/sea/launcher.test.ts
+++ b/scripts/sea/launcher.test.ts
@@ -114,6 +114,23 @@ describe.skipIf(process.platform === 'win32')('SEA launcher', () => {
 		expect(existsSync(join(cache, BUILD_ID, '.ready'))).toBe(true);
 	});
 
+	it('repairs a payload directory that lost its ready marker under concurrent starts', async () => {
+		const rounds = Number(process.env.SEA_LAUNCHER_STRESS_ROUNDS ?? 3);
+		for (let round = 0; round < rounds; round++) {
+			const cache = freshCache('stale-concurrent');
+			const payloadDir = join(cache, BUILD_ID);
+			mkdirSync(payloadDir, { recursive: true, mode: 0o700 });
+			writeFileSync(join(payloadDir, 'leftover'), '');
+
+			const runs = await Promise.all(Array.from({ length: 12 }, () => runLauncher(cache)));
+			for (const run of runs) loadedPayload(run);
+			expect(readdirSync(cache)).toEqual([BUILD_ID]);
+			expect(existsSync(join(payloadDir, '.ready'))).toBe(true);
+			expect(existsSync(join(payloadDir, 'leftover'))).toBe(false);
+			expect(existsSync(join(payloadDir, ENTRY))).toBe(true);
+		}
+	}, 60_000);
+
 	it('replaces a payload directory that lost its ready marker', async () => {
 		const cache = freshCache('stale');
 		const payloadDir = join(cache, BUILD_ID);

--- a/scripts/smoke-sea.sh
+++ b/scripts/smoke-sea.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Boot a marimohub SEA binary with in-memory storage and check that it serves
+# the API and the SPA. Used by release.yml before the binary is attached.
+#
+#   scripts/smoke-sea.sh apps/server/dist/sea/marimohub-linux-x64 [expected-version]
+
+set -euo pipefail
+
+binary="${1:?path to the marimohub binary is required}"
+expected_version="${2:-}"
+port="${PORT:-3123}"
+cache_dir="$(mktemp -d)"
+log="$cache_dir/server.log"
+
+cleanup() {
+	if [[ -n "${server_pid:-}" ]]; then
+		kill "$server_pid" 2>/dev/null || true
+		wait "$server_pid" 2>/dev/null || true
+	fi
+	rm -rf "$cache_dir"
+}
+trap cleanup EXIT
+
+fail() {
+	echo "smoke test failed: $1" >&2
+	echo "--- server log ---" >&2
+	cat "$log" >&2
+	exit 1
+}
+
+MARIMOHUB_SEA_CACHE_DIR="$cache_dir/cache" \
+	MARIMOHUB_STORAGE_BACKEND=memory \
+	MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true \
+	MARIMOHUB_COMPUTE_BACKEND=none \
+	MARIMOHUB_AUTH_BACKEND=dev \
+	PORT="$port" \
+	"$binary" >"$log" 2>&1 &
+server_pid=$!
+
+healthy=false
+for _ in $(seq 1 60); do
+	if curl -fsS "http://127.0.0.1:$port/api/health" >/dev/null 2>&1; then
+		healthy=true
+		break
+	fi
+	if ! kill -0 "$server_pid" 2>/dev/null; then
+		fail "server exited before becoming healthy"
+	fi
+	sleep 1
+done
+if [[ "$healthy" != true ]]; then
+	fail "/api/health did not respond within 60s"
+fi
+
+version_json="$(curl -fsS "http://127.0.0.1:$port/api/v1/version")" ||
+	fail "GET /api/v1/version failed"
+echo "version: $version_json"
+if [[ -n "$expected_version" && "$version_json" != *"\"$expected_version\""* ]]; then
+	fail "expected version $expected_version in /api/v1/version response: $version_json"
+fi
+
+index_html="$(curl -fsS "http://127.0.0.1:$port/")" || fail "GET / failed"
+if [[ "$index_html" != *"<div id=\"root\">"* ]]; then
+	fail "expected the SPA index at /, got: $(printf '%s' "$index_html" | head -c 300)"
+fi
+echo "smoke test passed"

--- a/scripts/smoke-sea.sh
+++ b/scripts/smoke-sea.sh
@@ -9,7 +9,10 @@ set -euo pipefail
 binary="${1:?path to the marimohub binary is required}"
 expected_version="${2:-}"
 port="${PORT:-3123}"
-cache_dir="$(mktemp -d)"
+# The launcher refuses a cache below a world-writable directory such as /tmp,
+# so keep the scratch tree under the user's own cache directory.
+mkdir -p "${XDG_CACHE_HOME:-$HOME/.cache}"
+cache_dir="$(mktemp -d "${XDG_CACHE_HOME:-$HOME/.cache}/marimohub-sea-smoke.XXXXXX")"
 log="$cache_dir/server.log"
 
 cleanup() {


### PR DESCRIPTION
## Summary

Each GitHub release now also carries marimohub-linux-x64, a Node single executable application (SEA) for x86-64 Linux hosts without Node. The container image and Helm chart remain the primary distribution; this is one extra asset for operators who deploy single files.

scripts/build-sea.mjs embeds apps/server/dist and packages/web/dist as SEA assets and injects the blob into a copy of the running node with postject. The server source is untouched. SEA only executes CommonJS and its require resolves built-ins only, so scripts/sea/launcher.cjs unpacks the assets to a per-build cache directory on first start, sets MARIMOHUB_STATIC_ROOT and MARIMOHUB_VERSION, and dynamically imports the real ESM bundle. The cache root is created 0700 and must be owned by the current user, because the unpacked bundle is executed.

release.yml gains a server-binary job that builds the binary, boots it with memory storage and dev auth via scripts/smoke-sea.sh to check the health, version, and SPA endpoints, and uploads it with a sha256. A publish-server-binary job verifies the checksum, attests build provenance, and attaches both files after the CLI job has created the release. The binary is not part of the CLI SHA256SUMS or SBOM and is not rebuilt by the recovery workflow.

Closes #308

## Verification

- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm build`

For docs-only changes:

- [ ] `pnpm --filter @marimo-hub/docs test`
- [ ] `pnpm --filter @marimo-hub/docs build`

## Notes

- Docs updated or not needed: ✅ done
- Security impact:
