### PR TITLE
feat: show personal storage in the marimo sidebar

### DIFF
--- a/docs/deploying/cks.md
+++ b/docs/deploying/cks.md
@@ -503,7 +503,10 @@ MARIMOHUB_EDITOR_SANDBOX_SHARING=exclusive                        # one kernel p
 MARIMOHUB_COMPUTE_COREWEAVE_USER_HOME_TEMPLATE_ID=<USER-HOME-TEMPLATE-ID>
 ```
 
-Editors then find their directory at `/mnt/<lowercase-email>`.
+Each editor's `/mnt/<lowercase-email>` appears as **Personal files** in marimo's
+sidebar. This requires a kernel image with
+[multi-root file browsing](https://github.com/marimo-team/marimo/pull/10727).
+Marimo 0.24.0 does not include this feature.
 
 ::: details How the mount works
 

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -476,8 +476,10 @@ describe('Session routes', () => {
 			path: `/mnt/${user.email}`,
 		}));
 		const home = { resolve };
-		const ownerCompute = makeFakeCompute();
-		const otherCompute = makeFakeCompute();
+		const ownerSandbox = makeFakeSandbox();
+		const otherSandbox = makeFakeSandbox();
+		const ownerCompute = fakeComputeFrom(ownerSandbox.instance);
+		const otherCompute = fakeComputeFrom(otherSandbox.instance);
 		const exclusiveOwner = exclusiveApi(ACTOR, ownerCompute, {
 			sandbox: sandboxConfig({ userHome: home }),
 		});
@@ -499,6 +501,18 @@ describe('Session routes', () => {
 			path: `/mnt/${STRANGER}@example.com`,
 		});
 		expect(resolve).toHaveBeenCalledTimes(2);
+		for (const [sandbox, userId] of [
+			[ownerSandbox, ACTOR],
+			[otherSandbox, STRANGER],
+		] as const) {
+			const config = sandbox.calls.writeFiles
+				.flat()
+				.find((file) => file.path === '/tmp/marimohub-config/marimo/marimo.toml');
+			expect(config?.content).toContain('[[file_browser.folders]]');
+			expect(config?.content).toContain(`path = "/mnt/${userId}@example.com"`);
+			expect(config?.content).toContain('name = "Personal files"');
+			expect(config?.content).toContain('default_width = "medium"');
+		}
 	});
 
 	it('does not provision shared apps with an editor personal home', async () => {
@@ -1000,6 +1014,7 @@ describe('Session routes', () => {
 		expect(config?.content).toContain('wasm = false');
 		expect(config?.content).toContain('molab = false');
 		expect(config?.content).not.toContain('[ai]');
+		expect(config?.content).not.toContain('file_browser');
 		expect(calls.setEnvVars).toContainEqual({
 			XDG_CONFIG_HOME: '/tmp/marimohub-config',
 		});

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1475,6 +1475,11 @@ export async function startNotebookSession(input: {
 							marimoNotebookDefaults,
 							marimoSharingDisabled,
 						];
+						if (userHome) {
+							contributors.push(() => ({
+								file_browser: { folders: [{ path: userHome.path, name: 'Personal files' }] },
+							}));
+						}
 						if (deps.ai) {
 							try {
 								const token = await mintAiSessionToken(


### PR DESCRIPTION
Show each CoreWeave editor's `/mnt/<email>` directory as **Personal files** in the marimo sidebar by adding it to `file_browser.folders`. Applies to persistent and temporary editors with personal storage configured.

Requires a kernel image containing marimo-team/marimo#10727. The setup docs note that marimo 0.24.0 does not include this feature.
