### PR TITLE
release: 0.4.0

### DIFF
--- a/apps/cli/Cargo.lock
+++ b/apps/cli/Cargo.lock
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "mohub"
-version = "0.3.12"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "base64 0.22.1",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mohub"
-version = "0.3.12"
+version = "0.4.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/marimo-team/marimohub"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: marimo-team/setup-marimohub-cli@15f7152034cdf6728c02be77d39526360ce60ec2 # v1.0.1
         with:
-          version: '0.3.12'
+          version: '0.4.0'
 
       - name: Sync notebook
         run: >-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "marimohub",
-	"version": "0.3.12",
+	"version": "0.4.0",
 	"private": true,
 	"license": "Apache-2.0",
 	"type": "module",


### PR DESCRIPTION
Merging this PR tags `v0.4.0` and publishes the container image, Helm chart, and mohub CLI.