### PR TITLE
fix(release): drop --retry-all-errors in the manylinux CLI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,10 +128,11 @@ jobs:
           dnf install -y python3-pip
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      # manylinux_2_28 ships curl 7.61, which predates --retry-all-errors (7.71).
       - name: Install dist
         shell: bash
         run: |
-          curl --proto '=https' --tlsv1.2 -LsSf --retry 5 --retry-all-errors --retry-delay 2 \
+          curl --proto '=https' --tlsv1.2 -LsSf --retry 5 --retry-delay 2 \
             https://github.com/axodotdev/cargo-dist/releases/download/v0.32.0/cargo-dist-installer.sh | sh
       - name: Build archive
         shell: bash


### PR DESCRIPTION
## Summary
The v0.4.0 release run failed and the tag can't be moved (the "Immutable tags" ruleset has no bypass actors), so 0.4.1 must be cut instead. Two fixes so that works cleanly:

- **manylinux CLI build**: *Install dist* failed with `curl: option --retry-all-errors: is unknown` ([job](https://github.com/marimo-team/marimohub/actions/runs/34531403444/job/103053044900)). The manylinux_2_28 container ships curl 7.61; the flag needs 7.71 and came in with #309. Dropped from the container job only; the other uses run on `ubuntu-latest`/`macos-15` hosts.
- **Release notes**: changelogithub defaults to "commits since the previous git tag", so v0.4.1's notes would only cover v0.4.0..v0.4.1 and drop the 43 commits in v0.3.12..v0.4.0. The release step now passes `--from` the newest published (non-draft, non-prerelease) GitHub release, and the recovery workflow does the same via `--notes-start-tag`. For a normal release the newest published release *is* the previous tag, so behaviour is unchanged there.

Dry run of `changelogithub --from v0.3.12 --to v0.4.0` locally produces the expected 43-commit grouped changelog.

## Test plan
- [x] `pnpm check` passes
- [ ] v0.4.1 release run gets past *Install dist* in the manylinux job
- [ ] v0.4.1 release notes include the v0.3.12..v0.4.0 commits