### PR TITLE
fix(release): start release notes at the last published release

### DIFF
--- a/.github/workflows/recover-cli-release.yml
+++ b/.github/workflows/recover-cli-release.yml
@@ -103,6 +103,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Match release.yml: notes start at the last published release.
+          FROM=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 \
+            --json tagName --jq '.[0].tagName // empty')
+          FROM_ARGS=()
+          if [[ -n "$FROM" && "$FROM" != "$RELEASE_TAG" ]]; then
+            FROM_ARGS=(--notes-start-tag "$FROM")
+          fi
           for attempt in 1 2 3 4; do
             scripts/verify-release-tag.sh "$RELEASE_TAG" "$SOURCE_SHA"
             if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
@@ -111,7 +118,7 @@ jobs:
             fi
             if gh release create "$RELEASE_TAG" \
               --verify-tag \
-              --generate-notes \
+              --generate-notes "${FROM_ARGS[@]}" \
               --title "$RELEASE_TAG"; then
               break
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,7 +309,7 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          # changelogithub diffs against the previous tag, so it needs full history.
+          # changelogithub diffs against the previous release tag, so it needs full history.
           fetch-depth: 0
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -325,12 +325,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Start the notes at the last published release, not the previous git
+          # tag, so commits behind a tag whose release never shipped still land
+          # in the next release's notes.
+          FROM=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 \
+            --json tagName --jq '.[0].tagName // empty')
+          FROM_ARGS=()
+          if [[ -n "$FROM" && "$FROM" != "$GITHUB_REF_NAME" ]]; then
+            FROM_ARGS=(--from "$FROM")
+          fi
           for attempt in 1 2 3 4; do
             if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
               echo "Release $GITHUB_REF_NAME already exists; keeping its release notes."
               break
             fi
-            if npx changelogithub@14.0.0; then
+            if npx changelogithub@14.0.0 "${FROM_ARGS[@]}"; then
               break
             fi
             if [[ "$attempt" == 4 ]]; then

--- a/development_docs/releasing.md
+++ b/development_docs/releasing.md
@@ -15,9 +15,11 @@ Releases are cut via a PR, never by pushing to `main` or hand-pushing tags.
 3. The tag push triggers [`release.yml`](../.github/workflows/release.yml),
    which publishes the container image and the Helm chart to GHCR, builds the
    cross-platform `mohub` binaries and binary-only wheels, and creates a GitHub
-   release whose changelog is generated from
-   the commits since the previous tag ([changelogithub](https://github.com/antfu/changelogithub),
-   so conventional-commit prefixes like `feat:`/`fix:` drive the grouping).
+   release whose changelog is generated from the commits since the last
+   published release ([changelogithub](https://github.com/antfu/changelogithub),
+   so conventional-commit prefixes like `feat:`/`fix:` drive the grouping). If
+   a tag's release never shipped, its commits roll into the next release's
+   notes.
 
 The x86-64 Linux build uses a glibc 2.28 image. Each native archive contains
 shell completions and man pages.


### PR DESCRIPTION
## Summary
Follow-up to #324, which merged before this commit was pushed.

changelogithub defaults to "commits since the previous git tag", so v0.4.1's notes would only cover v0.4.0..v0.4.1 and drop the 43 commits in v0.3.12..v0.4.0 (v0.4.0's release never shipped).

- The release step now passes `--from` the newest published (non-draft, non-prerelease) GitHub release. For a normal release that is the previous tag, so behaviour is unchanged there.
- The recovery workflow does the same via `gh release create --notes-start-tag`.
- `development_docs/releasing.md` updated to match.

Dry run of `changelogithub --from v0.3.12 --to v0.4.0` locally produces the expected 43-commit grouped changelog.

## Test plan
- [x] `pnpm check` passes
- [ ] v0.4.1 release notes include the v0.3.12..v0.4.0 commits