### PR TITLE
feat(release): re-attach the standalone Linux x64 server binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,74 @@ jobs:
       # The build task restores dist/ when its cache hits.
       - run: node scripts/check-bundle-size.mjs
 
+      # The release workflow only runs from a tag, so a broken SEA build or
+      # launcher would otherwise surface mid-release. Reuses the dist/ output
+      # the build step above produced.
+      - name: Build and smoke test the server binary
+        run: |
+          node scripts/build-sea.mjs --no-build
+          scripts/smoke-sea.sh apps/server/dist/sea/marimohub-linux-x64 \
+            "$(node -p 'require("./package.json").version')"
+
       - name: Save Vite Task cache
         if: success() && github.event_name == 'push'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: node_modules/.vite/task-cache
           key: ${{ steps.vite-task-cache.outputs.cache-primary-key }}
+
+  server-image:
+    name: Build server image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      VERSION: 0.0.0-ci
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      # The release workflow only builds this image from a tag, and it is the
+      # primary distribution, so build it here too. `load` keeps it on the
+      # runner for the boot check below; nothing is pushed.
+      - name: Build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: apps/server/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: marimohub:ci
+          build-args: |
+            MARIMOHUB_VERSION=${{ env.VERSION }}
+          cache-from: type=gha
+          # Forks get a read-only token, so only same-repo runs may write the cache.
+          cache-to: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=gha,mode=max' || '' }}
+
+      - name: Boot and check
+        id: boot
+        run: |
+          docker run -d --name marimohub-ci -p 3000:3000 \
+            -e MARIMOHUB_STORAGE_BACKEND=memory \
+            -e MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true \
+            -e MARIMOHUB_COMPUTE_BACKEND=none \
+            -e MARIMOHUB_AUTH_BACKEND=dev \
+            marimohub:ci
+          for _ in $(seq 1 60); do
+            curl -fsS http://127.0.0.1:3000/api/health >/dev/null 2>&1 && break
+            docker inspect -f '{{.State.Running}}' marimohub-ci | grep -qx true \
+              || { echo '::error::container exited before becoming healthy'; exit 1; }
+            sleep 1
+          done
+          # The loop above can also fall through after 60 tries, so re-check.
+          curl -fsS http://127.0.0.1:3000/api/health >/dev/null
+          curl -fsS http://127.0.0.1:3000/api/v1/version | grep -F "\"$VERSION\""
+          curl -fsS http://127.0.0.1:3000/ | grep -F '<div id="root">'
+
+      - name: Container logs
+        if: failure() && steps.boot.outcome == 'failure'
+        run: docker logs marimohub-ci
 
   dependency-review:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -35,6 +35,12 @@ jobs:
         run: |
           pnpm --filter @marimo-hub/api test cliManifest.spec
           pnpm cli:version-check
+      # Only the release workflow generates these, so a broken generator would
+      # otherwise surface mid-release.
+      - name: Generate shell completions and man pages
+        working-directory: apps/cli
+        run: cargo run --locked --example generate-assets -- generated
+
       - name: Validate distribution plan
         working-directory: apps/cli
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,10 @@ name: Release
 # Triggered by a semver tag, normally pushed by release-tag.yml when a
 # "release: X.Y.Z" PR is merged (see development_docs/releasing.md).
 # This publishes the container image and Helm chart to GHCR, builds native CLI
-# archives and binary wheels, and creates a GitHub release with checksums,
-# provenance, an SBOM, and a changelog generated from commits since the prior
-# tag. The chart version, appVersion, and image tag are pinned to the git tag.
+# archives and binary wheels plus a standalone Linux x64 server binary, and
+# creates a GitHub release with checksums, provenance, an SBOM, and a changelog
+# generated from commits since the prior tag. The chart version, appVersion,
+# and image tag are pinned to the git tag.
 #   helm upgrade --install marimohub oci://ghcr.io/marimo-team/charts/marimohub \
 #     --version 1.4.2 -n marimohub -f values.yaml
 on:
@@ -189,6 +190,46 @@ jobs:
             apps/cli/target/distrib/*.sum
           if-no-files-found: error
 
+  server-binary:
+    name: Build server binary (linux-x64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+        with:
+          version: 0.1.24
+          node-version-file: '.node-version'
+          sfw: true
+          cache: true
+          run-install: |
+            - args: ['--frozen-lockfile']
+
+      - name: Build web and server
+        run: vp run --fail-if-no-match --filter @marimo-hub/web --filter @marimo-hub/server build
+
+      # A Node single-executable (SEA): the runner's `node` with the server
+      # bundle and SPA injected as assets. See scripts/build-sea.mjs.
+      - name: Build binary
+        run: node scripts/build-sea.mjs --no-build
+
+      - name: Smoke test
+        run: scripts/smoke-sea.sh apps/server/dist/sea/marimohub-linux-x64 "${GITHUB_REF_NAME#v}"
+
+      - name: Checksum
+        working-directory: apps/server/dist/sea
+        run: sha256sum marimohub-linux-x64 > marimohub-linux-x64.sha256
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: marimohub-linux-x64
+          path: |
+            apps/server/dist/sea/marimohub-linux-x64
+            apps/server/dist/sea/marimohub-linux-x64.sha256
+          if-no-files-found: error
+
   image:
     name: Build & push image
     runs-on: ubuntu-latest
@@ -355,6 +396,40 @@ jobs:
           scripts/retry.sh gh release upload "$GITHUB_REF_NAME"
           release-assets/* --clobber
 
+  publish-server-binary:
+    name: Attach server binary
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # The CLI job creates the release; this only adds one more asset to it.
+    needs: [server-binary, publish-cli-release]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: marimohub-linux-x64
+          path: server-binary
+
+      - name: Verify checksum
+        working-directory: server-binary
+        run: sha256sum -c marimohub-linux-x64.sha256
+
+      - name: Attest server binary
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: server-binary/marimohub-linux-x64
+
+      - name: Attach server binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          scripts/retry.sh gh release upload "$GITHUB_REF_NAME"
+          server-binary/marimohub-linux-x64 server-binary/marimohub-linux-x64.sha256 --clobber
+
   cli-release-metadata:
     name: Publish CLI release metadata
     runs-on: ubuntu-latest
@@ -403,7 +478,17 @@ jobs:
     timeout-minutes: 5
     # Report the overall outcome once every release job has finished.
     needs:
-      [cli, cli-linux-x64, cli-installers, image, chart, publish-cli-release, cli-release-metadata]
+      [
+        cli,
+        cli-linux-x64,
+        cli-installers,
+        server-binary,
+        image,
+        chart,
+        publish-cli-release,
+        publish-server-binary,
+        cli-release-metadata,
+      ]
     if: always()
     steps:
       - name: Notify Slack - Release Success

--- a/apps/server/src/unavailableOptionalDependency.cjs
+++ b/apps/server/src/unavailableOptionalDependency.cjs
@@ -1,0 +1,6 @@
+// Bundled in place of optional native packages the server never ships
+// (see the `alias` map in vite.config.ts). Callers require these inside a
+// try/catch and fall back to pure JS; throwing here keeps that fallback while
+// leaving no bare `require()` in the bundle that Node would otherwise resolve
+// through every ancestor node_modules directory at runtime.
+throw new Error('optional dependency is not bundled with the marimohub server');

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite-plus';
 import { DUCKDB_EXTENSION_MANIFEST } from '../../packages/duckdb-wasm-runtime/src/extensionManifest';
 
@@ -20,6 +21,16 @@ export default defineConfig({
 		platform: 'node',
 		format: ['esm'],
 		dts: false,
+		// ws, node-fetch and pg probe for optional native packages with a guarded
+		// require(). Left unresolved, those become bare require() calls that Node
+		// resolves through every ancestor node_modules directory of wherever the
+		// bundle runs. Point them at a stub that throws so the fallback is taken.
+		alias: Object.fromEntries(
+			['bufferutil', 'utf-8-validate', 'encoding', 'pg-native'].map((name) => [
+				name,
+				fileURLToPath(new URL('./src/unavailableOptionalDependency.cjs', import.meta.url)),
+			]),
+		),
 		noExternal: [
 			/^@marimo-hub\//,
 			/^@modelcontextprotocol\//,

--- a/development_docs/releasing.md
+++ b/development_docs/releasing.md
@@ -24,6 +24,21 @@ Releases are cut via a PR, never by pushing to `main` or hand-pushing tags.
 The x86-64 Linux build uses a glibc 2.28 image. Each native archive contains
 shell completions and man pages.
 
+The release also attaches `marimohub-linux-x64`, a standalone server binary
+built with Node's single executable application (SEA) support by
+[`scripts/build-sea.mjs`](../scripts/build-sea.mjs). It is the runner's `node`
+with the server bundle and the SPA injected as assets; on first start it unpacks
+them to a cache directory and loads the bundle from there. The container image
+stays the primary distribution; the binary is a convenience for hosts without
+Node. It carries its own `.sha256` and a build provenance attestation (verify
+with `gh attestation verify marimohub-linux-x64 --repo marimo-team/marimohub`),
+but it is not in the CLI `SHA256SUMS` or SBOM, and the recovery workflow does
+not rebuild it.
+Build it locally with `pnpm build:sea` (outputs
+`apps/server/dist/sea/marimohub-<platform>-<arch>`) and check it with
+`scripts/smoke-sea.sh <binary>`. CI's `verify` job runs both on every PR, so a
+broken build or launcher fails there rather than halfway through a release.
+
 [`apps/cli/dist-workspace.toml`](../apps/cli/dist-workspace.toml) defines shell,
 PowerShell, Homebrew, and npm installers. It also defines the standalone
 `mohub-update` program. Run `dist plan --allow-dirty` from `apps/cli` to check

--- a/docs/deployment-options.md
+++ b/docs/deployment-options.md
@@ -36,6 +36,35 @@ MARIMOHUB_PERSIST_WORKSPACE=source
 - Everything is documented in [Configuration](./configuration.md).
 - Best for standard deployments (Docker, Podman, Kubernetes).
 
+The container image is the primary distribution. Each
+[GitHub release](https://github.com/marimo-team/marimohub/releases) also
+attaches `marimohub-linux-x64`, a standalone server binary for x86-64 Linux
+hosts without Node. It reads the same `MARIMOHUB_*` variables. On first start it
+unpacks its bundled files to `$XDG_CACHE_HOME/marimohub-sea/<build-id>`
+(default `~/.cache/marimohub-sea/<build-id>`); set `MARIMOHUB_SEA_CACHE_DIR` to
+use a different directory. The unpacked files are executed, so the binary
+refuses a cache directory that is a symlink, not owned by the current user, or
+reachable through a directory another user can write to, including sticky
+directories such as `/tmp`.
+
+Each release unpacks into its own `<build-id>` directory of roughly 75 MB, and
+earlier ones are left in place, because another instance may still be running
+from one. Delete the directories you no longer need after an upgrade.
+
+The example below is a throwaway configuration that keeps all state in memory.
+For a real deployment use the durable variables from the `.env` above.
+
+```bash
+curl -fsSLO https://github.com/marimo-team/marimohub/releases/latest/download/marimohub-linux-x64
+chmod +x marimohub-linux-x64
+
+export MARIMOHUB_STORAGE_BACKEND=memory
+export MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true
+export MARIMOHUB_COMPUTE_BACKEND=none
+export MARIMOHUB_AUTH_BACKEND=dev
+./marimohub-linux-x64
+```
+
 ## 2. SDK / library composition (the complex case)
 
 Import the adapters you want and construct `createApi(deps)` by hand. Use this

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"ready": "vp fmt && vp lint && pnpm typecheck && vp run -r test && vp run -r build",
 		"check": "vp check",
 		"typecheck": "vp run -r typecheck",
-		"test": "vp test tools/oxlint/anti-slop/index.test.ts --silent=passed-only --hideSkippedTests && vp run -r test --configLoader=runner --pool=threads --silent=passed-only --hideSkippedTests",
+		"test": "vp test tools/oxlint/anti-slop/index.test.ts scripts/sea/launcher.test.ts scripts/sea/payload.test.ts --silent=passed-only --hideSkippedTests && vp run -r test --configLoader=runner --pool=threads --silent=passed-only --hideSkippedTests",
 		"test:release-scripts": "bash scripts/release-helpers.test.sh",
 		"test:external-adapter": "node --test examples/external-adapter/oidc-login-policy.test.mjs",
 		"test:coverage": "pnpm test:coverage:root && pnpm test:coverage:web",
@@ -25,6 +25,7 @@
 		"schemas:generate": "pnpm --filter @marimo-hub/api openapi:generate && pnpm --filter @marimo-hub/api cli:generate && pnpm --filter @marimo-hub/core schemas:generate && vp fmt internal/schemas && pnpm --filter @marimo-hub/client generate && pnpm --filter @marimo-hub/docs integrations:generate",
 		"build": "vp run -r build",
 		"cli:version-check": "node scripts/check-cli-version.mjs",
+		"build:sea": "node scripts/build-sea.mjs",
 		"release": "node scripts/release.mjs",
 		"prepare": "vp config"
 	},
@@ -32,6 +33,7 @@
 		"@oxlint/plugins": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
 		"oxlint": "catalog:",
+		"postject": "catalog:",
 		"react-doctor": "catalog:",
 		"vite-plus": "catalog:"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ catalogs:
     pg-cursor:
       specifier: ^2.22.0
       version: 2.22.0
+    postject:
+      specifier: 1.0.0-alpha.6
+      version: 1.0.0-alpha.6
     react-aria-components:
       specifier: ^1.20.0
       version: 1.20.0
@@ -328,9 +331,12 @@ importers:
       oxlint:
         specifier: 'catalog:'
         version: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      postject:
+        specifier: 'catalog:'
+        version: 1.0.0-alpha.6
       react-doctor:
         specifier: 'catalog:'
-        version: 0.9.12(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(eslint@10.8.1(jiti@2.7.0))(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+        version: 0.9.12(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(eslint@10.8.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
@@ -1878,7 +1884,7 @@ importers:
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)'
 
 packages:
 
@@ -5365,6 +5371,10 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+
   compare-versions@6.1.1:
     resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
@@ -6987,6 +6997,11 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postject@1.0.0-alpha.6:
+    resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
@@ -10738,6 +10753,49 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.24':
     optional: true
 
+  '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      es-module-lexer: 1.7.0
+      obug: 2.1.2
+      pixelmatch: 7.2.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)'
+      ws: 8.21.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(@voidzero-dev/vite-plus-test@0.1.24)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - yaml
+
   '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -11298,6 +11356,8 @@ snapshots:
   commander@14.0.3: {}
 
   commander@2.20.3: {}
+
+  commander@9.5.0: {}
 
   compare-versions@6.1.1: {}
 
@@ -13063,7 +13123,7 @@ snapshots:
       oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxlint@1.77.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  oxlint@1.77.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.77.0
       '@oxlint/binding-android-arm64': 1.77.0
@@ -13084,6 +13144,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.77.0
       '@oxlint/binding-win32-ia32-msvc': 1.77.0
       '@oxlint/binding-win32-x64-msvc': 1.77.0
+      oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
 
   p-limit@3.1.0:
@@ -13214,6 +13275,10 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  postject@1.0.0-alpha.6:
+    dependencies:
+      commander: 9.5.0
+
   preact@10.29.2: {}
 
   prelude-ls@1.2.1: {}
@@ -13312,7 +13377,7 @@ snapshots:
       react-stately: 3.49.0(react@19.2.7)
       use-sync-external-store: 1.6.0(react@19.2.7)
 
-  react-doctor@0.9.12(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(eslint@10.8.1(jiti@2.7.0))(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
+  react-doctor@0.9.12(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))(eslint@10.8.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       '@astrojs/compiler': 4.0.0
       '@sentry/node': 10.70.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))
@@ -13324,7 +13389,7 @@ snapshots:
       jiti: 2.7.0
       magicast: 0.5.3
       oxc-resolver: 11.24.2
-      oxlint: 1.77.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.77.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0))
       oxlint-plugin-react-doctor: 0.9.12
       prompts: 2.4.2
       typescript: 5.9.3
@@ -14017,7 +14082,7 @@ snapshots:
       '@oxc-project/types': 0.133.0
       '@oxlint/plugins': 1.61.0
       '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
       oxfmt: 0.52.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))
       oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8(@voidzero-dev/vite-plus-test@0.1.24))(@voidzero-dev/vite-plus-core@0.1.24(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,6 +88,7 @@ catalog:
   oxlint: 1.67.0
   pg: ^8.23.0
   pg-cursor: ^2.22.0
+  postject: 1.0.0-alpha.6
   react-aria-components: ^1.20.0
   react-doctor: 0.9.12
   simple-icons: ^16.27.0

--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Build a single-executable marimohub server with Node SEA.
+//
+//   node scripts/build-sea.mjs            # builds web + server first
+//   node scripts/build-sea.mjs --no-build # reuse existing dist/ output
+//
+// Output: apps/server/dist/sea/marimohub-<platform>-<arch> (plus the
+// intermediate blob/config). Always targets the host: the executable is a copy
+// of the running `node` with the SEA blob injected, and there is no
+// cross-building, so run this on the target OS and architecture. Releases only
+// ship marimohub-linux-x64; other platforms are for local testing.
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { delimiter, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { inject } from 'postject';
+import { collectPayload } from './sea/payload.mjs';
+
+const SEA_FUSE = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
+
+const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const serverDist = join(repoRoot, 'apps/server/dist');
+const webDist = join(repoRoot, 'packages/web/dist');
+const outDir = join(serverDist, 'sea');
+const build = !process.argv.includes('--no-build');
+const nodeBinary = process.execPath;
+
+// The release runner installs vite-plus but no package manager, so workspace
+// binaries are reached through node_modules/.bin rather than `pnpm exec`.
+const binDir = join(repoRoot, 'node_modules/.bin');
+// `process.env` is case-insensitive on Windows but a spread copy of it is not,
+// so extend the key that is already there instead of adding a second one.
+const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+const run = (cmd, args, opts = {}) => {
+	console.log(`$ ${cmd} ${args.join(' ')}`);
+	execFileSync(cmd, args, {
+		stdio: 'inherit',
+		cwd: repoRoot,
+		env: { ...process.env, [pathKey]: `${binDir}${delimiter}${process.env[pathKey]}` },
+		...opts,
+	});
+};
+
+if (build) {
+	run('vp', ['run', '--filter', '@marimo-hub/web', '--filter', '@marimo-hub/server', 'build']);
+}
+for (const file of [join(serverDist, 'index.mjs'), join(webDist, 'index.html')]) {
+	if (!statSync(file, { throwIfNoEntry: false })?.isFile()) {
+		console.error(`missing ${file}; run without --no-build`);
+		process.exit(1);
+	}
+}
+
+rmSync(outDir, { recursive: true, force: true });
+
+const launcherSource = join(repoRoot, 'scripts/sea/launcher.cjs');
+const { assets, buildId } = collectPayload({
+	serverDist,
+	webDist,
+	shim: join(repoRoot, 'scripts/sea/importShim.cjs'),
+	launcher: launcherSource,
+});
+mkdirSync(outDir, { recursive: true });
+
+const version = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).version;
+const manifest = { version, buildId, files: Object.keys(assets) };
+const manifestPath = join(outDir, 'manifest.json');
+writeFileSync(manifestPath, JSON.stringify(manifest));
+assets['manifest.json'] = manifestPath;
+
+const launcher = join(outDir, 'launcher.cjs');
+cpSync(launcherSource, launcher);
+
+const seaConfig = join(outDir, 'sea-config.json');
+const blob = join(outDir, 'sea.blob');
+writeFileSync(
+	seaConfig,
+	JSON.stringify(
+		{
+			main: launcher,
+			output: blob,
+			disableExperimentalSEAWarning: true,
+			assets,
+		},
+		null,
+		2,
+	),
+);
+
+run(nodeBinary, ['--experimental-sea-config', seaConfig]);
+
+const exe = join(
+	outDir,
+	`marimohub-${process.platform}-${process.arch}${process.platform === 'win32' ? '.exe' : ''}`,
+);
+cpSync(nodeBinary, exe);
+if (process.platform === 'darwin') run('codesign', ['--remove-signature', exe]);
+
+// postject's own CLI would have to be reached through a package manager, and
+// the release runner has none; its library API resolves from the frozen
+// workspace lock just the same.
+console.log(`$ postject ${exe} NODE_SEA_BLOB ${blob}`);
+await inject(exe, 'NODE_SEA_BLOB', readFileSync(blob), {
+	sentinelFuse: SEA_FUSE,
+	...(process.platform === 'darwin' && { machoSegmentName: 'NODE_SEA' }),
+});
+
+if (process.platform === 'darwin') run('codesign', ['--sign', '-', exe]);
+
+const mb = (statSync(exe).size / 1024 / 1024).toFixed(0);
+console.log(
+	`\nbuilt ${exe} (${mb} MB, ${manifest.files.length} embedded files, build ${manifest.buildId})`,
+);

--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -8,7 +8,8 @@
 // intermediate blob/config). Always targets the host: the executable is a copy
 // of the running `node` with the SEA blob injected, and there is no
 // cross-building, so run this on the target OS and architecture. Releases only
-// ship marimohub-linux-x64; other platforms are for local testing.
+// ship marimohub-linux-x64; macOS is for local testing. Windows is refused
+// below.
 import { execFileSync } from 'node:child_process';
 import { cpSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -16,6 +17,17 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { inject } from 'postject';
 import { collectPayload } from './sea/payload.mjs';
+
+// The launcher guards the directory it unpacks executable code into with POSIX
+// ownership and mode bits. Windows only synthesises those: an ordinary
+// directory reports 0o777, so the binary refuses to start. Until that guard has
+// a Windows equivalent, do not produce an executable that cannot run.
+if (process.platform === 'win32') {
+	console.error(
+		'build-sea.mjs does not support Windows; see the cache checks in scripts/sea/launcher.cjs',
+	);
+	process.exit(1);
+}
 
 const SEA_FUSE = 'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2';
 
@@ -92,10 +104,7 @@ writeFileSync(
 
 run(nodeBinary, ['--experimental-sea-config', seaConfig]);
 
-const exe = join(
-	outDir,
-	`marimohub-${process.platform}-${process.arch}${process.platform === 'win32' ? '.exe' : ''}`,
-);
+const exe = join(outDir, `marimohub-${process.platform}-${process.arch}`);
 cpSync(nodeBinary, exe);
 if (process.platform === 'darwin') run('codesign', ['--remove-signature', exe]);
 

--- a/scripts/build-sea.mjs
+++ b/scripts/build-sea.mjs
@@ -11,7 +11,8 @@
 // ship marimohub-linux-x64; other platforms are for local testing.
 import { execFileSync } from 'node:child_process';
 import { cpSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
-import { delimiter, join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { inject } from 'postject';
 import { collectPayload } from './sea/payload.mjs';
@@ -25,24 +26,26 @@ const outDir = join(serverDist, 'sea');
 const build = !process.argv.includes('--no-build');
 const nodeBinary = process.execPath;
 
-// The release runner installs vite-plus but no package manager, so workspace
-// binaries are reached through node_modules/.bin rather than `pnpm exec`.
-const binDir = join(repoRoot, 'node_modules/.bin');
-// `process.env` is case-insensitive on Windows but a spread copy of it is not,
-// so extend the key that is already there instead of adding a second one.
-const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
 const run = (cmd, args, opts = {}) => {
 	console.log(`$ ${cmd} ${args.join(' ')}`);
-	execFileSync(cmd, args, {
-		stdio: 'inherit',
-		cwd: repoRoot,
-		env: { ...process.env, [pathKey]: `${binDir}${delimiter}${process.env[pathKey]}` },
-		...opts,
-	});
+	execFileSync(cmd, args, { stdio: 'inherit', cwd: repoRoot, ...opts });
 };
 
 if (build) {
-	run('vp', ['run', '--filter', '@marimo-hub/web', '--filter', '@marimo-hub/server', 'build']);
+	// The release runner has vite-plus but no package manager, and on Windows a
+	// `node_modules/.bin` entry is a `.cmd` shim that execFileSync cannot spawn.
+	// vite-plus ships its bin as a plain Node script, so run that.
+	const vpPackage = createRequire(import.meta.url).resolve('vite-plus/package.json');
+	const vp = join(dirname(vpPackage), JSON.parse(readFileSync(vpPackage, 'utf8')).bin.vp);
+	run(nodeBinary, [
+		vp,
+		'run',
+		'--filter',
+		'@marimo-hub/web',
+		'--filter',
+		'@marimo-hub/server',
+		'build',
+	]);
 }
 for (const file of [join(serverDist, 'index.mjs'), join(webDist, 'index.html')]) {
 	if (!statSync(file, { throwIfNoEntry: false })?.isFile()) {

--- a/scripts/sea/importShim.cjs
+++ b/scripts/sea/importShim.cjs
@@ -1,0 +1,4 @@
+// Unpacked beside the server bundle and required by absolute path, so this is
+// an ordinary on-disk module: its `import()` goes through the normal ESM loader
+// rather than the SEA loader's builtin-only resolution. See launcher.cjs.
+module.exports = (href) => import(href);

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -165,13 +165,20 @@ if (!fs.existsSync(readyMarker)) {
 	// Unpack into a sibling temp dir and rename so a crash mid-extract, or two
 	// instances starting at once, never leave a half-written payload behind.
 	const staging = fs.mkdtempSync(path.join(resolvedRoot, 'unpack-'));
-	for (const file of manifest.files) {
-		const target = path.join(staging, file);
-		fs.mkdirSync(path.dirname(target), { recursive: true });
-		fs.writeFileSync(target, Buffer.from(sea.getRawAsset(file)));
+	try {
+		for (const file of manifest.files) {
+			const target = path.join(staging, file);
+			fs.mkdirSync(path.dirname(target), { recursive: true });
+			fs.writeFileSync(target, Buffer.from(sea.getRawAsset(file)));
+		}
+		fs.writeFileSync(path.join(staging, '.ready'), '');
+		installPayload(staging);
+	} finally {
+		// A failed extract (a full disk, say) would otherwise leave most of a
+		// payload behind on every restart. After a successful install the
+		// directory has been renamed away, so this is a no-op.
+		fs.rmSync(staging, { recursive: true, force: true });
 	}
-	fs.writeFileSync(path.join(staging, '.ready'), '');
-	installPayload(staging);
 }
 
 process.env.MARIMOHUB_STATIC_ROOT ??= path.join(payloadDir, 'public');

--- a/scripts/sea/launcher.cjs
+++ b/scripts/sea/launcher.cjs
@@ -1,0 +1,189 @@
+// SEA entrypoint. Node's single-executable loader only runs CommonJS and its
+// `require` resolves built-ins only, so the real (ESM) server bundle is shipped
+// as assets, unpacked to a per-build cache directory on first start, and then
+// loaded with a dynamic import. Once on disk, `import.meta.url` inside the
+// bundle resolves the worker scripts and DuckDB wasm files exactly as it does
+// in the container image.
+const sea = require('node:sea');
+const fs = require('node:fs');
+const { createRequire } = require('node:module');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const manifest = JSON.parse(sea.getAsset('manifest.json', 'utf8'));
+
+const uid = process.getuid ? process.getuid() : null;
+// The unpacked bundle is executed, so the cache defaults to the user's own
+// cache directory, whose ancestors only the user and root can write. A shared
+// tmpdir would let any local user interfere with the path (see the checks below).
+let homeDir = null;
+try {
+	homeDir = os.homedir();
+} catch {
+	homeDir = null;
+}
+const cacheBase =
+	process.env.XDG_CACHE_HOME && path.isAbsolute(process.env.XDG_CACHE_HOME)
+		? process.env.XDG_CACHE_HOME
+		: homeDir && path.join(homeDir, '.cache');
+const cacheRoot =
+	process.env.MARIMOHUB_SEA_CACHE_DIR ?? (cacheBase ? path.join(cacheBase, 'marimohub-sea') : null);
+if (!cacheRoot) {
+	console.error('Cannot determine a cache directory; set MARIMOHUB_SEA_CACHE_DIR');
+	process.exit(1);
+}
+
+fs.mkdirSync(cacheRoot, { recursive: true, mode: 0o700 });
+
+// Reject a symlinked cacheRoot outright: in a sticky directory another user
+// could have planted it before the mkdir and can re-point it afterwards.
+if (fs.lstatSync(cacheRoot).isSymbolicLink()) {
+	console.error(`${cacheRoot} is a symlink; refusing to use it`);
+	process.exit(1);
+}
+
+// Every directory on the path to the unpacked bundle must be one no other user
+// can write: owned by the current user or root, and not group/world-writable.
+// Checking only cacheRoot is not enough, because whoever can write an ancestor
+// can swap cacheRoot for a symlink to a prepared tree between this check and
+// the import below. Sticky directories such as /tmp are rejected too: the
+// sticky bit stops renames, but a bundled module that still probes for an
+// optional package would resolve it through /tmp/node_modules. The resolved
+// path is checked, and used from here on, so an ancestor symlink maintained by
+// root (/home -> /var/home) is allowed while the import path itself contains
+// no symlink component.
+const resolvedRoot = fs.realpathSync(cacheRoot);
+const payloadDir = path.join(resolvedRoot, manifest.buildId);
+const readyMarker = path.join(payloadDir, '.ready');
+const rootStat = fs.lstatSync(resolvedRoot);
+if (uid !== null && rootStat.uid !== uid) {
+	console.error(`${cacheRoot} is not owned by the current user; set MARIMOHUB_SEA_CACHE_DIR`);
+	process.exit(1);
+}
+for (let dir = resolvedRoot; ; dir = path.dirname(dir)) {
+	const st = dir === resolvedRoot ? rootStat : fs.lstatSync(dir);
+	if (st.isSymbolicLink()) {
+		console.error(`${dir} is a symlink; refusing to use cache at ${cacheRoot}`);
+		process.exit(1);
+	}
+	if (uid !== null && st.uid !== uid && st.uid !== 0) {
+		console.error(
+			`${dir} is owned by uid ${st.uid}, not the current user or root; set MARIMOHUB_SEA_CACHE_DIR`,
+		);
+		process.exit(1);
+	}
+	if (st.mode & 0o022) {
+		console.error(
+			`${dir} is group or world-writable (mode ${(st.mode & 0o777).toString(8)}); refusing to use cache at ${cacheRoot}`,
+		);
+		process.exit(1);
+	}
+	if (path.dirname(dir) === dir) break;
+}
+
+// Replacing a damaged payload directory runs under this lock so concurrent
+// starts never remove a payload a peer has just repaired. The lock is held
+// only across a marker check and one rename, so one older than a minute, or
+// one whose creator is gone, belongs to a crashed process and is broken.
+// Breaking a stale lock is an unlink by path, so two starts that observe the
+// same stale lock at the same instant could both proceed; that is safe because
+// the rename that moves the damaged tree aside succeeds for only one of them.
+const repairLock = path.join(resolvedRoot, `${manifest.buildId}.repair.lock`);
+const REPAIR_LOCK_STALE_MS = 60_000;
+const sleepSync = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+function isStaleRepairLock() {
+	let st;
+	let pid;
+	try {
+		st = fs.statSync(repairLock);
+		pid = Number(fs.readFileSync(repairLock, 'utf8'));
+	} catch (error) {
+		if (error.code === 'ENOENT') return false;
+		throw error;
+	}
+	if (Date.now() - st.mtimeMs > REPAIR_LOCK_STALE_MS) return true;
+	if (!Number.isInteger(pid) || pid <= 0) return false;
+	try {
+		process.kill(pid, 0);
+		return false;
+	} catch (error) {
+		return error.code === 'ESRCH';
+	}
+}
+
+function acquireRepairLock() {
+	for (;;) {
+		try {
+			fs.writeFileSync(repairLock, String(process.pid), { flag: 'wx', mode: 0o600 });
+			return;
+		} catch (error) {
+			if (error.code !== 'EEXIST') throw error;
+		}
+		if (isStaleRepairLock()) {
+			fs.rmSync(repairLock, { force: true });
+			continue;
+		}
+		sleepSync(10);
+	}
+}
+
+// Moves `staging` into place. Returns false when a peer's identical payload
+// won the race, in which case `staging` has been discarded.
+function installPayload(staging) {
+	try {
+		fs.renameSync(staging, payloadDir);
+		return true;
+	} catch (error) {
+		if (error.code !== 'ENOTEMPTY' && error.code !== 'EEXIST') throw error;
+	}
+	if (fs.existsSync(readyMarker)) {
+		fs.rmSync(staging, { recursive: true, force: true });
+		return false;
+	}
+	// A payload directory without its marker is damaged (the rename is atomic,
+	// so only tampering or a partial delete gets here). Replace it rather than
+	// importing from it forever after. The damaged tree is moved aside before it
+	// is deleted: a recursive rm empties the directory first, and a peer's
+	// rename onto an empty directory succeeds, so deleting in place could
+	// strip a payload the peer just installed.
+	const damaged = `${staging}-damaged`;
+	acquireRepairLock();
+	try {
+		if (!fs.existsSync(readyMarker)) fs.renameSync(payloadDir, damaged);
+	} catch (error) {
+		if (error.code !== 'ENOENT') throw error;
+	} finally {
+		fs.rmSync(repairLock, { force: true });
+	}
+	fs.rmSync(damaged, { recursive: true, force: true });
+	return installPayload(staging);
+}
+
+if (!fs.existsSync(readyMarker)) {
+	// Unpack into a sibling temp dir and rename so a crash mid-extract, or two
+	// instances starting at once, never leave a half-written payload behind.
+	const staging = fs.mkdtempSync(path.join(resolvedRoot, 'unpack-'));
+	for (const file of manifest.files) {
+		const target = path.join(staging, file);
+		fs.mkdirSync(path.dirname(target), { recursive: true });
+		fs.writeFileSync(target, Buffer.from(sea.getRawAsset(file)));
+	}
+	fs.writeFileSync(path.join(staging, '.ready'), '');
+	installPayload(staging);
+}
+
+process.env.MARIMOHUB_STATIC_ROOT ??= path.join(payloadDir, 'public');
+process.env.MARIMOHUB_VERSION ??= manifest.version;
+
+// `import()` here would be resolved by the SEA loader, which only knows
+// built-in specifiers (Node 26 rejects a file URL outright), so the dynamic
+// import is delegated to a shim unpacked alongside the bundle.
+const shim = path.join(payloadDir, 'importShim.cjs');
+const dynamicImport = createRequire(shim)(shim);
+
+dynamicImport(pathToFileURL(path.join(payloadDir, 'dist', 'index.mjs')).href).catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/sea/launcher.test.ts
+++ b/scripts/sea/launcher.test.ts
@@ -1,0 +1,182 @@
+import { spawn } from 'node:child_process';
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Runs the real launcher under plain `node`, with `node:sea` replaced by a
+// preload that serves a stand-in payload. The unpacked entrypoint reports what
+// the launcher handed it, so a run's stdout tells us which payload was loaded.
+const launcher = fileURLToPath(new URL('./launcher.cjs', import.meta.url));
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+const BUILD_ID = 'testbuild';
+const ENTRY = 'dist/index.mjs';
+const SHIM = 'importShim.cjs';
+const SHIM_SOURCE = readFileSync(
+	fileURLToPath(new URL('./importShim.cjs', import.meta.url)),
+	'utf8',
+);
+const ENTRY_SOURCE = `console.log(JSON.stringify({
+	loaded: import.meta.url,
+	staticRoot: process.env.MARIMOHUB_STATIC_ROOT,
+	version: process.env.MARIMOHUB_VERSION,
+}));`;
+const STUB_SOURCE = `const Module = require('node:module');
+const manifest = ${JSON.stringify({ buildId: BUILD_ID, version: '0.0.0-test', files: [ENTRY, 'public/index.html', SHIM] })};
+const assets = {
+	[${JSON.stringify(ENTRY)}]: ${JSON.stringify(ENTRY_SOURCE)},
+	'public/index.html': '<div id="root"></div>',
+	[${JSON.stringify(SHIM)}]: ${JSON.stringify(SHIM_SOURCE)},
+};
+const load = Module._load;
+Module._load = function (request, ...rest) {
+	if (request !== 'node:sea') return load.call(this, request, ...rest);
+	return {
+		getAsset: () => JSON.stringify(manifest),
+		getRawAsset: (name) => Buffer.from(assets[name]),
+	};
+};`;
+
+// Scratch trees live under node_modules/.cache rather than the OS tmpdir: the
+// launcher rejects anything below a world-writable directory such as /tmp.
+let scratch: string;
+let stub: string;
+
+interface Run {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+const runLauncher = (cacheDir: string): Promise<Run> =>
+	new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, ['-r', stub, launcher], {
+			env: { ...process.env, MARIMOHUB_SEA_CACHE_DIR: cacheDir },
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+		let stdout = '';
+		let stderr = '';
+		child.stdout.on('data', (chunk: Buffer) => {
+			stdout += chunk.toString();
+		});
+		child.stderr.on('data', (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+		child.on('error', reject);
+		child.on('close', (code) => {
+			resolve({ code, stdout, stderr });
+		});
+	});
+
+const loadedPayload = (run: Run) => {
+	expect(run.stderr).toBe('');
+	expect(run.code).toBe(0);
+	return JSON.parse(run.stdout) as { loaded: string; staticRoot: string; version: string };
+};
+
+const freshCache = (name: string) => join(mkdtempSync(join(scratch, `${name}-`)), 'cache');
+
+beforeAll(() => {
+	mkdirSync(join(repoRoot, 'node_modules/.cache'), { recursive: true });
+	scratch = mkdtempSync(join(repoRoot, 'node_modules/.cache/sea-launcher-'));
+	stub = join(scratch, 'sea-stub.cjs');
+	writeFileSync(stub, STUB_SOURCE);
+});
+
+afterAll(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+describe.skipIf(process.platform === 'win32')('SEA launcher', () => {
+	it('unpacks the payload on first start and reuses it afterwards', async () => {
+		const cache = freshCache('reuse');
+		const payloadDir = join(cache, BUILD_ID);
+
+		const first = loadedPayload(await runLauncher(cache));
+		expect(first.loaded).toBe(`file://${join(payloadDir, ENTRY)}`);
+		expect(first.staticRoot).toBe(join(payloadDir, 'public'));
+		expect(first.version).toBe('0.0.0-test');
+		expect(existsSync(join(payloadDir, '.ready'))).toBe(true);
+		expect(existsSync(join(payloadDir, 'public/index.html'))).toBe(true);
+		expect(readdirSync(cache)).toEqual([BUILD_ID]);
+
+		writeFileSync(join(payloadDir, 'marker'), '');
+		const second = loadedPayload(await runLauncher(cache));
+		expect(second.loaded).toBe(first.loaded);
+		expect(existsSync(join(payloadDir, 'marker'))).toBe(true);
+	});
+
+	it('leaves a single payload when two instances start at once', async () => {
+		const cache = freshCache('concurrent');
+		const runs = await Promise.all([runLauncher(cache), runLauncher(cache)]);
+		for (const run of runs) loadedPayload(run);
+		expect(readdirSync(cache)).toEqual([BUILD_ID]);
+		expect(existsSync(join(cache, BUILD_ID, '.ready'))).toBe(true);
+	});
+
+	it('repairs a payload directory that lost its ready marker under concurrent starts', async () => {
+		const rounds = Number(process.env.SEA_LAUNCHER_STRESS_ROUNDS ?? 3);
+		for (let round = 0; round < rounds; round++) {
+			const cache = freshCache('stale-concurrent');
+			const payloadDir = join(cache, BUILD_ID);
+			mkdirSync(payloadDir, { recursive: true, mode: 0o700 });
+			writeFileSync(join(payloadDir, 'leftover'), '');
+
+			const runs = await Promise.all(Array.from({ length: 12 }, () => runLauncher(cache)));
+			for (const run of runs) loadedPayload(run);
+			expect(readdirSync(cache)).toEqual([BUILD_ID]);
+			expect(existsSync(join(payloadDir, '.ready'))).toBe(true);
+			expect(existsSync(join(payloadDir, 'leftover'))).toBe(false);
+			expect(existsSync(join(payloadDir, ENTRY))).toBe(true);
+		}
+	}, 60_000);
+
+	it('replaces a payload directory that lost its ready marker', async () => {
+		const cache = freshCache('stale');
+		const payloadDir = join(cache, BUILD_ID);
+		mkdirSync(payloadDir, { recursive: true, mode: 0o700 });
+		writeFileSync(join(payloadDir, 'leftover'), '');
+
+		loadedPayload(await runLauncher(cache));
+		expect(existsSync(join(payloadDir, '.ready'))).toBe(true);
+		expect(existsSync(join(payloadDir, 'leftover'))).toBe(false);
+		expect(existsSync(join(payloadDir, ENTRY))).toBe(true);
+	});
+
+	it('refuses a cache root that is a symlink', async () => {
+		const base = mkdtempSync(join(scratch, 'symlink-'));
+		mkdirSync(join(base, 'real'), { mode: 0o700 });
+		symlinkSync(join(base, 'real'), join(base, 'cache'));
+
+		const run = await runLauncher(join(base, 'cache'));
+		expect(run.code).toBe(1);
+		expect(run.stderr).toContain('is a symlink');
+		expect(readdirSync(join(base, 'real'))).toEqual([]);
+	});
+
+	it.each([
+		['world-writable', 0o777],
+		['sticky world-writable', 0o1777],
+		['group-writable', 0o770],
+	])('refuses a cache below a %s ancestor', async (_label, mode) => {
+		const base = mkdtempSync(join(scratch, 'ancestor-'));
+		const ancestor = join(base, 'shared');
+		mkdirSync(ancestor);
+		chmodSync(ancestor, mode);
+
+		const run = await runLauncher(join(ancestor, 'cache'));
+		expect(run.code).toBe(1);
+		expect(run.stderr).toContain(`${ancestor} is group or world-writable`);
+		expect(existsSync(join(ancestor, 'cache', BUILD_ID))).toBe(false);
+	});
+});

--- a/scripts/sea/launcher.test.ts
+++ b/scripts/sea/launcher.test.ts
@@ -38,6 +38,8 @@ const assets = {
 	'public/index.html': '<div id="root"></div>',
 	[${JSON.stringify(SHIM)}]: ${JSON.stringify(SHIM_SOURCE)},
 };
+// Lets one test drive the launcher into a failing extract.
+if (process.env.SEA_STUB_MISSING_ASSET) manifest.files = [...manifest.files, 'absent'];
 const load = Module._load;
 Module._load = function (request, ...rest) {
 	if (request !== 'node:sea') return load.call(this, request, ...rest);
@@ -58,10 +60,10 @@ interface Run {
 	stderr: string;
 }
 
-const runLauncher = (cacheDir: string): Promise<Run> =>
+const runLauncher = (cacheDir: string, env: Record<string, string> = {}): Promise<Run> =>
 	new Promise((resolve, reject) => {
 		const child = spawn(process.execPath, ['-r', stub, launcher], {
-			env: { ...process.env, MARIMOHUB_SEA_CACHE_DIR: cacheDir },
+			env: { ...process.env, MARIMOHUB_SEA_CACHE_DIR: cacheDir, ...env },
 			stdio: ['ignore', 'pipe', 'pipe'],
 		});
 		let stdout = '';
@@ -151,6 +153,18 @@ describe.skipIf(process.platform === 'win32')('SEA launcher', () => {
 		expect(existsSync(join(payloadDir, '.ready'))).toBe(true);
 		expect(existsSync(join(payloadDir, 'leftover'))).toBe(false);
 		expect(existsSync(join(payloadDir, ENTRY))).toBe(true);
+	});
+
+	// A supervisor restarting a binary that cannot finish extracting would
+	// otherwise leave most of a payload behind under `unpack-*` every time.
+	it('leaves nothing behind when extraction fails', async () => {
+		const cache = freshCache('failed-extract');
+
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const run = await runLauncher(cache, { SEA_STUB_MISSING_ASSET: '1' });
+			expect(run.code).not.toBe(0);
+			expect(readdirSync(cache)).toEqual([]);
+		}
 	});
 
 	it('refuses a cache root that is a symlink', async () => {

--- a/scripts/sea/payload.mjs
+++ b/scripts/sea/payload.mjs
@@ -1,0 +1,43 @@
+// What goes inside the SEA, and the id that identifies it.
+//
+// The id names the cache directory the launcher unpacks into, and a directory
+// carrying its `.ready` marker is reused as-is forever after. So everything
+// that decides what lands on disk, or that reads it back, has to feed the hash:
+// asset paths, asset contents, the import shim, and launcher.cjs itself.
+// Miss one and an upgraded binary silently runs an older payload.
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const walk = (dir) =>
+	readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+		const full = join(dir, entry.name);
+		return entry.isDirectory() ? walk(full) : [full];
+	});
+
+// The name the launcher requires out of the unpacked payload directory.
+export const SHIM_ASSET = 'importShim.cjs';
+
+// Returns the SEA asset map (key -> source path) and the payload's build id.
+// Keys are POSIX-style relative paths; the launcher unpacks them by the names
+// listed in manifest.json.
+export function collectPayload({ serverDist, webDist, shim, launcher }) {
+	const assets = {};
+	const hash = createHash('sha256');
+	const addFile = (key, file) => {
+		assets[key] = file;
+		hash.update(key).update(readFileSync(file));
+	};
+	const addTree = (root, prefix) => {
+		for (const file of walk(root).sort()) {
+			addFile(`${prefix}/${relative(root, file).split('\\').join('/')}`, file);
+		}
+	};
+	addTree(serverDist, 'dist');
+	addTree(webDist, 'public');
+	addFile(SHIM_ASSET, shim);
+	// The launcher is the SEA main rather than an asset, so it has no key of its
+	// own; the literal keeps its bytes from colliding with a keyed entry.
+	hash.update('launcher').update(readFileSync(launcher));
+	return { assets, buildId: hash.digest('hex').slice(0, 16) };
+}

--- a/scripts/sea/payload.mjs
+++ b/scripts/sea/payload.mjs
@@ -24,9 +24,18 @@ export const SHIM_ASSET = 'importShim.cjs';
 export function collectPayload({ serverDist, webDist, shim, launcher }) {
 	const assets = {};
 	const hash = createHash('sha256');
+	// Length-prefixed, so where one field ends and the next begins is never in
+	// doubt. Concatenating them raw lets different payloads hash alike without
+	// any SHA weakness: {a: 'A', b: 'B'} and {a: 'Adist/bB'} both produce
+	// `dist/aAdist/bB`, and the second would then run out of the first's cache.
+	const addField = (value) => {
+		const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value);
+		hash.update(`${bytes.length}:`).update(bytes);
+	};
 	const addFile = (key, file) => {
 		assets[key] = file;
-		hash.update(key).update(readFileSync(file));
+		addField(key);
+		addField(readFileSync(file));
 	};
 	const addTree = (root, prefix) => {
 		for (const file of walk(root).sort()) {
@@ -38,6 +47,7 @@ export function collectPayload({ serverDist, webDist, shim, launcher }) {
 	addFile(SHIM_ASSET, shim);
 	// The launcher is the SEA main rather than an asset, so it has no key of its
 	// own; the literal keeps its bytes from colliding with a keyed entry.
-	hash.update('launcher').update(readFileSync(launcher));
+	addField('launcher');
+	addField(readFileSync(launcher));
 	return { assets, buildId: hash.digest('hex').slice(0, 16) };
 }

--- a/scripts/sea/payload.test.ts
+++ b/scripts/sea/payload.test.ts
@@ -105,6 +105,19 @@ describe('SEA payload', () => {
 		expect(buildId()).not.toBe(before);
 	});
 
+	// Raw concatenation makes the boundary between a key and its contents
+	// invisible to the hash, so a single file can impersonate two.
+	it('frames keys and contents so one file cannot stand in for two', () => {
+		rmSync(inputs.serverDist, { recursive: true, force: true });
+		write(join(inputs.serverDist, 'a'), 'A');
+		write(join(inputs.serverDist, 'b'), 'B');
+		const twoFiles = buildId();
+
+		rmSync(inputs.serverDist, { recursive: true, force: true });
+		write(join(inputs.serverDist, 'a'), 'Adist/bB');
+		expect(buildId()).not.toBe(twoFiles);
+	});
+
 	// The launcher has no asset key of its own, so its bytes are hashed behind a
 	// literal. Without one it would run straight on from the last keyed asset,
 	// and these two payloads would produce the same byte stream.

--- a/scripts/sea/payload.test.ts
+++ b/scripts/sea/payload.test.ts
@@ -1,0 +1,121 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { collectPayload, SHIM_ASSET } from './payload.mjs';
+
+// A build id that fails to move when an input moves is the dangerous failure:
+// the launcher reuses any payload directory that already carries its `.ready`
+// marker, so an upgraded binary would keep running the previous payload.
+let scratch: string;
+let inputs: Parameters<typeof collectPayload>[0];
+
+const write = (path: string, contents: string) => {
+	mkdirSync(join(path, '..'), { recursive: true });
+	writeFileSync(path, contents);
+};
+
+const buildId = () => collectPayload(inputs).buildId;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), 'sea-payload-'));
+	inputs = {
+		serverDist: join(scratch, 'server'),
+		webDist: join(scratch, 'web'),
+		shim: join(scratch, 'importShim.cjs'),
+		launcher: join(scratch, 'launcher.cjs'),
+	};
+	write(join(inputs.serverDist, 'index.mjs'), 'export const server = 1;');
+	write(join(inputs.serverDist, 'workers/kernel.mjs'), 'export const worker = 1;');
+	write(join(inputs.webDist, 'index.html'), '<div id="root"></div>');
+	write(join(inputs.webDist, 'assets/app.js'), 'console.log(1);');
+	write(inputs.shim, 'module.exports = (href) => import(href);');
+	write(inputs.launcher, '// launcher');
+});
+
+afterEach(() => {
+	rmSync(scratch, { recursive: true, force: true });
+});
+
+describe('SEA payload', () => {
+	it('is stable for unchanged inputs', () => {
+		expect(buildId()).toBe(buildId());
+		expect(buildId()).toMatch(/^[0-9a-f]{16}$/);
+	});
+
+	it('embeds the shim under the name the launcher requires', () => {
+		const { assets } = collectPayload(inputs);
+		expect(assets[SHIM_ASSET]).toBe(inputs.shim);
+		expect(Object.keys(assets)).toEqual([
+			'dist/index.mjs',
+			'dist/workers/kernel.mjs',
+			'public/assets/app.js',
+			'public/index.html',
+			SHIM_ASSET,
+		]);
+	});
+
+	// launcher.cjs is CommonJS embedded in the executable and cannot import this
+	// constant, so the two sides agree only by convention. A rename on one side
+	// leaves the launcher requiring a file the build never embedded.
+	it('uses the shim name the launcher requires', () => {
+		const launcher = readFileSync(
+			fileURLToPath(new URL('./launcher.cjs', import.meta.url)),
+			'utf8',
+		);
+		expect(launcher).toContain(`'${SHIM_ASSET}'`);
+	});
+
+	it.each([
+		['a server bundle file', () => write(join(inputs.serverDist, 'index.mjs'), 'changed')],
+		[
+			'an SPA file',
+			() => write(join(inputs.webDist, 'index.html'), '<div id="root">changed</div>'),
+		],
+		['the import shim', () => write(inputs.shim, '// changed')],
+		// The launcher is the SEA main, not an asset, so it is the input most
+		// easily left out of the hash. It reads the unpacked payload, so a change
+		// to it must not reuse a directory an older launcher wrote.
+		['the launcher', () => write(inputs.launcher, '// changed')],
+	])('changes when %s changes', (_label, mutate) => {
+		const before = buildId();
+		mutate();
+		expect(buildId()).not.toBe(before);
+	});
+
+	it('changes when a file is added', () => {
+		const before = buildId();
+		write(join(inputs.webDist, 'assets/extra.js'), 'console.log(1);');
+		expect(buildId()).not.toBe(before);
+	});
+
+	it('changes when a file is removed', () => {
+		const before = buildId();
+		rmSync(join(inputs.webDist, 'assets/app.js'));
+		expect(buildId()).not.toBe(before);
+	});
+
+	// Hashing contents alone would collide here, and the launcher resolves the
+	// SPA and the worker scripts by path.
+	it('changes when a file is renamed but its contents are not', () => {
+		const before = buildId();
+		rmSync(join(inputs.serverDist, 'workers/kernel.mjs'));
+		write(join(inputs.serverDist, 'workers/renamed.mjs'), 'export const worker = 1;');
+		expect(buildId()).not.toBe(before);
+	});
+
+	// The launcher has no asset key of its own, so its bytes are hashed behind a
+	// literal. Without one it would run straight on from the last keyed asset,
+	// and these two payloads would produce the same byte stream.
+	it('separates the launcher from the asset hashed immediately before it', () => {
+		const shim = 'module.exports = (href) => import(href);';
+		write(inputs.shim, shim);
+		write(inputs.launcher, '// launcher');
+		const before = buildId();
+
+		write(inputs.shim, `${shim}// launcher`);
+		write(inputs.launcher, '');
+		expect(buildId()).not.toBe(before);
+	});
+});

--- a/scripts/smoke-sea.sh
+++ b/scripts/smoke-sea.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Boot a marimohub SEA binary with in-memory storage and check that it serves
+# the API and the SPA. Used by release.yml before the binary is attached.
+#
+#   scripts/smoke-sea.sh apps/server/dist/sea/marimohub-linux-x64 [expected-version]
+
+set -euo pipefail
+
+binary="${1:?path to the marimohub binary is required}"
+expected_version="${2:-}"
+port="${PORT:-3123}"
+# The launcher refuses a cache below a world-writable directory such as /tmp,
+# so keep the scratch tree under the user's own cache directory.
+mkdir -p "${XDG_CACHE_HOME:-$HOME/.cache}"
+cache_dir="$(mktemp -d "${XDG_CACHE_HOME:-$HOME/.cache}/marimohub-sea-smoke.XXXXXX")"
+log="$cache_dir/server.log"
+
+cleanup() {
+	if [[ -n "${server_pid:-}" ]]; then
+		kill "$server_pid" 2>/dev/null || true
+		wait "$server_pid" 2>/dev/null || true
+	fi
+	rm -rf "$cache_dir"
+}
+trap cleanup EXIT
+
+fail() {
+	echo "smoke test failed: $1" >&2
+	echo "--- server log ---" >&2
+	cat "$log" >&2
+	exit 1
+}
+
+MARIMOHUB_SEA_CACHE_DIR="$cache_dir/cache" \
+	MARIMOHUB_STORAGE_BACKEND=memory \
+	MARIMOHUB_ALLOW_EPHEMERAL_STORAGE=true \
+	MARIMOHUB_COMPUTE_BACKEND=none \
+	MARIMOHUB_AUTH_BACKEND=dev \
+	PORT="$port" \
+	"$binary" >"$log" 2>&1 &
+server_pid=$!
+
+healthy=false
+for _ in $(seq 1 60); do
+	if curl -fsS "http://127.0.0.1:$port/api/health" >/dev/null 2>&1; then
+		healthy=true
+		break
+	fi
+	if ! kill -0 "$server_pid" 2>/dev/null; then
+		fail "server exited before becoming healthy"
+	fi
+	sleep 1
+done
+if [[ "$healthy" != true ]]; then
+	fail "/api/health did not respond within 60s"
+fi
+
+version_json="$(curl -fsS "http://127.0.0.1:$port/api/v1/version")" ||
+	fail "GET /api/v1/version failed"
+echo "version: $version_json"
+if [[ -n "$expected_version" && "$version_json" != *"\"$expected_version\""* ]]; then
+	fail "expected version $expected_version in /api/v1/version response: $version_json"
+fi
+
+index_html="$(curl -fsS "http://127.0.0.1:$port/")" || fail "GET / failed"
+if [[ "$index_html" != *"<div id=\"root\">"* ]]; then
+	fail "expected the SPA index at /, got: $(printf '%s' "$index_html" | head -c 300)"
+fi
+echo "smoke test passed"


### PR DESCRIPTION
Relands #317, reverted in #323 after it broke the v0.4.0 release.

The release job sets itself up with setup-vp, which provides node and vp but no package manager, so build-sea.mjs died on `pnpm exec postject`. Postject is now called through its library API, which still resolves from the frozen workspace lock, and vp is reached through node_modules/.bin.

This also fixes a second fault the release never got far enough to hit. Inside a SEA main, `import()` resolves against built-in specifiers only: a file URL works on Node 24 but throws ERR_UNKNOWN_BUILTIN_MODULE on Node 26, and the server bundle has top-level await so `require()` is not an alternative. The bundle is now reached through a CommonJS shim unpacked beside it, whose `import()` goes through the ordinary loader. The build id covers the launcher and that shim, so an upgraded binary can never reuse a payload directory an older launcher wrote.

Asset collection and the build id move to scripts/sea/payload.mjs so they can be exercised directly, with coverage for every input that has to move the id.

CI now builds and boots the binary on every pull request instead of first exercising it from a tag, and does the same for the server image, which until now was built only during a release. cli.yml runs the release's shell completion and man page generator for the same reason.

Deployment docs note that each build id unpacks about 75 MB and that earlier ones are left in place, since another instance may still be running from one.

## Summary

Describe the change and the operator or contributor problem it solves.

## Verification

- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm build`

For docs-only changes:

- [ ] `pnpm --filter @marimo-hub/docs test`
- [ ] `pnpm --filter @marimo-hub/docs build`
