### PR TITLE
fix(runtime): ask marimo for SameSite=None when the kernel is framed cross-site

### DIFF
--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1563,7 +1563,7 @@ export async function startNotebookSession(input: {
 							return resolved;
 						},
 						async provision() {
-							const { baseUrl } = await this.$.exposure;
+							const { baseUrl, cookieSameSite } = await this.$.exposure;
 							const launchStrategy = await this.$.launchStrategy;
 							return provisioner.provision({
 								sandboxId,
@@ -1577,6 +1577,7 @@ export async function startNotebookSession(input: {
 								assetUrl: sandbox.assetUrl,
 								startupTimeoutMs: sandbox.startupTimeoutMs,
 								baseUrl,
+								cookieSameSite,
 								kernelAuthToken,
 								// A second editor writes the notebook file, so marimo must reload it.
 								marimoWatch:

--- a/packages/core/src/ports/sandboxExposure.ts
+++ b/packages/core/src/ports/sandboxExposure.ts
@@ -35,6 +35,15 @@ export interface ExposurePreparation {
 	 * serves at root).
 	 */
 	baseUrl?: string;
+	/**
+	 * `SameSite` marimo must set on its session cookie. `'none'` in `subdomain`
+	 * mode, where the kernel is framed cross-site: the cookie is third-party
+	 * there, so under the default `lax` a browser that restricts third-party
+	 * cookies drops it, marimo never completes the token exchange, and it
+	 * redirects to a login page it serves with `X-Frame-Options: DENY`.
+	 * Undefined in `proxy` mode, which is same-origin and needs no relaxation.
+	 */
+	cookieSameSite?: 'none';
 }
 
 export interface ExposureResult {

--- a/packages/core/src/services/runtime/SandboxProvisioner.ts
+++ b/packages/core/src/services/runtime/SandboxProvisioner.ts
@@ -201,6 +201,8 @@ export interface ProvisionOptions {
 	 * the proxied prefix. Omit in `subdomain` mode (the kernel serves at root).
 	 */
 	baseUrl?: string;
+	/** `SameSite` marimo must use for its session cookie; from the exposure's `prepare()`. */
+	cookieSameSite?: 'none';
 	marimoWatch?: boolean;
 	/**
 	 * CoreWeave-native filesystem snapshot id to restore the sandbox FROM, when the
@@ -978,6 +980,7 @@ export class SandboxProvisioner {
 					mode: options.launchMode,
 					assetUrl: options.assetUrl,
 					baseUrl: options.baseUrl,
+					cookieSameSite: options.cookieSameSite,
 					tokenPasswordFile:
 						options.kernelAuthToken !== undefined ? KERNEL_AUTH_TOKEN_FILE : undefined,
 					watch: options.marimoWatch,

--- a/packages/core/src/services/runtime/marimoLaunch.ts
+++ b/packages/core/src/services/runtime/marimoLaunch.ts
@@ -30,6 +30,14 @@ export interface MarimoLaunchParams {
 	 * websocket URLs resolve beneath the proxied prefix. Omit to serve at root.
 	 */
 	baseUrl?: string;
+	/**
+	 * `SameSite` for marimo's session cookie (`MARIMO_SESSION_COOKIE_SAMESITE`),
+	 * from the exposure's `prepare()`. `'none'` when the kernel is framed
+	 * cross-site. Needs a marimo that reads the variable (marimo-team/marimo PR
+	 * below); older kernels ignore it and keep the `lax` default, so setting it
+	 * unconditionally is safe across a mixed fleet of sandbox images.
+	 */
+	cookieSameSite?: 'none';
 	watch?: boolean;
 }
 
@@ -187,9 +195,17 @@ export function buildMarimoLaunch(
 	strategy: MarimoLaunchStrategyName = DEFAULT_LAUNCH_STRATEGY,
 ): MarimoLaunchPlan {
 	const plan = MARIMO_LAUNCH_STRATEGIES[strategy](params);
-	if (params.mode !== 'job') return plan;
+	// Prefixed on the whole command rather than inside `marimoCommand`, which is
+	// nested under `uv run`; `uv run` passes its own environment through. Jobs
+	// serve no browser and get no cookie, so they are left alone.
+	const start =
+		params.cookieSameSite !== undefined && params.mode !== 'job'
+			? `MARIMO_SESSION_COOKIE_SAMESITE=${params.cookieSameSite} ${plan.start}`
+			: plan.start;
+	if (params.mode !== 'job') return { ...plan, start };
 	return {
 		...plan,
+		start,
 		setup: [...plan.setup, { name: 'job_output_dir', command: "mkdir -p '__marimo__'" }],
 	};
 }

--- a/packages/core/src/services/runtime/sandboxExposure.test.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.test.ts
@@ -18,7 +18,7 @@ describe('SubdomainExposure', () => {
 	const exposure = new SubdomainExposure();
 
 	it('serves at root (no marimo base url)', async () => {
-		expect(await exposure.prepare(ctx)).toEqual({});
+		expect(await exposure.prepare(ctx)).toEqual({ cookieSameSite: 'none' });
 	});
 
 	it('adds the kernel token to the adapter URL and records no origin', async () => {
@@ -105,5 +105,22 @@ describe('kernelBasePathFromUrl', () => {
 		['https://hub.example/proxy/token///?access_token=secret', '/proxy/token'],
 	])('extracts the marimo base path from %s', (url, expected) => {
 		expect(kernelBasePathFromUrl(url)).toBe(expected);
+	});
+});
+
+describe('cookie SameSite', () => {
+	// The kernel is framed cross-site under `subdomain`, so marimo's session
+	// cookie is third-party: under the default `lax` a browser that restricts
+	// third-party cookies drops it, and marimo then redirects to a login page it
+	// serves with `X-Frame-Options: DENY`. See marimo-team/marimohub#328.
+	it('subdomain asks marimo for SameSite=None', async () => {
+		const prepared = await new SubdomainExposure().prepare(ctx);
+		expect(prepared.cookieSameSite).toBe('none');
+	});
+
+	// Proxy traffic is same-origin with the app, so nothing has to be relaxed.
+	it('proxy leaves the cookie alone', async () => {
+		const prepared = await new ProxyExposure(SECRET).prepare(ctx);
+		expect(prepared.cookieSameSite).toBeUndefined();
 	});
 });

--- a/packages/core/src/services/runtime/sandboxExposure.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.ts
@@ -29,7 +29,9 @@ export class SubdomainExposure implements SandboxExposure {
 	readonly mode = 'subdomain' as const;
 
 	async prepare(_ctx: ExposureContext): Promise<ExposurePreparation> {
-		return {};
+		// The kernel is framed cross-site here, so marimo's session cookie is a
+		// third-party cookie and must say so; see `ExposurePreparation`.
+		return { cookieSameSite: 'none' };
 	}
 
 	async finalize(exposedUrl: string, ctx: ExposureContext): Promise<ExposureResult> {


### PR DESCRIPTION
**This pull request was authored by a coding agent.**

Closes #328.

Under `subdomain` exposure the kernel is framed cross-site, so marimo's session cookie is third-party. Firefox drops it by default, the token exchange never persists, and marimo `303`s to `/auth/login` — a page it serves with `X-Frame-Options: DENY`. Permanently blank frame.

**Where the fix goes:** the exposure is what knows the kernel is cross-site, so `ExposurePreparation` carries it the same way it already carries `baseUrl` for `proxy`. `SubdomainExposure.prepare()` asks for `SameSite=None`; the provisioner passes `MARIMO_SESSION_COOKIE_SAMESITE`. `proxy` is same-origin and asks for nothing.

**Blocked on** the matching marimo change that reads the riable. Older kernels ignore it and keep `lax`, so this is safe on a mixed fleet of sandbox images.