### PR TITLE
fix: make sandbox auth opt-in and add notebook recovery UI

### DIFF
--- a/.github/workflows/object-browser-conformance.yml
+++ b/.github/workflows/object-browser-conformance.yml
@@ -31,7 +31,7 @@ jobs:
           docker run -d --name minio -p 19000:9000 \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           for i in $(seq 1 30); do
             curl -fsS http://127.0.0.1:19000/minio/health/live && break
             sleep 1

--- a/.github/workflows/storage-conformance.yml
+++ b/.github/workflows/storage-conformance.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           docker run -d --name minio -p 9000:9000 \
             -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z server /data
           docker run -d --name azurite -p 10000:10000 \
             mcr.microsoft.com/azure-storage/azurite:3.36.0 \
             azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck

--- a/development_docs/architecture.md
+++ b/development_docs/architecture.md
@@ -222,9 +222,9 @@ Under the default `MARIMOHUB_VIEWER_MODE=static`, viewers cannot start, open,
 or reach an app: session create, heartbeat, and stop require editor+, the
 proxy re-authorizes every HTTP request (WebSockets at each upgrade — an
 established socket lives until it closes) in `proxy` exposure. In `subdomain`
-exposure, the kernel URL contains marimo's per-session access token. The session
-read projections (list/get) withhold `sandbox_url` from callers the kernel gates
-would reject.
+exposure, [native kernel authentication](../docs/security.md#native-kernel-authentication)
+is optional (`MARIMOHUB_SANDBOX_AUTH=on`, default `off`). Session read projections
+(list/get) withhold `sandbox_url` from callers the kernel gates would reject.
 The UI says so rather than dangling an unopenable indicator. The reason is
 credential exposure: app sandboxes keep WIF credentials and integration
 secrets injected (apps commonly exist to query project data), and `marimo run`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,6 +291,14 @@ No compute (alias `noop`): notebooks are browsable but provisioning a kernel fai
 
 _No environment variables to set here._
 
+## Sandbox authentication
+
+### Native kernel authentication
+
+| Variable | Description | Required | Default | Example |
+| --- | --- | --- | --- | --- |
+| `MARIMOHUB_SANDBOX_AUTH` | Enable native marimo token authentication for new editor and app sessions: `on` or `off`. See [Native kernel authentication](./security.md#native-kernel-authentication) for deployment requirements. | — | `off` | `on` |
+
 ## Sandbox exposure
 
 Selected by `MARIMOHUB_SANDBOX_EXPOSURE` (default `subdomain`); one of `subdomain`, `proxy`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -35,12 +35,12 @@ MARIMOHUB_COMPUTE_SANDBOX_HOSTNAME=sandboxes.example.net
 `sandboxes.hub.example.com` or `hub.example.com` for kernels is rejected at boot.
 :::
 
-The kernel URL is **not authenticated by the hub**. It includes marimo's
-per-session `access_token` query parameter. marimo exchanges the token for its
-session cookie. Do not expose the kernel hostname or copy the URL outside the
-iframe. The session API shows `sandbox_url` only to callers who can reach that
-kernel: editors, the owner of an ephemeral viewer session, and viewers of the
-shared app when the [viewer mode](/apps#who-can-do-what) grants access.
+The hub does not authenticate direct kernel traffic. Protect the kernel endpoint
+at the ingress. [Native kernel authentication](#native-kernel-authentication)
+is optional and off by default. Treat kernel URLs as sensitive.
+
+The session API exposes `sandbox_url` only to authorized editors, ephemeral
+session owners, and shared-app viewers allowed by the [viewer mode](/apps#who-can-do-what).
 
 ### `proxy`: forwarded through the app
 
@@ -80,30 +80,34 @@ trust every notebook author in the deployment.
 
 ## Native kernel authentication
 
-The provisioner generates an independent 256-bit token for each interactive
-session. It writes the token to a reserved file outside the workspace and starts
-marimo with global `--quiet` plus `--token --token-password-file`. Quiet mode suppresses
-marimo's token-bearing startup URL, and captured failure output redacts an
-`access_token` value as a second safeguard. The token does not appear in the
-process command or server logs. Scheduled jobs do not start a server and do not
-use a token.
+`MARIMOHUB_SANDBOX_AUTH` controls native marimo authentication for new editor and
+app sessions:
 
-In `subdomain` mode, the client URL delivers the token to marimo. In `proxy`
-mode, the hub replaces caller credentials with the kernel token after it
-authorizes the request. This replacement applies to kernel HTTP requests and
-WebSocket upgrades. The hub does not send the token to VS Code or OpenCode.
+| Value           | Behavior                                                                                                          |
+| --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `off` (default) | Starts marimo with `--no-token` for cross-site iframe compatibility. Protect direct kernel access at the ingress. |
+| `on`            | Creates an independent 256-bit token per session and starts marimo with `--token --token-password-file`.          |
 
-Keep marimohub and your ingress in front of kernels. Native authentication
-limits access after a hostname or origin leak, but it does not replace TLS,
-origin isolation, or hub authorization.
+Hub login and proxy authorization do not change. Existing sessions retain their
+authentication mode. Stop and start them to apply a changed setting. Scheduled
+jobs do not use native authentication.
 
-::: warning Complete rolling upgrades promptly
-An old proxy replica cannot authenticate to a kernel that a new replica starts.
-An old lifecycle replica also cannot read that kernel's connection count. A
-mixed-version rollout can therefore return temporary 401 responses and report
-unknown connection counts. Complete the server rollout promptly. New replicas
-remain compatible with sessions started without a token by an earlier release.
-:::
+With `on`, the provisioner stores the token in a reserved file outside the
+workspace. The launch command contains the file path, not the token. Quiet mode
+suppresses token-bearing startup URLs, and log capture redacts `access_token`.
+
+In `subdomain` mode, marimo exchanges the URL's token for a session cookie. In
+`proxy` mode, the hub supplies the token after authorization for HTTP requests
+and WebSocket upgrades. It does not forward the token to secondary editor surfaces.
+Native authentication does not replace TLS, origin isolation, or hub authorization.
+
+Browser restrictions can block the session cookie inside a cross-site iframe.
+After 15 seconds, the UI offers Retry and Open in new window. Retry reloads only
+the frame. A separate window makes the kernel a first-party page. The prompt is
+dismissible and can also appear for healthy frames because browsers hide
+cross-origin load failures.
+
+This setting does not change cookie attributes or enable partitioned cookies.
 
 ## Secondary editor surfaces
 

--- a/docs/setup/compute/docker.md
+++ b/docs/setup/compute/docker.md
@@ -23,8 +23,8 @@ so kernel traffic goes through the hub's authentication and per-session
 authorization.
 
 ::: danger Direct kernel exposure
-Kernels use a per-session bearer token, but their URLs carry that token during
-login. If you deliberately publish them directly on a trusted, isolated network,
+[Native kernel authentication](/security#native-kernel-authentication) is off by default.
+For direct access on a trusted, isolated network,
 set `MARIMOHUB_COMPUTE_DOCKER_BIND_HOST=0.0.0.0` **and** set
 `MARIMOHUB_COMPUTE_DOCKER_HOST` to the server hostname browsers can reach.
 Never expose those ports to the public internet.

--- a/docs/setup/compute/podman.md
+++ b/docs/setup/compute/podman.md
@@ -20,8 +20,8 @@ so kernel traffic goes through the hub's authentication and per-session
 authorization.
 
 ::: danger Direct kernel exposure
-Kernels use a per-session bearer token, but their URLs carry that token during
-login. If you deliberately publish them directly on a trusted, isolated network,
+[Native kernel authentication](/security#native-kernel-authentication) is off by default.
+For direct access on a trusted, isolated network,
 set `MARIMOHUB_COMPUTE_PODMAN_BIND_HOST=0.0.0.0` **and** set
 `MARIMOHUB_COMPUTE_PODMAN_HOST` to the server hostname browsers can reach.
 Never expose those ports to the public internet.

--- a/examples/cloudflare-worker/README.md
+++ b/examples/cloudflare-worker/README.md
@@ -18,6 +18,12 @@ npx wrangler deploy                          # or: npx wrangler dev
   `assets.directory` → `../../packages/web/dist`.
 - `sandbox.Dockerfile` — the marimo kernel sandbox image (`cloudflare/sandbox` base).
 
+Set `MARIMOHUB_SANDBOX_AUTH` to `on` in `wrangler.jsonc` to enable native marimo
+authentication for new editor and app sessions. The default is `off`. Existing
+sessions keep their mode until stopped and restarted. See
+[Native kernel authentication](../../docs/security.md#native-kernel-authentication)
+for ingress requirements and cross-site cookie restrictions.
+
 ## Optional: E2B for compute
 
 Compute is a pluggable port — you can run kernels on [E2B](https://e2b.dev)

--- a/examples/cloudflare-worker/env.d.ts
+++ b/examples/cloudflare-worker/env.d.ts
@@ -5,6 +5,7 @@ declare global {
 		MARIMOHUB_EDITOR_SANDBOX_SHARING?: 'shared' | 'exclusive';
 		// Notebook jobs are off unless `on` (see docs/jobs.md).
 		MARIMOHUB_JOBS?: 'on' | 'off';
+		MARIMOHUB_SANDBOX_AUTH?: string;
 		NOTEBOOKS_BUCKET: R2Bucket;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		SANDBOX: DurableObjectNamespace<Sandbox<any>>;

--- a/examples/cloudflare-worker/src/index.test.ts
+++ b/examples/cloudflare-worker/src/index.test.ts
@@ -52,6 +52,41 @@ describe('Cloudflare Worker configuration', () => {
 		SANDBOX: {},
 	};
 
+	it.each([
+		[undefined, 'off'],
+		['', 'off'],
+		[' \t\n', 'off'],
+		['off', 'off'],
+		[' OFF ', 'off'],
+		['on', 'on'],
+		[' ON ', 'on'],
+	])('parses sandbox authentication %j as %s', (raw, expected) => {
+		const deps = buildDeps(new Request('https://hub.example.com'), {
+			...baseEnv,
+			MARIMOHUB_SANDBOX_AUTH: raw,
+		} as unknown as Env);
+		expect(deps.sandbox.auth).toBe(expected);
+	});
+
+	it.each(['true', 'false', 'none', 'partitioned'])(
+		'rejects invalid sandbox authentication %s at the request boundary',
+		async (raw) => {
+			const response = await worker.fetch(
+				new Request('https://hub.example.com/api/v1/capabilities'),
+				{ ...baseEnv, MARIMOHUB_SANDBOX_AUTH: raw } as unknown as Env,
+				{ waitUntil: vi.fn() } as unknown as ExecutionContext,
+			);
+			expect(response.status).toBe(500);
+			expect(await response.json()).toMatchObject({
+				success: false,
+				error: {
+					code: 'CONFIG_ERROR',
+					message: `Invalid MARIMOHUB_SANDBOX_AUTH: ${raw} (expected on, off)`,
+				},
+			});
+		},
+	);
+
 	it('parses MARIMOHUB_SUPER_ADMINS into a trimmed list, dropping empties', () => {
 		const deps = buildDeps(new Request('https://hub.example.com'), {
 			...baseEnv,

--- a/examples/cloudflare-worker/src/index.ts
+++ b/examples/cloudflare-worker/src/index.ts
@@ -32,6 +32,7 @@ import {
 	unsupportedBackendNotice,
 } from '@marimo-hub/config/compute-profiles';
 import { R2BucketAdapter } from '@marimo-hub/storage-r2';
+import { parseSandboxAuth } from '@marimo-hub/config/sandbox-auth';
 
 // Re-export the Sandbox Durable Object so wrangler can discover it, and
 // ContainerProxy so the sandbox can mount R2 by binding name without credentials.
@@ -188,6 +189,7 @@ export function buildDeps(
 			// Empty in tunnel mode (the adapter ignores it then); set only for
 			// subdomain exposure on a dedicated isolated domain.
 			hostname: sandboxHostname ?? '',
+			auth: parseSandboxAuth(env.MARIMOHUB_SANDBOX_AUTH),
 			workdir: env.SANDBOX_WORKDIR || '/workspace',
 			computeProfiles: [],
 			computeProfileOverride: 'none',

--- a/examples/cloudflare-worker/wrangler.jsonc
+++ b/examples/cloudflare-worker/wrangler.jsonc
@@ -14,6 +14,7 @@
 		"R2_BUCKET_NAME": "orgname-marimohub",
 		"R2_S3_ENDPOINT": "",
 		"SANDBOX_HOSTNAME": "",
+		"MARIMOHUB_SANDBOX_AUTH": "off",
 	},
 	// Serve the prebuilt SPA (built by `pnpm --filter @marimo-hub/web build`).
 	"assets": {

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -148,6 +148,8 @@ export interface SandboxConfig {
 	 * routing-token signing secret, so no separate secret field is needed.
 	 */
 	exposure?: SandboxExposure;
+	/** Native marimo token authentication for new sessions. Defaults to off. */
+	auth?: 'on' | 'off';
 	/**
 	 * Public URL for browser links (MARIMOHUB_APP_BASE_URL). Can include a path prefix.
 	 * Falls back to the request origin when unset.

--- a/packages/api/src/mcp/createMcpApp.test.ts
+++ b/packages/api/src/mcp/createMcpApp.test.ts
@@ -81,7 +81,7 @@ describe('MCP OAuth app', () => {
 			mcp: { publicBaseUrl: 'https://hub.example.com' },
 			compute,
 		});
-		deps.sandbox = { ...deps.sandbox, hostname: 'sandboxes.example.com' };
+		deps.sandbox = { ...deps.sandbox, hostname: 'sandboxes.example.com', auth: 'on' };
 		deps.authenticator = {
 			authenticate: async (request) => {
 				const token = bearerToken(request);

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -85,6 +85,20 @@ describe('Session routes', () => {
 		persistWorkspace: 'source',
 		...overrides,
 	});
+	const authWorld = () => {
+		const { instance, calls } = makeFakeSandbox();
+		return {
+			calls,
+			requestFor: (auth?: 'on' | 'off') =>
+				createTestApi({
+					bucket,
+					userId: ACTOR,
+					compute: fakeComputeFrom(instance),
+					deps: { sandbox: sandboxConfig({ auth }) },
+				}).request,
+		};
+	};
+
 	const exclusiveApi = (
 		userId: ReturnType<typeof uid>,
 		compute: ApiDeps['compute'] = makeFakeCompute(),
@@ -334,33 +348,118 @@ describe('Session routes', () => {
 		expect(data.error).toBeUndefined();
 	});
 
-	it('stores a kernel token without exposing it in the session response or command', async () => {
-		const { instance, calls } = makeFakeSandbox();
-		const request = createTestApi({
-			bucket,
-			userId: ACTOR,
-			compute: fakeComputeFrom(instance),
-		}).request;
+	it.each(['edit', 'app'] as const)(
+		'auth on: protects a new %s kernel without exposing its token in commands',
+		async (mode) => {
+			const { calls, requestFor } = authWorld();
+			const request = requestFor('on');
 
-		const data = await expectOk<ApiSession>(await request('POST', sessionsPath()));
+			const data = await expectOk<ApiSession>(await request('POST', sessionsPath(), { mode }));
+			const stored = await createServices(bucket).sessions.getSession(
+				pid,
+				data.session_id as SessionId,
+			);
+			expect(stored.kernel_auth_token).toMatch(KERNEL_AUTH_TOKEN_PATTERN);
+			expect(data).not.toHaveProperty('kernel_auth_token');
+
+			const url = new URL(data.sandbox_url!);
+			expect(url.searchParams.get('access_token')).toBe(stored.kernel_auth_token);
+			expect(calls.writeFile).toContainEqual({
+				path: KERNEL_AUTH_TOKEN_FILE,
+				content: stored.kernel_auth_token,
+			});
+			expect(calls.startProcess[0].cmd).toContain(
+				`--token --token-password-file '${KERNEL_AUTH_TOKEN_FILE}'`,
+			);
+			expect(calls.startProcess[0].cmd).not.toContain(stored.kernel_auth_token!);
+		},
+	);
+
+	it.each([
+		{ mode: 'edit', auth: undefined },
+		{ mode: 'app', auth: undefined },
+		{ mode: 'edit', auth: 'off' },
+		{ mode: 'app', auth: 'off' },
+	] as const)('auth $auth: starts a tokenless $mode kernel', async ({ mode, auth }) => {
+		const { calls, requestFor } = authWorld();
+		const request = requestFor(auth);
+		const data = await expectOk<ApiSession>(await request('POST', sessionsPath(), { mode }));
 		const stored = await createServices(bucket).sessions.getSession(
 			pid,
 			data.session_id as SessionId,
 		);
-		expect(stored.kernel_auth_token).toMatch(KERNEL_AUTH_TOKEN_PATTERN);
-		expect(data).not.toHaveProperty('kernel_auth_token');
-
-		const url = new URL(data.sandbox_url!);
-		expect(url.searchParams.get('access_token')).toBe(stored.kernel_auth_token);
-		expect(calls.writeFile).toContainEqual({
-			path: KERNEL_AUTH_TOKEN_FILE,
-			content: stored.kernel_auth_token,
-		});
-		expect(calls.startProcess[0].cmd).toContain(
-			`--token --token-password-file '${KERNEL_AUTH_TOKEN_FILE}'`,
-		);
-		expect(calls.startProcess[0].cmd).not.toContain(stored.kernel_auth_token!);
+		expect(stored.kernel_auth_token).toBeUndefined();
+		expect(new URL(data.sandbox_url!).searchParams.has('access_token')).toBe(false);
+		expect(calls.writeFile.some((file) => file.path === KERNEL_AUTH_TOKEN_FILE)).toBe(false);
+		expect(calls.startProcess[0].cmd).toContain('--no-token');
+		expect(calls.startProcess[0].cmd).not.toContain('--token-password-file');
 	});
+
+	it.each([
+		{ mode: 'edit', auth: 'on' },
+		{ mode: 'app', auth: 'on' },
+		{ mode: 'edit', auth: 'off' },
+		{ mode: 'app', auth: 'off' },
+	] as const)(
+		'preserves a running $mode session with auth $auth after configuration changes',
+		async ({ mode, auth }) => {
+			const { calls, requestFor } = authWorld();
+			const created = await expectOk<ApiSession>(
+				await requestFor(auth)('POST', sessionsPath(), { mode }),
+			);
+			const services = createServices(bucket);
+			const before = await services.sessions.getSession(pid, created.session_id as SessionId);
+			const reused = await expectOk<ApiSession>(
+				await requestFor(auth === 'on' ? 'off' : 'on')('POST', sessionsPath(), { mode }),
+			);
+			expect(reused.session_id).toBe(created.session_id);
+			expect(reused.sandbox_url).toBe(created.sandbox_url);
+			expect(reused.reused).toBe(true);
+			expect(
+				(await services.sessions.getSession(pid, created.session_id as SessionId))
+					.kernel_auth_token,
+			).toBe(before.kernel_auth_token);
+			expect(calls.startProcess).toHaveLength(1);
+		},
+	);
+
+	it.each([
+		{ mode: 'edit', before: 'on', after: 'off' },
+		{ mode: 'app', before: 'on', after: 'off' },
+		{ mode: 'edit', before: 'off', after: 'on' },
+		{ mode: 'app', before: 'off', after: 'on' },
+		{ mode: 'edit', before: 'on', after: 'on' },
+		{ mode: 'app', before: 'on', after: 'on' },
+	] as const)(
+		'uses auth $after for a new $mode session after stopping auth $before',
+		async ({ mode, before, after }) => {
+			const { calls, requestFor } = authWorld();
+			const original = await expectOk<ApiSession>(
+				await requestFor(before)('POST', sessionsPath(), { mode }),
+			);
+			const services = createServices(bucket);
+			const oldSession = await services.sessions.getSession(pid, original.session_id as SessionId);
+			const request = requestFor(after);
+			await expectOk(await request('DELETE', sessionsPath(`/${original.session_id}`)));
+			const next = await expectOk<ApiSession>(await request('POST', sessionsPath(), { mode }));
+			expect(next.session_id).not.toBe(original.session_id);
+			expect(next.reused).toBe(false);
+			const stored = await services.sessions.getSession(pid, next.session_id as SessionId);
+			const launch = calls.startProcess.at(-1)!.cmd;
+			if (after === 'on') {
+				expect(stored.kernel_auth_token).toMatch(KERNEL_AUTH_TOKEN_PATTERN);
+				expect(stored.kernel_auth_token).not.toBe(oldSession.kernel_auth_token);
+				expect(new URL(next.sandbox_url!).searchParams.get('access_token')).toBe(
+					stored.kernel_auth_token,
+				);
+				expect(launch).toContain('--token-password-file');
+			} else {
+				expect(stored.kernel_auth_token).toBeUndefined();
+				expect(new URL(next.sandbox_url!).searchParams.has('access_token')).toBe(false);
+				expect(launch).toContain('--no-token');
+			}
+		},
+	);
 
 	it('uses the configured sandbox startup timeout to bound the kernel port wait', async () => {
 		const sb = makeFakeSandbox();

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1335,7 +1335,7 @@ export async function startNotebookSession(input: {
 	await enforceSessionCap(deps, mode, pid, user.id, temporaryToRetire?.session_id);
 
 	const sandboxId = createSandboxId();
-	const kernelAuthToken = createKernelAuthToken();
+	const kernelAuthToken = sandbox.auth === 'on' ? createKernelAuthToken() : undefined;
 
 	const restoreFilesystemSnapshot =
 		!ephemeral && workspacePolicy.restoreFilesystemSnapshot

--- a/packages/api/src/sandboxProxy.test.ts
+++ b/packages/api/src/sandboxProxy.test.ts
@@ -843,44 +843,49 @@ describe('forwardHttp', () => {
 });
 
 describe('create-session in proxy mode', () => {
-	it('returns a /proxy/<token>/ client URL and persists the origin off-response', async () => {
-		const bucket = await createInitializedBucket();
-		const services = createServices(bucket);
-		const project = await services.projects.createProject({ name: 'P', description: 'd' }, ACTOR);
-		const pid = project.id as ProjectId;
-		const notebook = await services.notebooks.createNotebook(
-			pid,
-			{ title: 'NB', description: 'd', code: 'import marimo as mo' },
-			ACTOR,
-		);
+	it.each(['on', 'off'] as const)(
+		'auth %s: returns a proxy URL and persists the origin off-response',
+		async (auth) => {
+			const bucket = await createInitializedBucket();
+			const services = createServices(bucket);
+			const project = await services.projects.createProject({ name: 'P', description: 'd' }, ACTOR);
+			const pid = project.id as ProjectId;
+			const notebook = await services.notebooks.createNotebook(
+				pid,
+				{ title: 'NB', description: 'd', code: 'import marimo as mo' },
+				ACTOR,
+			);
 
-		const deps = makeTestDeps(bucket, {
-			authenticator: authAs(ACTOR),
-			compute: makeFakeCompute(),
-			sandbox: {
-				bucket: { name: 'test', endpoint: '' },
-				hostname: 'localhost',
-				workdir: '/workspace',
-				persistWorkspace: 'source',
-				exposure: new ProxyExposure(SECRET),
-				appBaseUrl: 'https://hub.example.com/marimohub',
-			},
-		});
-		const app = createApi(deps);
+			const deps = makeTestDeps(bucket, {
+				authenticator: authAs(ACTOR),
+				compute: makeFakeCompute(),
+				sandbox: {
+					auth,
+					bucket: { name: 'test', endpoint: '' },
+					hostname: 'localhost',
+					workdir: '/workspace',
+					persistWorkspace: 'source',
+					exposure: new ProxyExposure(SECRET),
+					appBaseUrl: 'https://hub.example.com/marimohub',
+				},
+			});
+			const app = createApi(deps);
 
-		const res = await app.request(`/api/v1/projects/${pid}/notebooks/${notebook.id}/sessions`, {
-			method: 'POST',
-		});
-		expect(res.status).toBe(200);
-		const { data } = (await res.json()) as { data: { session_id: string; sandbox_url: string } };
+			const res = await app.request(`/api/v1/projects/${pid}/notebooks/${notebook.id}/sessions`, {
+				method: 'POST',
+			});
+			expect(res.status).toBe(200);
+			const { data } = (await res.json()) as { data: { session_id: string; sandbox_url: string } };
 
-		const token = await signProxyToken(pid, data.session_id as never, SECRET);
-		expect(data.sandbox_url).toBe(`https://hub.example.com/marimohub/proxy/${token}/`);
-		// The server-reachable origin is persisted on the record but never in the response.
-		expect(data).not.toHaveProperty('sandbox_origin_url');
-		expect(data).not.toHaveProperty('kernel_auth_token');
-		const stored = await services.sessions.getSession(pid, data.session_id as never);
-		expect(stored.sandbox_origin_url).toBe('https://sandbox.example/kernel');
-		expect(stored.kernel_auth_token).toMatch(KERNEL_AUTH_TOKEN_PATTERN);
-	});
+			const token = await signProxyToken(pid, data.session_id as never, SECRET);
+			expect(data.sandbox_url).toBe(`https://hub.example.com/marimohub/proxy/${token}/`);
+			// The server-reachable origin is persisted on the record but never in the response.
+			expect(data).not.toHaveProperty('sandbox_origin_url');
+			expect(data).not.toHaveProperty('kernel_auth_token');
+			const stored = await services.sessions.getSession(pid, data.session_id as never);
+			expect(stored.sandbox_origin_url).toBe('https://sandbox.example/kernel');
+			if (auth === 'on') expect(stored.kernel_auth_token).toMatch(KERNEL_AUTH_TOKEN_PATTERN);
+			else expect(stored.kernel_auth_token).toBeUndefined();
+		},
+	);
 });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -10,6 +10,7 @@
 	"exports": {
 		".": "./src/index.ts",
 		"./compute-profiles": "./src/computeProfiles.ts",
+		"./sandbox-auth": "./src/sandboxAuth.ts",
 		"./spec": "./src/spec.ts",
 		"./package.json": "./package.json"
 	},

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -805,6 +805,24 @@ describe('createFromEnv sandbox exposure mode', () => {
 		MARIMOHUB_AUTH_BACKEND: 'dev',
 	};
 
+	it.each([undefined, '', ' \t\n', 'off', ' OFF '])(
+		'defaults or disables native kernel auth with %s',
+		(value) => {
+			expect(createFromEnv({ ...baseEnv, MARIMOHUB_SANDBOX_AUTH: value }).sandbox.auth).toBe('off');
+		},
+	);
+	it.each(['on', ' ON '])('enables native kernel auth with %s', (value) => {
+		expect(createFromEnv({ ...baseEnv, MARIMOHUB_SANDBOX_AUTH: value }).sandbox.auth).toBe('on');
+	});
+	it.each(['true', 'false', 'none', 'partitioned'])(
+		'rejects invalid sandbox auth policy %s',
+		(value) => {
+			expect(() => createFromEnv({ ...baseEnv, MARIMOHUB_SANDBOX_AUTH: value })).toThrow(
+				/MARIMOHUB_SANDBOX_AUTH/,
+			);
+		},
+	);
+
 	it('defaults to subdomain mode when unset', () => {
 		const deps = createFromEnv({ ...baseEnv });
 		expect(deps.sandbox.exposure?.mode).toBe('subdomain');

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -82,6 +82,7 @@ import { makeWif } from './wif';
 import { makeSandboxUserHome } from './userHome';
 import { parseEnum, parseEnumOr, parseIntEnv, parseList, parseOnOff, parseSecondsEnv } from './env';
 import type { Env } from './env';
+import { parseSandboxAuth } from './sandboxAuth';
 import { ConfigError } from './errors';
 import { checkSandboxHostIsolation } from './hostIsolation';
 import { buildPreflightChecks } from './preflightChecks';
@@ -699,9 +700,7 @@ export function createFromEnv(
 			// Unset defers to the core default (2 min); served on /api/v1/capabilities.
 			startupTimeoutMs: parseSecondsEnv(env, 'MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS'),
 			exposure,
-			auth: parseEnumOr(env, 'MARIMOHUB_SANDBOX_AUTH', ['on', 'off'] as const, 'off', {
-				docs: 'docs/security.md',
-			}),
+			auth: parseSandboxAuth(env.MARIMOHUB_SANDBOX_AUTH),
 			appBaseUrl: env.MARIMOHUB_APP_BASE_URL,
 			persistWorkspace: parsePersistWorkspace(env),
 			sessionLifetime,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -699,6 +699,9 @@ export function createFromEnv(
 			// Unset defers to the core default (2 min); served on /api/v1/capabilities.
 			startupTimeoutMs: parseSecondsEnv(env, 'MARIMOHUB_SANDBOX_STARTUP_TIMEOUT_SECONDS'),
 			exposure,
+			auth: parseEnumOr(env, 'MARIMOHUB_SANDBOX_AUTH', ['on', 'off'] as const, 'off', {
+				docs: 'docs/security.md',
+			}),
 			appBaseUrl: env.MARIMOHUB_APP_BASE_URL,
 			persistWorkspace: parsePersistWorkspace(env),
 			sessionLifetime,

--- a/packages/config/src/sandboxAuth.ts
+++ b/packages/config/src/sandboxAuth.ts
@@ -1,0 +1,13 @@
+import { parseEnumOr } from './env';
+
+export function parseSandboxAuth(raw: string | undefined): 'on' | 'off' {
+	return parseEnumOr(
+		{ MARIMOHUB_SANDBOX_AUTH: raw },
+		'MARIMOHUB_SANDBOX_AUTH',
+		['on', 'off'] as const,
+		'off',
+		{
+			docs: 'docs/security.md',
+		},
+	);
+}

--- a/packages/config/src/spec.ts
+++ b/packages/config/src/spec.ts
@@ -960,6 +960,24 @@ export const CONFIG_SPEC: ConfigGroup[] = [
 		],
 	},
 	{
+		name: 'Sandbox authentication',
+		backends: [
+			{
+				name: 'Native kernel authentication',
+				vars: [
+					{
+						id: 'MARIMOHUB_SANDBOX_AUTH',
+						name: 'Sandbox authentication',
+						description:
+							'Enable native marimo token authentication for new editor and app sessions: `on` or `off`. See [Native kernel authentication](./security.md#native-kernel-authentication) for deployment requirements.',
+						default: 'off',
+						example: 'on',
+					},
+				],
+			},
+		],
+	},
+	{
 		name: 'Sandbox exposure',
 		selector: 'MARIMOHUB_SANDBOX_EXPOSURE',
 		selectorDefault: 'subdomain',

--- a/packages/core/src/ports/sandboxExposure.ts
+++ b/packages/core/src/ports/sandboxExposure.ts
@@ -7,8 +7,8 @@ import type { NotebookId, ProjectId, SandboxId, SessionId } from '../ids';
  *
  * - `subdomain` — the kernel is reached DIRECTLY at the compute adapter's public
  *   URL on an isolated sandbox domain (`<id>.sandbox.example.com`). True
- *   cross-origin isolation; not authenticated by the hub. marimo authenticates
- *   the client with the per-session kernel token. The default mode.
+ *   cross-origin isolation; not authenticated by the hub. marimo optionally
+ *   authenticates the client with a per-session kernel token. The default mode.
  * - `proxy` — all kernel traffic is forwarded THROUGH the app at
  *   `…/proxy/<token>/…`, so it passes through the hub's auth + per-session
  *   authorization. Same-origin with the app (XSS-capable); for trusted
@@ -23,7 +23,7 @@ export interface ExposureContext {
 	notebookId: NotebookId;
 	sandboxId: SandboxId;
 	/** Independent credential used by marimo's native authentication. */
-	kernelAuthToken: string;
+	kernelAuthToken?: string;
 	/** The app's public base URL, which may include a path prefix. */
 	appBaseUrl: string;
 }

--- a/packages/core/src/services/runtime/sandboxExposure.test.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.test.ts
@@ -29,6 +29,14 @@ describe('SubdomainExposure', () => {
 		expect(result.originUrl).toBeUndefined();
 	});
 
+	it('omits authentication when no kernel token is configured', async () => {
+		const result = await exposure.finalize(
+			'https://sandbox.example.net/open?provider=one#notebook',
+			{ ...ctx, kernelAuthToken: undefined },
+		);
+		expect(result.clientUrl).toBe('https://sandbox.example.net/open?provider=one#notebook');
+	});
+
 	it('preserves provider query parameters and fragments', async () => {
 		const result = await exposure.finalize(
 			'https://sandbox.example.net/open?provider=one&provider=two&empty=#notebook',
@@ -39,15 +47,21 @@ describe('SubdomainExposure', () => {
 		);
 	});
 
-	it.each([
-		'https://sandbox.example.net/?access_token=provider-credential',
-		'https://sandbox.example.net/?access_token=',
-		'https://sandbox.example.net/?%61ccess_token=provider-credential',
-	])('rejects an adapter URL containing the reserved token parameter: %s', async (url) => {
-		await expect(exposure.finalize(url, ctx)).rejects.toThrow(
-			'Sandbox exposure URL contains reserved access_token query parameter',
-		);
-	});
+	describe.each([TEST_KERNEL_AUTH_TOKEN, undefined])(
+		'reserved URL tokens (kernel auth %s)',
+		(kernelAuthToken) => {
+			it.each([
+				'https://sandbox.example.net/?access_token=provider-credential',
+				'https://sandbox.example.net/?access_token=',
+				'https://sandbox.example.net/?%61ccess_token=provider-credential',
+				'https://sandbox.example.net/?access_token=one&access_token=two',
+			])('rejects the reserved parameter: %s', async (url) => {
+				await expect(exposure.finalize(url, { ...ctx, kernelAuthToken })).rejects.toThrow(
+					'Sandbox exposure URL contains reserved access_token query parameter',
+				);
+			});
+		},
+	);
 });
 
 describe('ProxyExposure', () => {

--- a/packages/core/src/services/runtime/sandboxExposure.ts
+++ b/packages/core/src/services/runtime/sandboxExposure.ts
@@ -22,8 +22,8 @@ export function kernelBasePathFromUrl(sandboxUrl?: string): string {
 
 /**
  * `subdomain` (default) — the browser reaches the kernel directly on its isolated
- * domain. The adapter URL carries marimo's access token. There is no proxying or
- * marimo base path.
+ * domain. When auth is enabled, the adapter URL carries marimo's access token.
+ * There is no proxying or marimo base path.
  */
 export class SubdomainExposure implements SandboxExposure {
 	readonly mode = 'subdomain' as const;
@@ -37,7 +37,9 @@ export class SubdomainExposure implements SandboxExposure {
 		if (url.searchParams.has('access_token')) {
 			throw new Error('Sandbox exposure URL contains reserved access_token query parameter');
 		}
-		url.searchParams.set('access_token', ctx.kernelAuthToken);
+		if (ctx.kernelAuthToken !== undefined) {
+			url.searchParams.set('access_token', ctx.kernelAuthToken);
+		}
 		return { clientUrl: url.toString() };
 	}
 }

--- a/packages/web/src/components/NotebookPage/NotebookFrame.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookFrame.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NotebookFrame } from './NotebookFrame';
+
+const SRC = 'https://kernel.example/?access_token=test-token&theme=dark';
+const frame = (src: string | undefined, title = 'Forecast') => (
+	<MemoryRouter>
+		<NotebookFrame src={src} title={title} />
+	</MemoryRouter>
+);
+const advance = async (milliseconds = 15_000) => {
+	await act(() => vi.advanceTimersByTime(milliseconds));
+};
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe('NotebookFrame recovery', () => {
+	it('offers recovery after a blocked frame fires load, preserving the original token URL', async () => {
+		render(frame(SRC));
+		const iframe = screen.getByTitle('Forecast');
+		fireEvent.load(iframe);
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		await advance();
+		expect(screen.getByRole('status')).toHaveTextContent('Notebook not visible?');
+		const link = screen.getByRole('link', { name: 'Open in new window' });
+		expect(link).toHaveAttribute('href', SRC);
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+		expect(screen.getByTitle('Forecast')).toBe(iframe);
+	});
+
+	it('dismisses help without reloading the running notebook', async () => {
+		const { rerender } = render(frame(SRC));
+		const iframe = screen.getByTitle('Forecast');
+		await advance();
+		fireEvent.click(screen.getByRole('button', { name: 'Dismiss notebook help' }));
+		rerender(frame(SRC));
+		fireEvent.load(iframe);
+		await advance();
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		expect(screen.getByTitle('Forecast')).toBe(iframe);
+	});
+
+	it('retries only the iframe and restarts the recovery delay', async () => {
+		render(frame(SRC));
+		const iframe = screen.getByTitle('Forecast');
+		await advance();
+		fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+		expect(screen.getByTitle('Forecast')).not.toBe(iframe);
+		expect(screen.getByTitle('Forecast')).toHaveAttribute('src', SRC);
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		await advance();
+		expect(screen.getByRole('status')).toBeInTheDocument();
+	});
+
+	it('resets dismissed recovery when the session URL changes', async () => {
+		const { rerender } = render(frame(SRC));
+		await advance();
+		fireEvent.click(screen.getByRole('button', { name: 'Dismiss notebook help' }));
+		rerender(frame('https://another-kernel.example/'));
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		await advance();
+		expect(screen.getByRole('link', { name: 'Open in new window' })).toHaveAttribute(
+			'href',
+			'https://another-kernel.example/',
+		);
+	});
+
+	it('does not show help before the delay, including after metadata rerenders', async () => {
+		const { rerender } = render(frame(SRC));
+		const iframe = screen.getByTitle('Forecast');
+		await advance(10_000);
+		rerender(frame(SRC, 'Renamed notebook'));
+		expect(screen.getByTitle('Renamed notebook')).toBe(iframe);
+		await advance(4999);
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		await advance(1);
+		expect(screen.getByRole('status')).toBeInTheDocument();
+	});
+
+	it('cancels the previous URL timeout when switching kernels before it fires', async () => {
+		const { rerender } = render(frame(SRC));
+		await advance(10_000);
+		rerender(frame('https://second-kernel.example/'));
+		await advance(5000);
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		await advance(10_000);
+		expect(screen.getByRole('link', { name: 'Open in new window' })).toHaveAttribute(
+			'href',
+			'https://second-kernel.example/',
+		);
+	});
+
+	it('cancels recovery when the URL disappears and starts fresh on reattachment', async () => {
+		const { rerender } = render(frame(SRC));
+		await advance(10_000);
+		rerender(frame(undefined));
+		await advance();
+		expect(screen.queryByTitle('Forecast')).not.toBeInTheDocument();
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		rerender(frame(SRC));
+		await advance(14_999);
+		expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		await advance(1);
+		expect(screen.getByRole('status')).toBeInTheDocument();
+	});
+
+	it.each([undefined, ''])(
+		'does not create a frame or recovery prompt without a URL (%s)',
+		async (src) => {
+			render(frame(src));
+			await advance();
+			expect(screen.queryByTitle('Forecast')).not.toBeInTheDocument();
+			expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		},
+	);
+
+	it.each([
+		'/hub/proxy/signed-routing-token/?theme=dark#cell',
+		'https://kernel.example/?access_token=a%2Bb&provider=one&provider=two#cell',
+	])('preserves the full URL across repeated retries: %s', async (src) => {
+		render(frame(src));
+		for (let attempt = 0; attempt < 2; attempt++) {
+			await advance();
+			expect(screen.getByRole('link', { name: 'Open in new window' })).toHaveAttribute('href', src);
+			const iframe = screen.getByTitle('Forecast');
+			fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+			expect(screen.getByTitle('Forecast')).not.toBe(iframe);
+			expect(screen.getByTitle('Forecast')).toHaveAttribute('src', src);
+			expect(screen.queryByRole('status')).not.toBeInTheDocument();
+		}
+	});
+});

--- a/packages/web/src/components/NotebookPage/NotebookFrame.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookFrame.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { ExternalLink, X } from 'lucide-react';
+import { Button, IconButton, LinkButton } from '@/components/ui';
+import { useTimeout } from '@/hooks/useTimeout';
+
+const RECOVERY_DELAY_MS = 15_000;
+
+export function NotebookFrame({ src, title }: { src?: string; title: string }) {
+	const [attempt, setAttempt] = useState(0);
+	if (!src) return null;
+	return (
+		<FrameAttempt
+			key={`${src}:${attempt}`}
+			src={src}
+			title={title}
+			onRetry={() => setAttempt((current) => current + 1)}
+		/>
+	);
+}
+
+function FrameAttempt({
+	src,
+	title,
+	onRetry,
+}: {
+	src: string;
+	title: string;
+	onRetry: () => void;
+}) {
+	const [showRecovery, setShowRecovery] = useState(false);
+
+	// Browsers fire load even for blocked cross-origin frames, so use a delayed prompt.
+	useTimeout(() => setShowRecovery(true), RECOVERY_DELAY_MS);
+
+	return (
+		<div className="flex size-full min-h-0 flex-col">
+			{showRecovery ? (
+				<output className="flex flex-wrap items-center gap-3 border-b bg-muted/50 px-4 py-2 text-sm">
+					<span className="min-w-0 flex-1">
+						<span className="font-medium">Notebook not visible?</span> Your browser may block
+						embedded content. Try opening it in a new window.
+					</span>
+					<Button size="sm" onPress={onRetry}>
+						Retry
+					</Button>
+					<LinkButton to={src} target="_blank" rel="noopener noreferrer" size="sm">
+						<ExternalLink className="size-3.5" />
+						Open in new window
+					</LinkButton>
+					<IconButton label="Dismiss notebook help" onPress={() => setShowRecovery(false)}>
+						<X className="size-4" />
+					</IconButton>
+				</output>
+			) : null}
+			<iframe
+				className="min-h-0 w-full flex-1 border-0"
+				src={src}
+				sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+				allow="clipboard-read; clipboard-write"
+				title={title}
+			/>
+		</div>
+	);
+}

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { act, screen, waitFor, within } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { sessionKeys } from '@/api/queryKeys';
 import {
@@ -20,6 +20,32 @@ async function chooseSurfaceAction(
 }
 
 describe('NotebookPage viewer modes', () => {
+	it.each(['edit', 'app'] as const)('offers recovery for the %s kernel', async (variant) => {
+		const setTimeout = globalThis.setTimeout;
+		vi.spyOn(globalThis, 'setTimeout').mockImplementation((callback, delay, ...args) =>
+			setTimeout(callback, delay === 15_000 ? 0 : delay, ...args),
+		);
+		makeFetch({
+			role: 'editor',
+			session: runningSession({
+				mode: variant,
+				sandbox_url: 'https://sandbox.example/kernel?access_token=kernel-secret#notebook',
+			}),
+		});
+		const { unmount } = renderPage(variant);
+		try {
+			const iframe = await screen.findByTitle('Forecast');
+			fireEvent.load(iframe);
+			const link = await screen.findByRole('link', { name: 'Open in new window' });
+			expect(link).toHaveAttribute('href', iframe.getAttribute('src'));
+			expect(link).toHaveAttribute('href', expect.stringContaining('access_token=kernel-secret'));
+			fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+			expect(screen.getByTitle('Forecast')).not.toBe(iframe);
+		} finally {
+			unmount();
+		}
+	});
+
 	it('opens and stops the configured VS Code iframe for an authorized editor', async () => {
 		const user = userEvent.setup();
 		makeFetch({

--- a/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.test.tsx
@@ -69,7 +69,7 @@ describe('NotebookPage viewer modes', () => {
 		expect(screen.getByTitle('Forecast in VS Code')).toBe(vscodeFrame);
 		expect(vscodeFrame.parentElement).toBe(vscodePanel);
 		expect(screen.getByTitle('Forecast')).toBe(notebookFrame);
-		expect(notebookFrame.parentElement).toBe(notebookPanel);
+		expect(notebookFrame.closest('[role="tabpanel"]')).toBe(notebookPanel);
 		expect(vscodePanel).toHaveAttribute('inert');
 		expect(opencodeFrame.closest('[role="tabpanel"]')).not.toHaveAttribute('inert');
 		expect(screen.getByRole('separator', { name: 'Resize split view' })).toBeInTheDocument();

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -54,6 +54,7 @@ import { canManageProject } from '@/lib/roles';
 import { SurfaceMenu } from './SurfaceMenu';
 import type { SecondarySurfaceFrame } from './SurfaceMenu';
 import { ShareMenu } from './ShareMenu';
+import { NotebookFrame } from './NotebookFrame';
 
 const SURFACE_TAB_ICONS = {
 	vscode: Code2,
@@ -312,15 +313,7 @@ function useNotebookPageModel({ variant = 'edit' }: { variant?: 'edit' | 'app' }
 				id: 'notebook',
 				label: 'Notebook',
 				icon: <FileCode2 />,
-				panel: (
-					<iframe
-						className="size-full border-0"
-						src={iframeSrc}
-						sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
-						allow="clipboard-read; clipboard-write"
-						title={title}
-					/>
-				),
+				panel: <NotebookFrame src={iframeSrc} title={title} />,
 				...(iframeSrc ? { browserUrl: iframeSrc } : {}),
 			},
 			...activeSecondaryFrames.map((frame) => {

--- a/packages/web/src/components/NotebookPage/NotebookPage.tsx
+++ b/packages/web/src/components/NotebookPage/NotebookPage.tsx
@@ -879,13 +879,7 @@ function renderNotebookPage(model: ReturnType<typeof useNotebookPageModel>) {
 						aria-hidden={takeover.isPending || undefined}
 					>
 						{isApp ? (
-							<iframe
-								className="size-full border-0"
-								src={iframeSrc}
-								sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
-								allow="clipboard-read; clipboard-write"
-								title={title}
-							/>
+							<NotebookFrame src={iframeSrc} title={title} />
 						) : (
 							<ApplicationTabs
 								ariaLabel="Notebook applications"

--- a/packages/web/src/hooks/useTimeout.test.tsx
+++ b/packages/web/src/hooks/useTimeout.test.tsx
@@ -1,0 +1,94 @@
+import { StrictMode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTimeout } from './useTimeout';
+
+function setup(delayMs: number | null = 1000) {
+	const callback = vi.fn();
+	return {
+		callback,
+		...renderHook(({ callback, delayMs }) => useTimeout(callback, delayMs), {
+			initialProps: { callback, delayMs },
+		}),
+	};
+}
+
+describe('useTimeout', () => {
+	beforeEach(() => vi.useFakeTimers());
+	afterEach(() => vi.useRealTimers());
+
+	it('runs once after the full delay', () => {
+		const { callback } = setup();
+		vi.advanceTimersByTime(999);
+		expect(callback).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(callback).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(5000);
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	it('uses the latest callback without postponing or rearming the timeout', () => {
+		const { callback, rerender } = setup();
+		vi.advanceTimersByTime(750);
+		const latest = vi.fn();
+		rerender({ callback: latest, delayMs: 1000 });
+		vi.advanceTimersByTime(250);
+		expect(latest).toHaveBeenCalledTimes(1);
+		expect(callback).not.toHaveBeenCalled();
+		rerender({ callback, delayMs: 1000 });
+		vi.advanceTimersByTime(2000);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('cancels a pending timeout with null and starts a full delay when enabled again', () => {
+		const { callback, rerender } = setup();
+		vi.advanceTimersByTime(750);
+		rerender({ callback, delayMs: null });
+		vi.advanceTimersByTime(5000);
+		expect(callback).not.toHaveBeenCalled();
+		rerender({ callback, delayMs: 1000 });
+		vi.advanceTimersByTime(999);
+		expect(callback).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not schedule while disabled', () => {
+		const { callback } = setup(null);
+		expect(vi.getTimerCount()).toBe(0);
+		vi.advanceTimersByTime(5000);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('replaces the pending timeout when the delay changes', () => {
+		const { callback, rerender } = setup();
+		vi.advanceTimersByTime(750);
+		rerender({ callback, delayMs: 2000 });
+		vi.advanceTimersByTime(1999);
+		expect(callback).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	it('schedules a zero delay asynchronously', () => {
+		const { callback } = setup(0);
+		expect(callback).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(0);
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	it('clears the pending timeout on unmount', () => {
+		const { callback, unmount } = setup();
+		unmount();
+		expect(vi.getTimerCount()).toBe(0);
+		vi.advanceTimersByTime(1000);
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it('fires once under Strict Mode effect replay', () => {
+		const callback = vi.fn();
+		renderHook(() => useTimeout(callback, 1000), { wrapper: StrictMode });
+		vi.advanceTimersByTime(1000);
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/web/src/hooks/useTimeout.ts
+++ b/packages/web/src/hooks/useTimeout.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+
+/** Null cancels the timeout; callback changes do not restart it. */
+export function useTimeout(callback: () => void, delayMs: number | null): void {
+	const saved = useRef(callback);
+	useEffect(() => {
+		saved.current = callback;
+	}, [callback]);
+
+	useEffect(() => {
+		if (delayMs === null) return;
+		const id = setTimeout(() => saved.current(), delayMs);
+		return () => clearTimeout(id);
+	}, [delayMs]);
+}

--- a/scripts/dev-services/compose.yaml
+++ b/scripts/dev-services/compose.yaml
@@ -7,7 +7,7 @@ name: marimohub-dev-services
 
 services:
   minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
     command: server /data --console-address ':9001'
     environment:
       MINIO_ROOT_USER: minioadmin
@@ -25,7 +25,7 @@ services:
       - minio-data:/data
 
   minio-seed:
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
Cross-site iframe cookie restrictions can prevent notebooks from loading after #302. Add `MARIMOHUB_SANDBOX_AUTH=on|off`, defaulting to `off` to restore compatibility. Existing sessions retain their authentication mode until stopped and restarted; hub and proxy authorization remain unchanged. Direct kernel access needs ingress protection when native authentication is off.

Offer Retry and Open in new window after 15 seconds, preserving the session URL and allowing users to dismiss the prompt without reloading the notebook. Because browsers hide cross-origin iframe failures, the prompt can also appear for healthy frames. Share timeout handling through `useTimeout` and cover timer cleanup, URL changes, auth transitions, and token rotation.

Centralize deployment guidance and keep native authentication separate from future cookie partitioning settings.

Fixes #328.
