### PR TITLE
Fix React Compiler warnings in builds and tests

### DIFF
--- a/packages/web/src/api/changeRequests.ts
+++ b/packages/web/src/api/changeRequests.ts
@@ -94,49 +94,54 @@ export function useNotebookChangeRequestPublisher(projectId: string, notebookId:
 			requestAttempt.inFlight += 1;
 			requestAttempt.lastUsedAt = now;
 			requestAttempt.settledAt = undefined;
-			try {
-				const data = await apiData(
-					apiClient.POST('/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/change-requests', {
-						params: {
-							path: { pid: projectId, nid: notebookId, sid: sessionId },
-							header: { 'idempotency-key': requestAttempt.idempotencyKey },
-						},
-						body: {
-							...(title ? { title } : {}),
-							...(targetProposalId ? { target_proposal_id: targetProposalId } : {}),
-						},
-						timeout: 120_000,
-					}),
-				);
-				if (currentScope.current === scope && attempts.current.get(attemptKey) === requestAttempt) {
-					requestAttempt.discardWhenSettled = true;
-					setPublished({ scope, value: data });
-				}
-				return data;
-			} catch (error) {
-				if (
-					attempts.current.get(attemptKey) === requestAttempt &&
-					isApiErrorCode(error, 'PROPOSAL_RETRY_REQUIRED')
-				) {
-					requestAttempt.discardWhenSettled = true;
-				}
-				throw error;
-			} finally {
-				requestAttempt.inFlight -= 1;
-				if (requestAttempt.inFlight === 0) {
+			return apiData(
+				apiClient.POST('/api/v1/projects/{pid}/notebooks/{nid}/sessions/{sid}/change-requests', {
+					params: {
+						path: { pid: projectId, nid: notebookId, sid: sessionId },
+						header: { 'idempotency-key': requestAttempt.idempotencyKey },
+					},
+					body: {
+						...(title ? { title } : {}),
+						...(targetProposalId ? { target_proposal_id: targetProposalId } : {}),
+					},
+					timeout: 120_000,
+				}),
+			)
+				.then((data) => {
 					if (
-						requestAttempt.discardWhenSettled &&
+						currentScope.current === scope &&
 						attempts.current.get(attemptKey) === requestAttempt
 					) {
-						attempts.current.delete(attemptKey);
-					} else {
-						const settledAt = Date.now();
-						requestAttempt.lastUsedAt = settledAt;
-						requestAttempt.settledAt = settledAt;
-						prunePublishAttempts(attempts.current, settledAt);
+						requestAttempt.discardWhenSettled = true;
+						setPublished({ scope, value: data });
 					}
-				}
-			}
+					return data;
+				})
+				.catch((error: unknown) => {
+					if (
+						attempts.current.get(attemptKey) === requestAttempt &&
+						isApiErrorCode(error, 'PROPOSAL_RETRY_REQUIRED')
+					) {
+						requestAttempt.discardWhenSettled = true;
+					}
+					throw error;
+				})
+				.finally(() => {
+					requestAttempt.inFlight -= 1;
+					if (requestAttempt.inFlight === 0) {
+						if (
+							requestAttempt.discardWhenSettled &&
+							attempts.current.get(attemptKey) === requestAttempt
+						) {
+							attempts.current.delete(attemptKey);
+						} else {
+							const settledAt = Date.now();
+							requestAttempt.lastUsedAt = settledAt;
+							requestAttempt.settledAt = settledAt;
+							prunePublishAttempts(attempts.current, settledAt);
+						}
+					}
+				});
 		},
 		onMutate: () => {
 			setMutationScope(scope);

--- a/packages/web/src/components/Account/CliDeviceLoginPage.tsx
+++ b/packages/web/src/components/Account/CliDeviceLoginPage.tsx
@@ -35,9 +35,11 @@ export interface CliDeviceLoginPageProps {
 	navigate?: (url: string) => void;
 }
 
-export function CliDeviceLoginPage({
-	navigate = (url) => window.location.assign(url),
-}: CliDeviceLoginPageProps) {
+function navigateToUrl(url: string) {
+	window.location.assign(url);
+}
+
+export function CliDeviceLoginPage({ navigate = navigateToUrl }: CliDeviceLoginPageProps) {
 	const initialCode = new URLSearchParams(window.location.search).get('user_code') ?? '';
 	const { user } = useAuth();
 	const approve = useApproveCliDeviceAuthorization();

--- a/packages/web/src/components/Account/CliLoginPage.tsx
+++ b/packages/web/src/components/Account/CliLoginPage.tsx
@@ -13,9 +13,11 @@ export interface CliLoginPageProps {
 	navigate?: (url: string) => void;
 }
 
-export function CliLoginPage({
-	navigate = (url) => window.location.assign(url),
-}: CliLoginPageProps) {
+function navigateToUrl(url: string) {
+	window.location.assign(url);
+}
+
+export function CliLoginPage({ navigate = navigateToUrl }: CliLoginPageProps) {
 	const request = parseCliLoginRequest(window.location.search);
 	const { user } = useAuth();
 	const approve = useApproveCliAuthorization();

--- a/packages/web/src/components/Account/OAuthConsentPage.tsx
+++ b/packages/web/src/components/Account/OAuthConsentPage.tsx
@@ -21,9 +21,11 @@ export interface OAuthConsentPageProps {
 	navigate?: (url: string) => void;
 }
 
-export function OAuthConsentPage({
-	navigate = (url) => window.location.assign(url),
-}: OAuthConsentPageProps) {
+function navigateToUrl(url: string) {
+	window.location.assign(url);
+}
+
+export function OAuthConsentPage({ navigate = navigateToUrl }: OAuthConsentPageProps) {
 	const id = new URLSearchParams(window.location.search).get('id');
 	const { user } = useAuth();
 	const preview = useOAuthAuthorizationPreview(id);

--- a/packages/web/src/components/Account/TokenGrantEditor.tsx
+++ b/packages/web/src/components/Account/TokenGrantEditor.tsx
@@ -61,13 +61,15 @@ export function TokenGrantEditor({ value, onChange, upperBound }: TokenGrantEdit
 		{ q: search.trim() || undefined },
 		{ enabled: Array.isArray(value.projects), throwOnError: false },
 	);
+	const boundActions = upperBound?.actions;
+	const boundProjects = upperBound?.projects;
 	const upperBoundActions = useMemo(
-		() => (Array.isArray(upperBound?.actions) ? new Set(upperBound.actions) : null),
-		[upperBound?.actions],
+		() => (Array.isArray(boundActions) ? new Set(boundActions) : null),
+		[boundActions],
 	);
 	const upperBoundProjects = useMemo(
-		() => (Array.isArray(upperBound?.projects) ? new Set(upperBound.projects) : null),
-		[upperBound?.projects],
+		() => (Array.isArray(boundProjects) ? new Set(boundProjects) : null),
+		[boundProjects],
 	);
 	const selectedProjectIds = useMemo(
 		() => new Set(Array.isArray(value.projects) ? value.projects : []),

--- a/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.tsx
+++ b/packages/web/src/components/Admin/AdminPolicyAnalyzerPage.tsx
@@ -1529,7 +1529,11 @@ export default function AdminPolicyAnalyzerPage() {
 		try {
 			const suite = parseSuite(suiteText, { allowEmpty: true });
 			if (suite.cases.length >= metadata.max_cases) {
-				throw new Error(`A suite can contain at most ${metadata.max_cases} scenarios.`);
+				reportError(
+					new Error(`A suite can contain at most ${metadata.max_cases} scenarios.`),
+					'The suite is invalid.',
+				);
+				return;
 			}
 			setSuiteText(JSON.stringify({ ...suite, cases: [...suite.cases, buildCase()] }, null, 2));
 			setFormError(null);

--- a/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
+++ b/packages/web/src/components/DataBrowser/DataBrowserPage.tsx
@@ -191,11 +191,7 @@ function useDataBrowserPageState() {
 
 	const refresh = async () => {
 		setRefreshing(true);
-		try {
-			await refreshBrowseQueries(queryClient);
-		} finally {
-			setRefreshing(false);
-		}
+		await refreshBrowseQueries(queryClient).finally(() => setRefreshing(false));
 	};
 
 	const selected = dataIntegrations.find((entry) => entry.id === iid);

--- a/packages/web/src/components/DataBrowser/SqlWorkspace.component.test.tsx
+++ b/packages/web/src/components/DataBrowser/SqlWorkspace.component.test.tsx
@@ -50,11 +50,9 @@ function useRunDataQueryMock() {
 		isPending,
 		mutateAsync: async (input: { sql: string; signal: AbortSignal }) => {
 			setPending(true);
-			try {
-				return await hookMocks.executeQuery(input);
-			} finally {
-				setPending(false);
-			}
+			return Promise.resolve()
+				.then(() => hookMocks.executeQuery(input))
+				.finally(() => setPending(false));
 		},
 	};
 }

--- a/packages/web/src/components/DataBrowser/SqlWorkspace.tsx
+++ b/packages/web/src/components/DataBrowser/SqlWorkspace.tsx
@@ -183,7 +183,7 @@ function SqlWorkspaceSession({
 	const [instruction, setInstruction] = useState('');
 	const [showHistory, setShowHistory] = useState(false);
 	const [error, setError] = useState<string | null>(null);
-	const editorReadiness = useMemo(createEditorReadinessStore, []);
+	const editorReadiness = useMemo(() => createEditorReadinessStore(), []);
 	const editorReady = useSyncExternalStore(
 		editorReadiness.subscribe,
 		editorReadiness.getSnapshot,
@@ -251,9 +251,8 @@ function SqlWorkspaceSession({
 				await executeStatement(0);
 			} catch (cause) {
 				if (!controller.signal.aborted) setError(errorMessage(cause));
-			} finally {
-				if (abortRef.current === controller) abortRef.current = null;
 			}
+			if (abortRef.current === controller) abortRef.current = null;
 		},
 		[historyItems, query, storageKey],
 	);

--- a/packages/web/src/components/WorkspaceBrowser/WorkspaceFilePreview.tsx
+++ b/packages/web/src/components/WorkspaceBrowser/WorkspaceFilePreview.tsx
@@ -16,6 +16,14 @@ import {
 	MAX_TEXT_EDITOR_BYTES,
 } from './workspacePreview';
 
+function loadEditorRuntime() {
+	return Promise.all([
+		import('codemirror'),
+		import('@codemirror/state'),
+		import('@codemirror/view'),
+	]);
+}
+
 function CodeEditor({
 	value,
 	readOnly,
@@ -28,7 +36,7 @@ function CodeEditor({
 	onSave: () => void;
 }) {
 	const host = useRef<HTMLDivElement>(null);
-	const initialValue = useRef(value).current;
+	const [initialValue] = useState(value);
 	const saveRef = useRef(onSave);
 	const changeRef = useRef(onChange);
 	const [loadError, setLoadError] = useState<string | null>(null);
@@ -41,11 +49,7 @@ function CodeEditor({
 		if (!host.current) return;
 		let cancelled = false;
 		let view: EditorView | undefined;
-		void Promise.all([
-			import('codemirror'),
-			import('@codemirror/state'),
-			import('@codemirror/view'),
-		])
+		void loadEditorRuntime()
 			.then(([{ basicSetup }, { EditorState }, { EditorView, keymap }]) => {
 				if (cancelled || !host.current) return;
 				view = new EditorView({
@@ -199,9 +203,8 @@ function FilePreviewContent({
 			toast.success(`Saved ${item.name}`);
 		} catch {
 			// The finder store owns adapter error reporting.
-		} finally {
-			setSaving(false);
 		}
+		setSaving(false);
 	};
 
 	if (textLike && blob.size <= MAX_TEXT_EDITOR_BYTES && !textError && text !== null) {

--- a/packages/web/src/components/form/schema-form/SchemaForm.tsx
+++ b/packages/web/src/components/form/schema-form/SchemaForm.tsx
@@ -380,11 +380,17 @@ function SecretField({
 	const reference = referenceSecret(value);
 	const [initialManaged] = useState(() => isKeepMarker(value));
 	const lastInline = useRef<unknown>(isKeepMarker(value) || typeof value === 'string' ? value : '');
-	const lastReference = useRef(reference);
+	const [lastReference, setLastReference] = useState(reference);
+	if (
+		reference !== undefined &&
+		(reference.$secret.backend !== lastReference?.$secret.backend ||
+			reference.$secret.locator !== lastReference?.$secret.locator)
+	) {
+		setLastReference(reference);
+	}
 	useEffect(() => {
-		if (reference) lastReference.current = reference;
-		else if (isKeepMarker(value) || typeof value === 'string') lastInline.current = value;
-	}, [reference, value]);
+		if (isKeepMarker(value) || typeof value === 'string') lastInline.current = value;
+	}, [value]);
 	const options = [
 		...(secretSources.inline ? ['inline'] : []),
 		...(secretSources.references.length > 0 ? ['reference'] : []),
@@ -402,7 +408,7 @@ function SecretField({
 	const selected = usesReference ? 'reference' : 'inline';
 	const externalValue =
 		reference ??
-		lastReference.current ??
+		lastReference ??
 		({
 			$secret: {
 				kind: 'reference',

--- a/packages/web/src/components/ui/ApplicationTabs.test.tsx
+++ b/packages/web/src/components/ui/ApplicationTabs.test.tsx
@@ -279,6 +279,33 @@ describe('ApplicationTabs', () => {
 		expect(open).toHaveBeenCalledWith('https://notebook.example/', '_blank', 'noopener,noreferrer');
 	});
 
+	it('keeps the close dialog open and allows retrying after a failure', async () => {
+		const user = userEvent.setup();
+		const error = new Error('Close failed');
+		const onClose = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce(undefined);
+		const onCloseError = vi.fn();
+		render(
+			<ApplicationTabs
+				ariaLabel="Workspace applications"
+				tabs={applicationTabs()}
+				onClose={onClose}
+				onCloseError={onCloseError}
+			/>,
+		);
+
+		await user.click(screen.getByRole('button', { name: 'Close VS Code' }));
+		await user.click(screen.getByRole('button', { name: 'Close VS Code' }));
+
+		expect(onCloseError).toHaveBeenCalledWith(error, expect.objectContaining({ id: 'vscode' }));
+		expect(screen.getByRole('dialog')).toBeVisible();
+		expect(screen.getByRole('button', { name: 'Close VS Code' })).toBeEnabled();
+		expect(screen.queryByText('Closing VS Code...')).toBeNull();
+
+		await user.click(screen.getByRole('button', { name: 'Close VS Code' }));
+		expect(onClose).toHaveBeenCalledTimes(2);
+		await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+	});
+
 	it('confirms and awaits a close before dismissing the dialog', async () => {
 		const user = userEvent.setup();
 		let finishClose!: () => void;

--- a/packages/web/src/components/ui/ApplicationTabs.tsx
+++ b/packages/web/src/components/ui/ApplicationTabs.tsx
@@ -442,10 +442,11 @@ export function ApplicationTabs({
 			await onClose(closingTab);
 			setCloseKey(undefined);
 		} catch (error) {
-			onCloseError?.(error, closingTab);
-		} finally {
 			setIsClosePending(false);
+			onCloseError?.(error, closingTab);
+			return;
 		}
+		setIsClosePending(false);
 	};
 
 	return (

--- a/packages/web/src/context/AuthContext.tsx
+++ b/packages/web/src/context/AuthContext.tsx
@@ -37,13 +37,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 				: withBasePath(`/api/auth/login?redirect_url=${encodeURIComponent(returnTo)}`);
 	}, []);
 
+	const logoutUrl = user?.logout_url;
 	const signOut = useCallback(() => {
-		if (user?.logout_url) {
-			window.location.href = withBasePath(user.logout_url);
+		if (logoutUrl) {
+			window.location.href = withBasePath(logoutUrl);
 		} else {
 			queryClient.setQueryData(userKeys.me(), null);
 		}
-	}, [user?.logout_url, queryClient]);
+	}, [logoutUrl, queryClient]);
 
 	const refetchUser = useCallback(() => {
 		void queryClient.invalidateQueries({ queryKey: userKeys.me() });


### PR DESCRIPTION
Fix React Compiler diagnostics that caused components and hooks to skip optimization during builds and appeared in test logs. Refactor unsupported callback syntax, align memo dependencies, and replace render-time ref reads while preserving cleanup, retries, and secret drafts.

Keep the compiler enabled and add regression coverage for retrying a failed tab close.
